### PR TITLE
refactor(vm): introduce collaborator interfaces and daemon adapters

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -844,6 +844,10 @@ func (d *Daemon) Start() error {
 		d.networkPlumber = &OVSNetworkPlumber{}
 	}
 
+	// Wire vm.Manager collaborators now that NATS, JetStream, network plumber,
+	// volume service, and resource manager are all ready.
+	d.vmMgr.SetDeps(d.buildVMManagerDeps())
+
 	// Protect daemon from OOM killer (prefer killing QEMU VMs instead)
 	if err := utils.SetOOMScore(os.Getpid(), -500); err != nil {
 		slog.Warn("Failed to set daemon OOM score", "err", err)

--- a/spinifex/daemon/network.go
+++ b/spinifex/daemon/network.go
@@ -40,7 +40,10 @@ type NetworkPlumber interface {
 // OVSNetworkPlumber implements NetworkPlumber using system commands.
 type OVSNetworkPlumber struct{}
 
-var _ NetworkPlumber = (*OVSNetworkPlumber)(nil)
+var (
+	_ NetworkPlumber    = (*OVSNetworkPlumber)(nil)
+	_ vm.NetworkPlumber = (*OVSNetworkPlumber)(nil)
+)
 
 func (p *OVSNetworkPlumber) SetupTapDevice(eniId, mac string) error {
 	tapName := TapDeviceName(eniId)

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -33,58 +33,34 @@ func newStateStoreAdapter(js *JetStreamManager) *stateStoreAdapter {
 }
 
 func (a *stateStoreAdapter) SaveRunningState(nodeID string, snapshot map[string]*vm.VM) error {
-	if a.js == nil {
-		return errors.New("JetStream manager not initialized")
-	}
 	return a.js.WriteState(nodeID, snapshot)
 }
 
 func (a *stateStoreAdapter) LoadRunningState(nodeID string) (map[string]*vm.VM, error) {
-	if a.js == nil {
-		return nil, errors.New("JetStream manager not initialized")
-	}
 	return a.js.LoadState(nodeID)
 }
 
 func (a *stateStoreAdapter) WriteStoppedInstance(id string, v *vm.VM) error {
-	if a.js == nil {
-		return errors.New("JetStream manager not initialized")
-	}
 	return a.js.WriteStoppedInstance(id, v)
 }
 
 func (a *stateStoreAdapter) LoadStoppedInstance(id string) (*vm.VM, error) {
-	if a.js == nil {
-		return nil, errors.New("JetStream manager not initialized")
-	}
 	return a.js.LoadStoppedInstance(id)
 }
 
 func (a *stateStoreAdapter) DeleteStoppedInstance(id string) error {
-	if a.js == nil {
-		return errors.New("JetStream manager not initialized")
-	}
 	return a.js.DeleteStoppedInstance(id)
 }
 
 func (a *stateStoreAdapter) ListStoppedInstances() ([]*vm.VM, error) {
-	if a.js == nil {
-		return nil, errors.New("JetStream manager not initialized")
-	}
 	return a.js.ListStoppedInstances()
 }
 
 func (a *stateStoreAdapter) WriteTerminatedInstance(id string, v *vm.VM) error {
-	if a.js == nil {
-		return errors.New("JetStream manager not initialized")
-	}
 	return a.js.WriteTerminatedInstance(id, v)
 }
 
 func (a *stateStoreAdapter) ListTerminatedInstances() ([]*vm.VM, error) {
-	if a.js == nil {
-		return nil, errors.New("JetStream manager not initialized")
-	}
 	return a.js.ListTerminatedInstances()
 }
 
@@ -274,9 +250,6 @@ func newInstanceTypeResolverAdapter(rm *ResourceManager) *instanceTypeResolverAd
 }
 
 func (a *instanceTypeResolverAdapter) Resolve(name string) (vm.InstanceTypeSpec, bool) {
-	if a.rm == nil {
-		return vm.InstanceTypeSpec{}, false
-	}
 	it := a.rm.instanceTypes[name]
 	if it == nil {
 		return vm.InstanceTypeSpec{}, false
@@ -306,9 +279,6 @@ func newResourceControllerAdapter(rm *ResourceManager) *resourceControllerAdapte
 }
 
 func (a *resourceControllerAdapter) Allocate(instanceType string) error {
-	if a.rm == nil {
-		return errors.New("resource manager not initialized")
-	}
 	it := a.rm.instanceTypes[instanceType]
 	if it == nil {
 		return fmt.Errorf("instance type %s not found", instanceType)
@@ -317,9 +287,6 @@ func (a *resourceControllerAdapter) Allocate(instanceType string) error {
 }
 
 func (a *resourceControllerAdapter) Deallocate(instanceType string) {
-	if a.rm == nil {
-		return
-	}
 	it := a.rm.instanceTypes[instanceType]
 	if it == nil {
 		return
@@ -328,8 +295,7 @@ func (a *resourceControllerAdapter) Deallocate(instanceType string) {
 }
 
 // volumeStateUpdaterAdapter satisfies vm.VolumeStateUpdater by delegating to
-// the daemon's volume service. It tolerates a nil service so callers don't
-// need to nil-check before invoking.
+// the daemon's volume service.
 type volumeStateUpdaterAdapter struct {
 	svc volumeStateUpdater
 }
@@ -348,9 +314,6 @@ func newVolumeStateUpdaterAdapter(svc volumeStateUpdater) *volumeStateUpdaterAda
 }
 
 func (a *volumeStateUpdaterAdapter) UpdateVolumeState(volumeID, state, instanceID, attachmentDevice string) error {
-	if a.svc == nil {
-		return nil
-	}
 	return a.svc.UpdateVolumeState(volumeID, state, instanceID, attachmentDevice)
 }
 
@@ -444,6 +407,3 @@ func (d *Daemon) buildVMManagerDeps() vm.Deps {
 		BindHost:           d.config.Host,
 	}
 }
-
-// OVSNetworkPlumber satisfies vm.NetworkPlumber directly (no wrapper).
-var _ vm.NetworkPlumber = (*OVSNetworkPlumber)(nil)

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -1,0 +1,449 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/qmp"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go"
+)
+
+// Thin adapters that satisfy the vm.Manager collaborator interfaces. The
+// bodies delegate to existing daemon methods or services; the manager
+// receives them via vm.Deps so it can drive lifecycle without importing the
+// daemon package.
+
+// stateStoreAdapter satisfies vm.StateStore by delegating to the cluster
+// JetStream manager. It also tolerates a nil JetStreamManager during early
+// boot so manager construction can happen before initJetStream returns.
+type stateStoreAdapter struct {
+	js *JetStreamManager
+}
+
+var _ vm.StateStore = (*stateStoreAdapter)(nil)
+
+func newStateStoreAdapter(js *JetStreamManager) *stateStoreAdapter {
+	return &stateStoreAdapter{js: js}
+}
+
+func (a *stateStoreAdapter) SaveRunningState(nodeID string, snapshot map[string]*vm.VM) error {
+	if a.js == nil {
+		return errors.New("JetStream manager not initialized")
+	}
+	return a.js.WriteState(nodeID, snapshot)
+}
+
+func (a *stateStoreAdapter) LoadRunningState(nodeID string) (map[string]*vm.VM, error) {
+	if a.js == nil {
+		return nil, errors.New("JetStream manager not initialized")
+	}
+	return a.js.LoadState(nodeID)
+}
+
+func (a *stateStoreAdapter) WriteStoppedInstance(id string, v *vm.VM) error {
+	if a.js == nil {
+		return errors.New("JetStream manager not initialized")
+	}
+	return a.js.WriteStoppedInstance(id, v)
+}
+
+func (a *stateStoreAdapter) LoadStoppedInstance(id string) (*vm.VM, error) {
+	if a.js == nil {
+		return nil, errors.New("JetStream manager not initialized")
+	}
+	return a.js.LoadStoppedInstance(id)
+}
+
+func (a *stateStoreAdapter) DeleteStoppedInstance(id string) error {
+	if a.js == nil {
+		return errors.New("JetStream manager not initialized")
+	}
+	return a.js.DeleteStoppedInstance(id)
+}
+
+func (a *stateStoreAdapter) ListStoppedInstances() ([]*vm.VM, error) {
+	if a.js == nil {
+		return nil, errors.New("JetStream manager not initialized")
+	}
+	return a.js.ListStoppedInstances()
+}
+
+func (a *stateStoreAdapter) WriteTerminatedInstance(id string, v *vm.VM) error {
+	if a.js == nil {
+		return errors.New("JetStream manager not initialized")
+	}
+	return a.js.WriteTerminatedInstance(id, v)
+}
+
+func (a *stateStoreAdapter) ListTerminatedInstances() ([]*vm.VM, error) {
+	if a.js == nil {
+		return nil, errors.New("JetStream manager not initialized")
+	}
+	return a.js.ListTerminatedInstances()
+}
+
+// volumeMounterAdapter satisfies vm.VolumeMounter by routing ebs.mount /
+// ebs.unmount NATS requests, mirroring Daemon.MountVolumes and
+// Daemon.unmountInstanceVolumes. The mount path mutates
+// instance.EBSRequests.Requests[k].NBDURI; unmount also flips boot/data
+// volumes back to "available" via VolumeStateUpdater so the AWS API view
+// stays consistent.
+type volumeMounterAdapter struct {
+	nc       *nats.Conn
+	node     string
+	volState vm.VolumeStateUpdater
+}
+
+var _ vm.VolumeMounter = (*volumeMounterAdapter)(nil)
+
+func newVolumeMounterAdapter(nc *nats.Conn, node string, volState vm.VolumeStateUpdater) *volumeMounterAdapter {
+	return &volumeMounterAdapter{nc: nc, node: node, volState: volState}
+}
+
+func (a *volumeMounterAdapter) topic(action string) string {
+	return fmt.Sprintf("ebs.%s.%s", a.node, action)
+}
+
+func (a *volumeMounterAdapter) Mount(instance *vm.VM) error {
+	instance.EBSRequests.Mu.Lock()
+	defer instance.EBSRequests.Mu.Unlock()
+
+	for k, v := range instance.EBSRequests.Requests {
+		ebsMountRequest, err := json.Marshal(v)
+		if err != nil {
+			slog.Error("Failed to marshal volume payload", "err", err)
+			return err
+		}
+
+		reply, err := a.nc.Request(a.topic("mount"), ebsMountRequest, 30*time.Second)
+
+		slog.Info("Mounting volume", "Vol", v.Name, "NBDURI", v.NBDURI)
+
+		if err != nil {
+			slog.Error("Failed to request EBS mount", "err", err)
+			return err
+		}
+
+		var ebsMountResponse types.EBSMountResponse
+		if err := json.Unmarshal(reply.Data, &ebsMountResponse); err != nil {
+			slog.Error("Failed to unmarshal volume response:", "err", err)
+			return err
+		}
+
+		if ebsMountResponse.Error != "" {
+			slog.Error("Failed to mount volume", "error", ebsMountResponse.Error)
+			return fmt.Errorf("failed to mount volume: %s", ebsMountResponse.Error)
+		}
+
+		slog.Debug("Mounted volume successfully", "response", ebsMountResponse.URI)
+		instance.EBSRequests.Requests[k].NBDURI = ebsMountResponse.URI
+	}
+
+	return nil
+}
+
+func (a *volumeMounterAdapter) Unmount(instance *vm.VM) error {
+	instance.EBSRequests.Mu.Lock()
+	defer instance.EBSRequests.Mu.Unlock()
+
+	for _, ebsRequest := range instance.EBSRequests.Requests {
+		ebsUnMountRequest, err := json.Marshal(ebsRequest)
+		if err != nil {
+			slog.Error("Failed to marshal volume payload for unmount", "err", err)
+			continue
+		}
+
+		msg, err := a.nc.Request(a.topic("unmount"), ebsUnMountRequest, 30*time.Second)
+		if err != nil {
+			slog.Error("Failed to unmount volume",
+				"name", ebsRequest.Name, "instance", instance.ID, "err", err)
+		} else {
+			slog.Info("Unmounted volume",
+				"instance", instance.ID, "volume", ebsRequest.Name, "data", string(msg.Data))
+		}
+
+		if !ebsRequest.EFI && !ebsRequest.CloudInit && a.volState != nil {
+			if err := a.volState.UpdateVolumeState(ebsRequest.Name, "available", "", ""); err != nil {
+				slog.Error("Failed to update volume state to available after unmount",
+					"volumeId", ebsRequest.Name, "err", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// qmpClientFactoryAdapter satisfies vm.QMPClientFactory. It performs only
+// the connect + qmp_capabilities handshake; the manager owns starting the
+// heartbeat goroutine on the returned client.
+type qmpClientFactoryAdapter struct{}
+
+var _ vm.QMPClientFactory = (*qmpClientFactoryAdapter)(nil)
+
+func newQMPClientFactoryAdapter() *qmpClientFactoryAdapter { return &qmpClientFactoryAdapter{} }
+
+func (a *qmpClientFactoryAdapter) Create(v *vm.VM) (*qmp.QMPClient, error) {
+	client, err := qmp.NewQMPClient(v.Config.QMPSocket)
+	if err != nil {
+		return nil, fmt.Errorf("connect QMP socket %s: %w", v.Config.QMPSocket, err)
+	}
+
+	if _, err := sendQMPHandshake(client, v.ID); err != nil {
+		_ = client.Conn.Close()
+		return nil, err
+	}
+
+	return client, nil
+}
+
+// sendQMPHandshake issues qmp_capabilities under the QMPClient's mutex. Mirrors
+// the slim version of Daemon.SendQMPCommand for the handshake; the daemon's
+// full helper still owns long-running command dispatch.
+func sendQMPHandshake(client *qmp.QMPClient, instanceID string) (*qmp.QMPResponse, error) {
+	if client == nil || client.Encoder == nil || client.Decoder == nil {
+		return nil, errors.New("QMP client is not initialized")
+	}
+
+	client.Mu.Lock()
+	defer client.Mu.Unlock()
+
+	if err := client.Conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		return nil, fmt.Errorf("set read deadline: %w", err)
+	}
+	defer func() { _ = client.Conn.SetReadDeadline(time.Time{}) }()
+
+	if err := client.Encoder.Encode(qmp.QMPCommand{Execute: "qmp_capabilities"}); err != nil {
+		return nil, fmt.Errorf("encode qmp_capabilities: %w", err)
+	}
+
+	for {
+		var msg map[string]any
+		if err := client.Decoder.Decode(&msg); err != nil {
+			return nil, fmt.Errorf("decode qmp_capabilities response: %w", err)
+		}
+		if _, ok := msg["event"]; ok {
+			continue
+		}
+		raw, err := json.Marshal(msg)
+		if err != nil {
+			return nil, fmt.Errorf("marshal qmp response: %w", err)
+		}
+		var resp qmp.QMPResponse
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			return nil, fmt.Errorf("unmarshal qmp response: %w", err)
+		}
+		if resp.Error != nil {
+			return nil, fmt.Errorf("qmp_capabilities failed: %s", resp.Error.Desc)
+		}
+		slog.Debug("QMP handshake complete", "instance", instanceID)
+		return &resp, nil
+	}
+}
+
+// processLauncherAdapter satisfies vm.ProcessLauncher. The real
+// implementation is a 1:1 wrapper over Config.Execute; the seam exists so
+// tests can substitute scripted commands.
+type processLauncherAdapter struct{}
+
+var _ vm.ProcessLauncher = (*processLauncherAdapter)(nil)
+
+func newProcessLauncherAdapter() *processLauncherAdapter { return &processLauncherAdapter{} }
+
+func (a *processLauncherAdapter) Launch(cfg *vm.Config) (*exec.Cmd, error) {
+	return cfg.Execute()
+}
+
+// instanceTypeResolverAdapter satisfies vm.InstanceTypeResolver. It looks up
+// the EC2 InstanceTypeInfo on the daemon's ResourceManager and projects the
+// QEMU-relevant numbers (vCPU, memory MiB, architecture) into the
+// SDK-agnostic vm.InstanceTypeSpec.
+type instanceTypeResolverAdapter struct {
+	rm *ResourceManager
+}
+
+var _ vm.InstanceTypeResolver = (*instanceTypeResolverAdapter)(nil)
+
+func newInstanceTypeResolverAdapter(rm *ResourceManager) *instanceTypeResolverAdapter {
+	return &instanceTypeResolverAdapter{rm: rm}
+}
+
+func (a *instanceTypeResolverAdapter) Resolve(name string) (vm.InstanceTypeSpec, bool) {
+	if a.rm == nil {
+		return vm.InstanceTypeSpec{}, false
+	}
+	it := a.rm.instanceTypes[name]
+	if it == nil {
+		return vm.InstanceTypeSpec{}, false
+	}
+	architecture := "x86_64"
+	if it.ProcessorInfo != nil && len(it.ProcessorInfo.SupportedArchitectures) > 0 && it.ProcessorInfo.SupportedArchitectures[0] != nil {
+		architecture = *it.ProcessorInfo.SupportedArchitectures[0]
+	}
+	return vm.InstanceTypeSpec{
+		VCPUs:        int(instanceTypeVCPUs(it)),
+		MemoryMiB:    int(instanceTypeMemoryMiB(it)),
+		Architecture: architecture,
+	}, true
+}
+
+// resourceControllerAdapter satisfies vm.ResourceController. Both Allocate
+// and Deallocate look up the EC2 InstanceTypeInfo by name before delegating
+// to the existing capacity-keyed resource manager methods.
+type resourceControllerAdapter struct {
+	rm *ResourceManager
+}
+
+var _ vm.ResourceController = (*resourceControllerAdapter)(nil)
+
+func newResourceControllerAdapter(rm *ResourceManager) *resourceControllerAdapter {
+	return &resourceControllerAdapter{rm: rm}
+}
+
+func (a *resourceControllerAdapter) Allocate(instanceType string) error {
+	if a.rm == nil {
+		return errors.New("resource manager not initialized")
+	}
+	it := a.rm.instanceTypes[instanceType]
+	if it == nil {
+		return fmt.Errorf("instance type %s not found", instanceType)
+	}
+	return a.rm.allocate(it)
+}
+
+func (a *resourceControllerAdapter) Deallocate(instanceType string) {
+	if a.rm == nil {
+		return
+	}
+	it := a.rm.instanceTypes[instanceType]
+	if it == nil {
+		return
+	}
+	a.rm.deallocate(it)
+}
+
+// volumeStateUpdaterAdapter satisfies vm.VolumeStateUpdater by delegating to
+// the daemon's volume service. It tolerates a nil service so callers don't
+// need to nil-check before invoking.
+type volumeStateUpdaterAdapter struct {
+	svc volumeStateUpdater
+}
+
+// volumeStateUpdater is the narrow slice of handlers_ec2_volume.VolumeServiceImpl
+// that the manager touches. Defining it locally avoids dragging the full
+// volume-service surface into the adapter.
+type volumeStateUpdater interface {
+	UpdateVolumeState(volumeID, state, instanceID, attachmentDevice string) error
+}
+
+var _ vm.VolumeStateUpdater = (*volumeStateUpdaterAdapter)(nil)
+
+func newVolumeStateUpdaterAdapter(svc volumeStateUpdater) *volumeStateUpdaterAdapter {
+	return &volumeStateUpdaterAdapter{svc: svc}
+}
+
+func (a *volumeStateUpdaterAdapter) UpdateVolumeState(volumeID, state, instanceID, attachmentDevice string) error {
+	if a.svc == nil {
+		return nil
+	}
+	return a.svc.UpdateVolumeState(volumeID, state, instanceID, attachmentDevice)
+}
+
+// onInstanceUpHook returns the daemon's OnInstanceUp callback. Subscribing
+// per-instance NATS topics is the only side-effect; the manager fires this
+// synchronously after a successful Pending→Running transition.
+func (d *Daemon) onInstanceUpHook() func(*vm.VM) {
+	return func(instance *vm.VM) {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+
+		if existing, ok := d.natsSubscriptions[instance.ID]; ok {
+			_ = existing.Unsubscribe()
+		}
+		consoleSubKey := instance.ID + ".console"
+		if existing, ok := d.natsSubscriptions[consoleSubKey]; ok {
+			_ = existing.Unsubscribe()
+		}
+
+		sub, err := d.natsConn.Subscribe(fmt.Sprintf("ec2.cmd.%s", instance.ID), d.handleEC2Events)
+		if err != nil {
+			slog.Error("OnInstanceUp: failed to subscribe to per-instance topic",
+				"instanceId", instance.ID, "err", err)
+			return
+		}
+		d.natsSubscriptions[instance.ID] = sub
+
+		consoleSub, err := d.natsConn.Subscribe(
+			fmt.Sprintf("ec2.%s.GetConsoleOutput", instance.ID),
+			d.handleEC2GetConsoleOutput,
+		)
+		if err != nil {
+			slog.Error("OnInstanceUp: failed to subscribe to console output topic",
+				"instanceId", instance.ID, "err", err)
+			return
+		}
+		d.natsSubscriptions[consoleSubKey] = consoleSub
+	}
+}
+
+// onInstanceDownHook returns the daemon's OnInstanceDown callback. It
+// unsubscribes the per-instance NATS topics that onInstanceUpHook
+// registered.
+func (d *Daemon) onInstanceDownHook() func(string) {
+	return func(instanceID string) {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+
+		if sub, ok := d.natsSubscriptions[instanceID]; ok {
+			if err := sub.Unsubscribe(); err != nil {
+				slog.Error("OnInstanceDown: failed to unsubscribe instance topic",
+					"instanceId", instanceID, "err", err)
+			}
+			delete(d.natsSubscriptions, instanceID)
+		}
+		consoleSubKey := instanceID + ".console"
+		if sub, ok := d.natsSubscriptions[consoleSubKey]; ok {
+			if err := sub.Unsubscribe(); err != nil {
+				slog.Error("OnInstanceDown: failed to unsubscribe console topic",
+					"instanceId", instanceID, "err", err)
+			}
+			delete(d.natsSubscriptions, consoleSubKey)
+		}
+	}
+}
+
+// buildVMManagerDeps assembles the vm.Deps struct for the running daemon.
+// All collaborators must already be initialized; callers are expected to
+// invoke this from Daemon.Start after services and JetStream are ready.
+func (d *Daemon) buildVMManagerDeps() vm.Deps {
+	volState := newVolumeStateUpdaterAdapter(d.volumeService)
+	return vm.Deps{
+		NodeID:             d.node,
+		StateStore:         newStateStoreAdapter(d.jsManager),
+		VolumeMounter:      newVolumeMounterAdapter(d.natsConn, d.node, volState),
+		QMPClientFactory:   newQMPClientFactoryAdapter(),
+		ProcessLauncher:    newProcessLauncherAdapter(),
+		NetworkPlumber:     d.networkPlumber,
+		InstanceTypes:      newInstanceTypeResolverAdapter(d.resourceMgr),
+		Resources:          newResourceControllerAdapter(d.resourceMgr),
+		VolumeStateUpdater: volState,
+		Hooks: vm.ManagerHooks{
+			OnInstanceUp:   d.onInstanceUpHook(),
+			OnInstanceDown: d.onInstanceDownHook(),
+		},
+		ShutdownSignal:     d.shuttingDown.Load,
+		CrashHandler:       d.handleInstanceCrash,
+		TransitionState:    d.TransitionState,
+		MarkInstanceFailed: d.markInstanceFailed,
+		DevNetworking:      d.config.Daemon.DevNetworking,
+		BindHost:           d.config.Host,
+	}
+}
+
+// OVSNetworkPlumber satisfies vm.NetworkPlumber directly (no wrapper).
+var _ vm.NetworkPlumber = (*OVSNetworkPlumber)(nil)

--- a/spinifex/vm/instance_type_resolver.go
+++ b/spinifex/vm/instance_type_resolver.go
@@ -1,0 +1,30 @@
+package vm
+
+// InstanceTypeSpec carries the QEMU-relevant numbers for an instance type
+// (vCPU/memory/architecture) without dragging the EC2 SDK type into the vm
+// package.
+type InstanceTypeSpec struct {
+	VCPUs        int
+	MemoryMiB    int
+	Architecture string
+}
+
+// InstanceTypeResolver returns the spec for an instance type name (e.g.
+// "t3.micro"). Returns ok=false when the type is unknown to the host.
+type InstanceTypeResolver interface {
+	Resolve(name string) (spec InstanceTypeSpec, ok bool)
+}
+
+// ResourceController reserves and releases capacity for an instance type.
+// Allocation is keyed by name so callers don't need to round-trip the EC2
+// SDK type. The real implementation is the daemon's ResourceManager.
+type ResourceController interface {
+	Allocate(instanceType string) error
+	Deallocate(instanceType string)
+}
+
+// VolumeStateUpdater is the narrow slice of the volume service the manager
+// touches: marking boot volumes "in-use" once a VM is confirmed running.
+type VolumeStateUpdater interface {
+	UpdateVolumeState(volumeID, state, instanceID, attachmentDevice string) error
+}

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -5,15 +5,81 @@ import (
 	"sync"
 )
 
-// Manager owns the in-memory map of running VMs on this node.
-type Manager struct {
-	mu  sync.Mutex
-	vms map[string]*VM
+// ManagerHooks are callbacks the manager fires synchronously on every
+// running/terminated transition. The daemon uses these to drive per-instance
+// NATS subscription/unsubscription. Hook fields may be nil; nil hooks are no-ops.
+type ManagerHooks struct {
+	OnInstanceUp   func(*VM)
+	OnInstanceDown func(id string)
 }
 
+// Deps bundles every collaborator the manager uses to drive lifecycle.
+// Fields may be nil where the manager does not yet require them; call sites
+// guard against nil so partial wiring during construction is safe.
+type Deps struct {
+	NodeID string
+
+	StateStore         StateStore
+	VolumeMounter      VolumeMounter
+	QMPClientFactory   QMPClientFactory
+	ProcessLauncher    ProcessLauncher
+	NetworkPlumber     NetworkPlumber
+	InstanceTypes      InstanceTypeResolver
+	Resources          ResourceController
+	VolumeStateUpdater VolumeStateUpdater
+	Hooks              ManagerHooks
+
+	// ShutdownSignal returns true once the daemon has begun coordinated
+	// shutdown. Crash handlers and restart logic short-circuit on true.
+	ShutdownSignal func() bool
+
+	// CrashHandler is invoked from the QEMU exit goroutine when the process
+	// terminates unexpectedly after startup was confirmed.
+	CrashHandler func(*VM, error)
+
+	// TransitionState applies a state transition to the supplied VM and
+	// persists the resulting running-state snapshot.
+	TransitionState func(*VM, InstanceState) error
+
+	// MarkInstanceFailed cleans up a VM whose launch errored mid-way.
+	MarkInstanceFailed func(*VM, string)
+
+	// DevNetworking enables the user-mode dev NIC (SSH hostfwd) on top of
+	// the VPC tap NIC. Mirrors Daemon.config.Daemon.DevNetworking.
+	DevNetworking bool
+	// BindHost is the daemon's listen IP, used when wiring user-mode
+	// hostfwd rules. Empty / "0.0.0.0" falls back to 127.0.0.1.
+	BindHost string
+}
+
+// Manager owns the in-memory map of running VMs on this node and every
+// lifecycle transition that mutates that map.
+type Manager struct {
+	mu   sync.Mutex
+	vms  map[string]*VM
+	deps Deps
+}
+
+// NewManager returns a Manager with no collaborators wired. Production code
+// uses NewManagerWithDeps; tests that only exercise the in-memory map keep
+// this convenience.
 func NewManager() *Manager {
 	return &Manager{vms: make(map[string]*VM)}
 }
+
+// NewManagerWithDeps returns a Manager wired with collaborators.
+func NewManagerWithDeps(deps Deps) *Manager {
+	return &Manager{vms: make(map[string]*VM), deps: deps}
+}
+
+// SetDeps replaces the manager's dependencies. The daemon constructs the
+// manager early (before NATS / JetStream / network plumber are available)
+// and calls SetDeps once those collaborators exist. Must not be called
+// concurrently with lifecycle methods.
+func (m *Manager) SetDeps(deps Deps) { m.deps = deps }
+
+// NodeID returns the node identifier the manager was constructed with.
+func (m *Manager) NodeID() string { return m.deps.NodeID }
 
 // Get returns the VM for id (and true) or (nil, false).
 func (m *Manager) Get(id string) (*VM, bool) {

--- a/spinifex/vm/manager_deps_test.go
+++ b/spinifex/vm/manager_deps_test.go
@@ -1,0 +1,217 @@
+package vm
+
+import (
+	"errors"
+	"maps"
+	"testing"
+)
+
+// fakeStateStore is a minimal in-memory StateStore used to verify Deps wiring.
+type fakeStateStore struct {
+	saved      map[string]map[string]*VM
+	stopped    map[string]*VM
+	terminated map[string]*VM
+}
+
+func newFakeStateStore() *fakeStateStore {
+	return &fakeStateStore{
+		saved:      map[string]map[string]*VM{},
+		stopped:    map[string]*VM{},
+		terminated: map[string]*VM{},
+	}
+}
+
+func (f *fakeStateStore) SaveRunningState(nodeID string, snap map[string]*VM) error {
+	cp := make(map[string]*VM, len(snap))
+	maps.Copy(cp, snap)
+	f.saved[nodeID] = cp
+	return nil
+}
+
+func (f *fakeStateStore) LoadRunningState(nodeID string) (map[string]*VM, error) {
+	if v, ok := f.saved[nodeID]; ok {
+		return v, nil
+	}
+	return map[string]*VM{}, nil
+}
+
+func (f *fakeStateStore) WriteStoppedInstance(id string, v *VM) error {
+	f.stopped[id] = v
+	return nil
+}
+
+func (f *fakeStateStore) LoadStoppedInstance(id string) (*VM, error) {
+	if v, ok := f.stopped[id]; ok {
+		return v, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeStateStore) DeleteStoppedInstance(id string) error {
+	delete(f.stopped, id)
+	return nil
+}
+
+func (f *fakeStateStore) ListStoppedInstances() ([]*VM, error) {
+	out := make([]*VM, 0, len(f.stopped))
+	for _, v := range f.stopped {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+func (f *fakeStateStore) WriteTerminatedInstance(id string, v *VM) error {
+	f.terminated[id] = v
+	return nil
+}
+
+func (f *fakeStateStore) ListTerminatedInstances() ([]*VM, error) {
+	out := make([]*VM, 0, len(f.terminated))
+	for _, v := range f.terminated {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+var _ StateStore = (*fakeStateStore)(nil)
+
+func TestNewManagerWithDeps_StoresDeps(t *testing.T) {
+	store := newFakeStateStore()
+	deps := Deps{
+		NodeID:     "node-a",
+		StateStore: store,
+		ShutdownSignal: func() bool {
+			return true
+		},
+	}
+	m := NewManagerWithDeps(deps)
+
+	if m.NodeID() != "node-a" {
+		t.Fatalf("NodeID: got %q, want %q", m.NodeID(), "node-a")
+	}
+	if m.deps.StateStore == nil {
+		t.Fatal("deps.StateStore: got nil after construction")
+	}
+	if !m.deps.ShutdownSignal() {
+		t.Fatal("ShutdownSignal callback: not preserved")
+	}
+
+	// Sanity: the manager's map is independent of any future Deps state.
+	if m.Count() != 0 {
+		t.Fatalf("Count on fresh manager: got %d, want 0", m.Count())
+	}
+}
+
+func TestSetDeps_OverridesDeps(t *testing.T) {
+	m := NewManager()
+	if m.NodeID() != "" {
+		t.Fatalf("NodeID on default manager: got %q, want empty", m.NodeID())
+	}
+
+	deps := Deps{NodeID: "node-b"}
+	m.SetDeps(deps)
+	if m.NodeID() != "node-b" {
+		t.Fatalf("NodeID after SetDeps: got %q, want %q", m.NodeID(), "node-b")
+	}
+
+	// Replacing deps fully overwrites prior deps, not merges.
+	m.SetDeps(Deps{NodeID: "node-c"})
+	if m.NodeID() != "node-c" {
+		t.Fatalf("NodeID after second SetDeps: got %q, want %q", m.NodeID(), "node-c")
+	}
+}
+
+func TestManagerHooks_InitiallyNil(t *testing.T) {
+	// A manager constructed without hooks must expose nil hook fields so
+	// call sites can no-op rather than panicking.
+	m := NewManager()
+	if m.deps.Hooks.OnInstanceUp != nil {
+		t.Fatal("OnInstanceUp: got non-nil on default manager")
+	}
+	if m.deps.Hooks.OnInstanceDown != nil {
+		t.Fatal("OnInstanceDown: got non-nil on default manager")
+	}
+}
+
+// fakeVolumeMounter records every call so lifecycle tests can assert ordering.
+type fakeVolumeMounter struct {
+	mounted, unmounted []string
+	mountErr           error
+}
+
+func (f *fakeVolumeMounter) Mount(v *VM) error {
+	f.mounted = append(f.mounted, v.ID)
+	return f.mountErr
+}
+
+func (f *fakeVolumeMounter) Unmount(v *VM) error {
+	f.unmounted = append(f.unmounted, v.ID)
+	return nil
+}
+
+var _ VolumeMounter = (*fakeVolumeMounter)(nil)
+
+func TestDeps_VolumeMounterSatisfiesInterface(t *testing.T) {
+	mounter := &fakeVolumeMounter{}
+	deps := Deps{VolumeMounter: mounter}
+	m := NewManagerWithDeps(deps)
+
+	if err := m.deps.VolumeMounter.Mount(&VM{ID: "i-1"}); err != nil {
+		t.Fatalf("Mount: %v", err)
+	}
+	if err := m.deps.VolumeMounter.Unmount(&VM{ID: "i-1"}); err != nil {
+		t.Fatalf("Unmount: %v", err)
+	}
+	if len(mounter.mounted) != 1 || mounter.mounted[0] != "i-1" {
+		t.Fatalf("mounted: got %v, want [i-1]", mounter.mounted)
+	}
+	if len(mounter.unmounted) != 1 || mounter.unmounted[0] != "i-1" {
+		t.Fatalf("unmounted: got %v, want [i-1]", mounter.unmounted)
+	}
+}
+
+func TestDeps_StateStoreSatisfiesInterface(t *testing.T) {
+	store := newFakeStateStore()
+	deps := Deps{NodeID: "n", StateStore: store}
+	m := NewManagerWithDeps(deps)
+
+	if err := m.deps.StateStore.WriteStoppedInstance("i-1", &VM{ID: "i-1"}); err != nil {
+		t.Fatalf("WriteStoppedInstance: %v", err)
+	}
+	got, err := m.deps.StateStore.LoadStoppedInstance("i-1")
+	if err != nil {
+		t.Fatalf("LoadStoppedInstance: %v", err)
+	}
+	if got == nil || got.ID != "i-1" {
+		t.Fatalf("LoadStoppedInstance: got %v, want VM{ID:i-1}", got)
+	}
+
+	if err := m.deps.StateStore.SaveRunningState("n", map[string]*VM{"i-1": {ID: "i-1"}}); err != nil {
+		t.Fatalf("SaveRunningState: %v", err)
+	}
+	loaded, err := m.deps.StateStore.LoadRunningState("n")
+	if err != nil {
+		t.Fatalf("LoadRunningState: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("LoadRunningState: got %d entries, want 1", len(loaded))
+	}
+}
+
+// failStateStore returns errors so lifecycle tests can verify propagation
+// when the manager wires through StateStore.
+type failStateStore struct{ *fakeStateStore }
+
+func (failStateStore) SaveRunningState(string, map[string]*VM) error {
+	return errors.New("save failed")
+}
+
+func TestDeps_StateStoreErrorPropagates(t *testing.T) {
+	deps := Deps{NodeID: "n", StateStore: failStateStore{newFakeStateStore()}}
+	m := NewManagerWithDeps(deps)
+
+	err := m.deps.StateStore.SaveRunningState("n", nil)
+	if err == nil {
+		t.Fatal("SaveRunningState: expected error from failStateStore, got nil")
+	}
+}

--- a/spinifex/vm/network_plumber.go
+++ b/spinifex/vm/network_plumber.go
@@ -1,0 +1,10 @@
+package vm
+
+// NetworkPlumber handles tap device and OVS bridge operations for VPC
+// networking. Defined here so the manager can hold the collaborator without
+// importing the daemon package; the daemon's OVSNetworkPlumber type satisfies
+// it structurally.
+type NetworkPlumber interface {
+	SetupTapDevice(eniID, mac string) error
+	CleanupTapDevice(eniID string) error
+}

--- a/spinifex/vm/process_launcher.go
+++ b/spinifex/vm/process_launcher.go
@@ -1,0 +1,10 @@
+package vm
+
+import "os/exec"
+
+// ProcessLauncher resolves a Config into an *exec.Cmd ready to Start(). The
+// real implementation is a 1-line wrapper over Config.Execute(); the seam
+// exists so tests can substitute scripted commands without spawning QEMU.
+type ProcessLauncher interface {
+	Launch(cfg *Config) (*exec.Cmd, error)
+}

--- a/spinifex/vm/qmp_client.go
+++ b/spinifex/vm/qmp_client.go
@@ -1,0 +1,10 @@
+package vm
+
+import "github.com/mulgadc/spinifex/spinifex/qmp"
+
+// QMPClientFactory connects a QMP client to a VM's QMP socket and runs the
+// qmp_capabilities handshake. The returned client is ready for command
+// dispatch. Heartbeats are owned by the manager, not the factory.
+type QMPClientFactory interface {
+	Create(v *VM) (*qmp.QMPClient, error)
+}

--- a/spinifex/vm/state_store.go
+++ b/spinifex/vm/state_store.go
@@ -1,0 +1,25 @@
+package vm
+
+// StateStore persists VM state across the three locations spinifex models:
+// per-node "running" state, the cluster-shared "stopped" bucket, and the
+// cluster-shared "terminated" bucket.
+//
+// The interface lives in the vm package; the live implementation is a thin
+// adapter in the daemon package wrapping the JetStream-backed bucket.
+type StateStore interface {
+	// SaveRunningState writes the snapshot of VMs currently running on the
+	// given node. The supplied map is owned by the caller and must not be
+	// retained.
+	SaveRunningState(nodeID string, snapshot map[string]*VM) error
+	// LoadRunningState returns the VMs persisted for the given node. An
+	// empty (non-nil) map is returned when no state exists.
+	LoadRunningState(nodeID string) (map[string]*VM, error)
+
+	WriteStoppedInstance(id string, v *VM) error
+	LoadStoppedInstance(id string) (*VM, error)
+	DeleteStoppedInstance(id string) error
+	ListStoppedInstances() ([]*VM, error)
+
+	WriteTerminatedInstance(id string, v *VM) error
+	ListTerminatedInstances() ([]*VM, error)
+}

--- a/spinifex/vm/volume_mounter.go
+++ b/spinifex/vm/volume_mounter.go
@@ -1,0 +1,13 @@
+package vm
+
+// VolumeMounter mounts and unmounts the EBS volumes attached to a VM. The
+// real implementation routes ebs.mount / ebs.unmount NATS requests; the
+// abstraction keeps NATS out of the manager.
+type VolumeMounter interface {
+	// Mount mounts every attached volume in v.EBSRequests.Requests, recording
+	// the resolved NBDURI back onto each request entry.
+	Mount(v *VM) error
+	// Unmount sends ebs.unmount for each attached volume. Errors are logged
+	// per volume and aggregated; partial failure is tolerated.
+	Unmount(v *VM) error
+}


### PR DESCRIPTION
Define StateStore, VolumeMounter, QMPClientFactory, ProcessLauncher, NetworkPlumber, InstanceTypeResolver, ResourceController, VolumeStateUpdater, and ManagerHooks in the vm package. Extend vm.Manager with a Deps struct and SetDeps so the daemon can wire collaborators after JetStream / NATS / network plumber are ready.

Add daemon-side adapters wrapping JetStreamManager, MountVolumes, the QMP connect+handshake, vm.Config.Execute, ResourceManager, and the volume service. Daemon.Start now constructs and injects them via vm.Manager.SetDeps.

Pure plumbing — no behaviour change. Lifecycle ownership stays on Daemon; subsequent work moves bodies onto the manager and exercises the deps.