### PR TITLE
feat: add Terraform nginx-alb example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 !example.tfvars
 scripts/iac/proxmox/clusters/
 
+# Generated SSH private keys from terraform examples (e.g. local_file.nginx_pem)
+*.pem
+
 # Go workspace
 go.work
 go.work.sum

--- a/docs/terraform/nginx-alb/README.md
+++ b/docs/terraform/nginx-alb/README.md
@@ -1,0 +1,54 @@
+# Nginx Web Servers with ALB
+
+Deploys two Nginx web server instances behind an Application Load Balancer on Spinifex.
+
+## What gets created
+
+| Resource | Name | Purpose |
+|---|---|---|
+| VPC | `nginx-alb-vpc` | Isolated network (10.20.0.0/16) |
+| Subnets | `nginx-alb-public-a`, `nginx-alb-public-b` | Two public subnets for ALB and instances |
+| Internet Gateway | `nginx-alb-igw` | Routes internet traffic |
+| Security Group | `nginx-alb-sg` | Allows SSH (22) and HTTP (80) inbound |
+| EC2 Instances | `nginx-alb-1`, `nginx-alb-2` | Debian 12 with Nginx via cloud-init |
+| ALB | `nginx-alb` | Application Load Balancer on port 80 |
+| Target Group | `nginx-alb-tg` | HTTP health-checked group for both instances |
+| Listener | HTTP :80 | Forwards traffic to the target group |
+
+## Prerequisites
+
+- Spinifex running locally (default: `https://localhost:9999`)
+- OpenTofu >= 1.6.0
+- AWS CLI profile `spinifex` configured
+
+## Deploy
+
+```bash
+cd spinifex/docs/terraform/nginx-alb
+export AWS_PROFILE=spinifex
+tofu init
+tofu apply
+```
+
+## Verify
+
+```bash
+# Hit the ALB — successive requests should alternate between Server 1 and Server 2
+curl http://<alb_dns_name>
+
+# Direct instance access
+curl http://<instance_1_public_ip>
+curl http://<instance_2_public_ip>
+
+# SSH into either instance
+ssh -i nginx-alb-demo.pem ec2-user@<instance_public_ip>
+
+# Check target health via AWS CLI
+aws elbv2 describe-target-health --target-group-arn <tg_arn>
+```
+
+## Cleanup
+
+```bash
+tofu destroy
+```

--- a/docs/terraform/nginx-alb/main.tf
+++ b/docs/terraform/nginx-alb/main.tf
@@ -1,0 +1,424 @@
+# Example: Nginx Web Servers with ALB on Spinifex
+#
+# Deploys a VPC with two public subnets, two EC2 instances running Nginx,
+# and an Application Load Balancer distributing HTTP traffic between them.
+# Demonstrates: VPC, subnets, internet gateway, route table, security group,
+# key pair, cloud-init user-data, EC2 instances, ALB, target group, and listener.
+#
+# Usage:
+#   cd spinifex/docs/terraform/nginx-alb
+#   export AWS_PROFILE=spinifex
+#   tofu init && tofu apply
+#
+# After apply:
+#   curl http://<alb_dns_name>     # Load-balanced Nginx
+#   curl http://<public_ip_1>      # Direct to instance 1
+#   curl http://<public_ip_2>      # Direct to instance 2
+#   ssh -i nginx-alb-demo.pem ec2-user@<public_ip>
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.65.0, < 5.66.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+
+variable "region" {
+  type    = string
+  default = "ap-southeast-2"
+}
+
+variable "spinifex_endpoint" {
+  type        = string
+  default     = "https://localhost:9999"
+  description = "Spinifex AWS gateway endpoint"
+}
+
+# ---------------------------------------------------------------------------
+# Provider — point the AWS provider at Spinifex
+# ---------------------------------------------------------------------------
+
+provider "aws" {
+  region = var.region
+
+  endpoints {
+    ec2            = var.spinifex_endpoint
+    iam            = var.spinifex_endpoint
+    sts            = var.spinifex_endpoint
+    elasticloadbalancingv2 = var.spinifex_endpoint
+  }
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+}
+
+# ---------------------------------------------------------------------------
+# Data sources
+# ---------------------------------------------------------------------------
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_ami" "debian12" {
+  most_recent = true
+  owners      = ["000000000000"] # Spinifex system images
+
+  filter {
+    name   = "name"
+    values = ["*debian-12*"]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# SSH Key Pair
+# ---------------------------------------------------------------------------
+
+resource "tls_private_key" "nginx" {
+  algorithm = "ED25519"
+}
+
+resource "aws_key_pair" "nginx" {
+  key_name   = "nginx-alb-demo"
+  public_key = tls_private_key.nginx.public_key_openssh
+}
+
+resource "local_file" "nginx_pem" {
+  filename        = "${path.module}/nginx-alb-demo.pem"
+  content         = tls_private_key.nginx.private_key_openssh
+  file_permission = "0600"
+}
+
+# ---------------------------------------------------------------------------
+# VPC
+# ---------------------------------------------------------------------------
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.20.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "nginx-alb-vpc"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Internet Gateway
+# ---------------------------------------------------------------------------
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "nginx-alb-igw"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Public Subnets (two AZs for the ALB)
+# ---------------------------------------------------------------------------
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.20.1.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "nginx-alb-public-a"
+  }
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.20.2.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "nginx-alb-public-b"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Route Table — send 0.0.0.0/0 through the internet gateway
+# ---------------------------------------------------------------------------
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "nginx-alb-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_b" {
+  subnet_id      = aws_subnet.public_b.id
+  route_table_id = aws_route_table.public.id
+}
+
+# ---------------------------------------------------------------------------
+# Security Group — SSH + HTTP inbound, all outbound
+# ---------------------------------------------------------------------------
+
+resource "aws_security_group" "web" {
+  name        = "nginx-alb-sg"
+  description = "Allow SSH and HTTP inbound"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "nginx-alb-sg"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# EC2 Instances — two Nginx servers with distinct landing pages
+# ---------------------------------------------------------------------------
+
+resource "aws_instance" "nginx_1" {
+  ami           = data.aws_ami.debian12.id
+  instance_type = "t3.small"
+
+  subnet_id              = aws_subnet.public_a.id
+  vpc_security_group_ids = [aws_security_group.web.id]
+  key_name               = aws_key_pair.nginx.key_name
+
+  associate_public_ip_address = true
+
+  user_data_base64 = base64encode(<<-USERDATA
+    #!/bin/bash
+    set -euo pipefail
+
+    apt-get update -y
+    apt-get install -y nginx
+
+    INSTANCE_ID=$(cat /var/lib/cloud/data/instance-id 2>/dev/null || hostname)
+    cat > /var/www/html/index.html <<HTML
+    <!DOCTYPE html>
+    <html>
+    <head><title>Spinifex ALB Demo</title></head>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 80px auto;">
+      <h1>Hello from Spinifex!</h1>
+      <p><strong>Instance:</strong> $INSTANCE_ID (Server 1)</p>
+      <p>This Nginx server is behind an Application Load Balancer.</p>
+      <hr>
+      <p><small>Provisioned via cloud-init user-data.</small></p>
+    </body>
+    </html>
+    HTML
+
+    systemctl enable nginx
+    systemctl restart nginx
+  USERDATA
+  )
+
+  tags = {
+    Name = "nginx-alb-1"
+  }
+}
+
+resource "aws_instance" "nginx_2" {
+  ami           = data.aws_ami.debian12.id
+  instance_type = "t3.small"
+
+  subnet_id              = aws_subnet.public_b.id
+  vpc_security_group_ids = [aws_security_group.web.id]
+  key_name               = aws_key_pair.nginx.key_name
+
+  associate_public_ip_address = true
+
+  user_data_base64 = base64encode(<<-USERDATA
+    #!/bin/bash
+    set -euo pipefail
+
+    apt-get update -y
+    apt-get install -y nginx
+
+    INSTANCE_ID=$(cat /var/lib/cloud/data/instance-id 2>/dev/null || hostname)
+    cat > /var/www/html/index.html <<HTML
+    <!DOCTYPE html>
+    <html>
+    <head><title>Spinifex ALB Demo</title></head>
+    <body style="font-family: sans-serif; max-width: 600px; margin: 80px auto;">
+      <h1>Hello from Spinifex!</h1>
+      <p><strong>Instance:</strong> $INSTANCE_ID (Server 2)</p>
+      <p>This Nginx server is behind an Application Load Balancer.</p>
+      <hr>
+      <p><small>Provisioned via cloud-init user-data.</small></p>
+    </body>
+    </html>
+    HTML
+
+    systemctl enable nginx
+    systemctl restart nginx
+  USERDATA
+  )
+
+  tags = {
+    Name = "nginx-alb-2"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Application Load Balancer
+# ---------------------------------------------------------------------------
+
+resource "aws_lb" "web" {
+  name               = "nginx-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.web.id]
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+
+  tags = {
+    Name = "nginx-alb"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Target Group — HTTP health-checked on port 80
+# ---------------------------------------------------------------------------
+
+resource "aws_lb_target_group" "nginx" {
+  name     = "nginx-alb-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 10
+  }
+
+  tags = {
+    Name = "nginx-alb-tg"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Register both instances as targets
+# ---------------------------------------------------------------------------
+
+resource "aws_lb_target_group_attachment" "nginx_1" {
+  target_group_arn = aws_lb_target_group.nginx.arn
+  target_id        = aws_instance.nginx_1.id
+  port             = 80
+}
+
+resource "aws_lb_target_group_attachment" "nginx_2" {
+  target_group_arn = aws_lb_target_group.nginx.arn
+  target_id        = aws_instance.nginx_2.id
+  port             = 80
+}
+
+# ---------------------------------------------------------------------------
+# Listener — forward HTTP :80 to the target group
+# ---------------------------------------------------------------------------
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.web.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nginx.arn
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+output "note" {
+  value = "EC2 instances can take 30+ seconds to boot after apply. If SSH or HTTP is unreachable, wait and retry."
+}
+
+output "alb_dns_name" {
+  value = aws_lb.web.dns_name
+}
+
+output "alb_url" {
+  value = "http://${aws_lb.web.dns_name}"
+}
+
+output "instance_1_id" {
+  value = aws_instance.nginx_1.id
+}
+
+output "instance_1_public_ip" {
+  value = aws_instance.nginx_1.public_ip
+}
+
+output "instance_2_id" {
+  value = aws_instance.nginx_2.id
+}
+
+output "instance_2_public_ip" {
+  value = aws_instance.nginx_2.public_ip
+}
+
+output "ssh_command_1" {
+  value = "ssh -i nginx-alb-demo.pem ec2-user@${aws_instance.nginx_1.public_ip}"
+}
+
+output "ssh_command_2" {
+  value = "ssh -i nginx-alb-demo.pem ec2-user@${aws_instance.nginx_2.public_ip}"
+}


### PR DESCRIPTION
## Summary
- Adds `docs/terraform/nginx-alb/` — an OpenTofu example that deploys two Nginx EC2 instances behind an Application Load Balancer on Spinifex (VPC, two public subnets, IGW, SG, key pair + cloud-init, ALB, target group, HTTP listener).
- Sits alongside the existing `bastion-private-subnet`, `nginx-webserver`, and `s3-webapp` examples.
- Gitignores generated `*.pem` files produced by the `local_file` SSH key output.

## Test plan
- [x] `tofu init && tofu apply` succeeds against local Spinifex (`https://localhost:9999`)
- [x] `curl http://<alb_dns_name>` alternates between Server 1 and Server 2
- [x] Direct `curl http://<instance_public_ip>` reaches each Nginx instance
- [x] `aws elbv2 describe-target-health` reports both targets healthy
- [x] `tofu destroy` cleans up all resources