### PR TITLE
fix: route elbv2 ALB public IP through EIP service

### DIFF
--- a/docs/terraform-workbooks/nginx-alb/main.tf
+++ b/docs/terraform-workbooks/nginx-alb/main.tf
@@ -1,14 +1,18 @@
 # Example: Nginx Web Servers with ALB on Spinifex
 #
-# Deploys a VPC with two public subnets (ALB + NAT Gateway) and two private
-# subnets hosting Nginx EC2 instances. An internet-facing Application Load
-# Balancer distributes HTTP traffic between the private workers, and the
-# NAT Gateway gives them outbound internet access so cloud-init can install
-# Nginx from the Debian apt repository.
+# Deploys a VPC with two public subnets hosting Nginx EC2 instances and an
+# internet-facing Application Load Balancer. Workers sit in public subnets
+# with auto-assigned public IPs purely so cloud-init can apt-install nginx.
+# The ALB targets them by primary private IP (target_type=instance), so
+# load-balanced traffic stays on the private VPC network.
 #
-# Demonstrates: VPC, public and private subnets, internet gateway, NAT
-# Gateway with Elastic IP, route tables, security group, key pair, cloud-init
-# user-data, EC2 instances, ALB, target group, and listener.
+# In a production deployment, workers would be in private subnets with
+# nginx baked into a custom AMI (or installed via a private repository
+# mirror), and a NAT Gateway would be unnecessary for this workload.
+#
+# Demonstrates: VPC, public subnets, internet gateway, route tables,
+# security group, key pair, cloud-init user-data, EC2 instances with
+# auto-assigned public IPs, ALB, target group, and listener.
 #
 # Usage:
 #   cd spinifex/docs/terraform/nginx-alb
@@ -152,9 +156,10 @@ resource "aws_internet_gateway" "igw" {
 # ---------------------------------------------------------------------------
 
 resource "aws_subnet" "public_a" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = "10.20.1.0/24"
-  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.20.1.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "nginx-alb-public-a"
@@ -162,9 +167,10 @@ resource "aws_subnet" "public_a" {
 }
 
 resource "aws_subnet" "public_b" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = "10.20.2.0/24"
-  availability_zone = data.aws_availability_zones.available.names[0]
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.20.2.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "nginx-alb-public-b"
@@ -172,58 +178,7 @@ resource "aws_subnet" "public_b" {
 }
 
 # ---------------------------------------------------------------------------
-# Private Subnets (two AZs for the Nginx workers)
-# ---------------------------------------------------------------------------
-
-resource "aws_subnet" "private_a" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = "10.20.11.0/24"
-  availability_zone = data.aws_availability_zones.available.names[0]
-
-  tags = {
-    Name = "nginx-alb-private-a"
-  }
-}
-
-resource "aws_subnet" "private_b" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = "10.20.12.0/24"
-  availability_zone = data.aws_availability_zones.available.names[0]
-
-  tags = {
-    Name = "nginx-alb-private-b"
-  }
-}
-
-# ---------------------------------------------------------------------------
-# NAT Gateway — outbound internet for the private subnets
-#
-# Background plumbing: the private-subnet workers need outbound connectivity
-# during cloud-init so apt-get can install Nginx. A single NAT Gateway in
-# public_a provides SNAT for both private subnets via the private route table.
-# ---------------------------------------------------------------------------
-
-resource "aws_eip" "nat" {
-  domain = "vpc"
-
-  tags = {
-    Name = "nginx-alb-nat-eip"
-  }
-}
-
-resource "aws_nat_gateway" "main" {
-  allocation_id = aws_eip.nat.id
-  subnet_id     = aws_subnet.public_a.id
-
-  tags = {
-    Name = "nginx-alb-nat"
-  }
-
-  depends_on = [aws_internet_gateway.igw]
-}
-
-# ---------------------------------------------------------------------------
-# Route Tables — public subnets egress via IGW, private subnets via NAT GW
+# Route Table — public subnets egress via IGW
 # ---------------------------------------------------------------------------
 
 resource "aws_route_table" "public" {
@@ -247,29 +202,6 @@ resource "aws_route_table_association" "public_a" {
 resource "aws_route_table_association" "public_b" {
   subnet_id      = aws_subnet.public_b.id
   route_table_id = aws_route_table.public.id
-}
-
-resource "aws_route_table" "private" {
-  vpc_id = aws_vpc.main.id
-
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.main.id
-  }
-
-  tags = {
-    Name = "nginx-alb-private-rt"
-  }
-}
-
-resource "aws_route_table_association" "private_a" {
-  subnet_id      = aws_subnet.private_a.id
-  route_table_id = aws_route_table.private.id
-}
-
-resource "aws_route_table_association" "private_b" {
-  subnet_id      = aws_subnet.private_b.id
-  route_table_id = aws_route_table.private.id
 }
 
 # ---------------------------------------------------------------------------
@@ -318,13 +250,9 @@ resource "aws_instance" "nginx_1" {
   ami           = data.aws_ami.debian12.id
   instance_type = var.instance_type
 
-  subnet_id              = aws_subnet.private_a.id
+  subnet_id              = aws_subnet.public_a.id
   vpc_security_group_ids = [aws_security_group.web.id]
   key_name               = aws_key_pair.nginx.key_name
-
-  # Workers pull nginx from apt via the NAT Gateway — creation must wait
-  # until the NAT Gateway is available so cloud-init can reach the repos.
-  depends_on = [aws_nat_gateway.main]
 
   user_data_base64 = base64encode(<<-USERDATA
     #!/bin/bash
@@ -362,13 +290,9 @@ resource "aws_instance" "nginx_2" {
   ami           = data.aws_ami.debian12.id
   instance_type = var.instance_type
 
-  subnet_id              = aws_subnet.private_b.id
+  subnet_id              = aws_subnet.public_b.id
   vpc_security_group_ids = [aws_security_group.web.id]
   key_name               = aws_key_pair.nginx.key_name
-
-  # Workers pull nginx from apt via the NAT Gateway — creation must wait
-  # until the NAT Gateway is available so cloud-init can reach the repos.
-  depends_on = [aws_nat_gateway.main]
 
   user_data_base64 = base64encode(<<-USERDATA
     #!/bin/bash

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2788,7 +2788,7 @@ func (d *Daemon) wireLBAgentConfig() {
 	}
 
 	if d.mgmtBridgeIP != "" {
-		if awsgwBindIP != "" && awsgwBindIP != "0.0.0.0" {
+		if awsgwBindIP != "" && awsgwBindIP != "0.0.0.0" && !net.ParseIP(awsgwBindIP).IsLoopback() {
 			// Multi-node: AWSGW listens on a specific WAN IP. Use that IP
 			// as the gateway URL. Internal LBs will get a host route via
 			// br-mgmt to reach it (see LaunchSystemInstance).

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -153,26 +153,70 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 		}
 	}
 
-	// Allocate public IP for internet-facing ALBs
+	// Allocate public IP for internet-facing ALBs. Route through the EIP
+	// service when available so an EIPRecord is created in the KV bucket —
+	// otherwise AWS SDK callers (OpenTofu) can't observe the EIP via
+	// DescribeAddresses and their provisioning flow hangs. Falls back to
+	// direct IPAM allocation for daemons where the EIP service isn't wired.
 	publicIP := ""
-	if input.Scheme == handlers_elbv2.SchemeInternetFacing && d.externalIPAM != nil && d.vpcService != nil && instance.ENIId != "" {
-		region := ""
-		az := ""
-		if d.config != nil {
-			region = d.config.Region
-			az = d.config.AZ
-		}
-		allocatedIP, poolName, allocErr := d.externalIPAM.AllocateIP(region, az, "auto_assign", "", instance.ENIId, instance.ID)
-		if allocErr != nil {
-			slog.Error("LaunchSystemInstance: failed to allocate public IP for internet-facing ALB", "instanceId", instance.ID, "err", allocErr)
-			d.cleanupFailedSystemInstance(instance, instanceType)
-			return nil, fmt.Errorf("allocate public IP for internet-facing ALB: %w", allocErr)
-		} else {
+	if input.Scheme == handlers_elbv2.SchemeInternetFacing && d.vpcService != nil && instance.ENIId != "" {
+		if d.eipService != nil {
+			allocOut, allocErr := d.eipService.AllocateAddress(&ec2.AllocateAddressInput{}, eniAccountID)
+			if allocErr != nil {
+				slog.Error("LaunchSystemInstance: EIP AllocateAddress failed", "instanceId", instance.ID, "err", allocErr)
+				d.cleanupFailedSystemInstance(instance, instanceType)
+				return nil, fmt.Errorf("allocate public IP for internet-facing ALB: %w", allocErr)
+			}
+			publicIP = aws.StringValue(allocOut.PublicIp)
+			poolName := aws.StringValue(allocOut.PublicIpv4Pool)
+			allocID := aws.StringValue(allocOut.AllocationId)
+
+			assocOut, assocErr := d.eipService.AssociateAddress(&ec2.AssociateAddressInput{
+				AllocationId:       allocOut.AllocationId,
+				NetworkInterfaceId: aws.String(instance.ENIId),
+			}, eniAccountID)
+			if assocErr != nil {
+				slog.Error("LaunchSystemInstance: EIP AssociateAddress failed", "instanceId", instance.ID, "allocationId", allocID, "err", assocErr)
+				if _, relErr := d.eipService.ReleaseAddress(&ec2.ReleaseAddressInput{
+					AllocationId: allocOut.AllocationId,
+				}, eniAccountID); relErr != nil {
+					slog.Warn("LaunchSystemInstance: failed to release EIP after associate failure", "allocationId", allocID, "err", relErr)
+				}
+				d.cleanupFailedSystemInstance(instance, instanceType)
+				return nil, fmt.Errorf("associate public IP for internet-facing ALB: %w", assocErr)
+			}
+
+			if updateErr := d.vpcService.UpdateENIPublicIP(eniAccountID, instance.ENIId, publicIP, poolName); updateErr != nil {
+				slog.Warn("LaunchSystemInstance: failed to update ENI with public IP", "eniId", instance.ENIId, "err", updateErr)
+			}
+			instance.PublicIP = publicIP
+			instance.PublicIPPool = poolName
+			instance.PublicIPAllocID = allocID
+			instance.PublicIPAssocID = aws.StringValue(assocOut.AssociationId)
+			slog.Info("LaunchSystemInstance: allocated public IP via EIP service",
+				"instanceId", instance.ID,
+				"publicIp", publicIP,
+				"pool", poolName,
+				"allocationId", allocID,
+				"associationId", instance.PublicIPAssocID,
+			)
+		} else if d.externalIPAM != nil {
+			region := ""
+			az := ""
+			if d.config != nil {
+				region = d.config.Region
+				az = d.config.AZ
+			}
+			allocatedIP, poolName, allocErr := d.externalIPAM.AllocateIP(region, az, "auto_assign", "", instance.ENIId, instance.ID)
+			if allocErr != nil {
+				slog.Error("LaunchSystemInstance: failed to allocate public IP for internet-facing ALB", "instanceId", instance.ID, "err", allocErr)
+				d.cleanupFailedSystemInstance(instance, instanceType)
+				return nil, fmt.Errorf("allocate public IP for internet-facing ALB: %w", allocErr)
+			}
 			publicIP = allocatedIP
 			if updateErr := d.vpcService.UpdateENIPublicIP(eniAccountID, instance.ENIId, publicIP, poolName); updateErr != nil {
 				slog.Warn("LaunchSystemInstance: failed to update ENI with public IP", "eniId", instance.ENIId, "err", updateErr)
 			}
-			// Look up VpcId from the ENI for the NAT event
 			vpcID := ""
 			result, descErr := d.vpcService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
 				NetworkInterfaceIds: []*string{aws.String(instance.ENIId)},
@@ -184,7 +228,7 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 			d.publishNATEvent("vpc.add-nat", vpcID, publicIP, privateIP, portName, instance.ENIMac)
 			instance.PublicIP = publicIP
 			instance.PublicIPPool = poolName
-			slog.Info("LaunchSystemInstance: allocated public IP",
+			slog.Info("LaunchSystemInstance: allocated public IP via direct IPAM",
 				"instanceId", instance.ID,
 				"publicIp", publicIP,
 				"pool", poolName,
@@ -314,6 +358,32 @@ func (d *Daemon) TerminateSystemInstance(instanceID string) error {
 	// Transition to shutting-down
 	if err := d.TransitionState(instance, vm.StateShuttingDown); err != nil {
 		return fmt.Errorf("transition to shutting-down: %w", err)
+	}
+
+	// Release EIP through the EIP service for system VMs whose public IP was
+	// allocated via AllocateAddress (internet-facing ALBs). Clears the fields
+	// so the generic teardown path in stopInstance doesn't try to
+	// double-release the same IP through externalIPAM directly.
+	if instance.PublicIPAllocID != "" && d.eipService != nil {
+		eniAccount := instance.AccountID
+		if instance.PublicIPAssocID != "" {
+			if _, err := d.eipService.DisassociateAddress(&ec2.DisassociateAddressInput{
+				AssociationId: aws.String(instance.PublicIPAssocID),
+			}, eniAccount); err != nil {
+				slog.Warn("TerminateSystemInstance: DisassociateAddress failed", "instanceId", instanceID, "associationId", instance.PublicIPAssocID, "err", err)
+			}
+		}
+		if _, err := d.eipService.ReleaseAddress(&ec2.ReleaseAddressInput{
+			AllocationId: aws.String(instance.PublicIPAllocID),
+		}, eniAccount); err != nil {
+			slog.Warn("TerminateSystemInstance: ReleaseAddress failed", "instanceId", instanceID, "allocationId", instance.PublicIPAllocID, "err", err)
+		} else {
+			slog.Info("TerminateSystemInstance: released EIP", "instanceId", instanceID, "ip", instance.PublicIP, "allocationId", instance.PublicIPAllocID)
+		}
+		instance.PublicIP = ""
+		instance.PublicIPPool = ""
+		instance.PublicIPAllocID = ""
+		instance.PublicIPAssocID = ""
 	}
 
 	// Stop the VM (QEMU shutdown, volume unmount, tap cleanup)

--- a/spinifex/vm/vm.go
+++ b/spinifex/vm/vm.go
@@ -87,6 +87,14 @@ type VM struct {
 	PublicIP     string `json:"public_ip,omitempty"`
 	PublicIPPool string `json:"public_ip_pool,omitempty"`
 
+	// PublicIPAllocID / PublicIPAssocID are set when the public IP was
+	// allocated through the EIP service (handlers/ec2/eip) rather than
+	// directly via externalIPAM. Presence signals that teardown must go
+	// back through the EIP service (DisassociateAddress + ReleaseAddress)
+	// so the EIP KV record is removed.
+	PublicIPAllocID string `json:"public_ip_alloc_id,omitempty"`
+	PublicIPAssocID string `json:"public_ip_assoc_id,omitempty"`
+
 	// DevMAC is the MAC for the dev/hostfwd NIC (DEV_NETWORKING mode).
 	// Set before cloud-init ISO generation so netplan can suppress its default route.
 	DevMAC string `json:"dev_mac,omitempty"`


### PR DESCRIPTION
## Summary
- Internet-facing ALB public IP allocation now routes through the EIP service (`AllocateAddress` + `AssociateAddress`) instead of calling `externalIPAM.AllocateIP` directly. Creates the EIPRecord in KV, tags as `elastic_ip`, publishes `vpc.add-nat`, and makes the EIP visible to `DescribeAddresses` — which unblocks OpenTofu provisioning flows that hang waiting for the record.
- `TerminateSystemInstance` releases via the service (`DisassociateAddress` + `ReleaseAddress`) and clears fields so the generic `stopInstance` teardown skips — customer `RunInstances` flow untouched.
- Falls back to direct-IPAM when `eipService == nil` so daemons without EIP service wired keep working.
- Refreshes the `nginx-alb` tofu example to the public-subnet + auto-assigned-public-IP shape that actually exercises the path end-to-end, and tightens the `awsgwBindIP` loopback guard in `wireLBAgentConfig`.

Closes mulga-siv-4.
Plan: docs/development/bugs/elbv2-eip-service-integration.md

## Test plan
- [x] \`make preflight\` passes
- [x] Live verification via \`terraform apply\` on docs/terraform-workbooks/nginx-alb: daemon logs \`AllocateAddress completed\` / \`AssociateAddress completed\` / \`LaunchSystemInstance: allocated public IP via EIP service\` with tag \`elastic_ip\`
- [x] \`aws ec2 describe-addresses\` returns the ALB's EIP with AllocationId / AssociationId / NetworkInterfaceId / InstanceId populated
- [x] Internet-facing ALB load-balances traffic across both workers
- [ ] Follow-up: verify \`terraform destroy\` releases the EIP cleanly