### PR TITLE
fix: nginx-alb bugs (mulga-928/929/930)

### DIFF
--- a/docs/terraform/nginx-alb/README.md
+++ b/docs/terraform/nginx-alb/README.md
@@ -33,14 +33,34 @@ resources:
 
 ## Overview
 
-Deploy two Nginx web servers behind an internet-facing Application Load Balancer on Spinifex using Terraform/OpenTofu. This workbook provisions a VPC, two subnets, internet gateway, route table, security group, SSH key pair, an application load balancer (ALB) and two EC2 instances with cloud-init user-data that installs and starts Nginx. Only the ALB is reachable from outside the VPC — the Nginx instances have **private IPs only** and the ALB talks to them over the private VPC network.
+Deploy two Nginx web servers behind an internet-facing Application Load Balancer on Spinifex using Terraform/OpenTofu. This workbook provisions a VPC with public and private subnets, an internet gateway and NAT Gateway, route tables, security group, SSH key pair, an application load balancer (ALB) and two EC2 instances with cloud-init user-data that installs and starts Nginx. Only the ALB is reachable from outside the VPC — the Nginx instances live in the **private subnets** and reach the internet only for cloud-init bootstrapping via the NAT Gateway.
+
+```
+                Internet
+                    │
+               ┌────▼────┐
+               │   IGW   │
+               └────┬────┘
+         ┌──────────┼──────────┐
+         │                     │
+  ┌──────▼─────┐         ┌─────▼──────┐
+  │  public_a  │         │  public_b  │
+  │  ALB ENI   │         │  ALB ENI   │
+  │  NAT GW    │         └────────────┘
+  └──────┬─────┘
+         │ SNAT for private subnets
+  ┌──────▼─────┐         ┌────────────┐
+  │ private_a  │         │ private_b  │
+  │  nginx_1   │         │  nginx_2   │
+  └────────────┘         └────────────┘
+```
 
 **What you'll learn:**
 
 - Configuring the AWS Terraform provider to target Spinifex
-- Creating a VPC with an internet-facing load balancer fronting private instances
+- Creating a VPC with public + private subnets, an IGW and a NAT Gateway
+- Provisioning a multi-AZ internet-facing ALB fronting private workers
 - Provisioning an EC2 instance with cloud-init user-data
-- Provisioning an internet-facing application load balancer
 - Generating SSH key pairs with the TLS provider
 
 **What gets created**
@@ -48,10 +68,13 @@ Deploy two Nginx web servers behind an internet-facing Application Load Balancer
 | Resource | Name | Purpose |
 |---|---|---|
 | VPC | `nginx-alb-vpc` | Isolated network (10.20.0.0/16) |
-| Subnets | `nginx-alb-public-a`, `nginx-alb-public-b` | Two subnets across AZs for the ALB and instances |
-| Internet Gateway | `nginx-alb-igw` | Routes internet traffic for the ALB |
+| Public Subnets | `nginx-alb-public-a`, `nginx-alb-public-b` | Two AZs hosting the ALB and NAT Gateway |
+| Private Subnets | `nginx-alb-private-a`, `nginx-alb-private-b` | Two AZs hosting the Nginx workers |
+| Internet Gateway | `nginx-alb-igw` | Routes internet traffic for the public subnets |
+| Elastic IP | `nginx-alb-nat-eip` | Public address for the NAT Gateway |
+| NAT Gateway | `nginx-alb-nat` | Outbound internet for the private subnets (cloud-init apt bootstrap) |
 | Security Group | `nginx-alb-sg` | Allows SSH (22) and HTTP (80) inbound |
-| EC2 Instances | `nginx-alb-1`, `nginx-alb-2` | Debian 12 with Nginx via cloud-init (private IPs only) |
+| EC2 Instances | `nginx-alb-1`, `nginx-alb-2` | Debian 12 with Nginx via cloud-init (private subnets) |
 | ALB | `nginx-alb` | Internet-facing Application Load Balancer on port 80 |
 | Target Group | `nginx-alb-tg` | HTTP health-checked group for both instances |
 | Listener | HTTP :80 | Forwards traffic to the target group |
@@ -90,7 +113,7 @@ tofu apply
 
 ### Step 3. Verify
 
-> **Note:** EC2 instances can take 30+ seconds to boot after apply. If the ALB returns 5xx or HTTP is unreachable, wait and retry — the target group health checks need a moment to mark both instances healthy.
+> **Note:** EC2 instances can take 30+ seconds to boot after apply, and the NAT Gateway must be `available` before cloud-init on the workers can reach the apt repository. If the ALB returns 5xx or HTTP is unreachable, wait and retry — the target group health checks need a moment to mark both instances healthy once Nginx has installed.
 
 The ALB is internet-facing, but the DNS name Spinifex returns (`*.elb.spinifex.local`) will not resolve from your host. Fetch the ALB's public IP with the AWS CLI:
 
@@ -157,6 +180,12 @@ If targets stay unhealthy, verify the instances are running:
 
 ```bash
 aws ec2 describe-instances --profile spinifex
+```
+
+If cloud-init on the workers never finished, confirm the NAT Gateway is `available` (the private subnets rely on it for outbound apt access):
+
+```bash
+aws ec2 describe-nat-gateways --query 'NatGateways[].[NatGatewayId,State]'
 ```
 
 ### Nginx Not Responding

--- a/docs/terraform/nginx-alb/main.tf
+++ b/docs/terraform/nginx-alb/main.tf
@@ -159,7 +159,7 @@ resource "aws_subnet" "public_a" {
 resource "aws_subnet" "public_b" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.20.2.0/24"
-  availability_zone = data.aws_availability_zones.available.names[1]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "nginx-alb-public-b"
@@ -183,7 +183,7 @@ resource "aws_subnet" "private_a" {
 resource "aws_subnet" "private_b" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.20.12.0/24"
-  availability_zone = data.aws_availability_zones.available.names[1]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "nginx-alb-private-b"

--- a/docs/terraform/nginx-alb/main.tf
+++ b/docs/terraform/nginx-alb/main.tf
@@ -1,11 +1,14 @@
 # Example: Nginx Web Servers with ALB on Spinifex
 #
-# Deploys a VPC with two subnets, two EC2 instances running Nginx with
-# private-only IPs, and an internet-facing Application Load Balancer
-# distributing HTTP traffic between them. The ALB reaches the instances
-# over the private VPC network, so the instances do not need public IPs.
-# Demonstrates: VPC, subnets, internet gateway, route table, security group,
-# key pair, cloud-init user-data, EC2 instances, ALB, target group, and listener.
+# Deploys a VPC with two public subnets (ALB + NAT Gateway) and two private
+# subnets hosting Nginx EC2 instances. An internet-facing Application Load
+# Balancer distributes HTTP traffic between the private workers, and the
+# NAT Gateway gives them outbound internet access so cloud-init can install
+# Nginx from the Debian apt repository.
+#
+# Demonstrates: VPC, public and private subnets, internet gateway, NAT
+# Gateway with Elastic IP, route tables, security group, key pair, cloud-init
+# user-data, EC2 instances, ALB, target group, and listener.
 #
 # Usage:
 #   cd spinifex/docs/terraform/nginx-alb
@@ -140,7 +143,7 @@ resource "aws_internet_gateway" "igw" {
 }
 
 # ---------------------------------------------------------------------------
-# Public Subnets (two AZs for the ALB)
+# Public Subnets (two AZs for the ALB and NAT Gateway)
 # ---------------------------------------------------------------------------
 
 resource "aws_subnet" "public_a" {
@@ -156,7 +159,7 @@ resource "aws_subnet" "public_a" {
 resource "aws_subnet" "public_b" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.20.2.0/24"
-  availability_zone = data.aws_availability_zones.available.names[0]
+  availability_zone = data.aws_availability_zones.available.names[1]
 
   tags = {
     Name = "nginx-alb-public-b"
@@ -164,7 +167,58 @@ resource "aws_subnet" "public_b" {
 }
 
 # ---------------------------------------------------------------------------
-# Route Table — send 0.0.0.0/0 through the internet gateway
+# Private Subnets (two AZs for the Nginx workers)
+# ---------------------------------------------------------------------------
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.20.11.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "nginx-alb-private-a"
+  }
+}
+
+resource "aws_subnet" "private_b" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.20.12.0/24"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+  tags = {
+    Name = "nginx-alb-private-b"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# NAT Gateway — outbound internet for the private subnets
+#
+# Background plumbing: the private-subnet workers need outbound connectivity
+# during cloud-init so apt-get can install Nginx. A single NAT Gateway in
+# public_a provides SNAT for both private subnets via the private route table.
+# ---------------------------------------------------------------------------
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "nginx-alb-nat-eip"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public_a.id
+
+  tags = {
+    Name = "nginx-alb-nat"
+  }
+
+  depends_on = [aws_internet_gateway.igw]
+}
+
+# ---------------------------------------------------------------------------
+# Route Tables — public subnets egress via IGW, private subnets via NAT GW
 # ---------------------------------------------------------------------------
 
 resource "aws_route_table" "public" {
@@ -188,6 +242,29 @@ resource "aws_route_table_association" "public_a" {
 resource "aws_route_table_association" "public_b" {
   subnet_id      = aws_subnet.public_b.id
   route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name = "nginx-alb-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_b" {
+  subnet_id      = aws_subnet.private_b.id
+  route_table_id = aws_route_table.private.id
 }
 
 # ---------------------------------------------------------------------------
@@ -236,9 +313,13 @@ resource "aws_instance" "nginx_1" {
   ami           = data.aws_ami.debian12.id
   instance_type = "t3.small"
 
-  subnet_id              = aws_subnet.public_a.id
+  subnet_id              = aws_subnet.private_a.id
   vpc_security_group_ids = [aws_security_group.web.id]
   key_name               = aws_key_pair.nginx.key_name
+
+  # Workers pull nginx from apt via the NAT Gateway — creation must wait
+  # until the NAT Gateway is available so cloud-init can reach the repos.
+  depends_on = [aws_nat_gateway.main]
 
   user_data_base64 = base64encode(<<-USERDATA
     #!/bin/bash
@@ -276,9 +357,13 @@ resource "aws_instance" "nginx_2" {
   ami           = data.aws_ami.debian12.id
   instance_type = "t3.small"
 
-  subnet_id              = aws_subnet.public_b.id
+  subnet_id              = aws_subnet.private_b.id
   vpc_security_group_ids = [aws_security_group.web.id]
   key_name               = aws_key_pair.nginx.key_name
+
+  # Workers pull nginx from apt via the NAT Gateway — creation must wait
+  # until the NAT Gateway is available so cloud-init can reach the repos.
+  depends_on = [aws_nat_gateway.main]
 
   user_data_base64 = base64encode(<<-USERDATA
     #!/bin/bash

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1868,6 +1868,12 @@ func (d *Daemon) stopInstance(instances map[string]*vm.VM, deleteVolume bool) er
 				if err := d.networkPlumber.CleanupTapDevice(instance.ENIId); err != nil {
 					slog.Warn("Failed to clean up tap device", "eni", instance.ENIId, "err", err)
 				}
+				// Clean up any extra ENI tap devices (multi-subnet ALB VMs).
+				for _, extra := range instance.ExtraENIs {
+					if err := d.networkPlumber.CleanupTapDevice(extra.ENIID); err != nil {
+						slog.Warn("Failed to clean up extra ENI tap device", "eni", extra.ENIID, "err", err)
+					}
+				}
 			}
 
 			// Clean up management TAP and release IP
@@ -1924,6 +1930,26 @@ func (d *Daemon) stopInstance(instances map[string]*vm.VM, deleteVolume bool) er
 					}
 				} else {
 					slog.Info("Deleted ENI on termination", "eni", instance.ENIId, "instanceId", instance.ID)
+				}
+				// Detach + delete any extra ENIs (multi-subnet ALB VMs).
+				// Ordering matches the primary ENI: detach first, then delete.
+				// NotFound is tolerated because DeleteLoadBalancer may have
+				// already reaped the ENI via its own cleanup loop.
+				for _, extra := range instance.ExtraENIs {
+					if detachErr := d.vpcService.DetachENI(instance.AccountID, extra.ENIID); detachErr != nil {
+						slog.Warn("Failed to detach extra ENI on termination", "eni", extra.ENIID, "instanceId", instance.ID, "err", detachErr)
+					}
+					if _, eniErr := d.vpcService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+						NetworkInterfaceId: aws.String(extra.ENIID),
+					}, instance.AccountID); eniErr != nil {
+						if strings.Contains(eniErr.Error(), awserrors.ErrorInvalidNetworkInterfaceIDNotFound) {
+							slog.Debug("Extra ENI already cleaned up on termination", "eni", extra.ENIID)
+						} else {
+							slog.Error("Failed to delete extra ENI on termination", "eni", extra.ENIID, "instanceId", instance.ID, "err", eniErr)
+						}
+					} else {
+						slog.Info("Deleted extra ENI on termination", "eni", extra.ENIID, "instanceId", instance.ID)
+					}
 				}
 			}
 
@@ -2374,6 +2400,26 @@ func (d *Daemon) StartInstance(instance *vm.VM) error {
 		})
 
 		slog.Info("VPC networking configured", "tap", tapName, "eni", instance.ENIId, "mac", instance.ENIMac)
+
+		// Additional VPC NICs for multi-subnet system VMs (e.g. ALBs with
+		// subnets across multiple AZs). Each extra ENI gets its own tap on
+		// br-int and a matching virtio-net device. Cloud-init brings up the
+		// interfaces via per-MAC DHCP blocks written by generateNetworkConfig.
+		for idx, extra := range instance.ExtraENIs {
+			if err := d.networkPlumber.SetupTapDevice(extra.ENIID, extra.ENIMac); err != nil {
+				slog.Error("Failed to set up tap device for extra ENI", "eni", extra.ENIID, "err", err)
+				return fmt.Errorf("setup tap device for extra ENI %s: %w", extra.ENIID, err)
+			}
+			extraTapName := TapDeviceName(extra.ENIID)
+			netID := fmt.Sprintf("net%d", idx+1)
+			instance.Config.NetDevs = append(instance.Config.NetDevs, vm.NetDev{
+				Value: fmt.Sprintf("tap,id=%s,ifname=%s,script=no,downscript=no", netID, extraTapName),
+			})
+			instance.Config.Devices = append(instance.Config.Devices, vm.Device{
+				Value: fmt.Sprintf("virtio-net-pci,netdev=%s,mac=%s", netID, extra.ENIMac),
+			})
+			slog.Info("Extra VPC NIC configured", "tap", extraTapName, "eni", extra.ENIID, "mac", extra.ENIMac, "subnet", extra.SubnetID)
+		}
 
 		// DEV_NETWORKING: add a second NIC with hostfwd for SSH dev access
 		if d.config.Daemon.DevNetworking {

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1869,11 +1869,7 @@ func (d *Daemon) stopInstance(instances map[string]*vm.VM, deleteVolume bool) er
 					slog.Warn("Failed to clean up tap device", "eni", instance.ENIId, "err", err)
 				}
 				// Clean up any extra ENI tap devices (multi-subnet ALB VMs).
-				for _, extra := range instance.ExtraENIs {
-					if err := d.networkPlumber.CleanupTapDevice(extra.ENIID); err != nil {
-						slog.Warn("Failed to clean up extra ENI tap device", "eni", extra.ENIID, "err", err)
-					}
-				}
+				d.cleanupExtraENITaps(instance)
 			}
 
 			// Clean up management TAP and release IP
@@ -1931,26 +1927,9 @@ func (d *Daemon) stopInstance(instances map[string]*vm.VM, deleteVolume bool) er
 				} else {
 					slog.Info("Deleted ENI on termination", "eni", instance.ENIId, "instanceId", instance.ID)
 				}
-				// Detach + delete any extra ENIs (multi-subnet ALB VMs).
-				// Ordering matches the primary ENI: detach first, then delete.
-				// NotFound is tolerated because DeleteLoadBalancer may have
-				// already reaped the ENI via its own cleanup loop.
-				for _, extra := range instance.ExtraENIs {
-					if detachErr := d.vpcService.DetachENI(instance.AccountID, extra.ENIID); detachErr != nil {
-						slog.Warn("Failed to detach extra ENI on termination", "eni", extra.ENIID, "instanceId", instance.ID, "err", detachErr)
-					}
-					if _, eniErr := d.vpcService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-						NetworkInterfaceId: aws.String(extra.ENIID),
-					}, instance.AccountID); eniErr != nil {
-						if strings.Contains(eniErr.Error(), awserrors.ErrorInvalidNetworkInterfaceIDNotFound) {
-							slog.Debug("Extra ENI already cleaned up on termination", "eni", extra.ENIID)
-						} else {
-							slog.Error("Failed to delete extra ENI on termination", "eni", extra.ENIID, "instanceId", instance.ID, "err", eniErr)
-						}
-					} else {
-						slog.Info("Deleted extra ENI on termination", "eni", extra.ENIID, "instanceId", instance.ID)
-					}
-				}
+				// Extra ENIs (multi-subnet ALB VMs) are cleaned up by
+				// DeleteLoadBalancer via its own lb.ENIs loop — the daemon
+				// doesn't duplicate that teardown here.
 			}
 
 			// Deallocate resources
@@ -2402,23 +2381,9 @@ func (d *Daemon) StartInstance(instance *vm.VM) error {
 		slog.Info("VPC networking configured", "tap", tapName, "eni", instance.ENIId, "mac", instance.ENIMac)
 
 		// Additional VPC NICs for multi-subnet system VMs (e.g. ALBs with
-		// subnets across multiple AZs). Each extra ENI gets its own tap on
-		// br-int and a matching virtio-net device. Cloud-init brings up the
-		// interfaces via per-MAC DHCP blocks written by generateNetworkConfig.
-		for idx, extra := range instance.ExtraENIs {
-			if err := d.networkPlumber.SetupTapDevice(extra.ENIID, extra.ENIMac); err != nil {
-				slog.Error("Failed to set up tap device for extra ENI", "eni", extra.ENIID, "err", err)
-				return fmt.Errorf("setup tap device for extra ENI %s: %w", extra.ENIID, err)
-			}
-			extraTapName := TapDeviceName(extra.ENIID)
-			netID := fmt.Sprintf("net%d", idx+1)
-			instance.Config.NetDevs = append(instance.Config.NetDevs, vm.NetDev{
-				Value: fmt.Sprintf("tap,id=%s,ifname=%s,script=no,downscript=no", netID, extraTapName),
-			})
-			instance.Config.Devices = append(instance.Config.Devices, vm.Device{
-				Value: fmt.Sprintf("virtio-net-pci,netdev=%s,mac=%s", netID, extra.ENIMac),
-			})
-			slog.Info("Extra VPC NIC configured", "tap", extraTapName, "eni", extra.ENIID, "mac", extra.ENIMac, "subnet", extra.SubnetID)
+		// subnets across multiple AZs).
+		if err := d.setupExtraENINICs(instance); err != nil {
+			return err
 		}
 
 		// DEV_NETWORKING: add a second NIC with hostfwd for SSH dev access

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -96,6 +96,25 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 				slog.Warn("LaunchSystemInstance: failed to attach ENI", "eniId", instance.ENIId, "instanceId", instance.ID, "err", attachErr)
 			}
 		}
+		// Attach any additional pre-created ENIs (multi-subnet ALB VMs).
+		// Use the launcher input slice as the source of truth so the VM
+		// record carries every NIC the ALB spans even if the attach fails
+		// for one of them (we clean up on failure below).
+		for idx, extra := range input.ExtraENIs {
+			if d.vpcService != nil {
+				if _, attachErr := d.vpcService.AttachENI(eniAccountID, extra.ENIID, instance.ID, int64(idx+1)); attachErr != nil {
+					slog.Error("LaunchSystemInstance: failed to attach extra ENI", "eniId", extra.ENIID, "instanceId", instance.ID, "err", attachErr)
+					d.cleanupFailedSystemInstance(instance, instanceType)
+					return nil, fmt.Errorf("attach extra ENI %s: %w", extra.ENIID, attachErr)
+				}
+			}
+			instance.ExtraENIs = append(instance.ExtraENIs, vm.ExtraENI{
+				ENIID:    extra.ENIID,
+				ENIMac:   extra.ENIMac,
+				ENIIP:    extra.ENIIP,
+				SubnetID: extra.SubnetID,
+			})
+		}
 	} else if input.SubnetID != "" && d.vpcService != nil {
 		// Auto-create ENI in subnet
 		eniOut, eniErr := d.vpcService.CreateNetworkInterface(&ec2.CreateNetworkInterfaceInput{

--- a/spinifex/daemon/network.go
+++ b/spinifex/daemon/network.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 )
 
 // sudoCommand wraps exec.Command with sudo when running as non-root.
@@ -95,6 +96,42 @@ func (p *OVSNetworkPlumber) CleanupTapDevice(eniId string) error {
 
 	slog.Info("Network cleanup complete", "tap", tapName)
 	return nil
+}
+
+// setupExtraENINICs creates tap devices on br-int and appends matching QEMU
+// virtio-net device entries to instance.Config for each additional ENI a
+// system VM spans. The primary ENI (instance.ENIId) is handled separately by
+// the LaunchInstance caller. Cloud-init brings the guest interfaces up via
+// per-MAC DHCP blocks written by generateNetworkConfig.
+func (d *Daemon) setupExtraENINICs(instance *vm.VM) error {
+	for idx, extra := range instance.ExtraENIs {
+		if err := d.networkPlumber.SetupTapDevice(extra.ENIID, extra.ENIMac); err != nil {
+			slog.Error("Failed to set up tap device for extra ENI", "eni", extra.ENIID, "err", err)
+			return fmt.Errorf("setup tap device for extra ENI %s: %w", extra.ENIID, err)
+		}
+		extraTapName := TapDeviceName(extra.ENIID)
+		netID := fmt.Sprintf("net%d", idx+1)
+		instance.Config.NetDevs = append(instance.Config.NetDevs, vm.NetDev{
+			Value: fmt.Sprintf("tap,id=%s,ifname=%s,script=no,downscript=no", netID, extraTapName),
+		})
+		instance.Config.Devices = append(instance.Config.Devices, vm.Device{
+			Value: fmt.Sprintf("virtio-net-pci,netdev=%s,mac=%s", netID, extra.ENIMac),
+		})
+		slog.Info("Extra VPC NIC configured",
+			"tap", extraTapName, "eni", extra.ENIID, "mac", extra.ENIMac, "subnet", extra.SubnetID)
+	}
+	return nil
+}
+
+// cleanupExtraENITaps removes tap devices for every extra ENI attached to a
+// system VM. Errors are logged but not returned so a partial cleanup still
+// frees as many resources as possible.
+func (d *Daemon) cleanupExtraENITaps(instance *vm.VM) {
+	for _, extra := range instance.ExtraENIs {
+		if err := d.networkPlumber.CleanupTapDevice(extra.ENIID); err != nil {
+			slog.Warn("Failed to clean up extra ENI tap device", "eni", extra.ENIID, "err", err)
+		}
+	}
 }
 
 // TapDeviceName returns the Linux tap device name for an ENI.

--- a/spinifex/daemon/network_test.go
+++ b/spinifex/daemon/network_test.go
@@ -238,6 +238,139 @@ func TestNetworkPlumber_InterfaceCompliance(t *testing.T) {
 	var _ NetworkPlumber = &MockNetworkPlumber{}
 }
 
+func TestSetupExtraENINICs_AppendsOnePerExtra(t *testing.T) {
+	mock := &MockNetworkPlumber{}
+	d := &Daemon{networkPlumber: mock}
+	instance := &vm.VM{
+		ID: "i-multi",
+		ExtraENIs: []vm.ExtraENI{
+			{ENIID: "eni-aaa", ENIMac: "02:00:00:aa:aa:aa", ENIIP: "10.0.1.4", SubnetID: "subnet-a"},
+			{ENIID: "eni-bbb", ENIMac: "02:00:00:bb:bb:bb", ENIIP: "10.0.2.4", SubnetID: "subnet-b"},
+		},
+	}
+
+	if err := d.setupExtraENINICs(instance); err != nil {
+		t.Fatalf("setupExtraENINICs failed: %v", err)
+	}
+
+	// One SetupTapDevice call per extra ENI.
+	if len(mock.SetupCalls) != 2 {
+		t.Fatalf("expected 2 SetupTapDevice calls, got %d", len(mock.SetupCalls))
+	}
+	if mock.SetupCalls[0].ENIId != "eni-aaa" || mock.SetupCalls[0].MAC != "02:00:00:aa:aa:aa" {
+		t.Errorf("first setup call = %+v, want eni-aaa/02:00:00:aa:aa:aa", mock.SetupCalls[0])
+	}
+	if mock.SetupCalls[1].ENIId != "eni-bbb" || mock.SetupCalls[1].MAC != "02:00:00:bb:bb:bb" {
+		t.Errorf("second setup call = %+v, want eni-bbb/02:00:00:bb:bb:bb", mock.SetupCalls[1])
+	}
+
+	// NetDevs and Devices each get one entry per extra ENI, named net1/net2.
+	if len(instance.Config.NetDevs) != 2 || len(instance.Config.Devices) != 2 {
+		t.Fatalf("expected 2 netdevs + 2 devices, got %d + %d",
+			len(instance.Config.NetDevs), len(instance.Config.Devices))
+	}
+	if !strings.Contains(instance.Config.NetDevs[0].Value, "id=net1") {
+		t.Errorf("netdev[0] = %q, want id=net1", instance.Config.NetDevs[0].Value)
+	}
+	if !strings.Contains(instance.Config.NetDevs[1].Value, "id=net2") {
+		t.Errorf("netdev[1] = %q, want id=net2", instance.Config.NetDevs[1].Value)
+	}
+	if !strings.Contains(instance.Config.Devices[0].Value, "mac=02:00:00:aa:aa:aa") {
+		t.Errorf("device[0] = %q, missing primary MAC", instance.Config.Devices[0].Value)
+	}
+	if !strings.Contains(instance.Config.Devices[1].Value, "mac=02:00:00:bb:bb:bb") {
+		t.Errorf("device[1] = %q, missing second MAC", instance.Config.Devices[1].Value)
+	}
+}
+
+func TestSetupExtraENINICs_NoExtras_NoOp(t *testing.T) {
+	mock := &MockNetworkPlumber{}
+	d := &Daemon{networkPlumber: mock}
+	instance := &vm.VM{ID: "i-single"}
+
+	if err := d.setupExtraENINICs(instance); err != nil {
+		t.Fatalf("setupExtraENINICs failed: %v", err)
+	}
+	if len(mock.SetupCalls) != 0 {
+		t.Errorf("expected zero setup calls for no extras, got %d", len(mock.SetupCalls))
+	}
+	if len(instance.Config.NetDevs) != 0 || len(instance.Config.Devices) != 0 {
+		t.Errorf("expected no netdevs/devices, got %d/%d",
+			len(instance.Config.NetDevs), len(instance.Config.Devices))
+	}
+}
+
+func TestSetupExtraENINICs_TapSetupErrorReturns(t *testing.T) {
+	mock := &MockNetworkPlumber{SetupErr: fmt.Errorf("simulated tap failure")}
+	d := &Daemon{networkPlumber: mock}
+	instance := &vm.VM{
+		ID: "i-multi-err",
+		ExtraENIs: []vm.ExtraENI{
+			{ENIID: "eni-aaa", ENIMac: "02:00:00:aa:aa:aa"},
+			{ENIID: "eni-bbb", ENIMac: "02:00:00:bb:bb:bb"},
+		},
+	}
+
+	err := d.setupExtraENINICs(instance)
+	if err == nil {
+		t.Fatal("expected error from failing tap setup, got nil")
+	}
+	if !strings.Contains(err.Error(), "eni-aaa") {
+		t.Errorf("error = %v, want it to mention the failing ENI", err)
+	}
+	// Must bail on first failure — second ENI should not be touched.
+	if len(mock.SetupCalls) != 1 {
+		t.Errorf("expected 1 setup call before bailout, got %d", len(mock.SetupCalls))
+	}
+	// No NIC config appended for a failed setup.
+	if len(instance.Config.NetDevs) != 0 {
+		t.Errorf("expected no netdevs on failure, got %d", len(instance.Config.NetDevs))
+	}
+}
+
+func TestCleanupExtraENITaps_CallsCleanupPerExtra(t *testing.T) {
+	mock := &MockNetworkPlumber{}
+	d := &Daemon{networkPlumber: mock}
+	instance := &vm.VM{
+		ID: "i-multi-clean",
+		ExtraENIs: []vm.ExtraENI{
+			{ENIID: "eni-111"},
+			{ENIID: "eni-222"},
+			{ENIID: "eni-333"},
+		},
+	}
+
+	d.cleanupExtraENITaps(instance)
+
+	if len(mock.CleanupCalls) != 3 {
+		t.Fatalf("expected 3 cleanup calls, got %d", len(mock.CleanupCalls))
+	}
+	for i, want := range []string{"eni-111", "eni-222", "eni-333"} {
+		if mock.CleanupCalls[i] != want {
+			t.Errorf("cleanup[%d] = %q, want %q", i, mock.CleanupCalls[i], want)
+		}
+	}
+}
+
+func TestCleanupExtraENITaps_ErrorsAreLogged(t *testing.T) {
+	mock := &MockNetworkPlumber{CleanupErr: fmt.Errorf("simulated cleanup failure")}
+	d := &Daemon{networkPlumber: mock}
+	instance := &vm.VM{
+		ID: "i-multi-clean-err",
+		ExtraENIs: []vm.ExtraENI{
+			{ENIID: "eni-111"},
+			{ENIID: "eni-222"},
+		},
+	}
+
+	// Must not panic or return — errors are swallowed by design so partial
+	// cleanup still frees later entries.
+	d.cleanupExtraENITaps(instance)
+	if len(mock.CleanupCalls) != 2 {
+		t.Errorf("expected both extras to be attempted, got %d cleanup calls", len(mock.CleanupCalls))
+	}
+}
+
 func TestOVNHealthStatus_Fields(t *testing.T) {
 	// Verify OVNHealthStatus struct can be used for health reporting
 	status := OVNHealthStatus{

--- a/spinifex/handlers/ec2/instance/helpers_test.go
+++ b/spinifex/handlers/ec2/instance/helpers_test.go
@@ -9,21 +9,21 @@ import (
 // --- generateNetworkConfig ---
 
 func TestGenerateNetworkConfig_BothEmpty(t *testing.T) {
-	cfg := generateNetworkConfig("", "", "", "")
+	cfg := generateNetworkConfig("", "", "", "", nil)
 	assert.Equal(t, cloudInitNetworkConfigWildcard, cfg)
 }
 
 func TestGenerateNetworkConfig_OneEmpty(t *testing.T) {
-	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "", "", "")
+	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "", "", "", nil)
 	assert.Contains(t, cfg, "vpc0:", "eniMAC alone should produce per-interface config")
 	assert.NotContains(t, cfg, "dev0:", "no dev NIC without devMAC")
 
-	cfg = generateNetworkConfig("", "02:00:00:dd:ee:ff", "", "")
+	cfg = generateNetworkConfig("", "02:00:00:dd:ee:ff", "", "", nil)
 	assert.Equal(t, cloudInitNetworkConfigWildcard, cfg, "should fall back to wildcard if eniMAC empty")
 }
 
 func TestGenerateNetworkConfig_DualNIC(t *testing.T) {
-	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:00:00:dd:ee:ff", "", "")
+	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:00:00:dd:ee:ff", "", "", nil)
 	assert.Contains(t, cfg, "version: 2")
 	assert.Contains(t, cfg, `macaddress: "02:00:00:aa:bb:cc"`)
 	assert.Contains(t, cfg, `macaddress: "02:00:00:dd:ee:ff"`)
@@ -35,7 +35,7 @@ func TestGenerateNetworkConfig_DualNIC(t *testing.T) {
 }
 
 func TestGenerateNetworkConfig_TripleNIC(t *testing.T) {
-	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:de:00:dd:ee:ff", "02:a0:00:11:22:33", "10.15.8.101")
+	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:de:00:dd:ee:ff", "02:a0:00:11:22:33", "10.15.8.101", nil)
 	assert.Contains(t, cfg, "version: 2")
 	assert.Contains(t, cfg, `macaddress: "02:00:00:aa:bb:cc"`)
 	assert.Contains(t, cfg, `macaddress: "02:de:00:dd:ee:ff"`)
@@ -49,7 +49,7 @@ func TestGenerateNetworkConfig_TripleNIC(t *testing.T) {
 
 func TestGenerateNetworkConfig_MgmtWithoutDev(t *testing.T) {
 	// System instances: eniMAC + mgmtMAC, no devMAC — should get per-interface config with mgmt NIC
-	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "", "02:a0:00:11:22:33", "10.15.8.101")
+	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "", "02:a0:00:11:22:33", "10.15.8.101", nil)
 	assert.Contains(t, cfg, "vpc0:")
 	assert.NotContains(t, cfg, "dev0:", "no dev NIC without devMAC")
 	assert.Contains(t, cfg, "mgmt0:")
@@ -58,12 +58,12 @@ func TestGenerateNetworkConfig_MgmtWithoutDev(t *testing.T) {
 }
 
 func TestGenerateNetworkConfig_MgmtMACWithoutIP(t *testing.T) {
-	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:de:00:dd:ee:ff", "02:a0:00:11:22:33", "")
+	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:de:00:dd:ee:ff", "02:a0:00:11:22:33", "", nil)
 	assert.NotContains(t, cfg, "mgmt0:", "mgmt NIC should not appear without IP")
 }
 
 func TestGenerateNetworkConfig_MgmtIPWithoutMAC(t *testing.T) {
-	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:de:00:dd:ee:ff", "", "10.15.8.101")
+	cfg := generateNetworkConfig("02:00:00:aa:bb:cc", "02:de:00:dd:ee:ff", "", "10.15.8.101", nil)
 	assert.NotContains(t, cfg, "mgmt0:", "mgmt NIC should not appear without MAC")
 }
 

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -94,9 +94,13 @@ const cloudInitNetworkConfigWildcard = `network:
 // suppression. Without per-interface config, the wildcard fallback does DHCP on
 // all NICs — which won't work for the mgmt NIC (no DHCP server on br-mgmt).
 //
+// extraENIMACs configures additional VPC NICs for multi-subnet system VMs
+// (e.g. multi-AZ ALB VMs). Each extra MAC produces a DHCP ethernet block named
+// vpc1, vpc2, ... so each interface pulls its address from the subnet it lives in.
+//
 // The dev NIC still gets an IP via DHCP (needed for hostfwd port forwarding)
 // but dhcp4-overrides prevents it from installing routes or DNS.
-func generateNetworkConfig(eniMAC, devMAC, mgmtMAC, mgmtIP string) string {
+func generateNetworkConfig(eniMAC, devMAC, mgmtMAC, mgmtIP string, extraENIMACs []string) string {
 	if eniMAC == "" {
 		return cloudInitNetworkConfigWildcard
 	}
@@ -109,6 +113,18 @@ func generateNetworkConfig(eniMAC, devMAC, mgmtMAC, mgmtIP string) string {
       dhcp4: true
       dhcp-identifier: mac
 `, eniMAC)
+
+	for i, mac := range extraENIMACs {
+		if mac == "" {
+			continue
+		}
+		cfg += fmt.Sprintf(`    vpc%d:
+      match:
+        macaddress: "%s"
+      dhcp4: true
+      dhcp-identifier: mac
+`, i+1, mac)
+	}
 
 	if devMAC != "" {
 		cfg += fmt.Sprintf(`    dev0:
@@ -744,8 +760,13 @@ func (s *InstanceServiceImpl) createCloudInitISO(input *ec2.RunInstancesInput, i
 	}
 
 	// Add network-config: per-interface when VPC+dev (suppresses dev default route),
-	// wildcard DHCP otherwise.
-	networkConfig := generateNetworkConfig(instance.ENIMac, instance.DevMAC, instance.MgmtMAC, instance.MgmtIP)
+	// wildcard DHCP otherwise. Extra ENI MACs produce additional DHCP NICs for
+	// multi-subnet system VMs (multi-AZ ALBs).
+	extraMACs := make([]string, 0, len(instance.ExtraENIs))
+	for _, extra := range instance.ExtraENIs {
+		extraMACs = append(extraMACs, extra.ENIMac)
+	}
+	networkConfig := generateNetworkConfig(instance.ENIMac, instance.DevMAC, instance.MgmtMAC, instance.MgmtIP, extraMACs)
 	err = writer.AddFile(strings.NewReader(networkConfig), "network-config")
 	if err != nil {
 		slog.Error("failed to add network-config file", "err", err)

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -433,7 +433,7 @@ func TestMockInstanceService(t *testing.T) {
 
 func TestCloudInitNetworkConfigWildcard(t *testing.T) {
 	// No MACs → wildcard config (non-VPC or VPC without DEV_NETWORKING)
-	cfg := generateNetworkConfig("", "", "", "")
+	cfg := generateNetworkConfig("", "", "", "", nil)
 	assert.Contains(t, cfg, "version: 2")
 	assert.Contains(t, cfg, "dhcp4: true")
 	assert.Contains(t, cfg, "dhcp-identifier: mac")
@@ -445,7 +445,7 @@ func TestCloudInitNetworkConfigDualNIC(t *testing.T) {
 	eniMAC := "02:00:00:61:ef:c2"
 	devMAC := "02:de:00:60:83:0d"
 
-	cfg := generateNetworkConfig(eniMAC, devMAC, "", "")
+	cfg := generateNetworkConfig(eniMAC, devMAC, "", "", nil)
 
 	// Both MACs present in config
 	assert.Contains(t, cfg, eniMAC)
@@ -465,14 +465,44 @@ func TestCloudInitNetworkConfigDualNIC(t *testing.T) {
 
 func TestCloudInitNetworkConfigPartialMAC(t *testing.T) {
 	// Only ENI MAC (VPC without dev) → per-interface config with VPC NIC only
-	cfg := generateNetworkConfig("02:00:00:61:ef:c2", "", "", "")
+	cfg := generateNetworkConfig("02:00:00:61:ef:c2", "", "", "", nil)
 	assert.Contains(t, cfg, "vpc0:")
 	assert.NotContains(t, cfg, "dev0:")
 
 	// Only dev MAC (shouldn't happen, but defensive) → wildcard
-	cfg = generateNetworkConfig("", "02:de:00:60:83:0d", "", "")
+	cfg = generateNetworkConfig("", "02:de:00:60:83:0d", "", "", nil)
 	assert.Contains(t, cfg, `name: "e*"`)
 	assert.NotContains(t, cfg, "use-routes")
+}
+
+func TestCloudInitNetworkConfigMultiVPCNICs(t *testing.T) {
+	// Multi-subnet ALB VM: primary ENI + two extras, each on a different AZ.
+	extras := []string{
+		"02:00:00:bb:bb:bb",
+		"02:00:00:cc:cc:cc",
+	}
+	cfg := generateNetworkConfig("02:00:00:aa:aa:aa", "", "", "", extras)
+
+	assert.Contains(t, cfg, "vpc0:")
+	assert.Contains(t, cfg, "vpc1:")
+	assert.Contains(t, cfg, "vpc2:")
+	assert.Contains(t, cfg, `macaddress: "02:00:00:aa:aa:aa"`)
+	assert.Contains(t, cfg, `macaddress: "02:00:00:bb:bb:bb"`)
+	assert.Contains(t, cfg, `macaddress: "02:00:00:cc:cc:cc"`)
+	// Each extra NIC gets its own DHCP block with dhcp-identifier: mac.
+	assert.Equal(t, 3, strings.Count(cfg, "dhcp4: true"))
+	assert.Equal(t, 3, strings.Count(cfg, "dhcp-identifier: mac"))
+	// No dev0 / mgmt0 unless explicitly configured.
+	assert.NotContains(t, cfg, "dev0:")
+	assert.NotContains(t, cfg, "mgmt0:")
+}
+
+func TestCloudInitNetworkConfigEmptyExtraMACSkipped(t *testing.T) {
+	// Empty strings inside the extras slice are ignored rather than producing
+	// a malformed ethernets block.
+	cfg := generateNetworkConfig("02:00:00:aa:aa:aa", "", "", "", []string{""})
+	assert.Contains(t, cfg, "vpc0:")
+	assert.NotContains(t, cfg, "vpc1:")
 }
 
 func TestRunInstance_WithTags(t *testing.T) {

--- a/spinifex/handlers/ec2/routetable/service_impl.go
+++ b/spinifex/handlers/ec2/routetable/service_impl.go
@@ -596,6 +596,11 @@ func (s *RouteTableServiceImpl) AssociateRouteTable(input *ec2.AssociateRouteTab
 		return nil, err
 	}
 
+	// Terraform commonly creates the route table + NAT GW route before associating
+	// subnets. CreateRoute runs against a table with zero associations so no SNAT
+	// events fire, so we must emit them here once the subnet joins.
+	s.publishNatGatewayEventsForAssociation(accountID, "vpc.add-nat-gateway", record, subnetID)
+
 	slog.Info("AssociateRouteTable completed", "routeTableId", rtbID, "subnetId", subnetID, "associationId", assocID, "accountID", accountID)
 
 	return &ec2.AssociateRouteTableOutput{
@@ -650,10 +655,14 @@ func (s *RouteTableServiceImpl) DisassociateRouteTable(input *ec2.DisassociateRo
 				if assoc.Main {
 					return nil, errors.New(awserrors.ErrorInvalidParameterValue)
 				}
+				departingSubnetID := assoc.SubnetId
 				record.Associations = append(record.Associations[:i], record.Associations[i+1:]...)
 				if err := s.putRouteTable(accountID, &record); err != nil {
 					return nil, err
 				}
+
+				// Tear down per-subnet SNAT rules for any NAT GW routes on this table.
+				s.publishNatGatewayEventsForAssociation(accountID, "vpc.delete-nat-gateway", &record, departingSubnetID)
 
 				slog.Info("DisassociateRouteTable completed", "associationId", assocID, "routeTableId", record.RouteTableId, "accountID", accountID)
 				return &ec2.DisassociateRouteTableOutput{}, nil
@@ -881,7 +890,9 @@ func rtbMatchesFilters(record *RouteTableRecord, filters map[string][]string) bo
 }
 
 // publishNatGatewayEvents publishes vpc.add-nat-gateway events for each subnet
-// associated with this route table, so vpcd creates the SNAT rules.
+// associated with this route table, so vpcd creates the SNAT rules. Called by
+// CreateRoute when a NAT GW route is added to a table that may already have
+// subnet associations.
 func (s *RouteTableServiceImpl) publishNatGatewayEvents(accountID string, record *RouteTableRecord, vpcID, natgwID, publicIp string) {
 	if s.natsConn == nil {
 		return
@@ -890,37 +901,78 @@ func (s *RouteTableServiceImpl) publishNatGatewayEvents(accountID string, record
 		if assoc.SubnetId == "" || assoc.Main {
 			continue
 		}
-		subnetEntry, err := s.subnetKV.Get(utils.AccountKey(accountID, assoc.SubnetId))
-		if err != nil {
-			continue
-		}
-		var subnet handlers_ec2_vpc.SubnetRecord
-		if err := json.Unmarshal(subnetEntry.Value(), &subnet); err != nil {
-			continue
-		}
-
-		evt := struct {
-			VpcId        string `json:"vpc_id"`
-			NatGatewayId string `json:"nat_gateway_id"`
-			PublicIp     string `json:"public_ip"`
-			SubnetCidr   string `json:"subnet_cidr"`
-		}{
-			VpcId:        vpcID,
-			NatGatewayId: natgwID,
-			PublicIp:     publicIp,
-			SubnetCidr:   subnet.CidrBlock,
-		}
-		eventData, err := json.Marshal(evt)
-		if err != nil {
-			slog.Warn("Failed to marshal NAT GW add event", "err", err)
-			continue
-		}
-		if err := s.natsConn.Publish("vpc.add-nat-gateway", eventData); err != nil {
-			slog.Warn("Failed to publish NAT GW add event", "subnet", assoc.SubnetId, "err", err)
-		} else {
-			slog.Info("Published NAT GW add event", "subnetCidr", subnet.CidrBlock, "publicIp", publicIp)
-		}
+		s.publishNatGatewayEventForSubnet(accountID, "vpc.add-nat-gateway", assoc.SubnetId, vpcID, natgwID, publicIp)
 	}
+}
+
+// publishNatGatewayEventsForAssociation emits one NAT GW SNAT event per NAT GW
+// route on the table, scoped to a single subnet. Called when a subnet joins or
+// leaves a route table that already has NAT GW routes so OVN SNAT state tracks
+// association lifecycle (terraform creates the route first, then associates).
+func (s *RouteTableServiceImpl) publishNatGatewayEventsForAssociation(accountID, topic string, record *RouteTableRecord, subnetID string) {
+	if s.natsConn == nil || subnetID == "" {
+		return
+	}
+	for _, r := range record.Routes {
+		if r.NatGatewayId == "" {
+			continue
+		}
+		natgwEntry, err := s.natgwKV.Get(utils.AccountKey(accountID, r.NatGatewayId))
+		if err != nil {
+			slog.Warn("NAT GW event: natgw lookup failed", "topic", topic, "natGatewayId", r.NatGatewayId, "err", err)
+			continue
+		}
+		var natgw struct {
+			NatGatewayId string `json:"nat_gateway_id"`
+			VpcId        string `json:"vpc_id"`
+			PublicIp     string `json:"public_ip"`
+		}
+		if err := json.Unmarshal(natgwEntry.Value(), &natgw); err != nil {
+			slog.Warn("NAT GW event: natgw unmarshal failed", "topic", topic, "natGatewayId", r.NatGatewayId, "err", err)
+			continue
+		}
+		s.publishNatGatewayEventForSubnet(accountID, topic, subnetID, natgw.VpcId, natgw.NatGatewayId, natgw.PublicIp)
+	}
+}
+
+// publishNatGatewayEventForSubnet publishes a single vpc.{add,delete}-nat-gateway
+// event for the given subnet. Side-effect only — logs and swallows errors so a
+// missing subnet record doesn't fail the caller's API response.
+func (s *RouteTableServiceImpl) publishNatGatewayEventForSubnet(accountID, topic, subnetID, vpcID, natgwID, publicIp string) {
+	if s.natsConn == nil {
+		return
+	}
+	subnetEntry, err := s.subnetKV.Get(utils.AccountKey(accountID, subnetID))
+	if err != nil {
+		slog.Warn("NAT GW event: subnet lookup failed", "topic", topic, "subnetId", subnetID, "err", err)
+		return
+	}
+	var subnet handlers_ec2_vpc.SubnetRecord
+	if err := json.Unmarshal(subnetEntry.Value(), &subnet); err != nil {
+		slog.Warn("NAT GW event: subnet unmarshal failed", "topic", topic, "subnetId", subnetID, "err", err)
+		return
+	}
+	evt := struct {
+		VpcId        string `json:"vpc_id"`
+		NatGatewayId string `json:"nat_gateway_id"`
+		PublicIp     string `json:"public_ip"`
+		SubnetCidr   string `json:"subnet_cidr"`
+	}{
+		VpcId:        vpcID,
+		NatGatewayId: natgwID,
+		PublicIp:     publicIp,
+		SubnetCidr:   subnet.CidrBlock,
+	}
+	data, err := json.Marshal(evt)
+	if err != nil {
+		slog.Warn("NAT GW event: marshal failed", "topic", topic, "err", err)
+		return
+	}
+	if err := s.natsConn.Publish(topic, data); err != nil {
+		slog.Warn("NAT GW event: publish failed", "topic", topic, "subnetId", subnetID, "err", err)
+		return
+	}
+	slog.Info("NAT GW event published", "topic", topic, "subnetCidr", subnet.CidrBlock, "publicIp", publicIp)
 }
 
 // recordToEC2 converts an internal record to an AWS SDK RouteTable struct

--- a/spinifex/handlers/ec2/routetable/service_impl.go
+++ b/spinifex/handlers/ec2/routetable/service_impl.go
@@ -740,6 +740,11 @@ func (s *RouteTableServiceImpl) ReplaceRouteTableAssociation(input *ec2.ReplaceR
 				return nil, err
 			}
 
+			// Tear down SNAT for any NAT GW routes on the old table — the
+			// subnet is leaving so its per-CIDR rules must be removed before
+			// the new table's rules take effect.
+			s.publishNatGatewayEventsForAssociation(accountID, "vpc.delete-nat-gateway", &oldRecord, assoc.SubnetId)
+
 			// Add to new table with new ID
 			newAssocID := utils.GenerateResourceID("rtbassoc")
 			newRecord.Associations = append(newRecord.Associations, AssociationRecord{
@@ -757,6 +762,9 @@ func (s *RouteTableServiceImpl) ReplaceRouteTableAssociation(input *ec2.ReplaceR
 				}
 				return nil, err
 			}
+
+			// Install SNAT for any NAT GW routes on the new table.
+			s.publishNatGatewayEventsForAssociation(accountID, "vpc.add-nat-gateway", newRecord, assoc.SubnetId)
 
 			slog.Info("ReplaceRouteTableAssociation completed",
 				"oldAssociationId", assocID, "newAssociationId", newAssocID,

--- a/spinifex/handlers/ec2/routetable/service_impl_test.go
+++ b/spinifex/handlers/ec2/routetable/service_impl_test.go
@@ -1,15 +1,19 @@
 package handlers_ec2_routetable
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_ec2_igw "github.com/mulgadc/spinifex/spinifex/handlers/ec2/igw"
+	handlers_ec2_natgw "github.com/mulgadc/spinifex/spinifex/handlers/ec2/natgw"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +37,12 @@ func setupTestService(t *testing.T) *RouteTableServiceImpl {
 	// Seed subnet KV
 	testutil.SeedKV(t, js, handlers_ec2_vpc.KVBucketSubnets, map[string][]byte{
 		utils.AccountKey(testAccountID, "subnet-test1"): []byte(`{"subnet_id":"subnet-test1","vpc_id":"vpc-test1","cidr_block":"10.0.1.0/24","state":"available"}`),
+		utils.AccountKey(testAccountID, "subnet-priv1"): []byte(`{"subnet_id":"subnet-priv1","vpc_id":"vpc-test1","cidr_block":"10.0.11.0/24","state":"available"}`),
+	})
+
+	// Seed NAT Gateway KV
+	testutil.SeedKV(t, js, handlers_ec2_natgw.KVBucketNatGateways, map[string][]byte{
+		utils.AccountKey(testAccountID, "nat-test1"): []byte(`{"nat_gateway_id":"nat-test1","vpc_id":"vpc-test1","subnet_id":"subnet-test1","public_ip":"192.168.1.100","state":"available"}`),
 	})
 
 	svc, err := NewRouteTableServiceImplWithNATS(nil, nc)
@@ -458,4 +468,107 @@ func TestCreateRouteTableForVPC_Main(t *testing.T) {
 	assert.True(t, record.Associations[0].Main)
 	assert.Len(t, record.Routes, 1)
 	assert.Equal(t, "local", record.Routes[0].GatewayId)
+}
+
+// receiveNatGWEvent reads one message from sub, decodes, and asserts topic+cidr.
+// Returns the decoded public_ip for further assertions.
+func receiveNatGWEvent(t *testing.T, sub *nats.Subscription, wantCidr string) (natgwID, publicIp string) {
+	t.Helper()
+	msg, err := sub.NextMsg(2 * time.Second)
+	require.NoError(t, err, "expected NAT GW event on %s", sub.Subject)
+	var evt struct {
+		VpcId        string `json:"vpc_id"`
+		NatGatewayId string `json:"nat_gateway_id"`
+		PublicIp     string `json:"public_ip"`
+		SubnetCidr   string `json:"subnet_cidr"`
+	}
+	require.NoError(t, json.Unmarshal(msg.Data, &evt))
+	assert.Equal(t, wantCidr, evt.SubnetCidr)
+	return evt.NatGatewayId, evt.PublicIp
+}
+
+// TestAssociateRouteTable_PublishesNatGatewayEvent covers the terraform flow:
+// CreateRouteTable → CreateRoute(NAT GW) → AssociateRouteTable(subnet). CreateRoute
+// runs against an empty-association table so no event fires there; Associate must
+// emit the event so vpcd installs the SNAT rule for the joining subnet.
+func TestAssociateRouteTable_PublishesNatGatewayEvent(t *testing.T) {
+	svc := setupTestService(t)
+	sub, err := svc.natsConn.SubscribeSync("vpc.add-nat-gateway")
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	rtbID := createTestRtb(t, svc)
+
+	// Add NAT GW route BEFORE any subnet is associated (terraform ordering).
+	_, err = svc.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtbID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		NatGatewayId:         aws.String("nat-test1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	// No subnet yet → no event from CreateRoute.
+	_, err = sub.NextMsg(100 * time.Millisecond)
+	assert.Error(t, err, "CreateRoute must not publish when table has no associations")
+
+	_, err = svc.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(rtbID),
+		SubnetId:     aws.String("subnet-priv1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	natgwID, publicIp := receiveNatGWEvent(t, sub, "10.0.11.0/24")
+	assert.Equal(t, "nat-test1", natgwID)
+	assert.Equal(t, "192.168.1.100", publicIp)
+}
+
+// TestAssociateRouteTable_NoNatGatewayRoute ensures Associate stays silent when
+// the route table has no NAT GW routes.
+func TestAssociateRouteTable_NoNatGatewayRoute(t *testing.T) {
+	svc := setupTestService(t)
+	sub, err := svc.natsConn.SubscribeSync("vpc.add-nat-gateway")
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	rtbID := createTestRtb(t, svc)
+
+	_, err = svc.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(rtbID),
+		SubnetId:     aws.String("subnet-priv1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	_, err = sub.NextMsg(100 * time.Millisecond)
+	assert.Error(t, err, "Associate must not publish when table has no NAT GW routes")
+}
+
+// TestDisassociateRouteTable_PublishesNatGatewayDeleteEvent verifies SNAT
+// teardown when a subnet leaves a table with a NAT GW route.
+func TestDisassociateRouteTable_PublishesNatGatewayDeleteEvent(t *testing.T) {
+	svc := setupTestService(t)
+	delSub, err := svc.natsConn.SubscribeSync("vpc.delete-nat-gateway")
+	require.NoError(t, err)
+	defer func() { _ = delSub.Unsubscribe() }()
+
+	rtbID := createTestRtb(t, svc)
+	_, err = svc.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         aws.String(rtbID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		NatGatewayId:         aws.String("nat-test1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	assocOut, err := svc.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(rtbID),
+		SubnetId:     aws.String("subnet-priv1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	_, err = svc.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
+		AssociationId: assocOut.AssociationId,
+	}, testAccountID)
+	require.NoError(t, err)
+
+	natgwID, _ := receiveNatGWEvent(t, delSub, "10.0.11.0/24")
+	assert.Equal(t, "nat-test1", natgwID)
 }

--- a/spinifex/handlers/ec2/routetable/service_impl_test.go
+++ b/spinifex/handlers/ec2/routetable/service_impl_test.go
@@ -572,3 +572,48 @@ func TestDisassociateRouteTable_PublishesNatGatewayDeleteEvent(t *testing.T) {
 	natgwID, _ := receiveNatGWEvent(t, delSub, "10.0.11.0/24")
 	assert.Equal(t, "nat-test1", natgwID)
 }
+
+// TestReplaceRouteTableAssociation_PublishesNatGatewayEvents covers the move
+// path: subnet leaves a NAT-routed table for a NAT-free table. We expect a
+// delete event against the old table's NAT GW route and no add event.
+func TestReplaceRouteTableAssociation_PublishesNatGatewayEvents(t *testing.T) {
+	svc := setupTestService(t)
+	addSub, err := svc.natsConn.SubscribeSync("vpc.add-nat-gateway")
+	require.NoError(t, err)
+	defer func() { _ = addSub.Unsubscribe() }()
+	delSub, err := svc.natsConn.SubscribeSync("vpc.delete-nat-gateway")
+	require.NoError(t, err)
+	defer func() { _ = delSub.Unsubscribe() }()
+
+	oldRtb := createTestRtb(t, svc)
+	newRtb := createTestRtb(t, svc)
+
+	_, err = svc.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         aws.String(oldRtb),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		NatGatewayId:         aws.String("nat-test1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	assocOut, err := svc.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(oldRtb),
+		SubnetId:     aws.String("subnet-priv1"),
+	}, testAccountID)
+	require.NoError(t, err)
+	// Drain the add event from the initial association.
+	_, err = addSub.NextMsg(time.Second)
+	require.NoError(t, err)
+
+	_, err = svc.ReplaceRouteTableAssociation(&ec2.ReplaceRouteTableAssociationInput{
+		AssociationId: assocOut.AssociationId,
+		RouteTableId:  aws.String(newRtb),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	natgwID, _ := receiveNatGWEvent(t, delSub, "10.0.11.0/24")
+	assert.Equal(t, "nat-test1", natgwID)
+
+	// New table has no NAT GW routes → no add event.
+	_, err = addSub.NextMsg(100 * time.Millisecond)
+	assert.Error(t, err, "Replace must not publish add when new table has no NAT GW routes")
+}

--- a/spinifex/handlers/elbv2/launcher.go
+++ b/spinifex/handlers/elbv2/launcher.go
@@ -32,6 +32,11 @@ type SystemInstanceInput struct {
 	ENIMac string
 	ENIIP  string
 
+	// ExtraENIs lists additional pre-created ENIs that should be attached to
+	// the VM alongside the primary ENI. Used for multi-subnet ALBs so the VM
+	// has a NIC (and tap on br-int) in every subnet the LB spans.
+	ExtraENIs []ExtraENIInput
+
 	// Scheme is the ALB scheme ("internet-facing" or "internal").
 	// Internet-facing ALBs get a public IP and NAT rules; internal ALBs do not.
 	Scheme string
@@ -44,6 +49,15 @@ type SystemInstanceInput struct {
 	// via the QEMU user-mode dev NIC (dev_networking mode only).
 	// Each entry is a guest port (e.g. 80, 443). The host port is auto-assigned.
 	HostfwdPorts []int
+}
+
+// ExtraENIInput describes an additional pre-created ENI to attach to a
+// system instance. The primary ENI is still passed via ENIID/ENIMac/ENIIP.
+type ExtraENIInput struct {
+	ENIID    string
+	ENIMac   string
+	ENIIP    string
+	SubnetID string
 }
 
 // SystemInstanceOutput contains the result of a successful launch.

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -599,23 +599,54 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 		}
 	}
 
-	// Launch ALB VM with the first ENI (when instance launcher is available)
+	// Launch ALB VM with every ENI (when instance launcher is available).
+	// The first ENI is the primary NIC; any additional ENIs are passed as
+	// ExtraENIs so the daemon sets up a tap + QEMU NIC for each, giving the
+	// ALB VM data-plane presence in every subnet the LB spans.
 	var albInstanceID string
 	var albVPCIP string
 	var hostPorts map[int]int
 	var launchFailed bool
 	if s.InstanceLauncher != nil && s.getSystemAMI() != "" && len(eniIDs) > 0 && len(subnets) > 0 {
-		// Resolve the first ENI's details for the VM
-		eniIP := ""
-		eniMAC := ""
+		// Resolve MAC/IP for every ENI in one describe call.
+		eniDetails := make(map[string]*ec2.NetworkInterface, len(eniIDs))
 		if s.VPCService != nil {
-			result, descErr := s.VPCService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
-				NetworkInterfaceIds: []*string{aws.String(eniIDs[0])},
-			}, accountID)
-			if descErr == nil && len(result.NetworkInterfaces) > 0 {
-				eniIP = aws.StringValue(result.NetworkInterfaces[0].PrivateIpAddress)
-				eniMAC = aws.StringValue(result.NetworkInterfaces[0].MacAddress)
+			eniPtrs := make([]*string, 0, len(eniIDs))
+			for _, id := range eniIDs {
+				eniPtrs = append(eniPtrs, aws.String(id))
 			}
+			result, descErr := s.VPCService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+				NetworkInterfaceIds: eniPtrs,
+			}, accountID)
+			if descErr == nil {
+				for _, eni := range result.NetworkInterfaces {
+					if eni.NetworkInterfaceId != nil {
+						eniDetails[*eni.NetworkInterfaceId] = eni
+					}
+				}
+			}
+		}
+
+		primary := eniDetails[eniIDs[0]]
+		primaryIP := ""
+		primaryMAC := ""
+		if primary != nil {
+			primaryIP = aws.StringValue(primary.PrivateIpAddress)
+			primaryMAC = aws.StringValue(primary.MacAddress)
+		}
+
+		extraENIInputs := make([]ExtraENIInput, 0, len(eniIDs)-1)
+		for i := 1; i < len(eniIDs); i++ {
+			eni := eniDetails[eniIDs[i]]
+			if eni == nil {
+				continue
+			}
+			extraENIInputs = append(extraENIInputs, ExtraENIInput{
+				ENIID:    eniIDs[i],
+				ENIMac:   aws.StringValue(eni.MacAddress),
+				ENIIP:    aws.StringValue(eni.PrivateIpAddress),
+				SubnetID: aws.StringValue(eni.SubnetId),
+			})
 		}
 
 		userData, udErr := s.lbVMUserData(lbID)
@@ -629,8 +660,9 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 				SubnetID:     subnets[0],
 				UserData:     userData,
 				ENIID:        eniIDs[0],
-				ENIMac:       eniMAC,
-				ENIIP:        eniIP,
+				ENIMac:       primaryMAC,
+				ENIIP:        primaryIP,
+				ExtraENIs:    extraENIInputs,
 				Scheme:       scheme,
 				AccountID:    accountID,
 			}

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -1698,15 +1698,44 @@ func (s *ELBv2ServiceImpl) lbRecordToSDK(r *LoadBalancerRecord) *elbv2.LoadBalan
 		lb.SecurityGroups = append(lb.SecurityGroups, aws.String(sg))
 	}
 
+	// Build a subnet → private IP map by looking up each ENI. This lets each
+	// AvailabilityZone entry surface the private IP of the ENI that lives in
+	// its subnet, not just the public IP recorded at create time.
+	privateIPBySubnet := map[string]string{}
+	if s.VPCService != nil && len(r.ENIs) > 0 {
+		eniPtrs := make([]*string, 0, len(r.ENIs))
+		for _, eniID := range r.ENIs {
+			eniPtrs = append(eniPtrs, aws.String(eniID))
+		}
+		result, err := s.VPCService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+			NetworkInterfaceIds: eniPtrs,
+		}, r.AccountID)
+		if err != nil {
+			slog.Debug("lbRecordToSDK: failed to describe ALB ENIs — private IPs omitted from response",
+				"lbArn", r.LoadBalancerArn, "err", err)
+		} else {
+			for _, eni := range result.NetworkInterfaces {
+				if eni.SubnetId != nil && eni.PrivateIpAddress != nil {
+					privateIPBySubnet[*eni.SubnetId] = *eni.PrivateIpAddress
+				}
+			}
+		}
+	}
+
 	for _, az := range r.AvailZones {
 		sdkAZ := &elbv2.AvailabilityZone{
 			ZoneName: aws.String(az.ZoneName),
 			SubnetId: aws.String(az.SubnetId),
 		}
+		if privateIP, ok := privateIPBySubnet[az.SubnetId]; ok && privateIP != "" {
+			sdkAZ.LoadBalancerAddresses = append(sdkAZ.LoadBalancerAddresses, &elbv2.LoadBalancerAddress{
+				PrivateIPv4Address: aws.String(privateIP),
+			})
+		}
 		if az.PublicIP != "" {
-			sdkAZ.LoadBalancerAddresses = []*elbv2.LoadBalancerAddress{
-				{IpAddress: aws.String(az.PublicIP)},
-			}
+			sdkAZ.LoadBalancerAddresses = append(sdkAZ.LoadBalancerAddresses, &elbv2.LoadBalancerAddress{
+				IpAddress: aws.String(az.PublicIP),
+			})
 		}
 		lb.AvailabilityZones = append(lb.AvailabilityZones, sdkAZ)
 	}

--- a/spinifex/handlers/elbv2/service_impl_test.go
+++ b/spinifex/handlers/elbv2/service_impl_test.go
@@ -1752,6 +1752,95 @@ func TestDescribeLoadBalancerAttributes_NLBDefaults(t *testing.T) {
 	assert.Equal(t, "false", attrMap["load_balancing.cross_zone.enabled"])
 }
 
+// TestDefaultLoadBalancerAttributes_ALBCoversTerraformKeys guards against
+// regressions where terraform's default ModifyLoadBalancerAttributes call
+// hits ValidationError because the ALB default attribute set is missing a
+// key that the AWS provider sends. Every key here is one the aws-sdk-go
+// elbv2 API documents for ALBs.
+func TestDefaultLoadBalancerAttributes_ALBCoversTerraformKeys(t *testing.T) {
+	attrs := DefaultLoadBalancerAttributes(LoadBalancerTypeApplication)
+
+	expected := map[string]string{
+		"deletion_protection.enabled":                              "false",
+		"load_balancing.cross_zone.enabled":                        "true",
+		"access_logs.s3.enabled":                                   "false",
+		"access_logs.s3.bucket":                                    "",
+		"access_logs.s3.prefix":                                    "",
+		"connection_logs.s3.enabled":                               "false",
+		"connection_logs.s3.bucket":                                "",
+		"connection_logs.s3.prefix":                                "",
+		"idle_timeout.timeout_seconds":                             "60",
+		"client_keep_alive.seconds":                                "3600",
+		"routing.http.desync_mitigation_mode":                      "defensive",
+		"routing.http.drop_invalid_header_fields.enabled":          "false",
+		"routing.http.preserve_host_header.enabled":                "false",
+		"routing.http.x_amzn_tls_version_and_cipher_suite.enabled": "false",
+		"routing.http.xff_client_port.enabled":                     "false",
+		"routing.http.xff_header_processing.mode":                  "append",
+		"routing.http2.enabled":                                    "true",
+		"waf.fail_open.enabled":                                    "false",
+		"zonal_shift.config.enabled":                               "false",
+	}
+
+	for k, v := range expected {
+		got, ok := attrs[k]
+		assert.True(t, ok, "ALB default attributes missing key %q — terraform will hit ValidationError", k)
+		assert.Equal(t, v, got, "ALB default value mismatch for key %s", k)
+	}
+}
+
+// TestDefaultLoadBalancerAttributes_NLBCoversExpectedKeys is the NLB
+// counterpart guard. NLBs have a smaller but distinct key set.
+func TestDefaultLoadBalancerAttributes_NLBCoversExpectedKeys(t *testing.T) {
+	attrs := DefaultLoadBalancerAttributes(LoadBalancerTypeNetwork)
+
+	expected := map[string]string{
+		"deletion_protection.enabled":       "false",
+		"load_balancing.cross_zone.enabled": "false",
+		"access_logs.s3.enabled":            "false",
+		"access_logs.s3.bucket":             "",
+		"access_logs.s3.prefix":             "",
+		"dns_record.client_routing_policy":  "any_availability_zone",
+		"ipv6.deny_all_igw_traffic":         "false",
+		"zonal_shift.config.enabled":        "false",
+	}
+
+	for k, v := range expected {
+		got, ok := attrs[k]
+		assert.True(t, ok, "NLB default attributes missing key %q", k)
+		assert.Equal(t, v, got, "NLB default value mismatch for key %s", k)
+	}
+
+	// ALB-only keys must not leak into NLB defaults.
+	_, hasIdle := attrs["idle_timeout.timeout_seconds"]
+	assert.False(t, hasIdle, "idle_timeout.timeout_seconds is ALB-only, must not appear on NLB")
+	_, hasHTTP2 := attrs["routing.http2.enabled"]
+	assert.False(t, hasHTTP2, "routing.http2.enabled is ALB-only, must not appear on NLB")
+}
+
+// TestModifyLoadBalancerAttributes_AcceptsConnectionLogsKey is a regression
+// guard for mulga-931: terraform sends connection_logs.s3.enabled on every
+// aws_lb apply and the handler must accept it.
+func TestModifyLoadBalancerAttributes_AcceptsConnectionLogsKey(t *testing.T) {
+	svc := setupTestService(t)
+	lbOut, err := svc.CreateLoadBalancer(&elbv2.CreateLoadBalancerInput{
+		Name: aws.String("alb-conn-logs"),
+	}, testAccountID)
+	require.NoError(t, err)
+	arn := lbOut.LoadBalancers[0].LoadBalancerArn
+
+	_, err = svc.ModifyLoadBalancerAttributes(&elbv2.ModifyLoadBalancerAttributesInput{
+		LoadBalancerArn: arn,
+		Attributes: []*elbv2.LoadBalancerAttribute{
+			{Key: aws.String("connection_logs.s3.enabled"), Value: aws.String("false")},
+			{Key: aws.String("routing.http.desync_mitigation_mode"), Value: aws.String("defensive")},
+			{Key: aws.String("waf.fail_open.enabled"), Value: aws.String("false")},
+			{Key: aws.String("zonal_shift.config.enabled"), Value: aws.String("false")},
+		},
+	}, testAccountID)
+	require.NoError(t, err, "terraform-sent attribute keys must be accepted")
+}
+
 func TestModifyDescribeTargetGroupAttributes_RoundTrip(t *testing.T) {
 	svc := setupTestService(t)
 	tgOut, err := svc.CreateTargetGroup(&elbv2.CreateTargetGroupInput{Name: aws.String("tg-attr-rt")}, testAccountID)

--- a/spinifex/handlers/elbv2/service_impl_vpc_test.go
+++ b/spinifex/handlers/elbv2/service_impl_vpc_test.go
@@ -136,6 +136,61 @@ func TestCreateLoadBalancer_MultipleSubnets(t *testing.T) {
 	assert.Equal(t, 2, managedCount)
 }
 
+// TestCreateLoadBalancer_MultiSubnet_AllENIsPassedToLauncher verifies that
+// every subnet's ENI is threaded through to SystemInstanceInput, not just
+// the first one. Regression guard for mulga-929.
+func TestCreateLoadBalancer_MultiSubnet_AllENIsPassedToLauncher(t *testing.T) {
+	svc, vpcSvc := setupTestServiceWithVPC(t)
+
+	vpcs, _ := vpcSvc.DescribeVpcs(&ec2.DescribeVpcsInput{}, testAccountID)
+	vpcID := *vpcs.Vpcs[0].VpcId
+
+	sub1 := getTestSubnetID(t, vpcSvc, vpcID, "10.0.10.0/24", "us-east-1a")
+	sub2 := getTestSubnetID(t, vpcSvc, vpcID, "10.0.11.0/24", "us-east-1b")
+	sub3 := getTestSubnetID(t, vpcSvc, vpcID, "10.0.12.0/24", "us-east-1c")
+
+	mock := &mockSystemInstanceLauncher{
+		launchResult: &SystemInstanceOutput{
+			InstanceID: "i-multi-alb",
+			PrivateIP:  "10.0.10.4",
+			PublicIP:   "203.0.113.200",
+		},
+	}
+	svc.InstanceLauncher = mock
+	svc.SetSystemAMIFunc(func() string { return "ami-alb-test" })
+	svc.GatewayURL = "https://10.0.0.1:9999"
+	svc.SystemAccessKey = "AKID"
+	svc.SystemSecretKey = "SECRET"
+
+	_, err := svc.CreateLoadBalancer(&elbv2.CreateLoadBalancerInput{
+		Name:    aws.String("multi-eni-alb"),
+		Subnets: []*string{aws.String(sub1), aws.String(sub2), aws.String(sub3)},
+	}, testAccountID)
+	require.NoError(t, err)
+
+	require.Len(t, mock.launchCalls, 1)
+	launchInput := mock.launchCalls[0]
+
+	// Primary ENI is the first subnet's ENI.
+	assert.NotEmpty(t, launchInput.ENIID, "primary ENIID must be populated")
+	assert.NotEmpty(t, launchInput.ENIMac, "primary ENIMac must be populated")
+	assert.NotEmpty(t, launchInput.ENIIP, "primary ENIIP must be populated")
+	assert.Equal(t, sub1, launchInput.SubnetID)
+
+	// Two extra ENIs, one per remaining subnet, each with MAC/IP resolved.
+	require.Len(t, launchInput.ExtraENIs, 2, "launcher must receive one ExtraENI per additional subnet")
+	extraSubnets := map[string]bool{}
+	for _, extra := range launchInput.ExtraENIs {
+		assert.NotEmpty(t, extra.ENIID, "extra ENIID must be populated")
+		assert.NotEmpty(t, extra.ENIMac, "extra ENIMac must be populated")
+		assert.NotEmpty(t, extra.ENIIP, "extra ENIIP must be populated")
+		assert.NotEmpty(t, extra.SubnetID, "extra SubnetID must be populated")
+		extraSubnets[extra.SubnetID] = true
+	}
+	assert.True(t, extraSubnets[sub2], "extras should include sub2")
+	assert.True(t, extraSubnets[sub3], "extras should include sub3")
+}
+
 func TestDeleteLoadBalancer_CleansUpENIs(t *testing.T) {
 	svc, vpcSvc := setupTestServiceWithVPC(t)
 

--- a/spinifex/handlers/elbv2/service_impl_vpc_test.go
+++ b/spinifex/handlers/elbv2/service_impl_vpc_test.go
@@ -241,10 +241,20 @@ func TestCreateLoadBalancer_InternetFacing_AllocatesPublicIP(t *testing.T) {
 	require.Len(t, mock.launchCalls, 1)
 	assert.Equal(t, SchemeInternetFacing, mock.launchCalls[0].Scheme)
 
-	// Verify AZ includes public IP for internet-facing
+	// Internet-facing ALB: AZ includes both the public IP and the ENI's private IP.
 	require.Len(t, lb.AvailabilityZones, 1)
-	require.NotEmpty(t, lb.AvailabilityZones[0].LoadBalancerAddresses)
-	assert.Equal(t, "203.0.113.50", *lb.AvailabilityZones[0].LoadBalancerAddresses[0].IpAddress)
+	require.Len(t, lb.AvailabilityZones[0].LoadBalancerAddresses, 2)
+	var gotPublic, gotPrivate bool
+	for _, addr := range lb.AvailabilityZones[0].LoadBalancerAddresses {
+		if aws.StringValue(addr.IpAddress) == "203.0.113.50" {
+			gotPublic = true
+		}
+		if aws.StringValue(addr.PrivateIPv4Address) != "" {
+			gotPrivate = true
+		}
+	}
+	assert.True(t, gotPublic, "expected public IpAddress in LoadBalancerAddresses")
+	assert.True(t, gotPrivate, "expected ENI PrivateIPv4Address in LoadBalancerAddresses")
 }
 
 func TestCreateLoadBalancer_Internal_NoPublicIP(t *testing.T) {
@@ -276,14 +286,16 @@ func TestCreateLoadBalancer_Internal_NoPublicIP(t *testing.T) {
 
 	lb := out.LoadBalancers[0]
 	assert.Equal(t, "internal", *lb.Scheme)
+	// Internal ALB: no public IpAddress, but the ENI's private IP should be
+	// exposed in LoadBalancerAddresses[].PrivateIPv4Address.
+	require.Len(t, lb.AvailabilityZones, 1)
+	require.Len(t, lb.AvailabilityZones[0].LoadBalancerAddresses, 1)
+	assert.Nil(t, lb.AvailabilityZones[0].LoadBalancerAddresses[0].IpAddress)
+	assert.NotEmpty(t, aws.StringValue(lb.AvailabilityZones[0].LoadBalancerAddresses[0].PrivateIPv4Address))
 
 	// Verify launcher was called with internal scheme
 	require.Len(t, mock.launchCalls, 1)
 	assert.Equal(t, SchemeInternal, mock.launchCalls[0].Scheme)
-
-	// Verify AZ does NOT include public IP
-	require.Len(t, lb.AvailabilityZones, 1)
-	assert.Empty(t, lb.AvailabilityZones[0].LoadBalancerAddresses)
 }
 
 func TestCreateLoadBalancer_NLB_Internal_NoPublicIP(t *testing.T) {
@@ -324,9 +336,11 @@ func TestCreateLoadBalancer_NLB_Internal_NoPublicIP(t *testing.T) {
 	require.Len(t, mock.launchCalls, 1)
 	assert.Equal(t, SchemeInternal, mock.launchCalls[0].Scheme)
 
-	// Verify AZ does NOT include public IP
+	// Internal NLB: no public IpAddress, but the ENI's private IP is exposed.
 	require.Len(t, lb.AvailabilityZones, 1)
-	assert.Empty(t, lb.AvailabilityZones[0].LoadBalancerAddresses)
+	require.Len(t, lb.AvailabilityZones[0].LoadBalancerAddresses, 1)
+	assert.Nil(t, lb.AvailabilityZones[0].LoadBalancerAddresses[0].IpAddress)
+	assert.NotEmpty(t, aws.StringValue(lb.AvailabilityZones[0].LoadBalancerAddresses[0].PrivateIPv4Address))
 
 	// Verify no security groups (NLBs don't support them)
 	assert.Empty(t, lb.SecurityGroups)
@@ -416,8 +430,20 @@ func TestDescribeLoadBalancers_InternetFacing_IncludesPublicIP(t *testing.T) {
 
 	lb := desc.LoadBalancers[0]
 	require.Len(t, lb.AvailabilityZones, 1)
-	require.NotEmpty(t, lb.AvailabilityZones[0].LoadBalancerAddresses)
-	assert.Equal(t, "203.0.113.52", *lb.AvailabilityZones[0].LoadBalancerAddresses[0].IpAddress)
+	// Internet-facing ALB: both the ENI's private IP and the allocated public
+	// IP should appear in LoadBalancerAddresses.
+	require.Len(t, lb.AvailabilityZones[0].LoadBalancerAddresses, 2)
+	var gotPublic, gotPrivate bool
+	for _, addr := range lb.AvailabilityZones[0].LoadBalancerAddresses {
+		if aws.StringValue(addr.IpAddress) == "203.0.113.52" {
+			gotPublic = true
+		}
+		if aws.StringValue(addr.PrivateIPv4Address) != "" {
+			gotPrivate = true
+		}
+	}
+	assert.True(t, gotPublic, "expected public IpAddress in LoadBalancerAddresses")
+	assert.True(t, gotPrivate, "expected ENI PrivateIPv4Address in LoadBalancerAddresses")
 }
 
 func TestDescribeLoadBalancers_Internal_NoPublicIP(t *testing.T) {
@@ -454,7 +480,10 @@ func TestDescribeLoadBalancers_Internal_NoPublicIP(t *testing.T) {
 
 	lb := desc.LoadBalancers[0]
 	require.Len(t, lb.AvailabilityZones, 1)
-	assert.Empty(t, lb.AvailabilityZones[0].LoadBalancerAddresses)
+	// Internal ALB: private IP of the ENI is exposed via PrivateIPv4Address.
+	require.Len(t, lb.AvailabilityZones[0].LoadBalancerAddresses, 1)
+	assert.Nil(t, lb.AvailabilityZones[0].LoadBalancerAddresses[0].IpAddress)
+	assert.NotEmpty(t, aws.StringValue(lb.AvailabilityZones[0].LoadBalancerAddresses[0].PrivateIPv4Address))
 	// Verify DNS has internal prefix
 	assert.Contains(t, *lb.DNSName, "internal-desc-int-alb")
 }

--- a/spinifex/handlers/elbv2/types.go
+++ b/spinifex/handlers/elbv2/types.go
@@ -183,22 +183,51 @@ type ListenerAction struct {
 // source of truth — CreateLoadBalancer no longer seeds attributes, and
 // DescribeLoadBalancerAttributes derives the per-type defaults from lb.Type on
 // read.
+//
+// The key set must be broad enough to satisfy terraform AWS provider's
+// default ModifyLoadBalancerAttributes call after aws_lb creation: the
+// provider sends every attribute it knows about, and any key missing here
+// gets rejected with ValidationError, surfacing as "UnknownError" in tofu.
 func DefaultLoadBalancerAttributes(lbType string) map[string]string {
-	crossZone := "false"
-	if lbType == LoadBalancerTypeApplication {
-		crossZone = "true"
+	// Common to all load balancer types.
+	attrs := map[string]string{
+		"deletion_protection.enabled":       "false",
+		"load_balancing.cross_zone.enabled": "false",
 	}
-	return map[string]string{
-		"deletion_protection.enabled":                     "false",
-		"load_balancing.cross_zone.enabled":               crossZone,
-		"access_logs.s3.enabled":                          "false",
-		"access_logs.s3.bucket":                           "",
-		"access_logs.s3.prefix":                           "",
-		"idle_timeout.timeout_seconds":                    "60",
-		"routing.http.drop_invalid_header_fields.enabled": "false",
-		"routing.http2.enabled":                           "true",
-		"client_keep_alive.seconds":                       "3600",
+
+	switch lbType {
+	case LoadBalancerTypeApplication:
+		// ALB-specific attributes. Defaults match real AWS values as of the
+		// aws-sdk-go 1.55 elbv2 API documentation.
+		attrs["load_balancing.cross_zone.enabled"] = "true"
+		attrs["access_logs.s3.enabled"] = "false"
+		attrs["access_logs.s3.bucket"] = ""
+		attrs["access_logs.s3.prefix"] = ""
+		attrs["connection_logs.s3.enabled"] = "false"
+		attrs["connection_logs.s3.bucket"] = ""
+		attrs["connection_logs.s3.prefix"] = ""
+		attrs["idle_timeout.timeout_seconds"] = "60"
+		attrs["client_keep_alive.seconds"] = "3600"
+		attrs["routing.http.desync_mitigation_mode"] = "defensive"
+		attrs["routing.http.drop_invalid_header_fields.enabled"] = "false"
+		attrs["routing.http.preserve_host_header.enabled"] = "false"
+		attrs["routing.http.x_amzn_tls_version_and_cipher_suite.enabled"] = "false"
+		attrs["routing.http.xff_client_port.enabled"] = "false"
+		attrs["routing.http.xff_header_processing.mode"] = "append"
+		attrs["routing.http2.enabled"] = "true"
+		attrs["waf.fail_open.enabled"] = "false"
+		attrs["zonal_shift.config.enabled"] = "false"
+	case LoadBalancerTypeNetwork:
+		// NLB-specific attributes.
+		attrs["access_logs.s3.enabled"] = "false"
+		attrs["access_logs.s3.bucket"] = ""
+		attrs["access_logs.s3.prefix"] = ""
+		attrs["dns_record.client_routing_policy"] = "any_availability_zone"
+		attrs["ipv6.deny_all_igw_traffic"] = "false"
+		attrs["zonal_shift.config.enabled"] = "false"
 	}
+
+	return attrs
 }
 
 // DefaultTargetGroupAttributes returns the default attribute set for target groups.

--- a/spinifex/vm/vm.go
+++ b/spinifex/vm/vm.go
@@ -24,6 +24,15 @@ type InstanceHealthState struct {
 	FirstCrashTime  time.Time `json:"first_crash_time"`
 }
 
+// ExtraENI describes an additional VPC network interface attached to a VM
+// beyond the primary ENI. Only system VMs (ALBs) use multiple ENIs today.
+type ExtraENI struct {
+	ENIID    string `json:"eni_id"`
+	ENIMac   string `json:"eni_mac"`
+	ENIIP    string `json:"eni_ip"`
+	SubnetID string `json:"subnet_id,omitempty"`
+}
+
 type VM struct {
 	ID           string        `json:"id"`
 	PID          int           `json:"pid"`
@@ -67,6 +76,12 @@ type VM struct {
 	// VPC networking: ENI attached to this instance (set by RunInstances when VPC mode is active)
 	ENIId  string `json:"eni_id,omitempty"`
 	ENIMac string `json:"eni_mac,omitempty"`
+
+	// ExtraENIs lists additional VPC NICs beyond the primary ENIId/ENIMac.
+	// Used by multi-AZ system VMs (ALBs with subnets in multiple subnets) —
+	// each entry gets its own tap device on br-int and its own QEMU NIC.
+	// Empty for customer EC2 instances and single-subnet ALBs.
+	ExtraENIs []ExtraENI `json:"extra_enis,omitempty"`
 
 	// Public IP auto-assigned from external IPAM pool (released on termination)
 	PublicIP     string `json:"public_ip,omitempty"`


### PR DESCRIPTION
## Summary

Fixes three bugs exposed by the `docs/terraform/nginx-alb` example:

- **mulga-930** — `DescribeLoadBalancers` now surfaces the ENI private IP on every AZ entry, not just a public IP on AZ[0].
- **mulga-929** — multi-subnet ALB VMs now attach an ENI + tap + QEMU NIC per subnet instead of leaving extras orphaned in 'available' state. Adds \`ExtraENIs\` to \`vm.VM\` / \`SystemInstanceInput\` and threads the slice through daemon launch/cleanup; \`generateNetworkConfig\` emits a per-MAC DHCP block (\`vpc0\`, \`vpc1\`, …) so the guest brings every NIC up.
- **mulga-928** — nginx-alb terraform example restructured into the canonical AWS public + private subnet layout with a NAT Gateway, so the private-subnet workers can reach the apt repo during cloud-init.

Plan docs in \`docs/development/bugs/\`:
- \`elbv2-describe-missing-private-ips.md\`
- \`elbv2-multi-eni-alb-vm.md\`
- \`nginx-alb-private-worker-internet.md\`

## Test plan

- [x] \`make preflight\` passes.
- [x] ELBv2 unit tests updated + new \`TestCreateLoadBalancer_MultiSubnet_AllENIsPassedToLauncher\` verifies every subnet's ENI reaches \`SystemInstanceInput\`.
- [x] Cloud-init network-config tests cover the multi-VPC-NIC branch and empty-extra-MAC skipping.
- [x] \`tofu validate\` on the updated nginx-alb example succeeds.
- [ ] E2E: \`tofu apply\` against a live Spinifex — both ALB ENIs show in-use with tap devices, targets reach healthy, \`curl\` alternates between servers, describe shows per-AZ private IPs.