### PR TITLE
feat: require host and x-amz-date in SigV4 SignedHeaders

### DIFF
--- a/spinifex/gateway/auth.go
+++ b/spinifex/gateway/auth.go
@@ -87,6 +87,15 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 				return
 			}
 
+			// Enforce that host and x-amz-date are signed. AWS SDKs always sign
+			// both; omitting either lets a captured Authorization header replay
+			// against a different vhost or outside the X-Amz-Date skew window.
+			// Mirrors predastore/auth.RequireSignedHeaders.
+			if !signedHeadersIncludeHostAndDate(signedHeaders) {
+				gw.writeSigV4Error(w, r, awserrors.ErrorIncompleteSignature)
+				return
+			}
+
 			// Parse Signature
 			var providedSignature string
 			if after, ok := strings.CutPrefix(parts[2], "Signature="); ok {
@@ -316,6 +325,21 @@ func buildCanonicalQueryString(queryString string) string {
 	}
 
 	return strings.Join(result, "&")
+}
+
+// signedHeadersIncludeHostAndDate reports whether the SigV4 SignedHeaders
+// list (";"-separated) includes both "host" and "x-amz-date".
+func signedHeadersIncludeHostAndDate(signedHeaders string) bool {
+	var hasHost, hasDate bool
+	for h := range strings.SplitSeq(signedHeaders, ";") {
+		switch strings.ToLower(strings.TrimSpace(h)) {
+		case "host":
+			hasHost = true
+		case "x-amz-date":
+			hasDate = true
+		}
+	}
+	return hasHost && hasDate
 }
 
 // canonicalHeaderName converts a lowercase header name to the canonical form for lookup.

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -1951,3 +1951,80 @@ func TestCheckPolicy_RootNonGlobalAccount_StillEvaluated(t *testing.T) {
 		t.Errorf("Expected status 403, got %d, body: %s", resp.StatusCode, string(body))
 	}
 }
+
+// TestSigV4Auth_RequireSignedHeaders verifies that requests whose SigV4
+// SignedHeaders list omits "host" or "x-amz-date" are rejected with
+// IncompleteSignature, before signature comparison runs. AWS SDKs always
+// sign both; omitting either lets a captured Authorization header replay
+// against a different vhost or outside the X-Amz-Date skew window.
+func TestSigV4Auth_RequireSignedHeaders(t *testing.T) {
+	handler := setupTestApp(testAccessKey, testSecretKey)
+
+	rewriteSignedHeaders := func(authHeader, list string) string {
+		parts := strings.Split(authHeader, ", ")
+		if len(parts) != 3 {
+			t.Fatalf("expected 3-part auth header, got %d", len(parts))
+		}
+		parts[1] = "SignedHeaders=" + list
+		return strings.Join(parts, ", ")
+	}
+
+	cases := []struct {
+		name       string
+		signedList string
+	}{
+		{"missing host", "x-amz-date"},
+		{"missing x-amz-date", "host"},
+		{"neither present", "content-type"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authHeader, timestamp := generateTestAuthHeader(
+				"GET", "/", "", "",
+				testAccessKey, testSecretKey, testRegion, testService,
+			)
+			authHeader = rewriteSignedHeaders(authHeader, tc.signedList)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Host = "localhost:9999"
+			req.Header.Set("Authorization", authHeader)
+			req.Header.Set("X-Amz-Date", timestamp)
+
+			resp := doRequest(handler, req)
+
+			if resp.StatusCode != http.StatusBadRequest {
+				body, _ := io.ReadAll(resp.Body)
+				t.Errorf("Expected status 400, got %d, body: %s", resp.StatusCode, string(body))
+			}
+			body, _ := io.ReadAll(resp.Body)
+			if !strings.Contains(string(body), "IncompleteSignature") {
+				t.Errorf("Expected IncompleteSignature error, got: %s", string(body))
+			}
+		})
+	}
+}
+
+func TestSignedHeadersIncludeHostAndDate(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"host;x-amz-date", true},
+		{"content-type;host;x-amz-date", true},
+		{"Host;X-Amz-Date", true},
+		{" host ; x-amz-date ", true},
+		{"x-amz-date", false},
+		{"host", false},
+		{"content-type", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := signedHeadersIncludeHostAndDate(tc.in)
+			if got != tc.want {
+				t.Errorf("signedHeadersIncludeHostAndDate(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
AWS SDKs always sign both host and x-amz-date. Accepting a SigV4 request that omits either lets a captured Authorization header replay against a different vhost or outside the X-Amz-Date skew window.

Mirrors predastore/auth.RequireSignedHeaders. Inlined here to avoid coupling the spinifex go.mod to an unreleased predastore version.