### PR TITLE
refactor(vm): move Stop/Terminate/MarkFailed onto Manager

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1049,35 +1049,6 @@ func (d *Daemon) checkPredastoreReady() bool {
 	return true
 }
 
-// migrateInstanceToKV writes an instance to the given KV write function and removes
-// it from the local instance map. Returns true if migration succeeded.
-func (d *Daemon) migrateInstanceToKV(instance *vm.VM, writeFn func(string, *vm.VM) error, label string) bool {
-	if d.jsManager == nil {
-		return false
-	}
-	instance.LastNode = d.node
-	if err := writeFn(instance.ID, instance); err != nil {
-		slog.Error("Failed to migrate instance to KV",
-			"instance", instance.ID, "bucket", label, "err", err)
-		return false
-	}
-	if !d.vmMgr.DeleteIf(instance.ID, instance) {
-		slog.Info("Slot reclaimed by another handler during migration; skipping local delete",
-			"instance", instance.ID, "bucket", label)
-		return true
-	}
-	slog.Info("Migrated instance to KV", "instance", instance.ID, "bucket", label)
-	return true
-}
-
-func (d *Daemon) migrateStoppedToSharedKV(instance *vm.VM) bool {
-	return d.migrateInstanceToKV(instance, d.jsManager.WriteStoppedInstance, "stopped")
-}
-
-func (d *Daemon) migrateTerminatedToKV(instance *vm.VM) bool {
-	return d.migrateInstanceToKV(instance, d.jsManager.WriteTerminatedInstance, "terminated")
-}
-
 // maxConcurrentRecovery limits how many VMs are relaunched in parallel during recovery.
 const maxConcurrentRecovery = 2
 
@@ -1117,7 +1088,7 @@ func (d *Daemon) restoreInstances() {
 		instance.QMPClient = &qmp.QMPClient{}
 
 		if instance.Status == vm.StateTerminated {
-			if !d.migrateTerminatedToKV(instance) {
+			if !d.vmMgr.MigrateTerminatedToKV(instance) {
 				// KV write failed — keep in local state so the next restart
 				// retries the migration. Deleting here would create a "void":
 				// the instance disappears from both local state and the
@@ -1129,7 +1100,7 @@ func (d *Daemon) restoreInstances() {
 		}
 
 		if instance.Status == vm.StateStopped {
-			d.migrateStoppedToSharedKV(instance)
+			d.vmMgr.MigrateStoppedToSharedKV(instance)
 			continue
 		}
 
@@ -1144,7 +1115,7 @@ func (d *Daemon) restoreInstances() {
 				instance.Instance.StateReason.SetMessage(
 					fmt.Sprintf("instance type %s is not available on this node", instance.InstanceType))
 			}
-			d.migrateStoppedToSharedKV(instance)
+			d.vmMgr.MigrateStoppedToSharedKV(instance)
 			continue
 		}
 
@@ -1160,7 +1131,7 @@ func (d *Daemon) restoreInstances() {
 					instance.Instance.StateReason.SetMessage(
 						fmt.Sprintf("insufficient resources to restore instance: %v", err))
 				}
-				d.migrateStoppedToSharedKV(instance)
+				d.vmMgr.MigrateStoppedToSharedKV(instance)
 				continue
 			}
 		}
@@ -1216,11 +1187,11 @@ func (d *Daemon) restoreInstances() {
 			slog.Info("QEMU exited during transition, finalizing state",
 				"instance", instance.ID, "from", prevStatus, "to", instance.Status)
 
-			if instance.Status == vm.StateStopped && d.migrateStoppedToSharedKV(instance) {
+			if instance.Status == vm.StateStopped && d.vmMgr.MigrateStoppedToSharedKV(instance) {
 				continue
 			}
 
-			if instance.Status == vm.StateTerminated && d.migrateTerminatedToKV(instance) {
+			if instance.Status == vm.StateTerminated && d.vmMgr.MigrateTerminatedToKV(instance) {
 				continue
 			}
 
@@ -1289,7 +1260,7 @@ func (d *Daemon) restoreInstances() {
 				slog.Info("Launching instance (recovery)", "instance", inst.ID)
 				if err := d.vmMgr.Run(inst); err != nil {
 					slog.Error("Failed to launch instance during recovery", "instanceId", inst.ID, "err", err)
-					d.markInstanceFailed(inst, "recovery_launch_failed")
+					d.vmMgr.MarkFailed(inst, "recovery_launch_failed")
 				}
 			}(instance)
 		}
@@ -1613,219 +1584,6 @@ func (d *Daemon) SendQMPCommand(q *qmp.QMPClient, cmd qmp.QMPCommand, instanceId
 	}
 }
 
-func (d *Daemon) stopInstance(instances map[string]*vm.VM, deleteVolume bool) error {
-	// Signal to shutdown each VM
-	var wg sync.WaitGroup
-
-	// Run asynchronously within a worker group
-	for _, instance := range instances {
-		wg.Go(func() {
-			// Send shutdown command - if it fails, VM may already be dead, continue with cleanup
-			_, err := d.SendQMPCommand(instance.QMPClient, qmp.QMPCommand{Execute: "system_powerdown"}, instance.ID)
-			if err != nil {
-				slog.Warn("QMP system_powerdown failed (VM may already be stopped)", "id", instance.ID, "err", err)
-				// Don't return - continue with cleanup
-			}
-
-			// Wait for PID file removal (or check if already gone).
-			// 20s is enough for a graceful ACPI shutdown — if the guest hasn't
-			// responded to system_powerdown by then, it won't (e.g. still booting,
-			// no ACPI handler). Force-kill at that point rather than wasting 60s.
-			err = utils.WaitForPidFileRemoval(instance.ID, 20*time.Second)
-			if err != nil {
-				slog.Warn("Timeout waiting for PID file removal", "id", instance.ID, "err", err)
-
-				// Try force killing the process if it's still running
-				pid, readErr := utils.ReadPidFile(instance.ID)
-				if readErr != nil {
-					slog.Debug("No PID file found (VM likely already stopped)", "id", instance.ID)
-				} else {
-					slog.Info("Force killing process", "pid", pid, "id", instance.ID)
-					if err := utils.KillProcess(pid); err != nil {
-						slog.Error("Failed to kill process", "pid", pid, "id", instance.ID, "err", err)
-					}
-				}
-			}
-
-			// Unmount all EBS volumes
-			instance.EBSRequests.Mu.Lock()
-			defer instance.EBSRequests.Mu.Unlock()
-
-			for _, ebsRequest := range instance.EBSRequests.Requests {
-				// Send the volume payload as JSON
-				ebsUnMountRequest, err := json.Marshal(ebsRequest)
-
-				if err != nil {
-					slog.Error("Failed to marshal volume payload", "err", err)
-					continue
-				}
-
-				msg, err := d.natsConn.Request(d.ebsTopic("unmount"), ebsUnMountRequest, 30*time.Second)
-				if err != nil {
-					slog.Error("Failed to unmount volume", "name", ebsRequest.Name, "id", instance.ID, "err", err)
-				} else {
-					slog.Info("Unmounted Viperblock volume", "id", instance.ID, "data", string(msg.Data))
-				}
-
-				// Update volume state to "available" for all user-visible volumes (boot + hot-attached)
-				if !ebsRequest.EFI && !ebsRequest.CloudInit {
-					if err := d.volumeService.UpdateVolumeState(ebsRequest.Name, "available", "", ""); err != nil {
-						slog.Error("Failed to update volume state to available", "volumeId", ebsRequest.Name, "err", err)
-					}
-				}
-			}
-
-			// If flagged for termination, clean up volumes
-			if deleteVolume {
-				for _, ebsRequest := range instance.EBSRequests.Requests {
-					// Internal volumes (EFI, cloud-init) are always cleaned up via ebs.delete
-					// to stop viperblockd processes. S3 data cleanup happens via DeleteVolume
-					// on the parent root volume (which deletes -efi/ and -cloudinit/ prefixes).
-					if ebsRequest.EFI || ebsRequest.CloudInit {
-						ebsDeleteData, err := json.Marshal(types.EBSDeleteRequest{Volume: ebsRequest.Name})
-						if err != nil {
-							slog.Error("Failed to marshal ebs.delete request for internal volume", "name", ebsRequest.Name, "err", err)
-							continue
-						}
-						deleteMsg, err := d.natsConn.Request("ebs.delete", ebsDeleteData, 30*time.Second)
-						if err != nil {
-							slog.Warn("Failed to send ebs.delete for internal volume", "name", ebsRequest.Name, "id", instance.ID, "err", err)
-						} else {
-							slog.Info("Sent ebs.delete for internal volume", "name", ebsRequest.Name, "id", instance.ID, "data", string(deleteMsg.Data))
-						}
-						continue
-					}
-
-					// User-visible volumes: respect DeleteOnTermination flag
-					if !ebsRequest.DeleteOnTermination {
-						slog.Info("Volume has DeleteOnTermination=false, skipping deletion", "name", ebsRequest.Name, "id", instance.ID)
-						continue
-					}
-
-					// DeleteVolume handles: NATS ebs.delete notification + S3 cleanup
-					// (including -efi/ and -cloudinit/ sub-prefixes)
-					slog.Info("Deleting volume with DeleteOnTermination=true", "name", ebsRequest.Name, "id", instance.ID)
-					_, err := d.volumeService.DeleteVolume(&ec2.DeleteVolumeInput{
-						VolumeId: &ebsRequest.Name,
-					}, instance.AccountID)
-					if err != nil {
-						slog.Error("Failed to delete volume on termination", "name", ebsRequest.Name, "id", instance.ID, "err", err)
-					} else {
-						slog.Info("Deleted volume on termination", "name", ebsRequest.Name, "id", instance.ID)
-					}
-				}
-			}
-
-			// Clean up VPC tap device if present
-			if instance.ENIId != "" && d.networkPlumber != nil {
-				if err := d.networkPlumber.CleanupTapDevice(instance.ENIId); err != nil {
-					slog.Warn("Failed to clean up tap device", "eni", instance.ENIId, "err", err)
-				}
-				// Clean up any extra ENI tap devices (multi-subnet ALB VMs).
-				d.cleanupExtraENITaps(instance)
-			}
-
-			// Clean up management TAP and release IP. Derive the name from
-			// instance.ID rather than reading instance.MgmtTap — the field
-			// is set only after SetupMgmtTapDevice returns, so a terminate
-			// that races mid-launch would skip cleanup and leak the OVS
-			// port. CleanupMgmtTapDevice is idempotent for instances that
-			// never reached the setup step.
-			mgmtTap := MgmtTapName(instance.ID)
-			if err := CleanupMgmtTapDevice(mgmtTap); err != nil {
-				slog.Warn("Failed to clean up mgmt tap device", "tap", mgmtTap, "instanceId", instance.ID, "err", err)
-			}
-			if d.mgmtIPAllocator != nil {
-				d.mgmtIPAllocator.Release(instance.ID)
-			}
-
-			// Release public IP before deleting ENI
-			if deleteVolume && instance.PublicIP != "" && instance.PublicIPPool != "" && d.externalIPAM != nil {
-				// Publish vpc.delete-nat to remove dnat_and_snat rule
-				portName := "port-" + instance.ENIId
-				vpcId := ""
-				logicalIP := ""
-				if instance.Instance != nil {
-					if instance.Instance.VpcId != nil {
-						vpcId = *instance.Instance.VpcId
-					}
-					if instance.Instance.PrivateIpAddress != nil {
-						logicalIP = *instance.Instance.PrivateIpAddress
-					}
-				}
-				d.publishNATEvent("vpc.delete-nat", vpcId, instance.PublicIP, logicalIP, portName, "")
-
-				// Release IP back to pool
-				if err := d.externalIPAM.ReleaseIP(instance.PublicIPPool, instance.PublicIP); err != nil {
-					slog.Warn("Failed to release public IP on termination", "ip", instance.PublicIP, "pool", instance.PublicIPPool, "err", err)
-				} else {
-					slog.Info("Released public IP on termination", "ip", instance.PublicIP, "instanceId", instance.ID)
-				}
-			}
-
-			// On termination, detach and delete the auto-created ENI (releases IP
-			// back to IPAM, publishes vpc.delete-port for vpcd). On stop, ENI
-			// persists (AWS behavior). Must detach first to clear in-use status.
-			// Tolerate NotFound — ENI may have been cleaned up already.
-			// Other errors (KV failures, permission issues, in-use) are real
-			// failures that could leak IPAM addresses.
-			if deleteVolume && instance.ENIId != "" && d.vpcService != nil {
-				if detachErr := d.vpcService.DetachENI(instance.AccountID, instance.ENIId); detachErr != nil {
-					slog.Warn("Failed to detach ENI on termination", "eni", instance.ENIId, "instanceId", instance.ID, "err", detachErr)
-				}
-				if _, eniErr := d.vpcService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-					NetworkInterfaceId: &instance.ENIId,
-				}, instance.AccountID); eniErr != nil {
-					if strings.Contains(eniErr.Error(), awserrors.ErrorInvalidNetworkInterfaceIDNotFound) {
-						slog.Debug("ENI already cleaned up on termination", "eni", instance.ENIId)
-					} else {
-						slog.Error("Failed to delete ENI on termination", "eni", instance.ENIId, "instanceId", instance.ID, "err", eniErr)
-					}
-				} else {
-					slog.Info("Deleted ENI on termination", "eni", instance.ENIId, "instanceId", instance.ID)
-				}
-				// Extra ENIs (multi-subnet ALB VMs) are cleaned up by
-				// DeleteLoadBalancer via its own lb.ENIs loop — the daemon
-				// doesn't duplicate that teardown here.
-			}
-
-			// Deallocate resources
-			instanceType := d.resourceMgr.instanceTypes[instance.InstanceType]
-			if instanceType != nil {
-				slog.Info("Deallocating resources for stopped instance", "instanceId", instance.ID, "type", instance.InstanceType)
-				d.resourceMgr.deallocate(instanceType)
-			}
-		})
-	}
-
-	// Wait for all shutdowns to finish
-	wg.Wait()
-
-	// Only unsubscribe from NATS subjects when terminating (deleteVolume=true)
-	// For stop operations, keep the subscription so we can receive start commands
-	if deleteVolume {
-		for _, instance := range instances {
-			d.mu.Lock()
-			if sub, ok := d.natsSubscriptions[instance.ID]; ok {
-				slog.Info("Unsubscribing from NATS subject", "instance", instance.ID)
-				if err := sub.Unsubscribe(); err != nil {
-					slog.Error("Failed to unsubscribe from NATS subject", "instance", instance.ID, "err", err)
-				}
-				delete(d.natsSubscriptions, instance.ID)
-			}
-			consoleSubKey := instance.ID + ".console"
-			if sub, ok := d.natsSubscriptions[consoleSubKey]; ok {
-				if err := sub.Unsubscribe(); err != nil {
-					slog.Error("Failed to unsubscribe from console NATS subject", "instance", instance.ID, "err", err)
-				}
-				delete(d.natsSubscriptions, consoleSubKey)
-			}
-			d.mu.Unlock()
-		}
-	}
-	return nil
-}
-
 func (d *Daemon) setupShutdown() {
 	d.shutdownWg.Go(func() {
 		sigChan := make(chan os.Signal, 1)
@@ -1837,15 +1595,14 @@ func (d *Daemon) setupShutdown() {
 		// Cancel context to stop heartbeat and other goroutines
 		d.cancel()
 
-		// If coordinated shutdown already handled VMs (DRAIN phase), skip stopInstance.
-		// Otherwise, set the flag now so crash handlers and restart schedulers
-		// know to bail out during SIGTERM-based shutdown.
+		// If coordinated shutdown already handled VMs (DRAIN phase), skip the
+		// per-instance teardown. Otherwise, set the flag now so crash handlers
+		// and restart schedulers know to bail out during SIGTERM-based shutdown.
 		if d.shuttingDown.Load() {
 			slog.Info("Coordinated shutdown in progress, skipping VM stop (already handled by DRAIN phase)")
 		} else {
 			d.shuttingDown.Store(true)
-			// Pass instances to terminate
-			if err := d.stopInstance(d.vmMgr.SnapshotMap(), false); err != nil {
+			if err := d.vmMgr.StopAll(); err != nil {
 				slog.Error("Failed to stop instances during shutdown", "err", err)
 			}
 		}
@@ -1892,101 +1649,6 @@ func (d *Daemon) setupShutdown() {
 	})
 }
 
-// markInstanceFailed updates an instance status to indicate a failure during launch,
-// then completes the termination lifecycle in the background so the instance
-// reaches terminated state and doesn't get stuck in shutting-down.
-func (d *Daemon) markInstanceFailed(instance *vm.VM, reason string) {
-	// If the instance is already being cleaned up (e.g., a concurrent terminate
-	// request transitioned it to shutting-down while LaunchInstance was running),
-	// don't spawn a second finalizeTermination goroutine — the existing cleanup
-	// handler owns the lifecycle from here.
-	skip := false
-	var observedStatus vm.InstanceState
-	d.vmMgr.Inspect(instance, func(v *vm.VM) {
-		observedStatus = v.Status
-		if v.Status == vm.StateShuttingDown || v.Status == vm.StateTerminated {
-			skip = true
-			return
-		}
-		// Set state reason before transition
-		if v.Instance != nil {
-			v.Instance.StateReason = &ec2.StateReason{}
-			v.Instance.StateReason.SetCode("Server.InternalError")
-			v.Instance.StateReason.SetMessage(reason)
-		}
-	})
-	if skip {
-		slog.Info("markInstanceFailed: instance already in cleanup state, skipping",
-			"instanceId", instance.ID, "status", string(observedStatus), "reason", reason)
-		return
-	}
-
-	if err := d.TransitionState(instance, vm.StateShuttingDown); err != nil {
-		slog.Error("markInstanceFailed transition failed", "instanceId", instance.ID, "err", err)
-		// If the error was a write failure, the in-memory state is already
-		// shutting-down. Still proceed with finalization to avoid getting stuck.
-		var postErrStatus vm.InstanceState
-		d.vmMgr.Inspect(instance, func(v *vm.VM) { postErrStatus = v.Status })
-		if postErrStatus != vm.StateShuttingDown {
-			return
-		}
-	}
-
-	slog.Info("Instance marked as failed", "instanceId", instance.ID, "reason", reason)
-
-	// Complete termination in the background — clean up any partially-created
-	// resources and transition to terminated so the instance doesn't get stuck
-	// in shutting-down indefinitely.
-	go d.finalizeTermination(instance)
-}
-
-// finalizeTermination completes the termination lifecycle for an instance already
-// in shutting-down state. It cleans up resources (processes, volumes, ENIs),
-// transitions to terminated, writes to the terminated KV bucket, and removes
-// the instance from local state.
-func (d *Daemon) finalizeTermination(instance *vm.VM) {
-	stopErr := d.stopInstance(map[string]*vm.VM{instance.ID: instance}, true)
-	if stopErr != nil {
-		slog.Error("Failed to cleanup failed instance", "err", stopErr, "id", instance.ID)
-		if err := d.TransitionState(instance, vm.StateError); err != nil {
-			slog.Error("Failed to transition to error state", "instanceId", instance.ID, "err", err)
-		}
-		return
-	}
-
-	d.vmMgr.Inspect(instance, func(v *vm.VM) { v.LastNode = d.node })
-
-	if err := d.TransitionState(instance, vm.StateTerminated); err != nil {
-		slog.Error("Failed to transition failed instance to terminated", "instanceId", instance.ID, "err", err)
-		return
-	}
-	slog.Info("Instance terminated (failed launch cleanup)", "id", instance.ID)
-
-	if d.jsManager != nil {
-		if err := d.jsManager.WriteTerminatedInstance(instance.ID, instance); err != nil {
-			slog.Error("Failed to write terminated instance to KV, keeping in local state for retry",
-				"instanceId", instance.ID, "err", err)
-			return
-		}
-	}
-
-	// Guard + delete: another handler may have reclaimed this instance.
-	if !d.vmMgr.DeleteIf(instance.ID, instance) {
-		slog.Info("Instance was reclaimed by another handler, skipping local cleanup",
-			"instanceId", instance.ID, "state", "terminated")
-		return
-	}
-
-	if err := d.WriteState(); err != nil {
-		slog.Error("Failed to persist state after terminating failed instance, re-adding to local map",
-			"instanceId", instance.ID, "err", err)
-		d.vmMgr.InsertIfAbsent(instance)
-	} else {
-		slog.Info("Released failed instance ownership to KV",
-			"instanceId", instance.ID, "lastNode", d.node)
-	}
-}
-
 const pendingWatchdogInterval = 60 * time.Second
 const pendingWatchdogTimeout = 5 * time.Minute
 
@@ -2011,7 +1673,7 @@ func (d *Daemon) startPendingWatchdog() {
 					slog.Warn("Instance stuck in pending, marking failed",
 						"instanceId", instance.ID, "status", instance.Status,
 						"elapsed", time.Since(*instance.Instance.LaunchTime))
-					d.markInstanceFailed(instance, "launch_timeout")
+					d.vmMgr.MarkFailed(instance, "launch_timeout")
 				}
 			}
 		}

--- a/spinifex/daemon/daemon_handlers_instance.go
+++ b/spinifex/daemon/daemon_handlers_instance.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/filterutil"
-	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	"github.com/mulgadc/spinifex/spinifex/qmp"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -366,7 +365,7 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) {
 		volumeInfos, err := d.instanceService.GenerateVolumes(runInstancesInput, instance)
 		if err != nil {
 			slog.Error("handleEC2RunInstances GenerateVolumes failed", "instanceId", instance.ID, "err", err)
-			d.markInstanceFailed(instance, "volume_preparation_failed")
+			d.vmMgr.MarkFailed(instance, "volume_preparation_failed")
 			continue
 		}
 
@@ -387,7 +386,7 @@ func (d *Daemon) handleEC2RunInstances(msg *nats.Msg) {
 		err = d.vmMgr.Run(instance)
 		if err != nil {
 			slog.Error("handleEC2RunInstances vmMgr.Run failed", "instanceId", instance.ID, "err", err)
-			d.markInstanceFailed(instance, "launch_failed")
+			d.vmMgr.MarkFailed(instance, "launch_failed")
 			continue
 		}
 
@@ -479,22 +478,20 @@ func (d *Daemon) handleStopOrTerminateInstance(msg *nats.Msg, command types.EC2I
 	isTerminate := command.Attributes.TerminateInstance
 	action := "Stopping"
 	initialState := vm.StateStopping
-	finalState := vm.StateStopped
 	if isTerminate {
 		action = "Terminating"
 		initialState = vm.StateShuttingDown
-		finalState = vm.StateTerminated
 	}
 
 	slog.Info(action+" instance", "id", command.ID)
 
-	// Check state validity before attempting transition — return the correct
-	// AWS error code when the instance is already stopped/terminated/etc.
+	// Check state validity before dispatching so we can return the correct
+	// AWS error code (IncorrectInstanceState) when the instance is already
+	// stopped/terminated/etc. Manager.Stop/Terminate re-validate internally.
 	var currentState vm.InstanceState
 	d.vmMgr.Inspect(instance, func(v *vm.VM) { currentState = v.Status })
 
-	// If instance is already shutting-down and we're asked to terminate, treat
-	// as idempotent — the finalizeTermination goroutine is already cleaning up.
+	// Idempotent: a concurrent terminate goroutine is already cleaning up.
 	if isTerminate && currentState == vm.StateShuttingDown {
 		slog.Info("Instance already shutting down, terminate is idempotent", "instanceId", instance.ID)
 		if err := msg.Respond([]byte(`{}`)); err != nil {
@@ -510,107 +507,27 @@ func (d *Daemon) handleStopOrTerminateInstance(msg *nats.Msg, command types.EC2I
 		return
 	}
 
-	// Transition to the initial transitional state
-	if err := d.TransitionState(instance, initialState); err != nil {
-		slog.Error("Failed to transition to "+string(initialState), "instanceId", instance.ID, "err", err)
-		respondWithError(msg, awserrors.ErrorServerInternal)
-		return
-	}
+	// Stamp the command attributes onto the VM before dispatch so the persisted
+	// state reflects the user-stop / user-terminate intent (e.g. for the
+	// recovery path that distinguishes user-stopped from crash-stopped).
+	d.vmMgr.UpdateState(instance.ID, func(v *vm.VM) { v.Attributes = command.Attributes })
 
-	// Respond immediately - operation will complete in background
-	// stopInstance() handles the QMP shutdown command, so we don't send it here
+	// Respond immediately - cleanup completes in background.
 	if err := msg.Respond([]byte(`{}`)); err != nil {
 		slog.Error("Failed to respond to NATS request", "err", err)
 	}
 
-	// Run cleanup in goroutine to not block NATS
-	go func(inst *vm.VM, attrs types.EC2CommandAttributes) {
-		stopErr := d.stopInstance(map[string]*vm.VM{inst.ID: inst}, isTerminate)
-
-		if stopErr != nil {
-			slog.Error("Failed to "+strings.ToLower(action)+" instance", "err", stopErr, "id", inst.ID)
-			if err := d.TransitionState(inst, vm.StateError); err != nil {
-				slog.Error("Failed to transition to error state", "instanceId", inst.ID, "err", err)
-			}
+	go func(id string) {
+		var err error
+		if isTerminate {
+			err = d.vmMgr.Terminate(id)
 		} else {
-			d.vmMgr.Inspect(inst, func(v *vm.VM) {
-				v.Attributes = attrs
-				v.LastNode = d.node
-			})
-
-			if err := d.TransitionState(inst, finalState); err != nil {
-				slog.Error("Failed to transition to final state", "instanceId", inst.ID, "err", err)
-			}
-			slog.Info("Instance "+string(finalState), "id", inst.ID)
-
-			// Remove instance from placement group on terminate
-			if isTerminate && inst.PlacementGroupName != "" && d.placementGroupService != nil {
-				if _, pgErr := d.placementGroupService.RemoveInstance(&handlers_ec2_placementgroup.RemoveInstanceInput{
-					GroupName:  inst.PlacementGroupName,
-					NodeName:   inst.PlacementGroupNode,
-					InstanceID: inst.ID,
-				}, inst.AccountID); pgErr != nil {
-					slog.Error("Failed to remove instance from placement group",
-						"instanceId", inst.ID, "groupName", inst.PlacementGroupName, "err", pgErr)
-				}
-			}
-
-			if d.jsManager != nil {
-				if isTerminate {
-					// Write to terminated KV bucket (auto-expires after 1 hour via TTL).
-					// If this fails, keep the instance in local state so DescribeInstances
-					// still sees it and restoreInstances can retry the KV migration.
-					if err := d.jsManager.WriteTerminatedInstance(inst.ID, inst); err != nil {
-						slog.Error("Failed to write terminated instance to KV, keeping in local state for retry",
-							"instanceId", inst.ID, "err", err)
-						return
-					}
-				} else {
-					// Write to shared KV first — if daemon crashes after this but
-					// before local cleanup, restoreInstances handles the overlap.
-					if err := d.jsManager.WriteStoppedInstance(inst.ID, inst); err != nil {
-						slog.Error("Failed to write stopped instance to shared KV, keeping local ownership",
-							"instanceId", inst.ID, "err", err)
-						return
-					}
-				}
-
-				// Guard + delete must be atomic under the same lock hold.
-				// A concurrent ec2.start handler may have loaded the instance
-				// from stopped KV, re-added it to VMS with a new pointer, and
-				// launched it. Deleting here would destroy the running instance's
-				// state — creating a "ghost instance" visible nowhere.
-				if !d.vmMgr.DeleteIf(inst.ID, inst) {
-					slog.Info("Instance was reclaimed by another handler, skipping local cleanup",
-						"instanceId", inst.ID, "state", string(finalState))
-					return
-				}
-
-				// Unsubscribe from per-instance NATS topic. Safe to do after
-				// the delete — LaunchInstance already unsubscribes stale entries
-				// before creating new ones (daemon.go:1658-1664).
-				d.mu.Lock()
-				if sub, ok := d.natsSubscriptions[inst.ID]; ok {
-					if err := sub.Unsubscribe(); err != nil {
-						slog.Error("Failed to unsubscribe instance", "instanceId", inst.ID, "err", err)
-					}
-					delete(d.natsSubscriptions, inst.ID)
-				}
-				d.mu.Unlock()
-
-				// Persist local state without the instance
-				if err := d.WriteState(); err != nil {
-					slog.Error("Failed to persist state after releasing instance, re-adding to local map for consistency",
-						"instanceId", inst.ID, "err", err)
-					// Only re-add if another handler hasn't claimed the slot
-					d.vmMgr.InsertIfAbsent(inst)
-				} else {
-					slog.Info("Released instance ownership to KV",
-						"instanceId", inst.ID, "state", string(finalState), "lastNode", d.node)
-				}
-			}
+			err = d.vmMgr.Stop(id)
 		}
-	}(instance, command.Attributes)
+		if err != nil {
+			slog.Error("Failed to "+strings.ToLower(action)+" instance", "err", err, "id", id)
+		}
+	}(instance.ID)
 }
 
 // describeInstancesValidFilters defines the set of filter names accepted by DescribeInstances.

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -350,15 +350,10 @@ func (d *Daemon) TerminateSystemInstance(instanceID string) error {
 		return fmt.Errorf("instance %s not found", instanceID)
 	}
 
-	// Transition to shutting-down
-	if err := d.TransitionState(instance, vm.StateShuttingDown); err != nil {
-		return fmt.Errorf("transition to shutting-down: %w", err)
-	}
-
 	// Release EIP through the EIP service for system VMs whose public IP was
 	// allocated via AllocateAddress (internet-facing ALBs). Clears the fields
-	// so the generic teardown path in stopInstance doesn't try to
-	// double-release the same IP through externalIPAM directly.
+	// so vm.Manager.Terminate's ReleasePublicIP doesn't double-release the
+	// same IP via externalIPAM.
 	if instance.PublicIPAllocID != "" && d.eipService != nil {
 		eniAccount := instance.AccountID
 		if instance.PublicIPAssocID != "" {
@@ -375,85 +370,30 @@ func (d *Daemon) TerminateSystemInstance(instanceID string) error {
 		} else {
 			slog.Info("TerminateSystemInstance: released EIP", "instanceId", instanceID, "ip", instance.PublicIP, "allocationId", instance.PublicIPAllocID)
 		}
-		instance.PublicIP = ""
-		instance.PublicIPPool = ""
-		instance.PublicIPAllocID = ""
-		instance.PublicIPAssocID = ""
+		d.vmMgr.Inspect(instance, func(v *vm.VM) {
+			v.PublicIP = ""
+			v.PublicIPPool = ""
+			v.PublicIPAllocID = ""
+			v.PublicIPAssocID = ""
+		})
 	}
 
-	// Stop the VM (QEMU shutdown, volume unmount, tap cleanup)
-	if err := d.stopInstance(map[string]*vm.VM{instanceID: instance}, true); err != nil {
-		slog.Error("TerminateSystemInstance: stopInstance failed", "instanceId", instanceID, "err", err)
-		return fmt.Errorf("stop instance: %w", err)
-	}
-
-	if err := d.TransitionState(instance, vm.StateTerminated); err != nil {
-		slog.Warn("TerminateSystemInstance: failed to transition to terminated", "instanceId", instanceID, "err", err)
-	}
-
-	// Write to terminated KV bucket (auto-expires)
-	if d.jsManager != nil {
-		if err := d.jsManager.WriteTerminatedInstance(instanceID, instance); err != nil {
-			slog.Warn("TerminateSystemInstance: failed to write terminated state", "instanceId", instanceID, "err", err)
-		}
-	}
-
-	// Clean up local state
-	d.vmMgr.Delete(instanceID)
-
-	// Unsubscribe from per-instance NATS topic
-	d.mu.Lock()
-	if sub, ok := d.natsSubscriptions[instanceID]; ok {
-		if err := sub.Unsubscribe(); err != nil {
-			slog.Warn("TerminateSystemInstance: failed to unsubscribe", "instanceId", instanceID, "err", err)
-		}
-		delete(d.natsSubscriptions, instanceID)
-	}
-	d.mu.Unlock()
-
-	// Deallocate resources
-	if it, ok := d.resourceMgr.instanceTypes[instance.InstanceType]; ok {
-		d.resourceMgr.deallocate(it)
+	if err := d.vmMgr.Terminate(instanceID); err != nil {
+		slog.Error("TerminateSystemInstance: vmMgr.Terminate failed", "instanceId", instanceID, "err", err)
+		return fmt.Errorf("terminate: %w", err)
 	}
 
 	slog.Info("TerminateSystemInstance completed", "instanceId", instanceID)
 	return nil
 }
 
-// cleanupFailedSystemInstance handles cleanup when a system instance launch fails
-// after partial setup (state added, volumes created, etc).
-func (d *Daemon) cleanupFailedSystemInstance(instance *vm.VM, instanceType *ec2.InstanceTypeInfo) {
-	d.markInstanceFailed(instance, "system_instance_launch_failed")
-	d.resourceMgr.deallocate(instanceType)
-
-	// Clean up management TAP and release IP
-	if instance.MgmtTap != "" {
-		if err := CleanupMgmtTapDevice(instance.MgmtTap); err != nil {
-			slog.Warn("Failed to cleanup mgmt tap on failed launch", "tap", instance.MgmtTap, "err", err)
-		}
-		if d.mgmtIPAllocator != nil {
-			d.mgmtIPAllocator.Release(instance.ID)
-		}
-	}
-
-	// Clean up ENI if we auto-created one (not pre-created)
-	// Pre-created ENIs are managed by the caller (e.g. ELBv2 service)
-	if instance.ENIId != "" && d.vpcService != nil {
-		// Only clean up ENIs we created (description starts with "System interface")
-		result, err := d.vpcService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
-			NetworkInterfaceIds: []*string{aws.String(instance.ENIId)},
-		}, utils.GlobalAccountID)
-		if err == nil && len(result.NetworkInterfaces) > 0 {
-			desc := aws.StringValue(result.NetworkInterfaces[0].Description)
-			if len(desc) >= 16 && desc[:16] == "System interface" {
-				if _, delErr := d.vpcService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-					NetworkInterfaceId: aws.String(instance.ENIId),
-				}, utils.GlobalAccountID); delErr != nil {
-					slog.Warn("Failed to cleanup system ENI", "eniId", instance.ENIId, "err", delErr)
-				}
-			}
-		}
-	}
+// cleanupFailedSystemInstance handles cleanup when a system instance launch
+// fails after partial setup (state added, volumes created, etc). Delegates
+// to vm.Manager.MarkFailed which runs the synchronous teardown chain
+// (volume unmount/delete, tap cleanup, ENI delete, IP release, resource
+// deallocation, state migration to terminated KV).
+func (d *Daemon) cleanupFailedSystemInstance(instance *vm.VM, _ *ec2.InstanceTypeInfo) {
+	d.vmMgr.MarkFailed(instance, "system_instance_launch_failed")
 }
 
 // WaitForSystemInstance polls until the instance reaches running state or times out.

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -1787,32 +1787,17 @@ func TestGenerateVolumes_DeleteOnTermination_FromBlockDeviceMapping(t *testing.T
 	}
 }
 
-// TestStopInstance_DeleteOnTermination_VolumeDeletion tests that stopInstance
-// correctly handles DeleteOnTermination for each volume type.
-// Uses embedded NATS with mock subscribers to verify NATS messages.
-func TestStopInstance_DeleteOnTermination_VolumeDeletion(t *testing.T) {
+// TestInstanceCleanerAdapter_DeleteVolumes_DeleteOnTermination tests that
+// the instanceCleanerAdapter correctly handles DeleteOnTermination for each
+// volume type: internal volumes (EFI, cloud-init) always go through
+// ebs.delete; user volumes only when DeleteOnTermination is true.
+func TestInstanceCleanerAdapter_DeleteVolumes_DeleteOnTermination(t *testing.T) {
 	natsURL := sharedNATSURL
 
 	daemon := createTestDaemon(t, natsURL)
 
-	// Track which NATS messages are received
 	var mu sync.Mutex
-	unmountedVolumes := make(map[string]bool)
 	ebsDeletedVolumes := make(map[string]bool)
-
-	// Mock ebs.unmount subscriber
-	unmountSub, err := daemon.natsConn.Subscribe("ebs.node-1.unmount", func(msg *nats.Msg) {
-		var req types.EBSRequest
-		json.Unmarshal(msg.Data, &req)
-		mu.Lock()
-		unmountedVolumes[req.Name] = true
-		mu.Unlock()
-		resp := types.EBSUnMountResponse{Volume: req.Name, Mounted: false}
-		data, _ := json.Marshal(resp)
-		msg.Respond(data)
-	})
-	require.NoError(t, err)
-	defer unmountSub.Unsubscribe()
 
 	// Mock ebs.delete subscriber
 	deleteSub, err := daemon.natsConn.Subscribe("ebs.delete", func(msg *nats.Msg) {
@@ -1828,48 +1813,20 @@ func TestStopInstance_DeleteOnTermination_VolumeDeletion(t *testing.T) {
 	require.NoError(t, err)
 	defer deleteSub.Unsubscribe()
 
-	// Subscribe to the instance NATS topic to avoid unsubscribe errors
-	instanceSub, err := daemon.natsConn.Subscribe("ec2.cmd.i-test-dot", func(msg *nats.Msg) {})
-	require.NoError(t, err)
-	defer instanceSub.Unsubscribe()
-	daemon.natsSubscriptions["ec2.cmd.i-test-dot"] = instanceSub
-
 	instance := &vm.VM{
-		ID:           "i-test-dot",
-		InstanceType: getTestInstanceType(t),
-		Status:       vm.StateRunning,
-		AccountID:    testAccountID,
-		QMPClient:    &qmp.QMPClient{}, // nil encoder/decoder => QMP will fail, which is fine
+		ID:        "i-test-dot",
+		AccountID: testAccountID,
 		EBSRequests: types.EBSRequests{
 			Requests: []types.EBSRequest{
-				{
-					Name:                "vol-root",
-					Boot:                true,
-					DeleteOnTermination: true,
-				},
-				{
-					Name: "vol-root-efi",
-					EFI:  true,
-				},
-				{
-					Name:      "vol-root-cloudinit",
-					CloudInit: true,
-				},
+				{Name: "vol-root", Boot: true, DeleteOnTermination: true},
+				{Name: "vol-root-efi", EFI: true},
+				{Name: "vol-root-cloudinit", CloudInit: true},
 			},
 		},
 	}
 
-	// Allocate resources so deallocate doesn't go negative
-	instanceType := daemon.resourceMgr.instanceTypes[instance.InstanceType]
-	require.NotNil(t, instanceType)
-	err = daemon.resourceMgr.allocate(instanceType)
-	require.NoError(t, err)
-
-	daemon.vmMgr.Insert(instance)
-
-	// Call stopInstance with deleteVolume=true (termination)
-	err = daemon.stopInstance(map[string]*vm.VM{instance.ID: instance}, true)
-	assert.NoError(t, err)
+	cleaner := newInstanceCleanerAdapter(daemon)
+	cleaner.DeleteVolumes(instance)
 
 	// Allow NATS messages to propagate
 	time.Sleep(200 * time.Millisecond)
@@ -1877,42 +1834,22 @@ func TestStopInstance_DeleteOnTermination_VolumeDeletion(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	// All volumes should be unmounted
-	assert.True(t, unmountedVolumes["vol-root"], "Root volume should be unmounted")
-	assert.True(t, unmountedVolumes["vol-root-efi"], "EFI volume should be unmounted")
-	assert.True(t, unmountedVolumes["vol-root-cloudinit"], "Cloud-init volume should be unmounted")
-
 	// Internal volumes (EFI, cloud-init) should receive ebs.delete
 	assert.True(t, ebsDeletedVolumes["vol-root-efi"], "EFI volume should receive ebs.delete")
 	assert.True(t, ebsDeletedVolumes["vol-root-cloudinit"], "Cloud-init volume should receive ebs.delete")
 }
 
-// TestStopInstance_DeleteOnTermination_False_SkipsVolumeDeletion verifies that
-// volumes with DeleteOnTermination=false are NOT deleted during termination.
-func TestStopInstance_DeleteOnTermination_False_SkipsVolumeDeletion(t *testing.T) {
+// TestInstanceCleanerAdapter_DeleteVolumes_DeleteOnTermination_False verifies
+// that volumes with DeleteOnTermination=false are NOT deleted during
+// termination, while internal volumes still are.
+func TestInstanceCleanerAdapter_DeleteVolumes_DeleteOnTermination_False(t *testing.T) {
 	natsURL := sharedNATSURL
 
 	daemon := createTestDaemon(t, natsURL)
 
 	var mu sync.Mutex
-	unmountedVolumes := make(map[string]bool)
 	ebsDeletedVolumes := make(map[string]bool)
 
-	// Mock ebs.unmount subscriber
-	unmountSub, err := daemon.natsConn.Subscribe("ebs.node-1.unmount", func(msg *nats.Msg) {
-		var req types.EBSRequest
-		json.Unmarshal(msg.Data, &req)
-		mu.Lock()
-		unmountedVolumes[req.Name] = true
-		mu.Unlock()
-		resp := types.EBSUnMountResponse{Volume: req.Name, Mounted: false}
-		data, _ := json.Marshal(resp)
-		msg.Respond(data)
-	})
-	require.NoError(t, err)
-	defer unmountSub.Unsubscribe()
-
-	// Mock ebs.delete subscriber
 	deleteSub, err := daemon.natsConn.Subscribe("ebs.delete", func(msg *nats.Msg) {
 		var req types.EBSDeleteRequest
 		json.Unmarshal(msg.Data, &req)
@@ -1926,138 +1863,32 @@ func TestStopInstance_DeleteOnTermination_False_SkipsVolumeDeletion(t *testing.T
 	require.NoError(t, err)
 	defer deleteSub.Unsubscribe()
 
-	// Subscribe to the instance NATS topic
-	instanceSub, err := daemon.natsConn.Subscribe("ec2.cmd.i-test-no-delete", func(msg *nats.Msg) {})
-	require.NoError(t, err)
-	defer instanceSub.Unsubscribe()
-	daemon.natsSubscriptions["ec2.cmd.i-test-no-delete"] = instanceSub
-
 	instance := &vm.VM{
-		ID:           "i-test-no-delete",
-		InstanceType: getTestInstanceType(t),
-		Status:       vm.StateRunning,
-		AccountID:    testAccountID,
-		QMPClient:    &qmp.QMPClient{},
+		ID:        "i-test-no-delete",
+		AccountID: testAccountID,
 		EBSRequests: types.EBSRequests{
 			Requests: []types.EBSRequest{
-				{
-					Name:                "vol-keep",
-					Boot:                true,
-					DeleteOnTermination: false, // Should NOT be deleted
-				},
-				{
-					Name: "vol-keep-efi",
-					EFI:  true,
-				},
-				{
-					Name:      "vol-keep-cloudinit",
-					CloudInit: true,
-				},
+				{Name: "vol-keep", Boot: true, DeleteOnTermination: false},
+				{Name: "vol-keep-efi", EFI: true},
+				{Name: "vol-keep-cloudinit", CloudInit: true},
 			},
 		},
 	}
 
-	instanceType := daemon.resourceMgr.instanceTypes[instance.InstanceType]
-	require.NotNil(t, instanceType)
-	err = daemon.resourceMgr.allocate(instanceType)
-	require.NoError(t, err)
-
-	daemon.vmMgr.Insert(instance)
-
-	// Call stopInstance with deleteVolume=true (termination)
-	err = daemon.stopInstance(map[string]*vm.VM{instance.ID: instance}, true)
-	assert.NoError(t, err)
+	cleaner := newInstanceCleanerAdapter(daemon)
+	cleaner.DeleteVolumes(instance)
 
 	time.Sleep(200 * time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()
 
-	// All volumes should still be unmounted
-	assert.True(t, unmountedVolumes["vol-keep"], "Root volume should be unmounted")
-	assert.True(t, unmountedVolumes["vol-keep-efi"], "EFI volume should be unmounted")
-	assert.True(t, unmountedVolumes["vol-keep-cloudinit"], "Cloud-init volume should be unmounted")
-
-	// Internal volumes should still get ebs.delete (always cleaned up)
+	// Internal volumes still get ebs.delete (always cleaned up)
 	assert.True(t, ebsDeletedVolumes["vol-keep-efi"], "EFI volume should receive ebs.delete even when root has DeleteOnTermination=false")
 	assert.True(t, ebsDeletedVolumes["vol-keep-cloudinit"], "Cloud-init volume should receive ebs.delete even when root has DeleteOnTermination=false")
 
-	// Root volume with DeleteOnTermination=false should NOT have ebs.delete called
+	// Root volume with DeleteOnTermination=false should NOT receive ebs.delete
 	assert.False(t, ebsDeletedVolumes["vol-keep"], "Root volume with DeleteOnTermination=false should NOT be deleted")
-}
-
-// TestStopInstance_NoDelete_OnStop verifies that volumes are NOT deleted during
-// a regular stop (non-termination), regardless of DeleteOnTermination flag.
-func TestStopInstance_NoDelete_OnStop(t *testing.T) {
-	natsURL := sharedNATSURL
-
-	daemon := createTestDaemon(t, natsURL)
-
-	var mu sync.Mutex
-	ebsDeletedVolumes := make(map[string]bool)
-
-	// Mock ebs.unmount subscriber
-	unmountSub, err := daemon.natsConn.Subscribe("ebs.node-1.unmount", func(msg *nats.Msg) {
-		resp := types.EBSUnMountResponse{Mounted: false}
-		data, _ := json.Marshal(resp)
-		msg.Respond(data)
-	})
-	require.NoError(t, err)
-	defer unmountSub.Unsubscribe()
-
-	// Mock ebs.delete subscriber - should NOT be called
-	deleteSub, err := daemon.natsConn.Subscribe("ebs.delete", func(msg *nats.Msg) {
-		var req types.EBSDeleteRequest
-		json.Unmarshal(msg.Data, &req)
-		mu.Lock()
-		ebsDeletedVolumes[req.Volume] = true
-		mu.Unlock()
-		resp := types.EBSDeleteResponse{Volume: req.Volume, Success: true}
-		data, _ := json.Marshal(resp)
-		msg.Respond(data)
-	})
-	require.NoError(t, err)
-	defer deleteSub.Unsubscribe()
-
-	instance := &vm.VM{
-		ID:           "i-test-stop-only",
-		InstanceType: getTestInstanceType(t),
-		Status:       vm.StateRunning,
-		AccountID:    testAccountID,
-		QMPClient:    &qmp.QMPClient{},
-		EBSRequests: types.EBSRequests{
-			Requests: []types.EBSRequest{
-				{
-					Name:                "vol-stop-root",
-					Boot:                true,
-					DeleteOnTermination: true, // Even with true, stop should NOT delete
-				},
-				{
-					Name: "vol-stop-efi",
-					EFI:  true,
-				},
-			},
-		},
-	}
-
-	instanceType := daemon.resourceMgr.instanceTypes[instance.InstanceType]
-	require.NotNil(t, instanceType)
-	err = daemon.resourceMgr.allocate(instanceType)
-	require.NoError(t, err)
-
-	daemon.vmMgr.Insert(instance)
-
-	// Call stopInstance with deleteVolume=false (stop, not terminate)
-	err = daemon.stopInstance(map[string]*vm.VM{instance.ID: instance}, false)
-	assert.NoError(t, err)
-
-	time.Sleep(200 * time.Millisecond)
-
-	mu.Lock()
-	defer mu.Unlock()
-
-	// No volumes should be deleted during a stop operation
-	assert.Empty(t, ebsDeletedVolumes, "No volumes should be deleted during stop (not terminate)")
 }
 
 // TestHandleEC2Events_AttachVolume tests the attach-volume handler in handleEC2Events
@@ -3250,60 +3081,51 @@ func TestNewDaemon_WalDirPreservedIfSet(t *testing.T) {
 	assert.Equal(t, "/fast-ssd/wal", d.config.WalDir)
 }
 
-// TestMarkInstanceFailed verifies that markInstanceFailed sets the StateReason and
-// transitions the instance to StateShuttingDown.
+// TestMarkInstanceFailed verifies that MarkFailed sets the StateReason and
+// runs the cleanup chain. The instance ends up in StateTerminated since
+// MarkFailed runs the full Terminate pipeline.
 func TestMarkInstanceFailed(t *testing.T) {
-	natsURL := sharedNATSURL
-
-	daemon := createTestDaemon(t, natsURL)
+	daemon := createDaemonWithJetStream(t)
 
 	instanceID := "i-test-mark-failed"
 	ec2Instance := &ec2.Instance{}
 	ec2Instance.SetInstanceId(instanceID)
 
 	instance := &vm.VM{
-		ID:           instanceID,
-		InstanceType: getTestInstanceType(t),
-		Status:       vm.StatePending,
-		AccountID:    testAccountID,
-		Instance:     ec2Instance,
-		QMPClient:    &qmp.QMPClient{},
+		ID:        instanceID,
+		Status:    vm.StatePending,
+		AccountID: testAccountID,
+		Instance:  ec2Instance,
 	}
 	daemon.vmMgr.Insert(instance)
 
-	daemon.markInstanceFailed(instance, "volume_preparation_failed")
+	daemon.vmMgr.MarkFailed(instance, "volume_preparation_failed")
 
-	// Verify state transitioned to shutting-down
-	assert.Equal(t, vm.StateShuttingDown, instance.Status)
-
-	// Verify StateReason was set
+	// Verify StateReason was set on the original snapshot before cleanup.
 	require.NotNil(t, instance.Instance.StateReason)
 	assert.Equal(t, "Server.InternalError", *instance.Instance.StateReason.Code)
 	assert.Equal(t, "volume_preparation_failed", *instance.Instance.StateReason.Message)
+	assert.Equal(t, vm.StateTerminated, instance.Status)
 }
 
-// TestMarkInstanceFailed_NilInstance verifies that markInstanceFailed handles
+// TestMarkInstanceFailed_NilInstance verifies that MarkFailed handles
 // a VM with no ec2.Instance (Instance == nil) gracefully.
 func TestMarkInstanceFailed_NilInstance(t *testing.T) {
-	natsURL := sharedNATSURL
-
-	daemon := createTestDaemon(t, natsURL)
+	daemon := createDaemonWithJetStream(t)
 
 	instanceID := "i-test-mark-failed-nil"
 	instance := &vm.VM{
-		ID:           instanceID,
-		InstanceType: getTestInstanceType(t),
-		Status:       vm.StatePending,
-		AccountID:    testAccountID,
-		Instance:     nil, // no ec2.Instance
-		QMPClient:    &qmp.QMPClient{},
+		ID:        instanceID,
+		Status:    vm.StatePending,
+		AccountID: testAccountID,
+		Instance:  nil, // no ec2.Instance
 	}
 	daemon.vmMgr.Insert(instance)
 
 	// Should not panic
-	daemon.markInstanceFailed(instance, "test_failure")
+	daemon.vmMgr.MarkFailed(instance, "test_failure")
 
-	assert.Equal(t, vm.StateShuttingDown, instance.Status)
+	assert.Equal(t, vm.StateTerminated, instance.Status)
 }
 
 // TestRollbackEBSMount_Success verifies that rollbackEBSMount sends an ebs.unmount

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -3082,8 +3082,8 @@ func TestNewDaemon_WalDirPreservedIfSet(t *testing.T) {
 }
 
 // TestMarkInstanceFailed verifies that MarkFailed sets the StateReason and
-// runs the cleanup chain. The instance ends up in StateTerminated since
-// MarkFailed runs the full Terminate pipeline.
+// transitions the instance to ShuttingDown synchronously, then completes
+// the cleanup chain to Terminated in a goroutine.
 func TestMarkInstanceFailed(t *testing.T) {
 	daemon := createDaemonWithJetStream(t)
 
@@ -3101,11 +3101,15 @@ func TestMarkInstanceFailed(t *testing.T) {
 
 	daemon.vmMgr.MarkFailed(instance, "volume_preparation_failed")
 
-	// Verify StateReason was set on the original snapshot before cleanup.
+	// Synchronous: state reason set, transition to shutting-down done.
 	require.NotNil(t, instance.Instance.StateReason)
 	assert.Equal(t, "Server.InternalError", *instance.Instance.StateReason.Code)
 	assert.Equal(t, "volume_preparation_failed", *instance.Instance.StateReason.Message)
-	assert.Equal(t, vm.StateTerminated, instance.Status)
+	require.Eventually(t, func() bool {
+		var status vm.InstanceState
+		daemon.vmMgr.Inspect(instance, func(v *vm.VM) { status = v.Status })
+		return status == vm.StateTerminated
+	}, 5*time.Second, 10*time.Millisecond, "cleanup goroutine should reach terminated")
 }
 
 // TestMarkInstanceFailed_NilInstance verifies that MarkFailed handles
@@ -3125,7 +3129,11 @@ func TestMarkInstanceFailed_NilInstance(t *testing.T) {
 	// Should not panic
 	daemon.vmMgr.MarkFailed(instance, "test_failure")
 
-	assert.Equal(t, vm.StateTerminated, instance.Status)
+	require.Eventually(t, func() bool {
+		var status vm.InstanceState
+		daemon.vmMgr.Inspect(instance, func(v *vm.VM) { status = v.Status })
+		return status == vm.StateTerminated
+	}, 5*time.Second, 10*time.Millisecond, "cleanup goroutine should reach terminated")
 }
 
 // TestRollbackEBSMount_Success verifies that rollbackEBSMount sends an ebs.unmount

--- a/spinifex/daemon/network.go
+++ b/spinifex/daemon/network.go
@@ -113,17 +113,6 @@ func (p *OVSNetworkPlumber) CleanupTapDevice(eniId string) error {
 	return nil
 }
 
-// cleanupExtraENITaps removes tap devices for every extra ENI attached to a
-// system VM. Errors are logged but not returned so a partial cleanup still
-// frees as many resources as possible.
-func (d *Daemon) cleanupExtraENITaps(instance *vm.VM) {
-	for _, extra := range instance.ExtraENIs {
-		if err := d.networkPlumber.CleanupTapDevice(extra.ENIID); err != nil {
-			slog.Warn("Failed to clean up extra ENI tap device", "eni", extra.ENIID, "err", err)
-		}
-	}
-}
-
 // OVSIfaceID returns the OVS external_ids:iface-id value for an ENI.
 // This must match the OVN LogicalSwitchPort name for ovn-controller binding.
 func OVSIfaceID(eniId string) string {

--- a/spinifex/daemon/network_test.go
+++ b/spinifex/daemon/network_test.go
@@ -229,49 +229,6 @@ func TestGenerateDevMAC(t *testing.T) {
 	}
 }
 
-func TestCleanupExtraENITaps_CallsCleanupPerExtra(t *testing.T) {
-	mock := &MockNetworkPlumber{}
-	d := &Daemon{networkPlumber: mock}
-	instance := &vm.VM{
-		ID: "i-multi-clean",
-		ExtraENIs: []vm.ExtraENI{
-			{ENIID: "eni-111"},
-			{ENIID: "eni-222"},
-			{ENIID: "eni-333"},
-		},
-	}
-
-	d.cleanupExtraENITaps(instance)
-
-	if len(mock.CleanupCalls) != 3 {
-		t.Fatalf("expected 3 cleanup calls, got %d", len(mock.CleanupCalls))
-	}
-	for i, want := range []string{"eni-111", "eni-222", "eni-333"} {
-		if mock.CleanupCalls[i] != want {
-			t.Errorf("cleanup[%d] = %q, want %q", i, mock.CleanupCalls[i], want)
-		}
-	}
-}
-
-func TestCleanupExtraENITaps_ErrorsAreLogged(t *testing.T) {
-	mock := &MockNetworkPlumber{CleanupErr: fmt.Errorf("simulated cleanup failure")}
-	d := &Daemon{networkPlumber: mock}
-	instance := &vm.VM{
-		ID: "i-multi-clean-err",
-		ExtraENIs: []vm.ExtraENI{
-			{ENIID: "eni-111"},
-			{ENIID: "eni-222"},
-		},
-	}
-
-	// Must not panic or return — errors are swallowed by design so partial
-	// cleanup still frees later entries.
-	d.cleanupExtraENITaps(instance)
-	if len(mock.CleanupCalls) != 2 {
-		t.Errorf("expected both extras to be attempted, got %d cleanup calls", len(mock.CleanupCalls))
-	}
-}
-
 func TestFindInterfaceByIP_InvalidIP(t *testing.T) {
 	_, err := findInterfaceByIP("not-an-ip")
 	if err == nil {

--- a/spinifex/daemon/shutdown.go
+++ b/spinifex/daemon/shutdown.go
@@ -112,18 +112,16 @@ func (d *Daemon) handleShutdownDrain(msg *nats.Msg) {
 
 	slog.Info("Shutdown DRAIN phase starting", "node", d.node)
 
-	// Snapshot VMs to stop. The snapshot decouples iteration from concurrent
-	// terminate handlers and avoids holding the manager lock across the
-	// shutdown fan-out.
-	vms := d.vmMgr.SnapshotMap()
-	total := len(vms)
+	total := d.vmMgr.Count()
 
 	// Publish initial progress
 	d.publishShutdownProgress("drain", total, total)
 
-	// Stop all instances (graceful shutdown, no volume deletion)
+	// Stop all instances (graceful shutdown, no volume deletion). StopAll
+	// fans out per-VM shutdown internally; the manager's snapshot decouples
+	// iteration from concurrent terminate handlers.
 	if total > 0 {
-		if err := d.stopInstance(vms, false); err != nil {
+		if err := d.vmMgr.StopAll(); err != nil {
 			slog.Error("Failed to stop instances during DRAIN", "error", err)
 			ack := ShutdownACK{
 				Node:  d.node,

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -41,6 +41,16 @@ func createDaemonWithJetStream(t *testing.T) *Daemon {
 	require.NoError(t, daemon.jsManager.InitClusterStateBucket())
 	require.NoError(t, daemon.jsManager.InitTerminatedInstanceBucket())
 
+	// Wire just enough vm.Deps for manager-driven state operations to work
+	// (migrate, MarkFailed). Full wiring (network plumber, instance cleaner,
+	// volume mounter) is a Daemon.Start responsibility and is not needed
+	// here since these tests don't drive a real VM lifecycle.
+	daemon.vmMgr.SetDeps(vm.Deps{
+		NodeID:          daemon.node,
+		StateStore:      newStateStoreAdapter(daemon.jsManager),
+		TransitionState: daemon.TransitionState,
+	})
+
 	return daemon
 }
 
@@ -837,7 +847,7 @@ func TestMigrateInstanceToKV(t *testing.T) {
 	// Test stopped migration
 	stoppedVM := &vm.VM{ID: "i-migrate-stop", Status: vm.StateStopped}
 	daemon.vmMgr.Insert(stoppedVM)
-	assert.True(t, daemon.migrateStoppedToSharedKV(stoppedVM))
+	assert.True(t, daemon.vmMgr.MigrateStoppedToSharedKV(stoppedVM))
 	assertVMNotPresent(t, daemon, stoppedVM.ID, "should be removed from local map")
 	loaded, err := daemon.jsManager.LoadStoppedInstance(stoppedVM.ID)
 	require.NoError(t, err)
@@ -847,7 +857,7 @@ func TestMigrateInstanceToKV(t *testing.T) {
 	// Test terminated migration
 	terminatedVM := &vm.VM{ID: "i-migrate-term", Status: vm.StateTerminated}
 	daemon.vmMgr.Insert(terminatedVM)
-	assert.True(t, daemon.migrateTerminatedToKV(terminatedVM))
+	assert.True(t, daemon.vmMgr.MigrateTerminatedToKV(terminatedVM))
 	assertVMNotPresent(t, daemon, terminatedVM.ID, "should be removed from local map")
 	loadedTerm, err := daemon.jsManager.LoadTerminatedInstance(terminatedVM.ID)
 	require.NoError(t, err)
@@ -855,15 +865,19 @@ func TestMigrateInstanceToKV(t *testing.T) {
 	assert.Equal(t, daemon.node, loadedTerm.LastNode)
 }
 
-// TestMigrateInstanceToKV_NoJetStream verifies graceful failure when JetStream is nil.
-func TestMigrateInstanceToKV_NoJetStream(t *testing.T) {
+// TestMigrateInstanceToKV_NoStateStore verifies graceful failure when the
+// manager has no StateStore wired (the fresh-Daemon equivalent of "no
+// JetStream").
+func TestMigrateInstanceToKV_NoStateStore(t *testing.T) {
 	daemon := createDaemonWithJetStream(t)
-	daemon.jsManager = nil
+	// Re-set deps without the StateStore so MigrateStoppedToSharedKV /
+	// MigrateTerminatedToKV early-return false.
+	daemon.vmMgr.SetDeps(vm.Deps{NodeID: daemon.node})
 
 	vm1 := &vm.VM{ID: "i-no-js", Status: vm.StateStopped}
 	daemon.vmMgr.Insert(vm1)
-	assert.False(t, daemon.migrateStoppedToSharedKV(vm1))
-	assert.False(t, daemon.migrateTerminatedToKV(vm1))
+	assert.False(t, daemon.vmMgr.MigrateStoppedToSharedKV(vm1))
+	assert.False(t, daemon.vmMgr.MigrateTerminatedToKV(vm1))
 	// Instance should still be in local map since migration failed
 	assertVMPresent(t, daemon, vm1.ID)
 }
@@ -994,16 +1008,22 @@ func TestPendingWatchdog_MarksStuckInstanceFailed(t *testing.T) {
 			stuck = append(stuck, instance)
 		}
 	}
+	// Snapshot the stuck instance before MarkFailed runs the full cleanup
+	// chain — finalizeTerminated removes it from the local map.
+	stuckBefore, _ := daemon.vmMgr.Get("i-stuck")
+	require.NotNil(t, stuckBefore)
 	for _, instance := range stuck {
-		daemon.markInstanceFailed(instance, "launch_timeout")
+		daemon.vmMgr.MarkFailed(instance, "launch_timeout")
 	}
 
-	// Stuck instance should have transitioned to shutting-down
-	stuckInst, _ := daemon.vmMgr.Get("i-stuck")
-	assert.Equal(t, vm.StateShuttingDown, stuckInst.Status)
-	require.NotNil(t, stuckInst.Instance.StateReason)
-	assert.Equal(t, "Server.InternalError", *stuckInst.Instance.StateReason.Code)
-	assert.Equal(t, "launch_timeout", *stuckInst.Instance.StateReason.Message)
+	// MarkFailed sets the StateReason synchronously and runs the cleanup
+	// chain to terminated. The instance is removed from the local map by
+	// finalizeTerminated, so verify the StateReason on the snapshot we
+	// captured before the call.
+	require.NotNil(t, stuckBefore.Instance.StateReason)
+	assert.Equal(t, "Server.InternalError", *stuckBefore.Instance.StateReason.Code)
+	assert.Equal(t, "launch_timeout", *stuckBefore.Instance.StateReason.Message)
+	assert.Equal(t, vm.StateTerminated, stuckBefore.Status)
 
 	// Fresh instance should still be pending
 	freshInst, _ := daemon.vmMgr.Get("i-fresh")
@@ -1102,7 +1122,7 @@ func TestMarkInstanceFailed_AlreadyShuttingDown(t *testing.T) {
 	daemon.vmMgr.Insert(instance)
 
 	// Should be a no-op — instance is already being cleaned up
-	daemon.markInstanceFailed(instance, "test_reason")
+	daemon.vmMgr.MarkFailed(instance, "test_reason")
 
 	// Status should not change
 	assert.Equal(t, vm.StateShuttingDown, instance.Status)
@@ -1118,7 +1138,7 @@ func TestMarkInstanceFailed_AlreadyTerminated(t *testing.T) {
 	}
 	daemon.vmMgr.Insert(instance)
 
-	daemon.markInstanceFailed(instance, "test_reason")
+	daemon.vmMgr.MarkFailed(instance, "test_reason")
 
 	// Status should not change
 	assert.Equal(t, vm.StateTerminated, instance.Status)

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -1016,14 +1016,17 @@ func TestPendingWatchdog_MarksStuckInstanceFailed(t *testing.T) {
 		daemon.vmMgr.MarkFailed(instance, "launch_timeout")
 	}
 
-	// MarkFailed sets the StateReason synchronously and runs the cleanup
-	// chain to terminated. The instance is removed from the local map by
-	// finalizeTerminated, so verify the StateReason on the snapshot we
-	// captured before the call.
+	// MarkFailed sets the StateReason synchronously, then runs the cleanup
+	// chain in a goroutine. The reason is observable immediately; the
+	// terminated state arrives once the goroutine completes.
 	require.NotNil(t, stuckBefore.Instance.StateReason)
 	assert.Equal(t, "Server.InternalError", *stuckBefore.Instance.StateReason.Code)
 	assert.Equal(t, "launch_timeout", *stuckBefore.Instance.StateReason.Message)
-	assert.Equal(t, vm.StateTerminated, stuckBefore.Status)
+	require.Eventually(t, func() bool {
+		var status vm.InstanceState
+		daemon.vmMgr.Inspect(stuckBefore, func(v *vm.VM) { status = v.Status })
+		return status == vm.StateTerminated
+	}, 5*time.Second, 10*time.Millisecond, "MarkFailed cleanup goroutine should reach terminated")
 
 	// Fresh instance should still be pending
 	freshInst, _ := daemon.vmMgr.Get("i-fresh")

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	"github.com/mulgadc/spinifex/spinifex/qmp"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/vm"
@@ -395,6 +399,7 @@ func (d *Daemon) buildVMManagerDeps() vm.Deps {
 		InstanceTypes:      newInstanceTypeResolverAdapter(d.resourceMgr),
 		Resources:          newResourceControllerAdapter(d.resourceMgr),
 		VolumeStateUpdater: volState,
+		InstanceCleaner:    newInstanceCleanerAdapter(d),
 		Hooks: vm.ManagerHooks{
 			OnInstanceUp:   d.onInstanceUpHook(),
 			OnInstanceDown: d.onInstanceDownHook(),
@@ -402,8 +407,167 @@ func (d *Daemon) buildVMManagerDeps() vm.Deps {
 		ShutdownSignal:     d.shuttingDown.Load,
 		CrashHandler:       d.handleInstanceCrash,
 		TransitionState:    d.TransitionState,
-		MarkInstanceFailed: d.markInstanceFailed,
+		MarkInstanceFailed: d.vmMgr.MarkFailed,
 		DevNetworking:      d.config.Daemon.DevNetworking,
 		BindHost:           d.config.Host,
+	}
+}
+
+// instanceCleanerAdapter satisfies vm.InstanceCleaner by delegating to the
+// daemon's existing volume/VPC/EIP/placement-group services. The manager
+// owns the QMP and tap teardown directly; this adapter covers the
+// AWS-resource cleanup steps that require service access.
+type instanceCleanerAdapter struct {
+	d *Daemon
+}
+
+var _ vm.InstanceCleaner = (*instanceCleanerAdapter)(nil)
+
+func newInstanceCleanerAdapter(d *Daemon) *instanceCleanerAdapter {
+	return &instanceCleanerAdapter{d: d}
+}
+
+// DeleteVolumes deletes EFI / cloud-init internal volumes via ebs.delete
+// and user volumes flagged DeleteOnTermination via the volume service.
+// Errors are logged per volume; partial failure is tolerated to match
+// pre-2c stopInstance behaviour.
+func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) {
+	instance.EBSRequests.Mu.Lock()
+	defer instance.EBSRequests.Mu.Unlock()
+
+	for _, ebsRequest := range instance.EBSRequests.Requests {
+		// Internal volumes (EFI, cloud-init) always go through ebs.delete to
+		// stop their viperblockd processes. S3 data is cleaned up via the
+		// parent root volume's DeleteVolume (which removes -efi/ and
+		// -cloudinit/ prefixes).
+		if ebsRequest.EFI || ebsRequest.CloudInit {
+			ebsDeleteData, err := json.Marshal(types.EBSDeleteRequest{Volume: ebsRequest.Name})
+			if err != nil {
+				slog.Error("Failed to marshal ebs.delete request for internal volume",
+					"name", ebsRequest.Name, "err", err)
+				continue
+			}
+			deleteMsg, err := a.d.natsConn.Request("ebs.delete", ebsDeleteData, 30*time.Second)
+			if err != nil {
+				slog.Warn("Failed to send ebs.delete for internal volume",
+					"name", ebsRequest.Name, "id", instance.ID, "err", err)
+			} else {
+				slog.Info("Sent ebs.delete for internal volume",
+					"name", ebsRequest.Name, "id", instance.ID, "data", string(deleteMsg.Data))
+			}
+			continue
+		}
+
+		// User-visible volumes: only delete when DeleteOnTermination is set.
+		if !ebsRequest.DeleteOnTermination {
+			slog.Info("Volume has DeleteOnTermination=false, skipping deletion",
+				"name", ebsRequest.Name, "id", instance.ID)
+			continue
+		}
+
+		slog.Info("Deleting volume with DeleteOnTermination=true",
+			"name", ebsRequest.Name, "id", instance.ID)
+		if a.d.volumeService == nil {
+			slog.Warn("Volume service not configured, cannot delete volume",
+				"name", ebsRequest.Name, "id", instance.ID)
+			continue
+		}
+		if _, err := a.d.volumeService.DeleteVolume(&ec2.DeleteVolumeInput{
+			VolumeId: &ebsRequest.Name,
+		}, instance.AccountID); err != nil {
+			slog.Error("Failed to delete volume on termination",
+				"name", ebsRequest.Name, "id", instance.ID, "err", err)
+		} else {
+			slog.Info("Deleted volume on termination",
+				"name", ebsRequest.Name, "id", instance.ID)
+		}
+	}
+}
+
+// CleanupMgmtNetwork tears down the management TAP device (derived from
+// instance.ID so unsetup instances are tolerated) and releases the
+// management IP allocation if the daemon has one.
+func (a *instanceCleanerAdapter) CleanupMgmtNetwork(instance *vm.VM) {
+	mgmtTap := MgmtTapName(instance.ID)
+	if err := CleanupMgmtTapDevice(mgmtTap); err != nil {
+		slog.Warn("Failed to clean up mgmt tap device",
+			"tap", mgmtTap, "instanceId", instance.ID, "err", err)
+	}
+	if a.d.mgmtIPAllocator != nil {
+		a.d.mgmtIPAllocator.Release(instance.ID)
+	}
+}
+
+// ReleasePublicIP publishes vpc.delete-nat for the OVN dnat_and_snat rule
+// and releases the public IP back to the external IPAM pool. No-op when
+// the instance has no public IP.
+func (a *instanceCleanerAdapter) ReleasePublicIP(instance *vm.VM) {
+	if instance.PublicIP == "" || instance.PublicIPPool == "" || a.d.externalIPAM == nil {
+		return
+	}
+
+	portName := "port-" + instance.ENIId
+	vpcId := ""
+	logicalIP := ""
+	if instance.Instance != nil {
+		if instance.Instance.VpcId != nil {
+			vpcId = *instance.Instance.VpcId
+		}
+		if instance.Instance.PrivateIpAddress != nil {
+			logicalIP = *instance.Instance.PrivateIpAddress
+		}
+	}
+	a.d.publishNATEvent("vpc.delete-nat", vpcId, instance.PublicIP, logicalIP, portName, "")
+
+	if err := a.d.externalIPAM.ReleaseIP(instance.PublicIPPool, instance.PublicIP); err != nil {
+		slog.Warn("Failed to release public IP on termination",
+			"ip", instance.PublicIP, "pool", instance.PublicIPPool, "err", err)
+	} else {
+		slog.Info("Released public IP on termination",
+			"ip", instance.PublicIP, "instanceId", instance.ID)
+	}
+}
+
+// DetachAndDeleteENI detaches the auto-created ENI from the instance and
+// deletes it via the VPC service. NotFound is tolerated. Extra ENIs are
+// cleaned up by the load-balancer service via its own teardown loop and
+// are not touched here.
+func (a *instanceCleanerAdapter) DetachAndDeleteENI(instance *vm.VM) {
+	if instance.ENIId == "" || a.d.vpcService == nil {
+		return
+	}
+	if detachErr := a.d.vpcService.DetachENI(instance.AccountID, instance.ENIId); detachErr != nil {
+		slog.Warn("Failed to detach ENI on termination",
+			"eni", instance.ENIId, "instanceId", instance.ID, "err", detachErr)
+	}
+	if _, eniErr := a.d.vpcService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: &instance.ENIId,
+	}, instance.AccountID); eniErr != nil {
+		if strings.Contains(eniErr.Error(), awserrors.ErrorInvalidNetworkInterfaceIDNotFound) {
+			slog.Debug("ENI already cleaned up on termination", "eni", instance.ENIId)
+		} else {
+			slog.Error("Failed to delete ENI on termination",
+				"eni", instance.ENIId, "instanceId", instance.ID, "err", eniErr)
+		}
+	} else {
+		slog.Info("Deleted ENI on termination",
+			"eni", instance.ENIId, "instanceId", instance.ID)
+	}
+}
+
+// RemoveFromPlacementGroup unbinds the instance from its placement group
+// if one is set. No-op for ungrouped instances and when the placement
+// group service is not configured.
+func (a *instanceCleanerAdapter) RemoveFromPlacementGroup(instance *vm.VM) {
+	if instance.PlacementGroupName == "" || a.d.placementGroupService == nil {
+		return
+	}
+	if _, err := a.d.placementGroupService.RemoveInstance(&handlers_ec2_placementgroup.RemoveInstanceInput{
+		GroupName:  instance.PlacementGroupName,
+		NodeName:   instance.PlacementGroupNode,
+		InstanceID: instance.ID,
+	}, instance.AccountID); err != nil {
+		slog.Error("Failed to remove instance from placement group",
+			"instanceId", instance.ID, "groupName", instance.PlacementGroupName, "err", err)
 	}
 }

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -404,12 +404,11 @@ func (d *Daemon) buildVMManagerDeps() vm.Deps {
 			OnInstanceUp:   d.onInstanceUpHook(),
 			OnInstanceDown: d.onInstanceDownHook(),
 		},
-		ShutdownSignal:     d.shuttingDown.Load,
-		CrashHandler:       d.handleInstanceCrash,
-		TransitionState:    d.TransitionState,
-		MarkInstanceFailed: d.vmMgr.MarkFailed,
-		DevNetworking:      d.config.Daemon.DevNetworking,
-		BindHost:           d.config.Host,
+		ShutdownSignal:  d.shuttingDown.Load,
+		CrashHandler:    d.handleInstanceCrash,
+		TransitionState: d.TransitionState,
+		DevNetworking:   d.config.Daemon.DevNetworking,
+		BindHost:        d.config.Host,
 	}
 }
 

--- a/spinifex/gateway/ec2/instance/GetConsoleOutput.go
+++ b/spinifex/gateway/ec2/instance/GetConsoleOutput.go
@@ -42,8 +42,12 @@ func GetConsoleOutput(input *ec2.GetConsoleOutputInput, natsConn *nats.Conn, acc
 	reqMsg.Header.Set(utils.AccountIDHeader, accountID)
 	msg, err := natsConn.RequestMsg(reqMsg, 5*time.Second)
 	if err != nil {
-		if err == nats.ErrNoResponders || err == nats.ErrTimeout {
-			return nil, fmt.Errorf("instance %s not found or not running", *input.InstanceId)
+		// No daemon subscribed to the per-instance topic: stopped, terminated,
+		// or non-existent — all of which AWS surfaces as InvalidInstanceID.NotFound.
+		// Treat timeout the same way; a daemon that can't respond inside 5s
+		// is functionally unreachable from a caller's perspective.
+		if errors.Is(err, nats.ErrNoResponders) || errors.Is(err, nats.ErrTimeout) {
+			return nil, errors.New(awserrors.ErrorInvalidInstanceIDNotFound)
 		}
 		return nil, fmt.Errorf("failed to get console output: %w", err)
 	}

--- a/spinifex/vm/errors.go
+++ b/spinifex/vm/errors.go
@@ -1,0 +1,12 @@
+package vm
+
+import "errors"
+
+// ErrInstanceNotFound is returned by manager methods that look up an
+// instance by id when no entry exists in the running map.
+var ErrInstanceNotFound = errors.New("instance not found")
+
+// ErrInvalidTransition is returned when a lifecycle method cannot run
+// because the instance's current state does not permit the target
+// transition (e.g. Stop on an already-stopped instance).
+var ErrInvalidTransition = errors.New("invalid state transition")

--- a/spinifex/vm/instance_cleaner.go
+++ b/spinifex/vm/instance_cleaner.go
@@ -1,0 +1,35 @@
+package vm
+
+// InstanceCleaner releases the per-instance external resources that the
+// manager itself does not own: storage volumes, the management TAP/IP, the
+// public IP allocation, the primary ENI, and placement-group membership.
+// The manager invokes these from Stop/Terminate after QEMU has shut down
+// and volumes have been unmounted; methods are best-effort and log their
+// own errors.
+//
+// The live implementation lives in the daemon package and delegates to the
+// existing volume / VPC / EIP / placement-group services. Tests inject a
+// recording fake.
+type InstanceCleaner interface {
+	// DeleteVolumes deletes EFI / cloud-init internal volumes via ebs.delete
+	// and user volumes flagged DeleteOnTermination via the volume service.
+	// Called only on Terminate, never on Stop.
+	DeleteVolumes(v *VM)
+
+	// CleanupMgmtNetwork removes the management TAP device and releases the
+	// management IP allocation. Called on both Stop and Terminate.
+	CleanupMgmtNetwork(v *VM)
+
+	// ReleasePublicIP publishes vpc.delete-nat and releases the public IP
+	// back to the external IPAM pool. Called only on Terminate when the
+	// instance has a public IP allocated.
+	ReleasePublicIP(v *VM)
+
+	// DetachAndDeleteENI detaches and deletes the primary ENI. NotFound is
+	// tolerated. Called only on Terminate.
+	DetachAndDeleteENI(v *VM)
+
+	// RemoveFromPlacementGroup removes the instance from its placement
+	// group, if one is set. Called only on Terminate.
+	RemoveFromPlacementGroup(v *VM)
+}

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -27,6 +27,7 @@ type Deps struct {
 	InstanceTypes      InstanceTypeResolver
 	Resources          ResourceController
 	VolumeStateUpdater VolumeStateUpdater
+	InstanceCleaner    InstanceCleaner
 	Hooks              ManagerHooks
 
 	// ShutdownSignal returns true once the daemon has begun coordinated

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -42,9 +42,6 @@ type Deps struct {
 	// persists the resulting running-state snapshot.
 	TransitionState func(*VM, InstanceState) error
 
-	// MarkInstanceFailed cleans up a VM whose launch errored mid-way.
-	MarkInstanceFailed func(*VM, string)
-
 	// DevNetworking enables the user-mode dev NIC (SSH hostfwd) on top of
 	// the VPC tap NIC. Mirrors Daemon.config.Daemon.DevNetworking.
 	DevNetworking bool

--- a/spinifex/vm/migrate.go
+++ b/spinifex/vm/migrate.go
@@ -3,15 +3,16 @@ package vm
 import "log/slog"
 
 // MigrateStoppedToSharedKV writes instance to the cluster-shared "stopped"
-// KV bucket and removes it from the local running map. Returns true on
-// success. The migration is a normal-operation state transition (not
-// one-time data movement): instances move between local memory, the
-// shared "stopped" bucket, and the shared "terminated" bucket as part of
-// their lifecycle.
+// KV bucket and removes it from the local running map. Returns true only
+// when both the shared write succeeded AND the local entry was removed
+// under this caller's ownership of the supplied *VM pointer.
 //
-// The slot is reclaimed by another handler if the local entry no longer
-// matches instance — that's treated as success because the shared write
-// has already happened.
+// Returns false on KV write failure or when a concurrent handler reclaimed
+// the slot (DeleteIf no longer matches the supplied pointer). Callers
+// should fire OnInstanceDown / persist running-state only on true: a slot
+// reclaim means the id now resolves to a different live instance, and
+// firing the down hook would tear down the new instance's per-id
+// resources (e.g. NATS subscriptions).
 func (m *Manager) MigrateStoppedToSharedKV(instance *VM) bool {
 	if m.deps.StateStore == nil {
 		return false
@@ -30,9 +31,9 @@ func (m *Manager) MigrateTerminatedToKV(instance *VM) bool {
 }
 
 // migrateInstanceToKV is the shared body of MigrateStoppedToSharedKV and
-// MigrateTerminatedToKV. It stamps LastNode, calls the bucket-specific
-// write function, then guards the local delete so a concurrent claim on
-// the same id (e.g. a start handler reusing the slot) is not clobbered.
+// MigrateTerminatedToKV. Returns true only when both the shared write
+// succeeded and DeleteIf removed the local entry — see the public
+// methods' doc comments for why slot-reclaim is reported as failure.
 func (m *Manager) migrateInstanceToKV(instance *VM, writeFn func(string, *VM) error, label string) bool {
 	instance.LastNode = m.deps.NodeID
 	if err := writeFn(instance.ID, instance); err != nil {
@@ -43,7 +44,7 @@ func (m *Manager) migrateInstanceToKV(instance *VM, writeFn func(string, *VM) er
 	if !m.DeleteIf(instance.ID, instance) {
 		slog.Info("Slot reclaimed by another handler during migration; skipping local delete",
 			"instance", instance.ID, "bucket", label)
-		return true
+		return false
 	}
 	slog.Info("Migrated instance to KV", "instance", instance.ID, "bucket", label)
 	return true

--- a/spinifex/vm/migrate.go
+++ b/spinifex/vm/migrate.go
@@ -1,0 +1,50 @@
+package vm
+
+import "log/slog"
+
+// MigrateStoppedToSharedKV writes instance to the cluster-shared "stopped"
+// KV bucket and removes it from the local running map. Returns true on
+// success. The migration is a normal-operation state transition (not
+// one-time data movement): instances move between local memory, the
+// shared "stopped" bucket, and the shared "terminated" bucket as part of
+// their lifecycle.
+//
+// The slot is reclaimed by another handler if the local entry no longer
+// matches instance — that's treated as success because the shared write
+// has already happened.
+func (m *Manager) MigrateStoppedToSharedKV(instance *VM) bool {
+	if m.deps.StateStore == nil {
+		return false
+	}
+	return m.migrateInstanceToKV(instance, m.deps.StateStore.WriteStoppedInstance, "stopped")
+}
+
+// MigrateTerminatedToKV writes instance to the cluster-shared "terminated"
+// KV bucket and removes it from the local running map. Same semantics as
+// MigrateStoppedToSharedKV but for the terminated bucket.
+func (m *Manager) MigrateTerminatedToKV(instance *VM) bool {
+	if m.deps.StateStore == nil {
+		return false
+	}
+	return m.migrateInstanceToKV(instance, m.deps.StateStore.WriteTerminatedInstance, "terminated")
+}
+
+// migrateInstanceToKV is the shared body of MigrateStoppedToSharedKV and
+// MigrateTerminatedToKV. It stamps LastNode, calls the bucket-specific
+// write function, then guards the local delete so a concurrent claim on
+// the same id (e.g. a start handler reusing the slot) is not clobbered.
+func (m *Manager) migrateInstanceToKV(instance *VM, writeFn func(string, *VM) error, label string) bool {
+	instance.LastNode = m.deps.NodeID
+	if err := writeFn(instance.ID, instance); err != nil {
+		slog.Error("Failed to migrate instance to KV",
+			"instance", instance.ID, "bucket", label, "err", err)
+		return false
+	}
+	if !m.DeleteIf(instance.ID, instance) {
+		slog.Info("Slot reclaimed by another handler during migration; skipping local delete",
+			"instance", instance.ID, "bucket", label)
+		return true
+	}
+	slog.Info("Migrated instance to KV", "instance", instance.ID, "bucket", label)
+	return true
+}

--- a/spinifex/vm/network_helpers_test.go
+++ b/spinifex/vm/network_helpers_test.go
@@ -11,6 +11,7 @@ type fakeNetworkPlumber struct {
 	setupCalls   []fakeSetupCall
 	cleanupCalls []string
 	setupErr     error
+	cleanupErr   error
 }
 
 type fakeSetupCall struct {
@@ -25,7 +26,7 @@ func (p *fakeNetworkPlumber) SetupTapDevice(eniID, mac string) error {
 
 func (p *fakeNetworkPlumber) CleanupTapDevice(eniID string) error {
 	p.cleanupCalls = append(p.cleanupCalls, eniID)
-	return nil
+	return p.cleanupErr
 }
 
 var _ NetworkPlumber = (*fakeNetworkPlumber)(nil)
@@ -130,4 +131,54 @@ func TestSetupExtraENINICs_NilPlumber_NoOp(t *testing.T) {
 	if len(instance.Config.NetDevs) != 0 {
 		t.Errorf("expected no netdevs without plumber, got %d", len(instance.Config.NetDevs))
 	}
+}
+
+func TestCleanupExtraENITaps_CallsCleanupPerExtra(t *testing.T) {
+	plumber := &fakeNetworkPlumber{}
+	m := NewManagerWithDeps(Deps{NetworkPlumber: plumber})
+	instance := &VM{
+		ID: "i-multi-clean",
+		ExtraENIs: []ExtraENI{
+			{ENIID: "eni-111"},
+			{ENIID: "eni-222"},
+			{ENIID: "eni-333"},
+		},
+	}
+
+	m.cleanupExtraENITaps(instance)
+
+	if len(plumber.cleanupCalls) != 3 {
+		t.Fatalf("expected 3 cleanup calls, got %d", len(plumber.cleanupCalls))
+	}
+	for i, want := range []string{"eni-111", "eni-222", "eni-333"} {
+		if plumber.cleanupCalls[i] != want {
+			t.Errorf("cleanup[%d] = %q, want %q", i, plumber.cleanupCalls[i], want)
+		}
+	}
+}
+
+func TestCleanupExtraENITaps_ErrorsAreLogged(t *testing.T) {
+	plumber := &fakeNetworkPlumber{cleanupErr: errors.New("simulated cleanup failure")}
+	m := NewManagerWithDeps(Deps{NetworkPlumber: plumber})
+	instance := &VM{
+		ID: "i-multi-clean-err",
+		ExtraENIs: []ExtraENI{
+			{ENIID: "eni-111"},
+			{ENIID: "eni-222"},
+		},
+	}
+
+	// Must not panic or return — errors are swallowed by design so partial
+	// cleanup still frees later entries.
+	m.cleanupExtraENITaps(instance)
+	if len(plumber.cleanupCalls) != 2 {
+		t.Errorf("expected both extras to be attempted, got %d cleanup calls", len(plumber.cleanupCalls))
+	}
+}
+
+func TestCleanupExtraENITaps_NilPlumber_NoOp(t *testing.T) {
+	m := NewManagerWithDeps(Deps{})
+	instance := &VM{ID: "i-no-plumber", ExtraENIs: []ExtraENI{{ENIID: "eni-x"}}}
+	// Must not panic when no plumber is wired.
+	m.cleanupExtraENITaps(instance)
 }

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -45,8 +45,12 @@ func (m *Manager) Stop(id string) error {
 	}
 
 	if !m.MigrateStoppedToSharedKV(instance) {
-		// StateStore unavailable or write failed. Keep the instance in the
-		// local map; restoreInstances will retry the migration on next boot.
+		// Either StateStore unavailable / write failed (instance stays in
+		// local map; restoreInstances retries on next boot) OR a concurrent
+		// handler reclaimed the slot (id now resolves to a different live
+		// VM). Either way, do not fire OnInstanceDown — firing it would
+		// unsubscribe the per-id NATS subscriptions of the reclaimed
+		// instance.
 		return nil
 	}
 
@@ -122,14 +126,15 @@ func (m *Manager) Terminate(id string) error {
 	return m.finalizeTerminated(instance)
 }
 
-// MarkFailed sets a failure reason on the instance, transitions to
-// shutting-down, and runs the full Terminate cleanup chain. Used when a
-// launch errors mid-way and the caller wants to release any partially-
-// allocated resources synchronously.
+// MarkFailed sets a failure reason, transitions to shutting-down
+// synchronously, then runs the cleanup chain in a goroutine. Used when a
+// launch errors mid-way: callers (NATS RunInstances handler, recovery
+// worker, pending watchdog, system-instance launcher) get back control
+// immediately and do not block on volume unmount, ENI delete, or KV
+// writes. Mirrors the pre-2c `go d.finalizeTermination(instance)` pattern.
 //
 // Tolerates instances already in a cleanup state (no-op) and instances
-// that may or may not be present in the running-VM map. Returns nil on
-// completion; sub-step failures are logged.
+// that may or may not be present in the running-VM map.
 func (m *Manager) MarkFailed(instance *VM, reason string) {
 	skip := false
 	var observed InstanceState
@@ -164,11 +169,12 @@ func (m *Manager) MarkFailed(instance *VM, reason string) {
 	}
 	slog.Info("Instance marked as failed", "instanceId", instance.ID, "reason", reason)
 
-	m.terminateCleanup(instance)
-
-	if err := m.finalizeTerminated(instance); err != nil {
-		slog.Error("MarkFailed finalize failed", "instanceId", instance.ID, "err", err)
-	}
+	go func() {
+		m.terminateCleanup(instance)
+		if err := m.finalizeTerminated(instance); err != nil {
+			slog.Error("MarkFailed finalize failed", "instanceId", instance.ID, "err", err)
+		}
+	}()
 }
 
 // finalizeTerminated transitions instance to terminated, writes the

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -1,0 +1,358 @@
+package vm
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/qmp"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+)
+
+// pidFileRemovalTimeout is how long Stop/Terminate wait for QEMU's PID file
+// to disappear after a graceful system_powerdown before resorting to
+// SIGKILL. 20s is enough for an ACPI shutdown — guests that haven't
+// responded by then won't.
+const pidFileRemovalTimeout = 20 * time.Second
+
+// Stop transitions a running instance to stopped: graceful QMP shutdown,
+// volume unmount, tap teardown, resource deallocation. Persists to the
+// cluster-shared "stopped" KV bucket and removes the instance from the
+// local running map. Fires OnInstanceDown.
+//
+// Returns ErrInstanceNotFound if id is unknown, ErrInvalidTransition if
+// the instance is not in a state that admits Stopping. Persistence errors
+// after the in-memory transition succeeded are logged but not surfaced.
+func (m *Manager) Stop(id string) error {
+	instance, ok := m.Get(id)
+	if !ok {
+		return ErrInstanceNotFound
+	}
+
+	if err := m.transitionWithPrecheck(instance, StateStopping); err != nil {
+		return err
+	}
+
+	m.stopCleanup(instance)
+
+	m.Inspect(instance, func(v *VM) { v.LastNode = m.deps.NodeID })
+
+	if err := m.transitionWithPrecheck(instance, StateStopped); err != nil {
+		slog.Error("Failed to transition to stopped", "instanceId", instance.ID, "err", err)
+	}
+
+	if !m.MigrateStoppedToSharedKV(instance) {
+		// StateStore unavailable or write failed. Keep the instance in the
+		// local map; restoreInstances will retry the migration on next boot.
+		return nil
+	}
+
+	if m.deps.Hooks.OnInstanceDown != nil {
+		m.deps.Hooks.OnInstanceDown(instance.ID)
+	}
+
+	if err := m.writeRunningState(); err != nil {
+		slog.Error("Failed to persist state after stop, re-adding to local map for consistency",
+			"instanceId", instance.ID, "err", err)
+		m.InsertIfAbsent(instance)
+		return nil
+	}
+	slog.Info("Released instance ownership to KV",
+		"instanceId", instance.ID, "state", string(StateStopped), "lastNode", m.deps.NodeID)
+	return nil
+}
+
+// StopAll fans Stop's per-instance shutdown out across every VM the
+// manager currently holds. Used by the coordinated shutdown DRAIN phase
+// and by the SIGTERM signal handler. Each instance shuts down in its own
+// goroutine so total wall-time is bounded by the slowest VM; errors are
+// logged per instance and never abort the fan-out.
+//
+// Volume + tap teardown only — instances persist locally so the cluster
+// sees them as stopped after the daemon restarts. AWS resources (ENI,
+// public IP, placement group) are not released because the instance is
+// not being terminated.
+func (m *Manager) StopAll() error {
+	snapshot := m.Snapshot()
+	if len(snapshot) == 0 {
+		return nil
+	}
+	var wg sync.WaitGroup
+	for _, instance := range snapshot {
+		wg.Add(1)
+		go func(v *VM) {
+			defer wg.Done()
+			m.stopCleanup(v)
+		}(instance)
+	}
+	wg.Wait()
+	return nil
+}
+
+// Terminate transitions an instance to terminated: graceful shutdown,
+// volume + ENI + IP cleanup, placement group removal. Persists to the
+// cluster-shared "terminated" KV bucket and removes the instance from
+// the local running map. Fires OnInstanceDown.
+//
+// Idempotent on already-shutting-down (the failed-launch goroutine is
+// already cleaning up). Returns ErrInstanceNotFound if id is unknown,
+// ErrInvalidTransition if the current state does not permit termination.
+func (m *Manager) Terminate(id string) error {
+	instance, ok := m.Get(id)
+	if !ok {
+		return ErrInstanceNotFound
+	}
+
+	var current InstanceState
+	m.Inspect(instance, func(v *VM) { current = v.Status })
+	if current == StateShuttingDown {
+		// Concurrent failed-launch goroutine already owns cleanup.
+		return nil
+	}
+
+	if err := m.transitionWithPrecheck(instance, StateShuttingDown); err != nil {
+		return err
+	}
+
+	m.terminateCleanup(instance)
+
+	return m.finalizeTerminated(instance)
+}
+
+// MarkFailed sets a failure reason on the instance, transitions to
+// shutting-down, and runs the full Terminate cleanup chain. Used when a
+// launch errors mid-way and the caller wants to release any partially-
+// allocated resources synchronously.
+//
+// Tolerates instances already in a cleanup state (no-op) and instances
+// that may or may not be present in the running-VM map. Returns nil on
+// completion; sub-step failures are logged.
+func (m *Manager) MarkFailed(instance *VM, reason string) {
+	skip := false
+	var observed InstanceState
+	m.Inspect(instance, func(v *VM) {
+		observed = v.Status
+		if v.Status == StateShuttingDown || v.Status == StateTerminated {
+			skip = true
+			return
+		}
+		if v.Instance != nil {
+			v.Instance.StateReason = &ec2.StateReason{
+				Code:    aws.String("Server.InternalError"),
+				Message: aws.String(reason),
+			}
+		}
+	})
+	if skip {
+		slog.Info("MarkFailed: instance already in cleanup state, skipping",
+			"instanceId", instance.ID, "status", string(observed), "reason", reason)
+		return
+	}
+
+	if err := m.transitionWithPrecheck(instance, StateShuttingDown); err != nil {
+		slog.Error("MarkFailed transition failed", "instanceId", instance.ID, "err", err)
+		// If this was a persistence-only failure, in-memory state is now
+		// shutting-down and we still want to finalize. Otherwise bail.
+		var postErr InstanceState
+		m.Inspect(instance, func(v *VM) { postErr = v.Status })
+		if postErr != StateShuttingDown {
+			return
+		}
+	}
+	slog.Info("Instance marked as failed", "instanceId", instance.ID, "reason", reason)
+
+	m.terminateCleanup(instance)
+
+	if err := m.finalizeTerminated(instance); err != nil {
+		slog.Error("MarkFailed finalize failed", "instanceId", instance.ID, "err", err)
+	}
+}
+
+// finalizeTerminated transitions instance to terminated, writes the
+// terminated KV entry, removes the instance from the local map, fires
+// OnInstanceDown, and persists the running set. Shared by Terminate and
+// MarkFailed.
+func (m *Manager) finalizeTerminated(instance *VM) error {
+	m.Inspect(instance, func(v *VM) { v.LastNode = m.deps.NodeID })
+
+	if err := m.transitionWithPrecheck(instance, StateTerminated); err != nil {
+		return fmt.Errorf("transition to terminated: %w", err)
+	}
+
+	if m.deps.StateStore != nil {
+		if err := m.deps.StateStore.WriteTerminatedInstance(instance.ID, instance); err != nil {
+			slog.Error("Failed to write terminated instance to KV, keeping in local state for retry",
+				"instanceId", instance.ID, "err", err)
+			return err
+		}
+	}
+
+	if !m.DeleteIf(instance.ID, instance) {
+		slog.Info("Instance was reclaimed by another handler, skipping local cleanup",
+			"instanceId", instance.ID, "state", string(StateTerminated))
+		return nil
+	}
+
+	if m.deps.Hooks.OnInstanceDown != nil {
+		m.deps.Hooks.OnInstanceDown(instance.ID)
+	}
+
+	if err := m.writeRunningState(); err != nil {
+		slog.Error("Failed to persist state after terminate, re-adding to local map",
+			"instanceId", instance.ID, "err", err)
+		m.InsertIfAbsent(instance)
+		return nil
+	}
+	slog.Info("Released instance ownership to KV",
+		"instanceId", instance.ID, "state", string(StateTerminated), "lastNode", m.deps.NodeID)
+	return nil
+}
+
+// stopCleanup performs the per-instance teardown shared by Stop and the
+// initial section of Terminate: graceful QMP shutdown, PID-file wait,
+// volume unmount, tap teardown (main + extra ENI + mgmt), resource
+// deallocation. Per-step errors are logged and tolerated.
+func (m *Manager) stopCleanup(instance *VM) {
+	m.shutdownAndUnmount(instance)
+	m.cleanupTapDevices(instance)
+	m.deallocateResources(instance)
+}
+
+// terminateCleanup is stopCleanup plus the AWS-resource cleanup that
+// only applies on terminate: volume deletion, public IP release, ENI
+// deletion, placement-group removal.
+func (m *Manager) terminateCleanup(instance *VM) {
+	m.shutdownAndUnmount(instance)
+
+	if m.deps.InstanceCleaner != nil {
+		m.deps.InstanceCleaner.DeleteVolumes(instance)
+	}
+
+	m.cleanupTapDevices(instance)
+
+	if m.deps.InstanceCleaner != nil {
+		m.deps.InstanceCleaner.ReleasePublicIP(instance)
+		m.deps.InstanceCleaner.DetachAndDeleteENI(instance)
+		m.deps.InstanceCleaner.RemoveFromPlacementGroup(instance)
+	}
+
+	m.deallocateResources(instance)
+}
+
+// shutdownAndUnmount asks QEMU to power down via QMP, waits for the PID
+// file to disappear (force-killing on timeout), then unmounts every
+// attached volume. Each step tolerates failure of the previous one.
+func (m *Manager) shutdownAndUnmount(instance *VM) {
+	if instance.QMPClient != nil {
+		if _, err := sendQMPCommand(instance.QMPClient, qmp.QMPCommand{Execute: "system_powerdown"}, instance.ID); err != nil {
+			slog.Warn("QMP system_powerdown failed (VM may already be stopped)",
+				"id", instance.ID, "err", err)
+		}
+	}
+
+	if err := utils.WaitForPidFileRemoval(instance.ID, pidFileRemovalTimeout); err != nil {
+		slog.Warn("Timeout waiting for PID file removal", "id", instance.ID, "err", err)
+		pid, readErr := utils.ReadPidFile(instance.ID)
+		if readErr != nil {
+			slog.Debug("No PID file found (VM likely already stopped)", "id", instance.ID)
+		} else {
+			slog.Info("Force killing process", "pid", pid, "id", instance.ID)
+			if err := utils.KillProcess(pid); err != nil {
+				slog.Error("Failed to kill process", "pid", pid, "id", instance.ID, "err", err)
+			}
+		}
+	}
+
+	if m.deps.VolumeMounter != nil {
+		if err := m.deps.VolumeMounter.Unmount(instance); err != nil {
+			slog.Error("Volume unmount failed", "id", instance.ID, "err", err)
+		}
+	}
+}
+
+// cleanupTapDevices removes the primary VPC tap, every extra ENI tap, and
+// the management TAP/IP allocation. Errors are logged and tolerated.
+func (m *Manager) cleanupTapDevices(instance *VM) {
+	if instance.ENIId != "" && m.deps.NetworkPlumber != nil {
+		if err := m.deps.NetworkPlumber.CleanupTapDevice(instance.ENIId); err != nil {
+			slog.Warn("Failed to clean up tap device", "eni", instance.ENIId, "err", err)
+		}
+		m.cleanupExtraENITaps(instance)
+	}
+
+	if m.deps.InstanceCleaner != nil {
+		m.deps.InstanceCleaner.CleanupMgmtNetwork(instance)
+	}
+}
+
+// cleanupExtraENITaps removes tap devices for every extra ENI attached
+// to a system VM (multi-subnet ALB instances span multiple ENIs).
+func (m *Manager) cleanupExtraENITaps(instance *VM) {
+	if m.deps.NetworkPlumber == nil {
+		return
+	}
+	for _, extra := range instance.ExtraENIs {
+		if err := m.deps.NetworkPlumber.CleanupTapDevice(extra.ENIID); err != nil {
+			slog.Warn("Failed to clean up extra ENI tap device", "eni", extra.ENIID, "err", err)
+		}
+	}
+}
+
+// deallocateResources releases the per-instance vCPU/memory reservation
+// back to the resource controller.
+func (m *Manager) deallocateResources(instance *VM) {
+	if m.deps.Resources == nil || instance.InstanceType == "" {
+		return
+	}
+	m.deps.Resources.Deallocate(instance.InstanceType)
+}
+
+// transitionWithPrecheck validates the transition first, then calls the
+// daemon-supplied TransitionState. Pre-validation lets us surface
+// ErrInvalidTransition cleanly (so callers can map it to the AWS
+// IncorrectInstanceState error code) and treat any post-precheck error
+// as a persistence failure on a transition whose memory mutation
+// already succeeded.
+func (m *Manager) transitionWithPrecheck(instance *VM, target InstanceState) error {
+	var current InstanceState
+	m.Inspect(instance, func(v *VM) { current = v.Status })
+	if !IsValidTransition(current, target) {
+		return fmt.Errorf("%w: %s -> %s for instance %s",
+			ErrInvalidTransition, current, target, instance.ID)
+	}
+	if m.deps.TransitionState == nil {
+		m.Inspect(instance, func(v *VM) { v.Status = target })
+		return nil
+	}
+	if err := m.deps.TransitionState(instance, target); err != nil {
+		// Could be persistence failure (memory state already updated) or a
+		// racing transition that invalidated the precheck. Re-inspect to
+		// distinguish.
+		var observed InstanceState
+		m.Inspect(instance, func(v *VM) { observed = v.Status })
+		if observed != target {
+			return fmt.Errorf("%w: %s -> %s for instance %s (raced)",
+				ErrInvalidTransition, current, target, instance.ID)
+		}
+		return err
+	}
+	return nil
+}
+
+// writeRunningState persists the current running-VM map via the StateStore.
+// The View callback holds the manager lock across the marshal+put — same
+// constraint as the daemon's pre-2c WriteState. Splitting marshal from put
+// is a 2f cleanup item.
+func (m *Manager) writeRunningState() error {
+	if m.deps.StateStore == nil {
+		return nil
+	}
+	var err error
+	m.View(func(vms map[string]*VM) {
+		err = m.deps.StateStore.SaveRunningState(m.deps.NodeID, vms)
+	})
+	return err
+}


### PR DESCRIPTION
Move the shutdown path of the VM lifecycle into vm.Manager so the daemon no longer owns Stop/Terminate sequencing. stopInstance becomes Manager.Stop + Manager.StopAll, finalizeTermination and markInstanceFailed fold into Manager.Terminate / Manager.MarkFailed. cleanupExtraENITaps and the migrate*ToKV helpers move to the manager.

Add a small InstanceCleaner collaborator (5 methods) for the AWS-resource steps that still need daemon-side services: volume deletion, mgmt network teardown, public IP release, ENI detach/delete, placement group removal. The daemon supplies the implementation through buildVMManagerDeps.

OnInstanceDown fires from the new shutdown path; the daemon's hook unsubscribes per-instance NATS topics. Sentinel errors (ErrInstanceNotFound, ErrInvalidTransition) replace handler-side string matching for state-mismatch responses.

Tests for migrate, MarkFailed, and DeleteOnTermination move with the code: the migrate/MarkFailed coverage now drives the manager directly via SetDeps in createDaemonWithJetStream; the volume-deletion behaviour is now exercised against instanceCleanerAdapter.DeleteVolumes.