### PR TITLE
fix: reconcile external IPAM pool on config drift (mulga-siv-24)

### DIFF
--- a/spinifex/handlers/ec2/vpc/external_ipam.go
+++ b/spinifex/handlers/ec2/vpc/external_ipam.go
@@ -117,36 +117,37 @@ func (m *ExternalIPAM) initPools() error {
 func (m *ExternalIPAM) initPool(pool ExternalPoolConfig) error {
 	chk, revision, err := m.getRecord(pool.Name)
 
-	// Catch all other errors
-	if !errors.Is(err, nats.ErrKeyNotFound) {
+	if err != nil && !errors.Is(err, nats.ErrKeyNotFound) {
 		return err
-	} else if errors.Is(err, nats.ErrKeyNotFound) {
-		// If key not found, proceed to creation
-		slog.Info("external IPAM pool not found, creating", "pool", pool.Name)
-	} else if chk.RangeStart != pool.RangeStart || chk.RangeEnd != pool.RangeEnd || chk.Source != pool.Source {
-		// Validate our pool has not changed, e.g editing spinifex.toml and specifying a new start/end/source
-		slog.Info("external IPAM pool start/end range changed, updating KV", "pool", pool.Name, "RangeStart", pool.RangeStart, "RangeEnd", pool.RangeEnd)
-
-		// Update record with the new start/end
-		chk.RangeStart = pool.RangeStart
-		chk.RangeEnd = pool.RangeEnd
-		chk.Source = pool.Source
-
-		data, err := json.Marshal(chk)
-		if err != nil {
-			return fmt.Errorf("marshal external IPAM record: %w", err)
-		}
-
-		if _, err := m.kv.Update(pool.Name, data, revision); err != nil {
-			slog.Warn("external IPAM update failed", "pool", pool.Name)
-			return err
-		}
-
-		return nil
-	} else if err == nil {
-		slog.Info("external IPAM pool already initialized", "pool", pool.Name)
-		return nil // Already exists
 	}
+
+	if err == nil {
+		if chk.RangeStart != pool.RangeStart || chk.RangeEnd != pool.RangeEnd || chk.Source != pool.Source {
+			slog.Info("external IPAM pool config drift, reconciling KV",
+				"pool", pool.Name,
+				"old_range", chk.RangeStart+"-"+chk.RangeEnd, "new_range", pool.RangeStart+"-"+pool.RangeEnd,
+				"old_source", chk.Source, "new_source", pool.Source)
+
+			chk.RangeStart = pool.RangeStart
+			chk.RangeEnd = pool.RangeEnd
+			chk.Source = pool.Source
+
+			data, err := json.Marshal(chk)
+			if err != nil {
+				return fmt.Errorf("marshal external IPAM record: %w", err)
+			}
+
+			if _, err := m.kv.Update(pool.Name, data, revision); err != nil {
+				slog.Warn("external IPAM update failed", "pool", pool.Name, "err", err)
+				return err
+			}
+			return nil
+		}
+		slog.Debug("external IPAM pool already initialized", "pool", pool.Name)
+		return nil
+	}
+
+	slog.Info("external IPAM pool not found, creating", "pool", pool.Name)
 
 	// TODO: Confirm gateway IP defined, should error, given we route traffic to the upstream DHCP gateway
 	gwIP := pool.GatewayIP


### PR DESCRIPTION
## Summary
- `initPool` first guard `if !errors.Is(err, nats.ErrKeyNotFound) { return err }` returns when `err == nil` (since `errors.Is(nil, ErrKeyNotFound)` is `false`). The drift-reconcile and "already initialized" branches were dead code.
- Restructure: bail on hard errors, reconcile or no-op when record exists, fall through to create when `ErrKeyNotFound`.
- Closes the user-visible `WARN Failed to allocate public IP ... err="invalid IP range:  - "` on `dhcp -> static` toml transitions (bead **mulga-siv-24**).

## Out of scope (follow-up)
- Evict stale `Allocated` entries that fall outside the new range
- Re-derive `gateway_ip` and release DHCP gateway lease on `dhcp -> static`
- Validate empty `range_start`/`range_end` when `source="static"` in `NewExternalIPAM`

## Test plan
- [x] `make preflight`
- [x] Dev-cluster repro from `docs/development/bugs/external-ipam-stale-bounds-on-config-change.md`:
  - Boot with `source="dhcp"`, launch instance, gets DHCP public IP
  - Stop services, edit toml to `source="static"` + range `192.168.1.200-210`, start
  - KV `wan` reconciled: `range_start=192.168.1.200`, `range_end=192.168.1.210`, `source=static`
  - `RunInstances` succeeds with public IP `192.168.1.200`
  - Daemon log: `external IPAM allocated IP pool=wan ip=192.168.1.200 type=auto_assign source=static`
- [ ] E2E (single + nightly) on push to main