### PR TITLE
refactor(vm): move Restore/crash recovery/watchdog onto Manager

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -15,7 +15,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -872,7 +871,7 @@ func (d *Daemon) Start() error {
 	d.resourceMgr.initSubscriptions(d.natsConn, d.handleEC2RunInstances, d.node)
 
 	d.startHeartbeat()
-	d.startPendingWatchdog()
+	d.vmMgr.StartPendingWatchdog(d.ctx)
 
 	d.ready.Store(true)
 	slog.Info("Daemon fully initialized", "node", d.node, "startupTime", time.Since(d.startTime).Round(time.Second))
@@ -1049,305 +1048,17 @@ func (d *Daemon) checkPredastoreReady() bool {
 	return true
 }
 
-// maxConcurrentRecovery limits how many VMs are relaunched in parallel during recovery.
-const maxConcurrentRecovery = 2
-
-// restoreInstances loads persisted VM state and re-launches instances that are
-// neither terminated nor flagged as user-stopped.
+// restoreInstances delegates to vm.Manager.Restore. Daemon-side shim
+// preserved so existing tests keep their bare-method call shape; phase 2f
+// migrates them into vm/ and removes the wrapper.
 func (d *Daemon) restoreInstances() {
-	// Check for clean shutdown marker
-	cleanShutdown := false
-	if d.jsManager != nil {
-		if marker, err := d.jsManager.ReadShutdownMarker(d.node); err == nil {
-			cleanShutdown = marker
-			if marker {
-				slog.Info("Clean shutdown marker found, trusting KV state")
-				_ = d.jsManager.DeleteShutdownMarker(d.node)
-			}
-		}
-	}
-
-	if !cleanShutdown {
-		slog.Warn("No clean shutdown marker — possible crash recovery, validating QEMU PIDs carefully")
-		time.Sleep(3 * time.Second)
-	}
-
-	err := d.LoadState()
-	if err != nil {
-		slog.Warn("Failed to load state, continuing with empty state", "error", err)
-		return
-	}
-
-	slog.Info("Loaded state", "instance count", d.vmMgr.Count())
-
-	// Phase 1: Reconnect running QEMU, finalize transitional states, collect VMs to relaunch
-	var toLaunch []*vm.VM
-
-	for _, instance := range d.vmMgr.Snapshot() {
-		instance.EBSRequests.Mu = sync.Mutex{}
-		instance.QMPClient = &qmp.QMPClient{}
-
-		if instance.Status == vm.StateTerminated {
-			if !d.vmMgr.MigrateTerminatedToKV(instance) {
-				// KV write failed — keep in local state so the next restart
-				// retries the migration. Deleting here would create a "void":
-				// the instance disappears from both local state and the
-				// terminated KV, making it invisible to DescribeInstances.
-				slog.Warn("Terminated instance KV migration failed, will retry on next restart",
-					"instance", instance.ID)
-			}
-			continue
-		}
-
-		if instance.Status == vm.StateStopped {
-			d.vmMgr.MigrateStoppedToSharedKV(instance)
-			continue
-		}
-
-		instanceType, ok := d.resourceMgr.instanceTypes[instance.InstanceType]
-		if !ok && instance.InstanceType != "" {
-			slog.Warn("Instance type not available on this node, moving to stopped",
-				"instanceId", instance.ID, "instanceType", instance.InstanceType)
-			instance.Status = vm.StateStopped
-			if instance.Instance != nil {
-				instance.Instance.StateReason = &ec2.StateReason{}
-				instance.Instance.StateReason.SetCode("Server.InsufficientInstanceCapacity")
-				instance.Instance.StateReason.SetMessage(
-					fmt.Sprintf("instance type %s is not available on this node", instance.InstanceType))
-			}
-			d.vmMgr.MigrateStoppedToSharedKV(instance)
-			continue
-		}
-
-		if ok {
-			slog.Info("Re-allocating resources for instance", "instanceId", instance.ID, "type", instance.InstanceType)
-			if err := d.resourceMgr.allocate(instanceType); err != nil {
-				slog.Error("Failed to re-allocate resources for instance on startup, moving to stopped",
-					"instanceId", instance.ID, "err", err)
-				instance.Status = vm.StateStopped
-				if instance.Instance != nil {
-					instance.Instance.StateReason = &ec2.StateReason{}
-					instance.Instance.StateReason.SetCode("Server.InsufficientInstanceCapacity")
-					instance.Instance.StateReason.SetMessage(
-						fmt.Sprintf("insufficient resources to restore instance: %v", err))
-				}
-				d.vmMgr.MigrateStoppedToSharedKV(instance)
-				continue
-			}
-		}
-
-		// Check if QEMU process is still alive from before the restart
-		if d.isInstanceProcessRunning(instance) {
-			// Verify NBD sockets are still valid. After a viperblock restart,
-			// old sockets are gone and QEMU's block devices are broken. Kill
-			// the orphaned QEMU and relaunch from scratch instead of
-			// reconnecting to an instance with dead storage.
-			if !d.areVolumeSocketsValid(instance) {
-				slog.Warn("QEMU alive but NBD sockets are stale, killing orphaned process for relaunch",
-					"instance", instance.ID)
-				pid, pidErr := utils.ReadPidFile(instance.ID)
-				if pidErr != nil || pid <= 0 {
-					slog.Error("Cannot read PID for orphaned QEMU, skipping relaunch",
-						"instanceId", instance.ID, "err", pidErr)
-					continue
-				}
-				// SIGKILL directly — orphaned QEMU with dead storage has no
-				// state worth a graceful shutdown, and KillProcess's 120s
-				// SIGTERM timeout would block daemon startup.
-				if proc, err := os.FindProcess(pid); err == nil {
-					_ = proc.Signal(syscall.SIGKILL)
-				}
-				// Wait for the process to actually die, then remove the PID
-				// file ourselves. SIGKILL cannot be caught, so QEMU never
-				// runs its cleanup handler and the PID file stays on disk.
-				if err := utils.WaitForProcessExit(pid, 10*time.Second); err != nil {
-					slog.Error("Orphaned QEMU did not exit after SIGKILL, skipping relaunch",
-						"instanceId", instance.ID, "pid", pid, "err", err)
-					continue
-				}
-				_ = utils.RemovePidFile(instance.ID)
-			} else {
-				slog.Info("Instance QEMU process still alive, reconnecting", "instance", instance.ID)
-				if err := d.reconnectInstance(instance); err != nil {
-					slog.Error("Failed to reconnect to running instance", "instanceId", instance.ID, "err", err)
-				}
-				continue
-			}
-		}
-
-		// QEMU is not running -- resolve transitional states from interrupted operations
-		switch instance.Status {
-		case vm.StateStopping, vm.StateShuttingDown:
-			prevStatus := instance.Status
-			if instance.Status == vm.StateStopping {
-				instance.Status = vm.StateStopped
-			} else {
-				instance.Status = vm.StateTerminated
-			}
-			slog.Info("QEMU exited during transition, finalizing state",
-				"instance", instance.ID, "from", prevStatus, "to", instance.Status)
-
-			if instance.Status == vm.StateStopped && d.vmMgr.MigrateStoppedToSharedKV(instance) {
-				continue
-			}
-
-			if instance.Status == vm.StateTerminated && d.vmMgr.MigrateTerminatedToKV(instance) {
-				continue
-			}
-
-			if err := d.WriteState(); err != nil {
-				slog.Error("Failed to persist state, will retry on next restart",
-					"instance", instance.ID, "error", err)
-				instance.Status = prevStatus // revert so next restart retries
-			}
-			continue
-		case vm.StateRunning:
-			// Was running but QEMU died - reset to pending so LaunchInstance can transition to running
-			instance.Status = vm.StatePending
-			slog.Info("Instance was running but QEMU exited, relaunching", "instance", instance.ID)
-		}
-
-		// Reset LaunchTime so the pending watchdog gives a fresh timeout window.
-		// Without this, the stale LaunchTime from the original launch causes the
-		// watchdog to immediately mark the instance as failed after a prolonged outage.
-		now := time.Now()
-		if instance.Instance != nil {
-			instance.Instance.LaunchTime = &now
-		}
-		toLaunch = append(toLaunch, instance)
-	}
-
-	// Phase 2: Relaunch crashed VMs with semaphore-based throttling
-	if len(toLaunch) > 0 {
-		// Subscribe to per-instance NATS topics before launching so that
-		// terminate/stop commands can reach this daemon while instances are
-		// still being relaunched. Without this, pending instances are
-		// unreachable via ec2.cmd.<id> and TerminateInstances fails.
-		d.mu.Lock()
-		for _, instance := range toLaunch {
-			sub, subErr := d.natsConn.Subscribe(fmt.Sprintf("ec2.cmd.%s", instance.ID), d.handleEC2Events)
-			if subErr != nil {
-				slog.Error("Failed to early-subscribe during recovery", "instanceId", instance.ID, "err", subErr)
-			} else {
-				d.natsSubscriptions[instance.ID] = sub
-			}
-		}
-		d.mu.Unlock()
-
-		slog.Info("Launching instances (recovery)", "count", len(toLaunch), "maxConcurrent", maxConcurrentRecovery)
-		sem := make(chan struct{}, maxConcurrentRecovery)
-		var wg sync.WaitGroup
-
-		for _, instance := range toLaunch {
-			sem <- struct{}{} // acquire
-			wg.Add(1)
-			go func(inst *vm.VM) {
-				defer wg.Done()
-				defer func() { <-sem }() // release
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("Panic during instance recovery", "instanceId", inst.ID, "panic", r, "stack", string(debug.Stack()))
-					}
-				}()
-				// Skip if instance was terminated while waiting for semaphore
-				var status vm.InstanceState
-				d.vmMgr.Inspect(inst, func(v *vm.VM) { status = v.Status })
-				if status != vm.StatePending && status != vm.StateProvisioning {
-					slog.Info("Instance state changed during recovery, skipping launch",
-						"instanceId", inst.ID, "status", string(status))
-					return
-				}
-				slog.Info("Launching instance (recovery)", "instance", inst.ID)
-				if err := d.vmMgr.Run(inst); err != nil {
-					slog.Error("Failed to launch instance during recovery", "instanceId", inst.ID, "err", err)
-					d.vmMgr.MarkFailed(inst, "recovery_launch_failed")
-				}
-			}(instance)
-		}
-		wg.Wait()
-	}
-
-	// Persist state after any migrations/removals during restore
-	if err := d.WriteState(); err != nil {
-		slog.Error("Failed to persist state after restore", "error", err)
-	}
+	d.vmMgr.Restore()
 }
 
-// isInstanceProcessRunning checks if the QEMU process for an instance is still alive.
-func (d *Daemon) isInstanceProcessRunning(instance *vm.VM) bool {
-	pid, err := utils.ReadPidFile(instance.ID)
-	if err != nil || pid <= 0 {
-		return false
-	}
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return process.Signal(syscall.Signal(0)) == nil
-}
-
-// areVolumeSocketsValid checks whether the NBD Unix sockets backing an
-// instance's volumes are reachable. A dial probe (not just os.Stat) is used
-// because viperblock may restart with sockets at the same paths — the file
-// exists but no process is listening on the old fd that QEMU holds.
+// areVolumeSocketsValid is a daemon-side shim around vm.AreVolumeSocketsValid
+// kept so the existing TestAreVolumeSocketsValid_* cases call the same name.
 func (d *Daemon) areVolumeSocketsValid(instance *vm.VM) bool {
-	instance.EBSRequests.Mu.Lock()
-	defer instance.EBSRequests.Mu.Unlock()
-
-	for _, req := range instance.EBSRequests.Requests {
-		if req.NBDURI == "" {
-			continue
-		}
-		serverType, sockPath, _, _, err := utils.ParseNBDURI(req.NBDURI)
-		if err != nil || serverType != "unix" {
-			continue // TCP or unparseable — can't validate locally
-		}
-		conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
-		if err != nil {
-			slog.Debug("NBD socket unreachable", "volume", req.Name, "socket", sockPath, "err", err)
-			return false
-		}
-		_ = conn.Close()
-	}
-	return true
-}
-
-// reconnectInstance re-establishes QMP and NATS connections to a running QEMU instance
-// after a daemon restart. This bypasses the state machine since recovery is not a
-// normal state transition.
-func (d *Daemon) reconnectInstance(instance *vm.VM) error {
-	if err := d.vmMgr.AttachQMP(instance); err != nil {
-		return fmt.Errorf("failed to reconnect QMP: %w", err)
-	}
-
-	d.mu.Lock()
-	sub, err := d.natsConn.Subscribe(fmt.Sprintf("ec2.cmd.%s", instance.ID), d.handleEC2Events)
-	if err != nil {
-		d.mu.Unlock()
-		if instance.QMPClient != nil && instance.QMPClient.Conn != nil {
-			_ = instance.QMPClient.Conn.Close()
-			instance.QMPClient = nil
-		}
-		return fmt.Errorf("failed to subscribe to NATS: %w", err)
-	}
-	d.natsSubscriptions[instance.ID] = sub
-
-	consoleSub, err := d.natsConn.Subscribe(fmt.Sprintf("ec2.%s.GetConsoleOutput", instance.ID), d.handleEC2GetConsoleOutput)
-	if err != nil {
-		d.mu.Unlock()
-		return fmt.Errorf("failed to subscribe to console output NATS: %w", err)
-	}
-	d.natsSubscriptions[instance.ID+".console"] = consoleSub
-	d.mu.Unlock()
-
-	instance.Status = vm.StateRunning
-
-	if err := d.WriteState(); err != nil {
-		return fmt.Errorf("failed to persist reconnected instance state: %w", err)
-	}
-
-	slog.Info("Successfully reconnected to running instance", "instance", instance.ID)
-	return nil
+	return vm.AreVolumeSocketsValid(instance)
 }
 
 // awaitShutdown blocks until the daemon's shutdown wait group completes.
@@ -1649,43 +1360,12 @@ func (d *Daemon) setupShutdown() {
 	})
 }
 
-const pendingWatchdogInterval = 60 * time.Second
-const pendingWatchdogTimeout = 5 * time.Minute
-
-// startPendingWatchdog runs a background goroutine that periodically checks for
-// instances stuck in pending/provisioning beyond a timeout and marks them failed.
-func (d *Daemon) startPendingWatchdog() {
-	ticker := time.NewTicker(pendingWatchdogInterval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-d.ctx.Done():
-				return
-			case <-ticker.C:
-				stuck := d.vmMgr.Filter(func(v *vm.VM) bool {
-					return (v.Status == vm.StatePending || v.Status == vm.StateProvisioning) &&
-						v.Instance != nil && v.Instance.LaunchTime != nil &&
-						time.Since(*v.Instance.LaunchTime) > pendingWatchdogTimeout
-				})
-
-				for _, instance := range stuck {
-					slog.Warn("Instance stuck in pending, marking failed",
-						"instanceId", instance.ID, "status", instance.Status,
-						"elapsed", time.Since(*instance.Instance.LaunchTime))
-					d.vmMgr.MarkFailed(instance, "launch_timeout")
-				}
-			}
-		}
-	}()
-}
-
-// ebsTopic returns a node-specific EBS NATS topic, e.g. "ebs.node1.mount".
-// This ensures mount/unmount requests are routed to the viperblock instance
-// running on the same node as the daemon (NBD sockets are local).
-func (d *Daemon) ebsTopic(action string) string {
-	return fmt.Sprintf("ebs.%s.%s", d.node, action)
-}
+// pendingWatchdogTimeout aliases the manager's exported watchdog timeout so
+// daemon-side tests (currently asserting LaunchTime is within the watchdog
+// window after restore) keep working without reaching into the vm package.
+//
+// Phase 2f cleanup: migrate the assertion into vm/ and delete the alias.
+const pendingWatchdogTimeout = vm.PendingWatchdogTimeout
 
 // respondWithVolumeAttachment builds an ec2.VolumeAttachment, marshals it to JSON, and
 // responds on the NATS message. Used by both AttachVolume and DetachVolume handlers.

--- a/spinifex/daemon/health.go
+++ b/spinifex/daemon/health.go
@@ -1,301 +1,46 @@
 package daemon
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"log/slog"
-	"os"
-	"os/exec"
-	"syscall"
 	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/vm"
 )
 
+// classifyCrashReason is preserved as a daemon-side shim so the existing
+// classify-crash-reason tests keep their bare-function call shape while
+// the implementation moved into the vm package alongside the manager.
+//
+// Phase 2f cleanup: migrate TestClassifyCrashReason_* into vm/ and delete.
+func classifyCrashReason(waitErr error) string {
+	return vm.ClassifyCrashReason(waitErr)
+}
+
+// Daemon-side aliases for vm package crash-recovery constants. Tests in
+// health_test.go reference these by their pre-2e bare names. Phase 2f
+// cleanup migrates those tests into vm/ and removes the aliases.
 const (
-	maxRestartsInWindow = 3
-	restartWindow       = 10 * time.Minute
-	restartBackoffBase  = 5 * time.Second
-	restartBackoffMax   = 2 * time.Minute
+	maxRestartsInWindow = vm.MaxRestartsInWindow
+	restartWindow       = vm.RestartWindow
 )
 
-// restartBackoff computes the exponential backoff delay for the given
-// restart count. Pure function — no side effects.
+// restartBackoff is a daemon-side shim mirroring classifyCrashReason; the
+// pure implementation lives on vm so the manager's MaybeRestart can use
+// it without a daemon import.
 func restartBackoff(restartCount int) time.Duration {
-	delay := restartBackoffBase
-	for range restartCount {
-		delay *= 2
-		if delay > restartBackoffMax {
-			return restartBackoffMax
-		}
-	}
-	return delay
+	return vm.RestartBackoff(restartCount)
 }
 
-// classifyCrashReason extracts a human-readable crash reason from the error
-// returned by cmd.Wait(). Uses exec.ExitError + syscall.WaitStatus to
-// distinguish OOM kills (SIGKILL), segfaults (SIGSEGV), etc.
-func classifyCrashReason(waitErr error) string {
-	if waitErr == nil {
-		return "clean-exit"
-	}
-
-	var exitErr *exec.ExitError
-	if !errors.As(waitErr, &exitErr) {
-		return "unknown"
-	}
-
-	status, ok := exitErr.Sys().(syscall.WaitStatus)
-	if !ok {
-		return "unknown"
-	}
-
-	if status.Signaled() {
-		switch status.Signal() {
-		case syscall.SIGKILL:
-			return "oom-killed"
-		case syscall.SIGSEGV:
-			return "segfault"
-		case syscall.SIGABRT:
-			return "abort"
-		default:
-			return fmt.Sprintf("signal-%d", status.Signal())
-		}
-	}
-
-	if status.Exited() {
-		return fmt.Sprintf("exit-%d", status.ExitStatus())
-	}
-
-	return "unknown"
-}
-
-// handleInstanceCrash is called by the QEMU launch goroutine after cmd.Wait()
-// returns during runtime (after startup was confirmed successful). It detects
-// the crash reason, transitions the instance to error state, cleans up resources,
-// and schedules a restart if policy allows.
+// handleInstanceCrash and maybeRestartInstance are daemon-side shims
+// around the manager methods that own crash recovery. Pre-2f tests still
+// invoke them through the daemon receiver; the bodies live in
+// vm/crash_recovery.go.
+//
+// Phase 2f cleanup: migrate the daemon health_test.go cases into vm/ and
+// delete the shims.
 func (d *Daemon) handleInstanceCrash(instance *vm.VM, waitErr error) {
-	// Guard: if instance is not running, this was an expected exit
-	// (stopInstance/terminateInstance set status before QEMU exits)
-	var status vm.InstanceState
-	d.vmMgr.Inspect(instance, func(v *vm.VM) { status = v.Status })
-
-	if status != vm.StateRunning {
-		slog.Debug("QEMU exited but instance not in running state, skipping crash handler",
-			"instance", instance.ID, "status", status)
-		return
-	}
-
-	// Guard: coordinated shutdown in progress
-	if d.shuttingDown.Load() {
-		slog.Debug("QEMU exited during coordinated shutdown, skipping crash handler",
-			"instance", instance.ID)
-		return
-	}
-
-	reason := classifyCrashReason(waitErr)
-	slog.Error("VM process crashed", "instance", instance.ID, "reason", reason, "err", waitErr)
-
-	// Transition to error state
-	if err := d.TransitionState(instance, vm.StateError); err != nil {
-		slog.Error("Failed to transition crashed instance to error state",
-			"instance", instance.ID, "err", err)
-	}
-
-	// Update health tracking
-	now := time.Now()
-	d.vmMgr.Inspect(instance, func(v *vm.VM) {
-		v.Health.CrashCount++
-		v.Health.LastCrashTime = now
-		v.Health.LastCrashReason = reason
-		if v.Health.FirstCrashTime.IsZero() {
-			v.Health.FirstCrashTime = now
-		}
-		v.Running = false
-		v.PID = 0
-	})
-
-	// Deallocate resources to fix phantom reservation
-	instanceType, ok := d.resourceMgr.instanceTypes[instance.InstanceType]
-	if ok && instanceType != nil {
-		slog.Info("Deallocating resources for crashed instance",
-			"instance", instance.ID, "type", instance.InstanceType)
-		d.resourceMgr.deallocate(instanceType)
-	}
-
-	// Clean up stale QMP socket so QEMU can rebind on restart
-	if instance.Config.QMPSocket != "" {
-		_ = os.Remove(instance.Config.QMPSocket)
-	}
-
-	// Unmount EBS volumes (same pattern as stopInstance)
-	d.unmountInstanceVolumes(instance)
-
-	// Persist state
-	if err := d.WriteState(); err != nil {
-		slog.Error("Failed to persist state after crash handling",
-			"instance", instance.ID, "err", err)
-	}
-
-	d.maybeRestartInstance(instance)
+	d.vmMgr.HandleCrash(instance, waitErr)
 }
 
-// unmountInstanceVolumes sends NATS unmount requests for all volumes attached
-// to the instance and updates their state to "available".
-func (d *Daemon) unmountInstanceVolumes(instance *vm.VM) {
-	instance.EBSRequests.Mu.Lock()
-	defer instance.EBSRequests.Mu.Unlock()
-
-	for _, ebsRequest := range instance.EBSRequests.Requests {
-		ebsUnMountRequest, err := json.Marshal(ebsRequest)
-		if err != nil {
-			slog.Error("Failed to marshal volume payload for crash cleanup",
-				"err", err)
-			continue
-		}
-
-		msg, err := d.natsConn.Request(d.ebsTopic("unmount"), ebsUnMountRequest, 30*time.Second)
-		if err != nil {
-			slog.Error("Failed to unmount volume after crash",
-				"name", ebsRequest.Name, "instance", instance.ID, "err", err)
-		} else {
-			slog.Info("Unmounted volume after crash",
-				"instance", instance.ID, "volume", ebsRequest.Name, "data", string(msg.Data))
-		}
-
-		// Update user-visible volume state to "available"
-		if !ebsRequest.EFI && !ebsRequest.CloudInit {
-			if err := d.volumeService.UpdateVolumeState(ebsRequest.Name, "available", "", ""); err != nil {
-				slog.Error("Failed to update volume state to available after crash",
-					"volumeId", ebsRequest.Name, "err", err)
-			}
-		}
-	}
-}
-
-// maybeRestartInstance checks restart policy and schedules a restart if allowed.
 func (d *Daemon) maybeRestartInstance(instance *vm.VM) {
-	if d.shuttingDown.Load() {
-		slog.Info("Skipping restart during shutdown", "instance", instance.ID)
-		return
-	}
-
-	now := time.Now()
-
-	var (
-		crashCount   int
-		restartCount int
-		exceeded     bool
-	)
-	d.vmMgr.Inspect(instance, func(v *vm.VM) {
-		health := &v.Health
-		if !health.FirstCrashTime.IsZero() && now.Sub(health.FirstCrashTime) > restartWindow {
-			slog.Info("Crash window expired, resetting counters", "instance", v.ID)
-			health.CrashCount = 1
-			health.FirstCrashTime = now
-			health.RestartCount = 0
-		}
-		if health.CrashCount > maxRestartsInWindow {
-			exceeded = true
-			crashCount = health.CrashCount
-			return
-		}
-		restartCount = health.RestartCount
-	})
-	if exceeded {
-		slog.Error("Instance exceeded max restarts in window, leaving in error state",
-			"instance", instance.ID,
-			"crashes", crashCount,
-			"window", restartWindow,
-			"max", maxRestartsInWindow)
-		return
-	}
-
-	// Check resource availability
-	instanceType, ok := d.resourceMgr.instanceTypes[instance.InstanceType]
-	if !ok || instanceType == nil {
-		slog.Error("Unknown instance type, cannot restart",
-			"instance", instance.ID, "type", instance.InstanceType)
-		return
-	}
-
-	if d.resourceMgr.canAllocate(instanceType, 1) < 1 {
-		slog.Error("Insufficient resources to restart instance",
-			"instance", instance.ID, "type", instance.InstanceType)
-		return
-	}
-
-	delay := restartBackoff(restartCount)
-
-	slog.Info("Scheduling instance restart",
-		"instance", instance.ID,
-		"delay", delay,
-		"restartCount", restartCount+1)
-
-	time.AfterFunc(delay, func() {
-		d.restartCrashedInstance(instance)
-	})
-}
-
-// restartCrashedInstance re-verifies the instance is still in error state
-// and relaunches it via LaunchInstance.
-func (d *Daemon) restartCrashedInstance(instance *vm.VM) {
-	var skipReason string
-	var restartCount int
-	d.vmMgr.Inspect(instance, func(v *vm.VM) {
-		if v.Status != vm.StateError {
-			skipReason = fmt.Sprintf("not in error state (%s)", v.Status)
-			return
-		}
-		if d.shuttingDown.Load() {
-			skipReason = "shutting down"
-			return
-		}
-		v.Health.RestartCount++
-		restartCount = v.Health.RestartCount
-	})
-	if skipReason != "" {
-		slog.Info("Skipping restart of crashed instance",
-			"instance", instance.ID, "reason", skipReason)
-		return
-	}
-
-	slog.Info("Restarting crashed instance",
-		"instance", instance.ID,
-		"restartCount", restartCount)
-
-	// Re-allocate resources before relaunch — handleCrashedInstance deallocates
-	// them, so we must re-reserve before starting the VM again.
-	instanceType, ok := d.resourceMgr.instanceTypes[instance.InstanceType]
-	if !ok || instanceType == nil {
-		slog.Error("Unknown instance type during restart, cannot re-allocate resources",
-			"instance", instance.ID, "type", instance.InstanceType)
-		return
-	}
-	if err := d.resourceMgr.allocate(instanceType); err != nil {
-		slog.Error("Insufficient resources to restart crashed instance",
-			"instance", instance.ID, "type", instance.InstanceType, "err", err)
-		return
-	}
-
-	// Transition Error → Pending (valid now that we added it to the transitions map)
-	if err := d.TransitionState(instance, vm.StatePending); err != nil {
-		slog.Error("Failed to transition instance to pending for restart",
-			"instance", instance.ID, "err", err)
-		d.resourceMgr.deallocate(instanceType)
-		return
-	}
-
-	// vmMgr.Run handles the full relaunch flow:
-	// check PID → mount → exec QEMU → attach QMP → NATS subscribe (via hook) → Running
-	if err := d.vmMgr.Run(instance); err != nil {
-		slog.Error("Failed to restart crashed instance",
-			"instance", instance.ID, "err", err)
-		d.resourceMgr.deallocate(instanceType)
-		if err := d.TransitionState(instance, vm.StateError); err != nil {
-			slog.Error("Failed to transition instance back to error after restart failure",
-				"instance", instance.ID, "err", err)
-		}
-	}
+	d.vmMgr.MaybeRestart(instance)
 }

--- a/spinifex/daemon/health_test.go
+++ b/spinifex/daemon/health_test.go
@@ -230,6 +230,18 @@ func newTestDaemon(t *testing.T) (*Daemon, func()) {
 		resourceMgr: rm,
 		vmMgr:       vm.NewManager(),
 	}
+	// Wire the dependencies the manager-internal crash handler relies on
+	// (TransitionState, ResourceController, InstanceTypes, ShutdownSignal).
+	// jsManager is still nil so TransitionState's WriteState will fail —
+	// matching the pre-2e shape where the in-memory status flip survives a
+	// write failure.
+	d.vmMgr.SetDeps(vm.Deps{
+		NodeID:          d.node,
+		TransitionState: d.TransitionState,
+		Resources:       newResourceControllerAdapter(rm),
+		InstanceTypes:   newInstanceTypeResolverAdapter(rm),
+		ShutdownSignal:  d.shuttingDown.Load,
+	})
 	return d, func() { nc.Close() }
 }
 

--- a/spinifex/daemon/health_test.go
+++ b/spinifex/daemon/health_test.go
@@ -72,18 +72,8 @@ func TestHandleInstanceCrash_SkipsNonRunning(t *testing.T) {
 }
 
 func TestHandleInstanceCrash_SkipsShuttingDown(t *testing.T) {
-	nc, err := nats.Connect(sharedNATSURL)
-	require.NoError(t, err)
-	defer nc.Close()
-
-	rm, err := NewResourceManager()
-	require.NoError(t, err)
-
-	d := &Daemon{
-		natsConn:    nc,
-		resourceMgr: rm,
-		vmMgr:       vm.NewManager(),
-	}
+	d, cleanup := newTestDaemon(t)
+	defer cleanup()
 	d.shuttingDown.Store(true)
 
 	instance := &vm.VM{

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -47,11 +47,12 @@ func createDaemonWithJetStream(t *testing.T) *Daemon {
 	// responsibility and is not needed here since these tests don't drive
 	// a real VM lifecycle.
 	daemon.vmMgr.SetDeps(vm.Deps{
-		NodeID:          daemon.node,
-		StateStore:      newStateStoreAdapter(daemon.jsManager),
-		TransitionState: daemon.TransitionState,
-		InstanceTypes:   newInstanceTypeResolverAdapter(daemon.resourceMgr),
-		Resources:       newResourceControllerAdapter(daemon.resourceMgr),
+		NodeID:                     daemon.node,
+		StateStore:                 newStateStoreAdapter(daemon.jsManager),
+		TransitionState:            daemon.TransitionState,
+		InstanceTypes:              newInstanceTypeResolverAdapter(daemon.resourceMgr),
+		Resources:                  newResourceControllerAdapter(daemon.resourceMgr),
+		ConsumeCleanShutdownMarker: daemon.consumeCleanShutdownMarker(),
 	})
 
 	return daemon

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -42,13 +42,16 @@ func createDaemonWithJetStream(t *testing.T) *Daemon {
 	require.NoError(t, daemon.jsManager.InitTerminatedInstanceBucket())
 
 	// Wire just enough vm.Deps for manager-driven state operations to work
-	// (migrate, MarkFailed). Full wiring (network plumber, instance cleaner,
-	// volume mounter) is a Daemon.Start responsibility and is not needed
-	// here since these tests don't drive a real VM lifecycle.
+	// (migrate, MarkFailed, Restore classification). Full wiring (network
+	// plumber, instance cleaner, volume mounter) is a Daemon.Start
+	// responsibility and is not needed here since these tests don't drive
+	// a real VM lifecycle.
 	daemon.vmMgr.SetDeps(vm.Deps{
 		NodeID:          daemon.node,
 		StateStore:      newStateStoreAdapter(daemon.jsManager),
 		TransitionState: daemon.TransitionState,
+		InstanceTypes:   newInstanceTypeResolverAdapter(daemon.resourceMgr),
+		Resources:       newResourceControllerAdapter(daemon.resourceMgr),
 	})
 
 	return daemon

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -439,9 +439,11 @@ func (d *Daemon) consumeCleanShutdownMarker() func() bool {
 
 // onInstanceUpHook returns the daemon's OnInstanceUp callback. Subscribing
 // per-instance NATS topics is the only side-effect; the manager fires this
-// synchronously after a successful Pending→Running transition.
-func (d *Daemon) onInstanceUpHook() func(*vm.VM) {
-	return func(instance *vm.VM) {
+// synchronously after a successful Pending→Running transition. Returns the
+// first subscribe error so the manager (specifically reconnectInstance) can
+// roll back QMP rather than persist a half-reachable instance to KV.
+func (d *Daemon) onInstanceUpHook() func(*vm.VM) error {
+	return func(instance *vm.VM) error {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 
@@ -457,7 +459,7 @@ func (d *Daemon) onInstanceUpHook() func(*vm.VM) {
 		if err != nil {
 			slog.Error("OnInstanceUp: failed to subscribe to per-instance topic",
 				"instanceId", instance.ID, "err", err)
-			return
+			return fmt.Errorf("subscribe ec2.cmd.%s: %w", instance.ID, err)
 		}
 		d.natsSubscriptions[instance.ID] = sub
 
@@ -468,9 +470,10 @@ func (d *Daemon) onInstanceUpHook() func(*vm.VM) {
 		if err != nil {
 			slog.Error("OnInstanceUp: failed to subscribe to console output topic",
 				"instanceId", instance.ID, "err", err)
-			return
+			return fmt.Errorf("subscribe ec2.%s.GetConsoleOutput: %w", instance.ID, err)
 		}
 		d.natsSubscriptions[consoleSubKey] = consoleSub
+		return nil
 	}
 }
 

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -360,6 +360,14 @@ func (a *resourceControllerAdapter) Deallocate(instanceType string) {
 	a.rm.deallocate(it)
 }
 
+func (a *resourceControllerAdapter) CanAllocate(instanceType string, count int) int {
+	it := a.rm.instanceTypes[instanceType]
+	if it == nil {
+		return 0
+	}
+	return a.rm.canAllocate(it, count)
+}
+
 // volumeStateUpdaterAdapter satisfies vm.VolumeStateUpdater by delegating to
 // the daemon's volume service.
 type volumeStateUpdaterAdapter struct {
@@ -381,6 +389,52 @@ func newVolumeStateUpdaterAdapter(svc volumeStateUpdater) *volumeStateUpdaterAda
 
 func (a *volumeStateUpdaterAdapter) UpdateVolumeState(volumeID, state, instanceID, attachmentDevice string) error {
 	return a.svc.UpdateVolumeState(volumeID, state, instanceID, attachmentDevice)
+}
+
+// onInstanceRecoveringHook returns the daemon's OnInstanceRecovering
+// callback. Restore fires it once per instance about to be relaunched so
+// concurrent terminate commands can land on this node before launch
+// completes — without it, ec2.cmd.<id> would only be subscribed by
+// onInstanceUpHook after launch success, leaving a window where the
+// instance is reachable by DescribeInstances (in StatePending) but not
+// by EC2 commands. Mirrors the pre-2e early-subscribe block in
+// daemon.restoreInstances.
+func (d *Daemon) onInstanceRecoveringHook() func(*vm.VM) {
+	return func(instance *vm.VM) {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+
+		if _, ok := d.natsSubscriptions[instance.ID]; ok {
+			return
+		}
+		sub, err := d.natsConn.Subscribe(fmt.Sprintf("ec2.cmd.%s", instance.ID), d.handleEC2Events)
+		if err != nil {
+			slog.Error("OnInstanceRecovering: failed to early-subscribe per-instance topic",
+				"instanceId", instance.ID, "err", err)
+			return
+		}
+		d.natsSubscriptions[instance.ID] = sub
+	}
+}
+
+// consumeCleanShutdownMarker returns the daemon's
+// ConsumeCleanShutdownMarker callback. Returns true (and deletes the
+// marker) when a clean shutdown was recorded for this node on the
+// previous run; returns false otherwise so Restore takes the cautious
+// "validate stale PIDs" path.
+func (d *Daemon) consumeCleanShutdownMarker() func() bool {
+	return func() bool {
+		if d.jsManager == nil {
+			return false
+		}
+		marker, err := d.jsManager.ReadShutdownMarker(d.node)
+		if err != nil || !marker {
+			return false
+		}
+		slog.Info("Clean shutdown marker found, trusting KV state")
+		_ = d.jsManager.DeleteShutdownMarker(d.node)
+		return true
+	}
 }
 
 // onInstanceUpHook returns the daemon's OnInstanceUp callback. Subscribing
@@ -463,15 +517,17 @@ func (d *Daemon) buildVMManagerDeps() vm.Deps {
 		VolumeStateUpdater: volState,
 		InstanceCleaner:    newInstanceCleanerAdapter(d),
 		Hooks: vm.ManagerHooks{
-			OnInstanceUp:   d.onInstanceUpHook(),
-			OnInstanceDown: d.onInstanceDownHook(),
+			OnInstanceUp:         d.onInstanceUpHook(),
+			OnInstanceDown:       d.onInstanceDownHook(),
+			OnInstanceRecovering: d.onInstanceRecoveringHook(),
 		},
-		ShutdownSignal:  d.shuttingDown.Load,
-		CrashHandler:    d.handleInstanceCrash,
-		TransitionState: d.TransitionState,
-		DevNetworking:   d.config.Daemon.DevNetworking,
-		BindHost:        d.config.Host,
-		DetachDelay:     d.detachDelay,
+		ShutdownSignal:             d.shuttingDown.Load,
+		CrashHandler:               d.handleInstanceCrash,
+		TransitionState:            d.TransitionState,
+		DevNetworking:              d.config.Daemon.DevNetworking,
+		BindHost:                   d.config.Host,
+		DetachDelay:                d.detachDelay,
+		ConsumeCleanShutdownMarker: d.consumeCleanShutdownMarker(),
 	}
 }
 

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -29,7 +29,7 @@ func TestOnInstanceUpHook_RegistersBothPerInstanceTopics(t *testing.T) {
 	d, _ := newHookTestDaemon(t)
 	instance := &vm.VM{ID: "i-up-basic"}
 
-	d.onInstanceUpHook()(instance)
+	require.NoError(t, d.onInstanceUpHook()(instance))
 
 	cmdSub, ok := d.natsSubscriptions[instance.ID]
 	require.True(t, ok, "ec2.cmd subscription must be registered under instance ID")
@@ -44,13 +44,13 @@ func TestOnInstanceUpHook_ReplacesExistingSubsOnDoubleUp(t *testing.T) {
 	d, _ := newHookTestDaemon(t)
 	instance := &vm.VM{ID: "i-up-twice"}
 
-	d.onInstanceUpHook()(instance)
+	require.NoError(t, d.onInstanceUpHook()(instance))
 	first := d.natsSubscriptions[instance.ID]
 	firstConsole := d.natsSubscriptions[instance.ID+".console"]
 	require.NotNil(t, first)
 	require.NotNil(t, firstConsole)
 
-	d.onInstanceUpHook()(instance)
+	require.NoError(t, d.onInstanceUpHook()(instance))
 	second := d.natsSubscriptions[instance.ID]
 	secondConsole := d.natsSubscriptions[instance.ID+".console"]
 	require.NotNil(t, second)
@@ -70,7 +70,7 @@ func TestOnInstanceDownHook_UnsubscribesAndDeletes(t *testing.T) {
 	d, _ := newHookTestDaemon(t)
 	instance := &vm.VM{ID: "i-down"}
 
-	d.onInstanceUpHook()(instance)
+	require.NoError(t, d.onInstanceUpHook()(instance))
 	cmdSub := d.natsSubscriptions[instance.ID]
 	consoleSub := d.natsSubscriptions[instance.ID+".console"]
 	require.NotNil(t, cmdSub)
@@ -100,8 +100,8 @@ func TestOnInstanceDownHook_OnlyRemovesTargetedInstance(t *testing.T) {
 	keep := &vm.VM{ID: "i-keep"}
 	drop := &vm.VM{ID: "i-drop"}
 
-	d.onInstanceUpHook()(keep)
-	d.onInstanceUpHook()(drop)
+	require.NoError(t, d.onInstanceUpHook()(keep))
+	require.NoError(t, d.onInstanceUpHook()(drop))
 	require.Len(t, d.natsSubscriptions, 4)
 
 	d.onInstanceDownHook()(drop.ID)

--- a/spinifex/vm/crash_recovery.go
+++ b/spinifex/vm/crash_recovery.go
@@ -1,0 +1,273 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const (
+	// MaxRestartsInWindow is the cap on automatic crash-restarts inside
+	// RestartWindow before the manager leaves the instance in StateError.
+	MaxRestartsInWindow = 3
+	// RestartWindow is the rolling window over which crashes count toward
+	// MaxRestartsInWindow. Crashes older than this reset the counter.
+	RestartWindow      = 10 * time.Minute
+	restartBackoffBase = 5 * time.Second
+	restartBackoffMax  = 2 * time.Minute
+)
+
+// RestartBackoff computes the exponential backoff delay for the given
+// restart count. Pure function — no side effects.
+func RestartBackoff(restartCount int) time.Duration {
+	delay := restartBackoffBase
+	for range restartCount {
+		delay *= 2
+		if delay > restartBackoffMax {
+			return restartBackoffMax
+		}
+	}
+	return delay
+}
+
+// ClassifyCrashReason extracts a human-readable crash reason from the error
+// returned by cmd.Wait(). Uses exec.ExitError + syscall.WaitStatus to
+// distinguish OOM kills (SIGKILL), segfaults (SIGSEGV), etc.
+func ClassifyCrashReason(waitErr error) string {
+	if waitErr == nil {
+		return "clean-exit"
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) {
+		return "unknown"
+	}
+
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return "unknown"
+	}
+
+	if status.Signaled() {
+		switch status.Signal() {
+		case syscall.SIGKILL:
+			return "oom-killed"
+		case syscall.SIGSEGV:
+			return "segfault"
+		case syscall.SIGABRT:
+			return "abort"
+		default:
+			return fmt.Sprintf("signal-%d", status.Signal())
+		}
+	}
+
+	if status.Exited() {
+		return fmt.Sprintf("exit-%d", status.ExitStatus())
+	}
+
+	return "unknown"
+}
+
+// HandleCrash is the QEMU exit goroutine's reaction when cmd.Wait() returns
+// during runtime (after startup was confirmed). It detects the crash reason,
+// transitions the instance to error state, releases resources, unmounts
+// volumes, and triggers MaybeRestart.
+//
+// Wired as Deps.CrashHandler so the launch goroutine in lifecycle.go can
+// invoke it without importing the manager into a separate goroutine spawner.
+func (m *Manager) HandleCrash(instance *VM, waitErr error) {
+	var status InstanceState
+	m.Inspect(instance, func(v *VM) { status = v.Status })
+
+	if status != StateRunning {
+		slog.Debug("QEMU exited but instance not in running state, skipping crash handler",
+			"instance", instance.ID, "status", status)
+		return
+	}
+
+	if m.deps.ShutdownSignal != nil && m.deps.ShutdownSignal() {
+		slog.Debug("QEMU exited during coordinated shutdown, skipping crash handler",
+			"instance", instance.ID)
+		return
+	}
+
+	reason := ClassifyCrashReason(waitErr)
+	slog.Error("VM process crashed", "instance", instance.ID, "reason", reason, "err", waitErr)
+
+	if m.deps.TransitionState != nil {
+		if err := m.deps.TransitionState(instance, StateError); err != nil {
+			slog.Error("Failed to transition crashed instance to error state",
+				"instance", instance.ID, "err", err)
+		}
+	}
+
+	now := time.Now()
+	m.Inspect(instance, func(v *VM) {
+		v.Health.CrashCount++
+		v.Health.LastCrashTime = now
+		v.Health.LastCrashReason = reason
+		if v.Health.FirstCrashTime.IsZero() {
+			v.Health.FirstCrashTime = now
+		}
+		v.Running = false
+		v.PID = 0
+	})
+
+	if m.deps.Resources != nil && instance.InstanceType != "" {
+		slog.Info("Deallocating resources for crashed instance",
+			"instance", instance.ID, "type", instance.InstanceType)
+		m.deps.Resources.Deallocate(instance.InstanceType)
+	}
+
+	if instance.Config.QMPSocket != "" {
+		_ = os.Remove(instance.Config.QMPSocket)
+	}
+
+	if m.deps.VolumeMounter != nil {
+		if err := m.deps.VolumeMounter.Unmount(instance); err != nil {
+			slog.Error("Volume unmount failed during crash handling",
+				"instance", instance.ID, "err", err)
+		}
+	}
+
+	if err := m.writeRunningState(); err != nil {
+		slog.Error("Failed to persist state after crash handling",
+			"instance", instance.ID, "err", err)
+	}
+
+	m.MaybeRestart(instance)
+}
+
+// MaybeRestart checks restart policy and schedules a restart via
+// time.AfterFunc when allowed. Bails out on coordinated shutdown, unknown
+// instance type, exhausted restart window, or insufficient host capacity.
+func (m *Manager) MaybeRestart(instance *VM) {
+	if m.deps.ShutdownSignal != nil && m.deps.ShutdownSignal() {
+		slog.Info("Skipping restart during shutdown", "instance", instance.ID)
+		return
+	}
+
+	now := time.Now()
+
+	var (
+		crashCount   int
+		restartCount int
+		exceeded     bool
+	)
+	m.Inspect(instance, func(v *VM) {
+		health := &v.Health
+		if !health.FirstCrashTime.IsZero() && now.Sub(health.FirstCrashTime) > RestartWindow {
+			slog.Info("Crash window expired, resetting counters", "instance", v.ID)
+			health.CrashCount = 1
+			health.FirstCrashTime = now
+			health.RestartCount = 0
+		}
+		if health.CrashCount > MaxRestartsInWindow {
+			exceeded = true
+			crashCount = health.CrashCount
+			return
+		}
+		restartCount = health.RestartCount
+	})
+	if exceeded {
+		slog.Error("Instance exceeded max restarts in window, leaving in error state",
+			"instance", instance.ID,
+			"crashes", crashCount,
+			"window", RestartWindow,
+			"max", MaxRestartsInWindow)
+		return
+	}
+
+	if m.deps.InstanceTypes != nil {
+		if _, ok := m.deps.InstanceTypes.Resolve(instance.InstanceType); !ok {
+			slog.Error("Unknown instance type, cannot restart",
+				"instance", instance.ID, "type", instance.InstanceType)
+			return
+		}
+	}
+
+	if m.deps.Resources != nil {
+		if m.deps.Resources.CanAllocate(instance.InstanceType, 1) < 1 {
+			slog.Error("Insufficient resources to restart instance",
+				"instance", instance.ID, "type", instance.InstanceType)
+			return
+		}
+	}
+
+	delay := RestartBackoff(restartCount)
+
+	slog.Info("Scheduling instance restart",
+		"instance", instance.ID,
+		"delay", delay,
+		"restartCount", restartCount+1)
+
+	time.AfterFunc(delay, func() {
+		m.RestartCrashedInstance(instance)
+	})
+}
+
+// RestartCrashedInstance re-verifies the instance is still in error state
+// and relaunches it via Manager.Run. Reallocates resources before relaunch
+// (HandleCrash deallocates them) and rolls back the transition + allocation
+// if the relaunch fails.
+func (m *Manager) RestartCrashedInstance(instance *VM) {
+	var skipReason string
+	var restartCount int
+	m.Inspect(instance, func(v *VM) {
+		if v.Status != StateError {
+			skipReason = fmt.Sprintf("not in error state (%s)", v.Status)
+			return
+		}
+		if m.deps.ShutdownSignal != nil && m.deps.ShutdownSignal() {
+			skipReason = "shutting down"
+			return
+		}
+		v.Health.RestartCount++
+		restartCount = v.Health.RestartCount
+	})
+	if skipReason != "" {
+		slog.Info("Skipping restart of crashed instance",
+			"instance", instance.ID, "reason", skipReason)
+		return
+	}
+
+	slog.Info("Restarting crashed instance",
+		"instance", instance.ID,
+		"restartCount", restartCount)
+
+	if m.deps.Resources == nil {
+		slog.Error("ResourceController not wired, cannot restart crashed instance",
+			"instance", instance.ID)
+		return
+	}
+	if err := m.deps.Resources.Allocate(instance.InstanceType); err != nil {
+		slog.Error("Insufficient resources to restart crashed instance",
+			"instance", instance.ID, "type", instance.InstanceType, "err", err)
+		return
+	}
+
+	if m.deps.TransitionState != nil {
+		if err := m.deps.TransitionState(instance, StatePending); err != nil {
+			slog.Error("Failed to transition instance to pending for restart",
+				"instance", instance.ID, "err", err)
+			m.deps.Resources.Deallocate(instance.InstanceType)
+			return
+		}
+	}
+
+	if err := m.Run(instance); err != nil {
+		slog.Error("Failed to restart crashed instance",
+			"instance", instance.ID, "err", err)
+		m.deps.Resources.Deallocate(instance.InstanceType)
+		if m.deps.TransitionState != nil {
+			if err := m.deps.TransitionState(instance, StateError); err != nil {
+				slog.Error("Failed to transition instance back to error after restart failure",
+					"instance", instance.ID, "err", err)
+			}
+		}
+	}
+}

--- a/spinifex/vm/instance_type_resolver.go
+++ b/spinifex/vm/instance_type_resolver.go
@@ -21,6 +21,10 @@ type InstanceTypeResolver interface {
 type ResourceController interface {
 	Allocate(instanceType string) error
 	Deallocate(instanceType string)
+	// CanAllocate returns how many instances of instanceType could be
+	// allocated right now (0 to count). Used by the crash-recovery
+	// scheduler to avoid restarting a VM the host can't fit.
+	CanAllocate(instanceType string, count int) int
 }
 
 // VolumeStateUpdater is the narrow slice of the volume service the manager

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -151,7 +151,15 @@ func (m *Manager) launch(instance *VM) error {
 	}
 
 	if m.deps.Hooks.OnInstanceUp != nil {
-		m.deps.Hooks.OnInstanceUp(instance)
+		// Launch path: per-instance subscribe failures are logged and the
+		// launch still succeeds, mirroring the pre-2e early-subscribe block
+		// in handleEC2RunInstances. The instance is reachable via cluster
+		// fan-out (DescribeInstances) and the next OnInstanceUp on a
+		// state-touching event will reinstall the subs idempotently.
+		if err := m.deps.Hooks.OnInstanceUp(instance); err != nil {
+			slog.Error("OnInstanceUp hook reported error during launch",
+				"instance", instance.ID, "err", err)
+		}
 	}
 
 	return nil

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -9,8 +9,13 @@ import (
 // ManagerHooks are callbacks the manager fires synchronously on every
 // running/terminated transition. The daemon uses these to drive per-instance
 // NATS subscription/unsubscription. Hook fields may be nil; nil hooks are no-ops.
+//
+// OnInstanceUp returns an error so callers can distinguish a soft launch
+// (subscribe failures only logged) from a reconnect (failures must roll back
+// QMP and abort the reconnect). Callers that don't care about the error may
+// ignore it.
 type ManagerHooks struct {
-	OnInstanceUp   func(*VM)
+	OnInstanceUp   func(*VM) error
 	OnInstanceDown func(id string)
 	// OnInstanceRecovering fires from Restore once per instance that is
 	// about to be relaunched. The daemon subscribes only the command

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -12,6 +12,13 @@ import (
 type ManagerHooks struct {
 	OnInstanceUp   func(*VM)
 	OnInstanceDown func(id string)
+	// OnInstanceRecovering fires from Restore once per instance that is
+	// about to be relaunched. The daemon subscribes only the command
+	// topic (ec2.cmd.<id>) here so concurrent terminate commands can
+	// reach this node while the relaunch is in flight; the subsequent
+	// OnInstanceUp on launch success is idempotent and reinstalls both
+	// the command and console subscriptions.
+	OnInstanceRecovering func(*VM)
 }
 
 // Deps bundles every collaborator the manager uses to drive lifecycle.
@@ -54,6 +61,13 @@ type Deps struct {
 	// during DetachVolume, and the polling interval for blockdev-del retry.
 	// Zero is acceptable in tests; production uses 1s.
 	DetachDelay time.Duration
+
+	// ConsumeCleanShutdownMarker reports whether the previous daemon run
+	// recorded a clean shutdown marker for this node, deleting it as a
+	// side effect. Restore uses the result to decide whether to wait
+	// briefly for stale QEMU PIDs to die before classifying state. Nil
+	// is treated as "no marker" (cautious recovery).
+	ConsumeCleanShutdownMarker func() bool
 }
 
 // Manager owns the in-memory map of running VMs on this node and every

--- a/spinifex/vm/restore.go
+++ b/spinifex/vm/restore.go
@@ -1,0 +1,364 @@
+package vm
+
+import (
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"runtime/debug"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/qmp"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+)
+
+// maxConcurrentRecovery limits how many VMs are relaunched in parallel during
+// recovery. Cold-AMI clones plus QEMU exec start are I/O-heavy; bounding the
+// fan-out keeps the host responsive while still parallelising the slow path.
+const maxConcurrentRecovery = 2
+
+// Restore loads persisted VM state and re-launches instances that are
+// neither terminated nor flagged as user-stopped. Steps:
+//
+//  1. Consume the clean-shutdown marker (deps callback). Without one, sleep
+//     briefly so any stale QEMU PIDs from a crashed previous run finish dying
+//     before isInstanceProcessRunning is consulted.
+//  2. Load the per-node running snapshot via StateStore.
+//  3. Classify each instance — terminated/stopped go to their shared KV
+//     buckets; running with live QEMU + valid sockets reconnects via QMP;
+//     transitional states finalise; everything else queues for relaunch.
+//  4. Fan out Manager.Run across the relaunch queue with a semaphore.
+//
+// All errors are logged; Restore never fails fatally — it always leaves the
+// daemon in a usable state.
+func (m *Manager) Restore() {
+	cleanShutdown := false
+	if m.deps.ConsumeCleanShutdownMarker != nil {
+		cleanShutdown = m.deps.ConsumeCleanShutdownMarker()
+	}
+	if !cleanShutdown {
+		slog.Warn("No clean shutdown marker — possible crash recovery, validating QEMU PIDs carefully")
+		time.Sleep(3 * time.Second)
+	}
+
+	if err := m.loadRunningState(); err != nil {
+		slog.Warn("Failed to load state, continuing with empty state", "error", err)
+		return
+	}
+
+	slog.Info("Loaded state", "instance count", m.Count())
+
+	toLaunch := m.classifyRestoredInstances()
+
+	if len(toLaunch) > 0 {
+		m.relaunchAll(toLaunch)
+	}
+
+	if err := m.writeRunningState(); err != nil {
+		slog.Error("Failed to persist state after restore", "error", err)
+	}
+}
+
+// loadRunningState replaces the manager's running set with the snapshot
+// persisted for this node. Returns an error only if the StateStore
+// surfaced one — a missing key produces an empty map and no error.
+func (m *Manager) loadRunningState() error {
+	if m.deps.StateStore == nil {
+		return fmt.Errorf("StateStore not wired")
+	}
+	loaded, err := m.deps.StateStore.LoadRunningState(m.deps.NodeID)
+	if err != nil {
+		return err
+	}
+	m.Replace(loaded)
+	return nil
+}
+
+// classifyRestoredInstances walks every loaded VM and routes it: stopped
+// and terminated instances go to their shared KV buckets and are dropped
+// from the local map; running instances with live QEMU + reachable NBD
+// sockets reconnect via QMP; transitional states (Stopping, ShuttingDown)
+// finalise to their stable counterparts; the remainder is returned for
+// relaunch via Manager.Run.
+func (m *Manager) classifyRestoredInstances() []*VM {
+	var toLaunch []*VM
+
+	for _, instance := range m.Snapshot() {
+		instance.EBSRequests.Mu = sync.Mutex{}
+		instance.QMPClient = &qmp.QMPClient{}
+
+		if instance.Status == StateTerminated {
+			if !m.MigrateTerminatedToKV(instance) {
+				// KV write failed — keep in local state so the next restart
+				// retries the migration. Deleting here would create a "void":
+				// the instance disappears from both local state and the
+				// terminated KV, making it invisible to DescribeInstances.
+				slog.Warn("Terminated instance KV migration failed, will retry on next restart",
+					"instance", instance.ID)
+			}
+			continue
+		}
+
+		if instance.Status == StateStopped {
+			m.MigrateStoppedToSharedKV(instance)
+			continue
+		}
+
+		typeKnown := true
+		if m.deps.InstanceTypes != nil {
+			_, typeKnown = m.deps.InstanceTypes.Resolve(instance.InstanceType)
+		}
+		if !typeKnown && instance.InstanceType != "" {
+			slog.Warn("Instance type not available on this node, moving to stopped",
+				"instanceId", instance.ID, "instanceType", instance.InstanceType)
+			markUnschedulable(instance,
+				fmt.Sprintf("instance type %s is not available on this node", instance.InstanceType))
+			m.MigrateStoppedToSharedKV(instance)
+			continue
+		}
+
+		if typeKnown && m.deps.Resources != nil && instance.InstanceType != "" {
+			slog.Info("Re-allocating resources for instance", "instanceId", instance.ID, "type", instance.InstanceType)
+			if err := m.deps.Resources.Allocate(instance.InstanceType); err != nil {
+				slog.Error("Failed to re-allocate resources for instance on startup, moving to stopped",
+					"instanceId", instance.ID, "err", err)
+				markUnschedulable(instance,
+					fmt.Sprintf("insufficient resources to restore instance: %v", err))
+				m.MigrateStoppedToSharedKV(instance)
+				continue
+			}
+		}
+
+		if isInstanceProcessRunning(instance) {
+			if !AreVolumeSocketsValid(instance) {
+				slog.Warn("QEMU alive but NBD sockets are stale, killing orphaned process for relaunch",
+					"instance", instance.ID)
+				if !killOrphanedQEMU(instance) {
+					continue
+				}
+			} else {
+				slog.Info("Instance QEMU process still alive, reconnecting", "instance", instance.ID)
+				if err := m.reconnectInstance(instance); err != nil {
+					slog.Error("Failed to reconnect to running instance", "instanceId", instance.ID, "err", err)
+				}
+				continue
+			}
+		}
+
+		// QEMU is not running -- resolve transitional states from interrupted operations.
+		switch instance.Status {
+		case StateStopping, StateShuttingDown:
+			if m.finalizeTransitionalRestore(instance) {
+				continue
+			}
+			continue
+		case StateRunning:
+			instance.Status = StatePending
+			slog.Info("Instance was running but QEMU exited, relaunching", "instance", instance.ID)
+		}
+
+		// Reset LaunchTime so the pending watchdog gives a fresh timeout window.
+		// Without this, the stale LaunchTime from the original launch causes the
+		// watchdog to immediately mark the instance as failed after a prolonged outage.
+		now := time.Now()
+		if instance.Instance != nil {
+			instance.Instance.LaunchTime = &now
+		}
+		toLaunch = append(toLaunch, instance)
+	}
+
+	return toLaunch
+}
+
+// markUnschedulable flips an instance to Stopped with an
+// InsufficientInstanceCapacity StateReason so DescribeInstances surfaces a
+// useful error after a node loses the ability to host the type.
+func markUnschedulable(instance *VM, reason string) {
+	instance.Status = StateStopped
+	if instance.Instance != nil {
+		instance.Instance.StateReason = &ec2.StateReason{}
+		instance.Instance.StateReason.SetCode("Server.InsufficientInstanceCapacity")
+		instance.Instance.StateReason.SetMessage(reason)
+	}
+}
+
+// killOrphanedQEMU SIGKILLs a QEMU process whose NBD storage no longer
+// works (viperblock restarted with fresh sockets). Returns true when the
+// process is gone (or was never running) and the caller should proceed
+// with classification; false when the kill failed and the instance
+// should be skipped this cycle.
+//
+// SIGKILL directly: orphaned QEMU with dead storage has no state worth a
+// graceful shutdown, and KillProcess's 120s SIGTERM timeout would block
+// daemon startup.
+func killOrphanedQEMU(instance *VM) bool {
+	pid, pidErr := utils.ReadPidFile(instance.ID)
+	if pidErr != nil || pid <= 0 {
+		slog.Error("Cannot read PID for orphaned QEMU, skipping relaunch",
+			"instanceId", instance.ID, "err", pidErr)
+		return false
+	}
+	if proc, err := os.FindProcess(pid); err == nil {
+		_ = proc.Signal(syscall.SIGKILL)
+	}
+	// SIGKILL cannot be caught; QEMU never runs its cleanup so the PID
+	// file stays on disk. Wait for the process to die, then remove it.
+	if err := utils.WaitForProcessExit(pid, 10*time.Second); err != nil {
+		slog.Error("Orphaned QEMU did not exit after SIGKILL, skipping relaunch",
+			"instanceId", instance.ID, "pid", pid, "err", err)
+		return false
+	}
+	_ = utils.RemovePidFile(instance.ID)
+	return true
+}
+
+// finalizeTransitionalRestore resolves an instance whose QEMU is gone but
+// whose persisted state was Stopping or ShuttingDown — flipping it to its
+// stable counterpart and migrating to the appropriate shared KV bucket.
+// Returns true on a clean migration; false signals the caller to retry on
+// the next restart.
+func (m *Manager) finalizeTransitionalRestore(instance *VM) bool {
+	prevStatus := instance.Status
+	if instance.Status == StateStopping {
+		instance.Status = StateStopped
+	} else {
+		instance.Status = StateTerminated
+	}
+	slog.Info("QEMU exited during transition, finalizing state",
+		"instance", instance.ID, "from", prevStatus, "to", instance.Status)
+
+	if instance.Status == StateStopped && m.MigrateStoppedToSharedKV(instance) {
+		return true
+	}
+	if instance.Status == StateTerminated && m.MigrateTerminatedToKV(instance) {
+		return true
+	}
+
+	if err := m.writeRunningState(); err != nil {
+		slog.Error("Failed to persist state, will retry on next restart",
+			"instance", instance.ID, "error", err)
+		instance.Status = prevStatus // revert so next restart retries
+	}
+	return true
+}
+
+// relaunchAll kicks the recovery launch loop. Per pre-2e behaviour, we
+// announce each instance via OnInstanceRecovering before launching so the
+// daemon can early-subscribe ec2.cmd.<id>; that lets a concurrent terminate
+// reach this node while the relaunch is still pending. The OnInstanceUp
+// hook fired after a successful launch reinstalls both per-instance subs
+// idempotently.
+func (m *Manager) relaunchAll(toLaunch []*VM) {
+	if m.deps.Hooks.OnInstanceRecovering != nil {
+		for _, instance := range toLaunch {
+			m.deps.Hooks.OnInstanceRecovering(instance)
+		}
+	}
+
+	slog.Info("Launching instances (recovery)", "count", len(toLaunch), "maxConcurrent", maxConcurrentRecovery)
+	sem := make(chan struct{}, maxConcurrentRecovery)
+	var wg sync.WaitGroup
+
+	for _, instance := range toLaunch {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(inst *VM) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("Panic during instance recovery",
+						"instanceId", inst.ID, "panic", r, "stack", string(debug.Stack()))
+				}
+			}()
+
+			var status InstanceState
+			m.Inspect(inst, func(v *VM) { status = v.Status })
+			if status != StatePending && status != StateProvisioning {
+				slog.Info("Instance state changed during recovery, skipping launch",
+					"instanceId", inst.ID, "status", string(status))
+				return
+			}
+			slog.Info("Launching instance (recovery)", "instance", inst.ID)
+			if err := m.Run(inst); err != nil {
+				slog.Error("Failed to launch instance during recovery", "instanceId", inst.ID, "err", err)
+				m.MarkFailed(inst, "recovery_launch_failed")
+			}
+		}(instance)
+	}
+	wg.Wait()
+}
+
+// reconnectInstance re-establishes the QMP connection for an instance whose
+// QEMU survived the daemon restart, fires OnInstanceUp so the daemon
+// reinstalls per-instance NATS subscriptions, and persists the running
+// state. Bypasses the state-machine validation because reconnect is not a
+// modelled transition.
+func (m *Manager) reconnectInstance(instance *VM) error {
+	if err := m.AttachQMP(instance); err != nil {
+		return fmt.Errorf("failed to reconnect QMP: %w", err)
+	}
+
+	instance.Status = StateRunning
+
+	if m.deps.Hooks.OnInstanceUp != nil {
+		m.deps.Hooks.OnInstanceUp(instance)
+	}
+
+	if err := m.writeRunningState(); err != nil {
+		return fmt.Errorf("failed to persist reconnected instance state: %w", err)
+	}
+
+	slog.Info("Successfully reconnected to running instance", "instance", instance.ID)
+	return nil
+}
+
+// isInstanceProcessRunning checks whether the QEMU process recorded in
+// the instance's PID file is still alive. Returns false on any failure
+// path (missing PID file, dead PID, signal-0 error).
+func isInstanceProcessRunning(instance *VM) bool {
+	pid, err := utils.ReadPidFile(instance.ID)
+	if err != nil || pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}
+
+// AreVolumeSocketsValid reports whether the NBD Unix sockets backing the
+// instance's volumes are reachable. A dial probe (not just os.Stat) is
+// required because viperblock may restart with sockets at the same paths
+// — the file exists but no process is listening on the old fd that QEMU
+// holds. TCP and unparseable URIs are treated as valid (we can't probe
+// remote viperblockd from the recovery path).
+//
+// Exported so the daemon-side test suite can assert socket-validity
+// behaviour through the existing test helper without reaching into
+// manager internals.
+func AreVolumeSocketsValid(instance *VM) bool {
+	instance.EBSRequests.Mu.Lock()
+	defer instance.EBSRequests.Mu.Unlock()
+
+	for _, req := range instance.EBSRequests.Requests {
+		if req.NBDURI == "" {
+			continue
+		}
+		serverType, sockPath, _, _, err := utils.ParseNBDURI(req.NBDURI)
+		if err != nil || serverType != "unix" {
+			continue
+		}
+		conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+		if err != nil {
+			slog.Debug("NBD socket unreachable", "volume", req.Name, "socket", sockPath, "err", err)
+			return false
+		}
+		_ = conn.Close()
+	}
+	return true
+}

--- a/spinifex/vm/restore.go
+++ b/spinifex/vm/restore.go
@@ -297,16 +297,30 @@ func (m *Manager) relaunchAll(toLaunch []*VM) {
 // reinstalls per-instance NATS subscriptions, and persists the running
 // state. Bypasses the state-machine validation because reconnect is not a
 // modelled transition.
+//
+// Subscribe failure during the hook is treated as a hard error: the QMP
+// connection is closed (so the heartbeat goroutine exits on the next tick
+// when status leaves StateRunning) and the error is propagated. The caller
+// in classifyRestoredInstances logs and moves on; the instance remains in
+// the loaded map and will be retried on the next daemon restart. Status is
+// only flipped to StateRunning after subscribes are confirmed live so a
+// failed reconnect does not advertise a half-working instance to peers.
 func (m *Manager) reconnectInstance(instance *VM) error {
 	if err := m.AttachQMP(instance); err != nil {
 		return fmt.Errorf("failed to reconnect QMP: %w", err)
 	}
 
-	instance.Status = StateRunning
-
 	if m.deps.Hooks.OnInstanceUp != nil {
-		m.deps.Hooks.OnInstanceUp(instance)
+		if err := m.deps.Hooks.OnInstanceUp(instance); err != nil {
+			if instance.QMPClient != nil && instance.QMPClient.Conn != nil {
+				_ = instance.QMPClient.Conn.Close()
+				instance.QMPClient = nil
+			}
+			return fmt.Errorf("failed to reinstall per-instance NATS subscriptions: %w", err)
+		}
 	}
+
+	instance.Status = StateRunning
 
 	if err := m.writeRunningState(); err != nil {
 		return fmt.Errorf("failed to persist reconnected instance state: %w", err)

--- a/spinifex/vm/volumes_test.go
+++ b/spinifex/vm/volumes_test.go
@@ -346,7 +346,7 @@ func TestReboot_DoesNotFireHooks(t *testing.T) {
 
 	var upCalls, downCalls int
 	hooks := ManagerHooks{
-		OnInstanceUp:   func(*VM) { upCalls++ },
+		OnInstanceUp:   func(*VM) error { upCalls++; return nil },
 		OnInstanceDown: func(string) { downCalls++ },
 	}
 	m := NewManagerWithDeps(Deps{Hooks: hooks})

--- a/spinifex/vm/watchdog.go
+++ b/spinifex/vm/watchdog.go
@@ -1,0 +1,48 @@
+package vm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const (
+	// PendingWatchdogInterval is the polling cadence for the stuck-in-pending
+	// watchdog. Exported so tests can match production's window without
+	// repeating the literal.
+	PendingWatchdogInterval = 60 * time.Second
+	// PendingWatchdogTimeout is how long an instance may stay in
+	// Pending/Provisioning before the watchdog marks it failed.
+	PendingWatchdogTimeout = 5 * time.Minute
+)
+
+// StartPendingWatchdog spawns a background goroutine that periodically
+// scans for instances stuck in Pending/Provisioning beyond
+// PendingWatchdogTimeout and marks them failed via Manager.MarkFailed. The
+// goroutine exits when ctx is cancelled. Safe to call once per Manager
+// (additional calls would duplicate the goroutine).
+func (m *Manager) StartPendingWatchdog(ctx context.Context) {
+	ticker := time.NewTicker(PendingWatchdogInterval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				stuck := m.Filter(func(v *VM) bool {
+					return (v.Status == StatePending || v.Status == StateProvisioning) &&
+						v.Instance != nil && v.Instance.LaunchTime != nil &&
+						time.Since(*v.Instance.LaunchTime) > PendingWatchdogTimeout
+				})
+
+				for _, instance := range stuck {
+					slog.Warn("Instance stuck in pending, marking failed",
+						"instanceId", instance.ID, "status", instance.Status,
+						"elapsed", time.Since(*instance.Instance.LaunchTime))
+					m.MarkFailed(instance, "launch_timeout")
+				}
+			}
+		}
+	}()
+}


### PR DESCRIPTION
Phase 2e of vm-lifecycle-extraction. Restore + reconnect, the QEMU exit crash handler chain, and the pending-launch watchdog leave the daemon package and become methods on vm.Manager.

- vm/restore.go — Manager.Restore loads per-node state, classifies VMs (terminate / stop migrate to shared KV; running with live QEMU and valid NBD sockets reconnect via QMP; transitional states finalise), and fans Run out across the relaunch queue with the existing semaphore.
- vm/crash_recovery.go — Manager.HandleCrash, MaybeRestart, and RestartCrashedInstance own the post-exit chain. ClassifyCrashReason and RestartBackoff become exported pure helpers.
- vm/watchdog.go — Manager.StartPendingWatchdog spawns the stuck-in-pending scanner. Daemon.Start drives it with d.ctx.
- ManagerHooks gains OnInstanceRecovering, fired by Restore once per relaunch so the daemon can early-subscribe ec2.cmd.<id> while a concurrent terminate races; OnInstanceUp on launch success reinstalls both per-instance subs idempotently.
- Deps gains ConsumeCleanShutdownMarker so the manager doesn't reach into JetStream for the marker decision.
- ResourceController gains CanAllocate so MaybeRestart can precheck capacity without round-tripping the EC2 SDK type.

Daemon-side wrappers (handleInstanceCrash, maybeRestartInstance, restoreInstances, areVolumeSocketsValid, classifyCrashReason, restartBackoff) are preserved as one-liner shims so the existing health/state test cases keep their bare-name calls; phase 2f migrates those into vm/ and deletes the shims.

Daemon.Start: vmMgr.Restore() runs before subscribeAll, with OnInstanceUp/OnInstanceRecovering hooks firing on the same NATS connection that connectNATS already established. vmMgr.StartPendingWatchdog replaces the pre-2e startPendingWatchdog goroutine.

Net change: -486 lines on the daemon side. make preflight clean.