### PR TITLE
feat:: BlockDeviceMappings DeviceName

### DIFF
--- a/hive/config/config.go
+++ b/hive/config/config.go
@@ -143,7 +143,8 @@ type EBSRequest struct {
 	CloudInit           bool
 	DeleteOnTermination bool
 	NBDURI              string // NBD URI - socket path (nbd:unix:/path.sock) or TCP (nbd://host:port)
-	DeviceName          string // Device name (e.g. /dev/sdf) for hot-plugged volumes
+	DeviceName          string // AWS API device name (e.g. /dev/sdf) for hot-plugged volumes
+	GuestDevice         string // Actual guest device path (e.g. /dev/vdc) discovered via QMP
 }
 
 // NBDTransport defines the transport type for NBD connections

--- a/hive/daemon/daemon_handlers.go
+++ b/hive/daemon/daemon_handlers.go
@@ -299,6 +299,17 @@ func (d *Daemon) handleAttachVolume(msg *nats.Msg, command qmp.Command, instance
 		return
 	}
 
+	// Discover actual guest device name via QMP query-block
+	guestDevice := device // fallback to AWS API name
+	deviceMap, qmpErr := queryGuestDeviceMap(d, instance.QMPClient, instance.ID)
+	if qmpErr != nil {
+		slog.Warn("AttachVolume: failed to query guest device map, using API device name", "volumeId", volumeID, "err", qmpErr)
+	} else if gd, ok := deviceMap[deviceID]; ok {
+		guestDevice = gd
+		slog.Info("AttachVolume: discovered guest device", "volumeId", volumeID, "qemuDevice", deviceID, "guestDevice", guestDevice)
+	}
+	ebsRequest.GuestDevice = guestDevice
+
 	// Update instance state: replace existing entry for this volume (handles
 	// stop/start cycles that keep stale entries) or append a new one.
 	instance.EBSRequests.Mu.Lock()
@@ -315,12 +326,12 @@ func (d *Daemon) handleAttachVolume(msg *nats.Msg, command qmp.Command, instance
 	}
 	instance.EBSRequests.Mu.Unlock()
 
-	// Update BlockDeviceMappings on the ec2.Instance
+	// Update BlockDeviceMappings on the ec2.Instance using actual guest device name
 	d.Instances.Mu.Lock()
 	if instance.Instance != nil {
 		now := time.Now()
 		mapping := &ec2.InstanceBlockDeviceMapping{}
-		mapping.SetDeviceName(device)
+		mapping.SetDeviceName(guestDevice)
 		mapping.Ebs = &ec2.EbsInstanceBlockDevice{}
 		mapping.Ebs.SetVolumeId(volumeID)
 		mapping.Ebs.SetAttachTime(now)
@@ -331,7 +342,7 @@ func (d *Daemon) handleAttachVolume(msg *nats.Msg, command qmp.Command, instance
 	d.Instances.Mu.Unlock()
 
 	// Update volume metadata in S3
-	if err := d.volumeService.UpdateVolumeState(volumeID, "in-use", command.ID, device); err != nil {
+	if err := d.volumeService.UpdateVolumeState(volumeID, "in-use", command.ID, guestDevice); err != nil {
 		slog.Error("AttachVolume: failed to update volume metadata", "volumeId", volumeID, "err", err)
 	}
 
@@ -340,7 +351,7 @@ func (d *Daemon) handleAttachVolume(msg *nats.Msg, command qmp.Command, instance
 		slog.Error("AttachVolume: failed to write state", "err", err)
 	}
 
-	d.respondWithVolumeAttachment(msg, respondWithError, volumeID, command.ID, device, "attached")
+	d.respondWithVolumeAttachment(msg, respondWithError, volumeID, command.ID, guestDevice, "attached")
 	slog.Info("Volume attached successfully", "volumeId", volumeID, "instanceId", command.ID, "device", device)
 }
 
@@ -930,6 +941,9 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) {
 			d.markInstanceFailed(instance, "launch_failed")
 			continue
 		}
+
+		// Discover actual guest device names via QMP query-block
+		d.updateGuestDeviceNames(instance)
 
 		successCount++
 		slog.Info("handleEC2RunInstances launched instance", "instanceId", instance.ID)

--- a/hive/daemon/daemon_test.go
+++ b/hive/daemon/daemon_test.go
@@ -1690,7 +1690,7 @@ func TestGenerateVolumes_DeleteOnTermination_FromBlockDeviceMapping(t *testing.T
 			if tt.deleteOnTerminationFlag != nil {
 				input.BlockDeviceMappings = []*ec2.BlockDeviceMapping{
 					{
-						DeviceName: aws.String("/dev/xvda"),
+						DeviceName: aws.String("/dev/vda"),
 						Ebs: &ec2.EbsBlockDevice{
 							VolumeSize:          aws.Int64(8),
 							DeleteOnTermination: tt.deleteOnTerminationFlag,

--- a/hive/daemon/device_map.go
+++ b/hive/daemon/device_map.go
@@ -1,0 +1,179 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/mulgadc/hive/hive/qmp"
+	"github.com/mulgadc/hive/hive/vm"
+)
+
+// pciAddrRegexp extracts the PCI address component from a QDev path.
+// Example QDev: "/machine/peripheral-anon/device[0]/virtio-backend"
+// The device[N] index determines PCI enumeration order.
+var pciAddrRegexp = regexp.MustCompile(`device\[(\d+)\]`)
+
+// queryGuestDeviceMap uses QMP query-block to build a map from QEMU device ID
+// (e.g. "os", "cloudinit", "vdisk-vol-xxx") to the guest device path
+// (e.g. "/dev/vda", "/dev/vdb", "/dev/vdc").
+//
+// The mapping is derived from PCI address order: virtio-blk-pci devices are
+// enumerated by the guest kernel in PCI bus order, which corresponds to the
+// device index in the QDev path.
+func queryGuestDeviceMap(d *Daemon, qmpClient *qmp.QMPClient, instanceID string) (map[string]string, error) {
+	resp, err := d.SendQMPCommand(qmpClient, qmp.QMPCommand{Execute: "query-block"}, instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("query-block failed: %w", err)
+	}
+
+	var devices []qmp.BlockDevice
+	if err := parseQueryBlockResponse(resp.Return, &devices); err != nil {
+		return nil, fmt.Errorf("failed to parse query-block response: %w", err)
+	}
+
+	return buildDeviceMap(devices), nil
+}
+
+// buildDeviceMap takes a list of BlockDevices from QMP and returns a map
+// from QEMU device ID to guest /dev/vdX path, sorted by PCI address.
+func buildDeviceMap(devices []qmp.BlockDevice) map[string]string {
+	type deviceEntry struct {
+		name     string
+		pciIndex int
+	}
+
+	var virtioDevices []deviceEntry
+
+	for _, dev := range devices {
+		// Skip non-virtio devices (floppy, ide, sd)
+		if dev.Inserted == nil && dev.QDev == "" {
+			continue
+		}
+		// Filter out legacy devices by name
+		switch dev.Device {
+		case "floppy0", "sd0", "ide1-cd0":
+			continue
+		}
+		// Must have a QDev path to determine PCI order
+		if dev.QDev == "" {
+			continue
+		}
+		// Skip non-virtio devices (those without virtio-backend in QDev)
+		if !strings.Contains(dev.QDev, "virtio-backend") {
+			continue
+		}
+
+		pciIndex := extractPCIIndex(dev.QDev)
+		if pciIndex < 0 {
+			slog.Warn("Could not extract PCI index from QDev path", "device", dev.Device, "qdev", dev.QDev)
+			continue
+		}
+
+		virtioDevices = append(virtioDevices, deviceEntry{
+			name:     dev.Device,
+			pciIndex: pciIndex,
+		})
+	}
+
+	// Sort by PCI index — this determines /dev/vd* letter assignment
+	sort.Slice(virtioDevices, func(i, j int) bool {
+		return virtioDevices[i].pciIndex < virtioDevices[j].pciIndex
+	})
+
+	result := make(map[string]string, len(virtioDevices))
+	for i, entry := range virtioDevices {
+		if i >= 26 {
+			break // /dev/vda through /dev/vdz only
+		}
+		guestDev := fmt.Sprintf("/dev/vd%c", 'a'+i)
+		result[entry.name] = guestDev
+	}
+
+	return result
+}
+
+// parseQueryBlockResponse unmarshals the raw QMP return value into a slice of BlockDevices.
+func parseQueryBlockResponse(raw json.RawMessage, out *[]qmp.BlockDevice) error {
+	return json.Unmarshal(raw, out)
+}
+
+// updateGuestDeviceNames queries the running VM's QMP to discover actual guest device
+// paths and updates the instance's BlockDeviceMappings and EBSRequests accordingly.
+func (d *Daemon) updateGuestDeviceNames(instance *vm.VM) {
+	if instance.QMPClient == nil {
+		return
+	}
+
+	deviceMap, err := queryGuestDeviceMap(d, instance.QMPClient, instance.ID)
+	if err != nil {
+		slog.Warn("Failed to query guest device map, BlockDeviceMappings will use API names",
+			"instanceId", instance.ID, "err", err)
+		return
+	}
+
+	// Update EBSRequests with guest device names
+	instance.EBSRequests.Mu.Lock()
+	for i, req := range instance.EBSRequests.Requests {
+		var qemuDeviceID string
+		if req.Boot {
+			qemuDeviceID = "os"
+		} else if req.CloudInit {
+			qemuDeviceID = "cloudinit"
+		} else {
+			// Hot-plugged volumes use "vdisk-{volumeID}" as the QEMU device ID
+			qemuDeviceID = fmt.Sprintf("vdisk-%s", req.Name)
+		}
+
+		if guestDev, ok := deviceMap[qemuDeviceID]; ok {
+			instance.EBSRequests.Requests[i].GuestDevice = guestDev
+		}
+	}
+	instance.EBSRequests.Mu.Unlock()
+
+	// Update BlockDeviceMappings DeviceName to use actual guest paths
+	d.Instances.Mu.Lock()
+	if instance.Instance != nil {
+		for _, bdm := range instance.Instance.BlockDeviceMappings {
+			if bdm.Ebs == nil || bdm.Ebs.VolumeId == nil {
+				continue
+			}
+			// The root volume QEMU device ID is "os"
+			if guestDev, ok := deviceMap["os"]; ok && bdm.DeviceName != nil {
+				// Match root volume: it's the first BDM entry (or has the root volume ID)
+				instance.EBSRequests.Mu.Lock()
+				for _, req := range instance.EBSRequests.Requests {
+					if req.Boot && req.Name == *bdm.Ebs.VolumeId {
+						bdm.DeviceName = &guestDev
+						break
+					}
+				}
+				instance.EBSRequests.Mu.Unlock()
+			}
+		}
+	}
+	d.Instances.Mu.Unlock()
+
+	if err := d.WriteState(); err != nil {
+		slog.Error("Failed to persist state after guest device name update", "instanceId", instance.ID, "err", err)
+	}
+
+	slog.Info("Updated guest device names", "instanceId", instance.ID, "deviceMap", deviceMap)
+}
+
+// extractPCIIndex parses the device index from a QDev path.
+// For example: "/machine/peripheral-anon/device[3]/virtio-backend" → 3
+func extractPCIIndex(qdev string) int {
+	matches := pciAddrRegexp.FindStringSubmatch(qdev)
+	if len(matches) < 2 {
+		return -1
+	}
+	var idx int
+	if _, err := fmt.Sscanf(matches[1], "%d", &idx); err != nil {
+		return -1
+	}
+	return idx
+}

--- a/hive/daemon/device_map_test.go
+++ b/hive/daemon/device_map_test.go
@@ -1,0 +1,190 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/mulgadc/hive/hive/qmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractPCIIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		qdev string
+		want int
+	}{
+		{
+			name: "standard peripheral-anon device",
+			qdev: "/machine/peripheral-anon/device[0]/virtio-backend",
+			want: 0,
+		},
+		{
+			name: "device index 3",
+			qdev: "/machine/peripheral-anon/device[3]/virtio-backend",
+			want: 3,
+		},
+		{
+			name: "hotplug device with higher index",
+			qdev: "/machine/peripheral/hotplug1/device[12]/virtio-backend",
+			want: 12,
+		},
+		{
+			name: "unattached device without brackets",
+			qdev: "/machine/unattached/device[24]",
+			want: 24,
+		},
+		{
+			name: "empty string",
+			qdev: "",
+			want: -1,
+		},
+		{
+			name: "no device brackets",
+			qdev: "/machine/peripheral/something",
+			want: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractPCIIndex(tt.qdev)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestBuildDeviceMap tests the core device mapping logic using the example
+// QMP query-block response from qmp.go:72
+func TestBuildDeviceMap(t *testing.T) {
+	// Simulate the exact QMP response from the example in qmp.go
+	devices := []qmp.BlockDevice{
+		{
+			IOStatus: "ok",
+			Device:   "os",
+			Locked:   false,
+			Inserted: &qmp.BlockInserted{
+				Image: qmp.BlockImage{
+					VirtualSize: 4294967296,
+					Filename:    "nbd://127.0.0.1:44801",
+					Format:      "raw",
+				},
+			},
+			QDev: "/machine/peripheral-anon/device[0]/virtio-backend",
+			Type: "unknown",
+		},
+		{
+			IOStatus: "ok",
+			Device:   "cloudinit",
+			Locked:   false,
+			Inserted: &qmp.BlockInserted{
+				Image: qmp.BlockImage{
+					VirtualSize: 1048576,
+					Filename:    "nbd://127.0.0.1:42911",
+					Format:      "raw",
+				},
+				RO: true,
+			},
+			QDev: "/machine/peripheral-anon/device[3]/virtio-backend",
+			Type: "unknown",
+		},
+		{
+			IOStatus:  "ok",
+			Device:    "ide1-cd0",
+			Locked:    false,
+			Removable: true,
+			QDev:      "/machine/unattached/device[24]",
+			Type:      "unknown",
+		},
+		{
+			Device:    "floppy0",
+			Locked:    false,
+			Removable: true,
+			QDev:      "/machine/unattached/device[18]",
+			Type:      "unknown",
+		},
+		{
+			Device:    "sd0",
+			Locked:    false,
+			Removable: true,
+			Type:      "unknown",
+		},
+	}
+
+	result := buildDeviceMap(devices)
+
+	assert.Equal(t, "/dev/vda", result["os"], "root disk should be /dev/vda")
+	assert.Equal(t, "/dev/vdb", result["cloudinit"], "cloudinit should be /dev/vdb")
+	assert.NotContains(t, result, "ide1-cd0", "ide device should be excluded")
+	assert.NotContains(t, result, "floppy0", "floppy should be excluded")
+	assert.NotContains(t, result, "sd0", "sd device should be excluded")
+	assert.Len(t, result, 2, "should only have 2 virtio devices")
+}
+
+func TestBuildDeviceMapWithHotplug(t *testing.T) {
+	devices := []qmp.BlockDevice{
+		{
+			Device:   "os",
+			Inserted: &qmp.BlockInserted{},
+			QDev:     "/machine/peripheral-anon/device[0]/virtio-backend",
+		},
+		{
+			Device:   "cloudinit",
+			Inserted: &qmp.BlockInserted{},
+			QDev:     "/machine/peripheral-anon/device[3]/virtio-backend",
+		},
+		{
+			Device:   "vdisk-vol-abc123",
+			Inserted: &qmp.BlockInserted{},
+			QDev:     "/machine/peripheral/hotplug1/device[10]/virtio-backend",
+		},
+		{
+			Device:   "vdisk-vol-def456",
+			Inserted: &qmp.BlockInserted{},
+			QDev:     "/machine/peripheral/hotplug2/device[11]/virtio-backend",
+		},
+		// Legacy devices to filter out
+		{Device: "floppy0", QDev: "/machine/unattached/device[18]"},
+		{Device: "sd0"},
+		{Device: "ide1-cd0", QDev: "/machine/unattached/device[24]"},
+	}
+
+	result := buildDeviceMap(devices)
+
+	assert.Equal(t, "/dev/vda", result["os"])
+	assert.Equal(t, "/dev/vdb", result["cloudinit"])
+	assert.Equal(t, "/dev/vdc", result["vdisk-vol-abc123"])
+	assert.Equal(t, "/dev/vdd", result["vdisk-vol-def456"])
+	assert.Len(t, result, 4)
+}
+
+func TestBuildDeviceMapEmpty(t *testing.T) {
+	result := buildDeviceMap(nil)
+	assert.Empty(t, result)
+}
+
+func TestBuildDeviceMapPCIOrdering(t *testing.T) {
+	// Test that PCI ordering is correct when devices are returned out of order
+	devices := []qmp.BlockDevice{
+		{
+			Device:   "cloudinit",
+			Inserted: &qmp.BlockInserted{},
+			QDev:     "/machine/peripheral-anon/device[5]/virtio-backend",
+		},
+		{
+			Device:   "os",
+			Inserted: &qmp.BlockInserted{},
+			QDev:     "/machine/peripheral-anon/device[1]/virtio-backend",
+		},
+		{
+			Device:   "vdisk-vol-123",
+			Inserted: &qmp.BlockInserted{},
+			QDev:     "/machine/peripheral/hotplug1/device[3]/virtio-backend",
+		},
+	}
+
+	result := buildDeviceMap(devices)
+
+	assert.Equal(t, "/dev/vda", result["os"], "lowest PCI index gets /dev/vda")
+	assert.Equal(t, "/dev/vdb", result["vdisk-vol-123"], "middle PCI index gets /dev/vdb")
+	assert.Equal(t, "/dev/vdc", result["cloudinit"], "highest PCI index gets /dev/vdc")
+}

--- a/hive/handlers/ec2/instance/service_impl.go
+++ b/hive/handlers/ec2/instance/service_impl.go
@@ -147,7 +147,7 @@ func (s *InstanceServiceImpl) RunInstance(input *ec2.RunInstancesInput) (*vm.VM,
 func (s *InstanceServiceImpl) GenerateVolumes(input *ec2.RunInstancesInput, instance *vm.VM) ([]VolumeInfo, error) {
 
 	var size int = 4 * 1024 * 1024 * 1024 // 4GB default size
-	var deviceName = "/dev/xvda"          // Default device name
+	var deviceName = "/dev/vda"           // Default device name (virtio-blk-pci)
 	var volumeType string
 	var iops int
 	var imageId string


### PR DESCRIPTION
Use QMP query-block to discover actual /dev/vdX device paths inside the guest VM instead of reporting Xen-style /dev/xvda or /dev/sd* names.
