### PR TITLE
fix: wrap missed NATS/S3 dial sites with admin.DialTarget

### DIFF
--- a/cmd/spinifex/cmd/get.go
+++ b/cmd/spinifex/cmd/get.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -90,7 +91,7 @@ func loadConfigAndConnect() (*config.ClusterConfig, *nats.Conn, error) {
 	}
 
 	nodeConfig := cfg.Nodes[cfg.Node]
-	nc, err := utils.ConnectNATS(nodeConfig.NATS.Host, nodeConfig.NATS.ACL.Token, nodeConfig.NATS.CACert)
+	nc, err := utils.ConnectNATS(admin.DialTarget(nodeConfig.NATS.Host), nodeConfig.NATS.ACL.Token, nodeConfig.NATS.CACert)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to NATS: %w", err)
 	}

--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/nbd"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -170,7 +171,7 @@ func (svc *Service) Reload() (err error) {
 
 func launchService(cfg *Config) (err error) {
 	// Connect to NATS
-	nc, err := utils.ConnectNATS(cfg.NatsHost, cfg.NatsToken, cfg.NatsCACert)
+	nc, err := utils.ConnectNATS(admin.DialTarget(cfg.NatsHost), cfg.NatsToken, cfg.NatsCACert)
 	if err != nil {
 		slog.Error("Failed to connect to NATS", "err", err)
 		return err
@@ -404,7 +405,7 @@ func launchService(cfg *Config) (err error) {
 			Region:     cfg.Region,
 			AccessKey:  cfg.AccessKey,
 			SecretKey:  cfg.SecretKey,
-			Host:       cfg.S3Host,
+			Host:       admin.DialTarget(cfg.S3Host),
 		}
 
 		// TODO: Improve based on system availability. Default 128MB cache
@@ -530,7 +531,7 @@ func launchService(cfg *Config) (err error) {
 			PidFile:    nbdPidFile,
 			PluginPath: cfg.PluginPath,
 			BaseDir:    cfg.BaseDir,
-			Host:       cfg.S3Host,
+			Host:       admin.DialTarget(cfg.S3Host),
 			Verbose:    false,
 			Size:       utils.SafeUint64ToInt64(vb.GetVolumeSize()),
 			Volume:     ebsRequest.Name,

--- a/spinifex/services/vpcd/vpcd.go
+++ b/spinifex/services/vpcd/vpcd.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
@@ -274,7 +275,7 @@ func launchService(cfg *Config) error {
 	slog.Info("OVN preflight passed (br-int exists, ovn-controller running)")
 
 	// Connect to NATS
-	nc, err := utils.ConnectNATS(cfg.NatsHost, cfg.NatsToken, cfg.NatsCACert)
+	nc, err := utils.ConnectNATS(admin.DialTarget(cfg.NatsHost), cfg.NatsToken, cfg.NatsCACert)
 	if err != nil {
 		slog.Error("Failed to connect to NATS", "err", err)
 		return err


### PR DESCRIPTION
## Summary

Hotfix for gaps in mulga-siv-8.5. The dial-site migration wrapped daemon + awsgw with `admin.DialTarget` but missed three call sites — vpcd, viperblockd, and the `spx get` CLI — which still read `cfg.NatsHost` / `cfg.S3Host` raw. With the post-siv-8 default `BindIP=0.0.0.0` they try to dial `0.0.0.0:4222` / `0.0.0.0:8443` and fail TLS SAN verification (the cert SANs loopback + every `DiscoverLocalIPs()` interface IP, never `0.0.0.0`).

Wrapped call sites:

- `spinifex/services/viperblockd/viperblockd.go:173` — `utils.ConnectNATS`
- `spinifex/services/viperblockd/viperblockd.go:407` — `s3.S3Config{Host: ...}`
- `spinifex/services/viperblockd/viperblockd.go:533` — `nbd.NBDKitConfig{Host: ...}`
- `spinifex/services/vpcd/vpcd.go:277` — `utils.ConnectNATS`
- `cmd/spinifex/cmd/get.go:93` — `utils.ConnectNATS` (CLI)

`admin.DialTarget` rewrites `0.0.0.0:N` → `127.0.0.1:N`. Sidecars share the host with NATS/predastore so loopback is the right in-process dial target and 127.0.0.1 is always in the cert SANs.

Bead: mulga-siv-10.

## Test plan

- [x] `make preflight` clean — golangci-lint 0 issues, govulncheck 0 vulns, race tests pass.
- [ ] `make deploy` on single-node host: `journalctl -u spinifex-vpcd` shows NATS connect to `127.0.0.1:4222` (no TLS SAN error). Same for `spinifex-viperblock`.
- [ ] `spx get <something>` CLI works against `BindIP=0.0.0.0` config.