### PR TITLE
feat(daemon): siv-60 heal reconcile — phase 1 (probe-heal trigger)

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -229,6 +229,12 @@ type Daemon struct {
 	// as a string. Cleared back to "" on the next successful sync.
 	lastKVSyncError atomic.Value
 
+	// reconciling coalesces concurrent reconcileOnHeal invocations. Both
+	// the NATS reconnect callback and the peer-probe heal edge may fire
+	// near-simultaneously on the same heal; the second caller observes
+	// the flag set and returns.
+	reconciling atomic.Bool
+
 	mu sync.Mutex
 }
 
@@ -322,21 +328,13 @@ func (d *Daemon) onNATSDisconnect(_ *nats.Conn, _ error) {
 }
 
 // onNATSReconnect runs when the NATS client reattaches to a server. Marks
-// NATS connected, bumps the retry counter, and pushes the full local instance
-// state to KV so the cluster view re-converges. The KV push runs in a goroutine
-// to keep the NATS client callback non-blocking.
+// NATS connected, bumps the retry counter, and dispatches reconcileOnHeal
+// in a goroutine to keep this NATS client callback non-blocking.
 func (d *Daemon) onNATSReconnect(_ *nats.Conn) {
 	d.natsConnected.Store(true)
 	d.natsRetryCount.Add(1)
 
-	if d.jsManager == nil {
-		return
-	}
-	go func() {
-		if err := d.WriteState(); err != nil {
-			slog.Warn("Reconnect KV resync failed", "error", err)
-		}
-	}()
+	go d.reconcileOnHeal("nats-reconnect")
 }
 
 // getSystemMemory returns the total system memory in GB

--- a/spinifex/daemon/peer_health.go
+++ b/spinifex/daemon/peer_health.go
@@ -98,6 +98,15 @@ func (d *Daemon) probePeersOnce(client *http.Client, peers []config.Config) {
 	prev := d.peersReachable.Swap(reachable)
 	if prev != reachable {
 		slog.Info("peer reachability changed", "reachable", reachable, "peers", len(peers))
+		if reachable {
+			// Scenario C heal edge: local NATS client stayed connected
+			// to its local server throughout the partition so
+			// onNATSReconnect never fires. The peer-probe flip is the
+			// only signal that the cluster is back. Goroutine keeps
+			// the probe ticker non-blocking; reconcileOnHeal coalesces
+			// with any concurrent NATS-reconnect path.
+			go d.reconcileOnHeal("peer-probe-heal")
+		}
 	}
 }
 

--- a/spinifex/daemon/reconcile.go
+++ b/spinifex/daemon/reconcile.go
@@ -38,5 +38,12 @@ func (d *Daemon) reconcileOnHeal(reason string) {
 		return
 	}
 
+	// Re-fire default-VPC bootstrap. Idempotent — every step checks
+	// for existing infrastructure before creating. Covers the failure
+	// mode where startCluster ran during partition and the initial
+	// CreateInternetGateway / CreateSecurityGroup calls returned errors
+	// against an unreachable NATS.
+	d.ensureDefaultVPCInfrastructure()
+
 	slog.Info("reconcileOnHeal: complete", "reason", reason, "revision", d.Revision())
 }

--- a/spinifex/daemon/reconcile.go
+++ b/spinifex/daemon/reconcile.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"log/slog"
+)
+
+// reconcileOnHeal runs the post-heal resync. Fires from two edges:
+//   - onNATSReconnect, when the local NATS client reattaches.
+//   - probePeersOnce, when peer reachability flips false→true (the only
+//     signal in Scenario C where the NATS client stayed connected to its
+//     local server throughout the partition).
+//
+// Both edges may fire near-simultaneously on the same heal. reconciling
+// coalesces them: the second caller observes the flag set and returns,
+// keeping the work to one round-trip.
+//
+// The caller is expected to invoke this in a goroutine — both call sites
+// run on latency-sensitive callbacks (NATS client thread, peer-probe
+// ticker) and the reconcile path performs KV I/O.
+func (d *Daemon) reconcileOnHeal(reason string) {
+	if d.jsManager == nil {
+		return
+	}
+	if !d.reconciling.CompareAndSwap(false, true) {
+		slog.Debug("reconcileOnHeal: already running, coalescing", "reason", reason)
+		return
+	}
+	defer d.reconciling.Store(false)
+
+	slog.Info("reconcileOnHeal: starting", "reason", reason, "node", d.node)
+
+	// Push fresh local running-instance state. This re-establishes our
+	// row in the cluster-wide instance-state bucket regardless of what
+	// it held mid-partition (stale, missing, or clobbered by a peer's
+	// stream snapshot restore).
+	if err := d.WriteState(); err != nil {
+		slog.Warn("reconcileOnHeal: WriteState failed", "reason", reason, "error", err)
+		return
+	}
+
+	slog.Info("reconcileOnHeal: complete", "reason", reason, "revision", d.Revision())
+}

--- a/spinifex/daemon/reconcile_test.go
+++ b/spinifex/daemon/reconcile_test.go
@@ -1,0 +1,124 @@
+package daemon
+
+import (
+	"crypto/tls"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/config"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReconcileOnHeal_NilJetStream — no jsManager ⇒ early return. Guard
+// against panics in tests + single-node deployments where the manager is
+// optional.
+func TestReconcileOnHeal_NilJetStream(t *testing.T) {
+	d := &Daemon{}
+	d.reconcileOnHeal("test") // must not panic
+	assert.Equal(t, uint64(0), d.Revision())
+}
+
+// TestReconcileOnHeal_BumpsRevision — jsManager non-nil ⇒ WriteState runs,
+// stateRevision increments. Uses the same local-file path TestDaemonWriteState
+// exercises so we don't need a live NATS server.
+func TestReconcileOnHeal_BumpsRevision(t *testing.T) {
+	d := &Daemon{
+		config:    &config.Config{DataDir: t.TempDir()},
+		vmMgr:     vm.NewManager(),
+		jsManager: &JetStreamManager{}, // non-nil; WriteStateBytesBestEffort no-ops without a kv
+	}
+	d.vmMgr.Insert(&vm.VM{ID: "i-r1", InstanceType: "t3.micro"})
+
+	d.reconcileOnHeal("test")
+	assert.Equal(t, uint64(1), d.Revision())
+
+	d.reconcileOnHeal("test")
+	assert.Equal(t, uint64(2), d.Revision(), "second sequential call also runs once finished")
+}
+
+// TestReconcileOnHeal_CoalescesConcurrent — when reconciling is already set
+// (i.e. a prior heal goroutine is mid-flight), a second invocation must
+// observe the flag and return without re-running WriteState. Simulated by
+// pre-setting the flag.
+func TestReconcileOnHeal_Coalesces(t *testing.T) {
+	d := &Daemon{
+		config:    &config.Config{DataDir: t.TempDir()},
+		vmMgr:     vm.NewManager(),
+		jsManager: &JetStreamManager{},
+	}
+	d.reconciling.Store(true)
+
+	d.reconcileOnHeal("test")
+
+	assert.Equal(t, uint64(0), d.Revision(), "coalesced call must not run WriteState")
+	assert.True(t, d.reconciling.Load(), "coalesced call must not clear the in-flight flag")
+}
+
+// TestReconcileOnHeal_ConcurrentRaceCoalesces — fire many goroutines and
+// assert revision ≤ goroutine count. The exact final count depends on
+// scheduling, but coalescing guarantees we never double-write inside a single
+// overlapping window. The looser bound is enough — we assert no panics and
+// at least one write succeeded.
+func TestReconcileOnHeal_ConcurrentRaceCoalesces(t *testing.T) {
+	d := &Daemon{
+		config:    &config.Config{DataDir: t.TempDir()},
+		vmMgr:     vm.NewManager(),
+		jsManager: &JetStreamManager{},
+	}
+
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	start := make(chan struct{})
+	for range N {
+		go func() {
+			defer wg.Done()
+			<-start
+			d.reconcileOnHeal("race")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	rev := d.Revision()
+	assert.GreaterOrEqual(t, rev, uint64(1), "at least one heal must have run")
+	assert.LessOrEqual(t, rev, uint64(N), "writes bounded by goroutine count")
+	assert.False(t, d.reconciling.Load(), "flag must clear after race settles")
+}
+
+// TestProbePeersOnce_TriggersReconcileOnHeal — false→true edge in the peer
+// probe must fire reconcileOnHeal (Scenario C: NATS client stays connected to
+// loopback so onNATSReconnect is the wrong signal). Waits up to 1s for the
+// goroutine to bump Revision.
+func TestProbePeersOnce_TriggersReconcileOnHeal(t *testing.T) {
+	f := newPeerHealthFixture(t, 1)
+	d, _ := daemonForPeerHealth(t, f.cfg)
+	d.config = &config.Config{DataDir: t.TempDir()}
+	d.vmMgr = vm.NewManager()
+	d.jsManager = &JetStreamManager{}
+
+	client := &http.Client{
+		Timeout:   peerProbeTimeout,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	peers := d.peerNodes()
+	require.Len(t, peers, 1)
+
+	// Start unreachable so the next probe is the false→true edge.
+	f.peers[0].setHealthy(false)
+	d.probePeersOnce(client, peers)
+	require.False(t, d.peersReachable.Load())
+	require.Equal(t, uint64(0), d.Revision())
+
+	f.peers[0].setHealthy(true)
+	d.probePeersOnce(client, peers)
+	require.True(t, d.peersReachable.Load())
+
+	require.Eventually(t, func() bool { return d.Revision() >= 1 },
+		1*time.Second, 10*time.Millisecond,
+		"reconcileOnHeal goroutine must run on peer-probe false→true edge")
+}


### PR DESCRIPTION
## Summary

- Adds `reconcileOnHeal(reason)` on `Daemon`, idempotent via a `reconciling atomic.Bool` so the two heal callbacks landing on the same heal don't double-push.
- Wires the peer-probe false→true edge in `probePeersOnce` to call `reconcileOnHeal` in a goroutine. This is the only heal signal in Scenario C, where the local NATS client stays connected to its loopback server throughout the route-port partition and `onNATSReconnect` never fires.
- Replaces the inline `WriteState` goroutine in `onNATSReconnect` with `reconcileOnHeal("nats-reconnect")` so both edges go through the same coalesced entry point.

## Stacked on

#205 (siv-58, DDIL Scenarios B/C standalone mode flip). Base is `feat/ddil-scenarios-abc`; will rebase onto `dev` once #205 lands.

## Scope

Phase 1 of mulga-siv-60. Phase 2 (KV pull → merge → push for stopped/terminated/per-node-running buckets + bootstrap re-fire) is open and will land as follow-up commits on this branch before the PR moves out of draft.

Plan: `mulga/docs/development/feature/ddil-heal-reconcile.md`.

## Test plan

- [x] `go test ./spinifex/daemon/ -count=1 -race` green (incl. 5 new tests covering nil-jsManager, revision bump, coalescing, concurrent race, and the peer-probe false→true → reconcileOnHeal path).
- [x] `make preflight` green.
- [ ] DDIL harness Scenario C: assert post-heal KV reflects deltas applied while the minority was partitioned away (depends on phase 2).