### PR TITLE
fix(daemon): drop ensureDefaultVPCInfrastructure from reconcileOnHeal (siv-60 follow-up)

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -612,12 +612,17 @@ func NewDaemon(cfg *config.ClusterConfig) (*Daemon, error) {
 		requireNATSTimeout: 30 * time.Second,
 		exitFunc:           os.Exit,
 	}
-	// Single-node clusters have no peers to lose — keep peersReachable
-	// permanently true so Mode() can flip to "cluster" the moment NATS comes
-	// up, without waiting for a probe cycle that will never find anyone.
-	if d.peerCount() == 0 {
-		d.peersReachable.Store(true)
-	}
+	// Initialise peersReachable optimistically. Mode() also requires
+	// natsConnected, which starts false, so the optimistic init never
+	// causes Mode() to falsely report cluster — but it does prevent the
+	// first probe tick from triggering a spurious "heal" edge on
+	// multi-node clusters at startup (zero-value false → first-successful-
+	// probe true would otherwise fire reconcileOnHeal at boot,
+	// concurrently with startCluster's own bootstrap and perturbing the
+	// timing the DDIL harness relies on). Single-node clusters never
+	// run a probe at all, so this also keeps the prior single-node
+	// behaviour where Mode() flips to cluster the moment NATS comes up.
+	d.peersReachable.Store(true)
 	return d, nil
 }
 

--- a/spinifex/daemon/reconcile.go
+++ b/spinifex/daemon/reconcile.go
@@ -38,12 +38,16 @@ func (d *Daemon) reconcileOnHeal(reason string) {
 		return
 	}
 
-	// Re-fire default-VPC bootstrap. Idempotent — every step checks
-	// for existing infrastructure before creating. Covers the failure
-	// mode where startCluster ran during partition and the initial
-	// CreateInternetGateway / CreateSecurityGroup calls returned errors
-	// against an unreachable NATS.
-	d.ensureDefaultVPCInfrastructure()
+	// NOTE: an earlier revision called d.ensureDefaultVPCInfrastructure()
+	// here. DDIL Scenario C regressed because the very first peer-probe
+	// tick on multi-node startup flips peersReachable false→true and
+	// triggers this path concurrently with startCluster's own
+	// ensureDefaultVPCInfrastructure call. The Describe→Create→Attach
+	// sequence is not cluster-wide singleton, so multiple daemons +
+	// double calls per daemon could race and produce duplicate IGW
+	// attachments, corrupting default-VPC routing. Heal-time bootstrap
+	// re-fire needs leader election or a debounce against the
+	// startup-time path before re-introducing.
 
 	slog.Info("reconcileOnHeal: complete", "reason", reason, "revision", d.Revision())
 }


### PR DESCRIPTION
## Summary

- DDIL Scenario C regressed after #211 merged. Last green DDIL run was [25671044714](https://github.com/mulgadc/spinifex/actions/runs/25671044714) (SHA 40e3d847, pre-merge); first failing run is [25706585637](https://github.com/mulgadc/spinifex/actions/runs/25706585637) (SHA 5c108b17, post-merge).
- Root cause: `peersReachable` starts as the zero value (false) on multi-node clusters. The first `probePeersOnce` tick at daemon startup flips it false→true, which now triggers `reconcileOnHeal` concurrently with `startCluster`'s own `ensureDefaultVPCInfrastructure` call. The `Describe→Create→Attach` sequence has no cluster-wide singleton, so 3 daemons × 2 callers each raced and produced duplicate IGW attachments, corrupting default-VPC routing. Scenarios A/B don't depend on that routing path for their witnesses; C does (witness tunnel SSH).
- Fix: drop the bootstrap re-fire from `reconcileOnHeal`. Phase 1 heal trigger + coalescing stays. Inline `NOTE` left so the next attempt has the context — heal-time bootstrap re-fire needs leader election or a debounce against the startup-time path before re-landing.

## Stacked on

#205 (siv-58). Base is `feat/ddil-scenarios-abc`; rebases onto `dev` along with #205.

## Test plan

- [ ] `go test ./spinifex/daemon/ -count=1 -race` green (all 5 reconcile tests + sibling suites unchanged).
- [x] `make preflight` green (diff coverage 83.1%).
- [ ] DDIL Scenarios A/B/C green on this branch.