### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -312,7 +312,7 @@ var viperblockStartCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println("Viperblock service started", service)
+		fmt.Println("Viperblock service started")
 	},
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/mulgadc/spinifex/security/code-scanning/7](https://github.com/mulgadc/spinifex/security/code-scanning/7)

The safest fix is to **stop logging structured objects that may carry secrets** and log only non-sensitive, constant metadata (e.g., service name and status).

Best minimal change (without changing functionality):
- In `cmd/spinifex/cmd/service.go`, inside `viperblockStartCmd`’s `Run` function, replace:
  - `fmt.Println("Viperblock service started", service)`
- with:
  - `fmt.Println("Viperblock service started")`

This preserves user-visible behavior (“service started” message) while removing the dangerous object serialization path that could include `SecretKey`.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
