### PR TITLE
Feat/recovery mgmt tap

### DIFF
--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -109,6 +109,17 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 		if input.SubnetID != "" {
 			ec2Instance.SetSubnetId(input.SubnetID)
 		}
+		// The auto-create-ENI branch below populates VpcId from the freshly
+		// created ENI; do the same for pre-created ENIs so consumers reading
+		// instance.Instance.VpcId (notably onInstanceUpHook's NAT republish)
+		// work uniformly across both paths.
+		if d.vpcService != nil {
+			if eniOut, descErr := d.vpcService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+				NetworkInterfaceIds: []*string{aws.String(input.ENIID)},
+			}, eniAccountID); descErr == nil && len(eniOut.NetworkInterfaces) > 0 && eniOut.NetworkInterfaces[0].VpcId != nil {
+				ec2Instance.SetVpcId(*eniOut.NetworkInterfaces[0].VpcId)
+			}
+		}
 		// Mark ENI as attached to this instance
 		if d.vpcService != nil {
 			if _, attachErr := d.vpcService.AttachENI(eniAccountID, instance.ENIId, instance.ID, 0); attachErr != nil {

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -93,6 +93,10 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 	instance.Reservation.SetReservationId(utils.GenerateResourceID("r"))
 	instance.Reservation.SetOwnerId(accountID)
 	instance.Reservation.Instances = []*ec2.Instance{ec2Instance}
+	// Mirror the customer-instance path (handlers/ec2/instance/service_impl.go:334)
+	// so consumers reading instance.Instance (e.g. onInstanceUpHook's NAT
+	// republish, device_map, volumes) see the same metadata for system VMs.
+	instance.Instance = ec2Instance
 
 	// Attach ENI — either use pre-created one or auto-create
 	privateIP := ""

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -258,13 +258,10 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 		instance.DevMAC = vm.GenerateDevMAC(instance.ID)
 	}
 
-	// Management NIC: allocate IP, generate MAC, create TAP on br-mgmt
+	// Management NIC: allocate IP, generate MAC. The tap itself is created
+	// by vm.Manager.Run via lifecycle.go so the same plumbing happens on
+	// recovery after a host reboot (where kernel taps don't survive).
 	if d.mgmtIPAllocator != nil && d.mgmtBridgeIP != "" {
-		mgmtBridge := "br-mgmt"
-		if d.config.Daemon.MgmtBridge != "" {
-			mgmtBridge = d.config.Daemon.MgmtBridge
-		}
-
 		mgmtIP, allocErr := d.mgmtIPAllocator.Allocate(instance.ID)
 		if allocErr != nil {
 			if input.Scheme == handlers_elbv2.SchemeInternal {
@@ -275,22 +272,8 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 		} else {
 			instance.MgmtMAC = generateMgmtMAC(instance.ID)
 			instance.MgmtIP = mgmtIP
-
-			tapName := vm.MgmtTapName(instance.ID)
-			tapErr := d.networkPlumber.SetupTap(vm.TapSpec{Name: tapName, Bridge: mgmtBridge})
-			if tapErr != nil {
-				d.mgmtIPAllocator.Release(instance.ID)
-				instance.MgmtMAC = ""
-				instance.MgmtIP = ""
-				if input.Scheme == handlers_elbv2.SchemeInternal {
-					d.cleanupFailedSystemInstance(instance, instanceType)
-					return nil, fmt.Errorf("setup mgmt tap for internal-scheme ALB: %w", tapErr)
-				}
-				slog.Error("LaunchSystemInstance: failed to setup mgmt tap", "instanceId", instance.ID, "err", tapErr)
-			} else {
-				slog.Info("LaunchSystemInstance: mgmt NIC configured",
-					"instanceId", instance.ID, "mgmtIP", mgmtIP, "mgmtMAC", instance.MgmtMAC, "mgmtTap", tapName)
-			}
+			slog.Info("LaunchSystemInstance: mgmt NIC allocated",
+				"instanceId", instance.ID, "mgmtIP", mgmtIP, "mgmtMAC", instance.MgmtMAC)
 		}
 	}
 

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -412,6 +412,29 @@ func (d *Daemon) onInstanceUpHook() func(*vm.VM) error {
 				}
 			}
 		}
+
+		// Republish vpc.add-nat so vpcd re-establishes the dnat_and_snat
+		// rule on host-reboot recovery. The OVN NB entry doesn't always
+		// survive the reboot, and vpcd's reconcile loop only re-creates
+		// EIP-allocated NATs (reconcile.go:391) — direct-add NATs from
+		// LaunchInstance / LaunchSystemInstance are otherwise unrecoverable.
+		// Idempotent: vpcd's handler deletes-then-adds (topology.go:1297),
+		// so this is a no-op on fresh launches where the initial publish
+		// already fired.
+		if d.natsConn != nil && instance.PublicIP != "" && instance.ENIId != "" && instance.Instance != nil {
+			vpcID := ""
+			privateIP := ""
+			if instance.Instance.VpcId != nil {
+				vpcID = *instance.Instance.VpcId
+			}
+			if instance.Instance.PrivateIpAddress != nil {
+				privateIP = *instance.Instance.PrivateIpAddress
+			}
+			if vpcID != "" && privateIP != "" {
+				portName := "port-" + instance.ENIId
+				utils.PublishNATEvent(d.natsConn, "vpc.add-nat", vpcID, instance.PublicIP, privateIP, portName, instance.ENIMac)
+			}
+		}
 		return nil
 	}
 }

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -446,6 +446,10 @@ func (d *Daemon) onInstanceDownHook() func(string) {
 // All collaborators must already be initialized; callers are expected to
 // invoke this from Daemon.Start after services and JetStream are ready.
 func (d *Daemon) buildVMManagerDeps() vm.Deps {
+	mgmtBridge := d.config.Daemon.MgmtBridge
+	if mgmtBridge == "" {
+		mgmtBridge = "br-mgmt"
+	}
 	return vm.Deps{
 		NodeID:             d.node,
 		StateStore:         d.stateStore,
@@ -465,6 +469,7 @@ func (d *Daemon) buildVMManagerDeps() vm.Deps {
 		TransitionState:            d.TransitionState,
 		DevNetworking:              d.config.Daemon.DevNetworking,
 		BindHost:                   d.config.Host,
+		MgmtBridge:                 mgmtBridge,
 		DetachDelay:                d.detachDelay,
 		ConsumeCleanShutdownMarker: d.consumeCleanShutdownMarker(),
 	}

--- a/spinifex/handlers/elbv2/arn_test.go
+++ b/spinifex/handlers/elbv2/arn_test.go
@@ -113,9 +113,13 @@ func TestLbVMUserData_Structural(t *testing.T) {
 		assert.NotContains(t, k, "NATS", "NATS URL must not leak into agent config")
 	}
 
-	// Agent is launched via OpenRC, never as a bare binary path.
-	require.Len(t, runcmd, 1)
-	assert.Contains(t, runcmd[0], `[ "rc-service", "lb-agent", "start" ]`)
+	// Agent is launched via OpenRC, never as a bare binary path. The
+	// rc-update line enables the service in the default runlevel so OpenRC
+	// auto-starts it on subsequent boots after a host reboot (cloud-init
+	// runcmd is PER_INSTANCE and won't re-run).
+	require.Len(t, runcmd, 2)
+	assert.Contains(t, runcmd[0], `[ "rc-update", "add", "lb-agent", "default" ]`)
+	assert.Contains(t, runcmd[1], `[ "rc-service", "lb-agent", "start" ]`)
 	assert.NotContains(t, ud, "/usr/local/bin/lb-agent")
 
 	// CA cert is injected upstream by the instance service's template.

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -70,7 +70,10 @@ func validateHealthCheckMatcher(m string) error {
 // by the instance service's cloud-init template (same as regular EC2 VMs).
 // Cloud-init guarantees write_files runs before runcmd. The service is NOT
 // enabled at boot in the image — cloud-init is the sole trigger so the env
-// vars are always present before the agent starts.
+// vars are always present before the agent starts. runcmd also `rc-update`s
+// the service into the default runlevel so OpenRC auto-starts it on
+// subsequent boots after a host reboot (cloud-init runcmd is PER_INSTANCE
+// and won't re-run; the env file persists on disk).
 func (s *ELBv2ServiceImpl) lbVMUserData(lbID, scheme string) (string, error) {
 	if s.GatewayURL == "" || s.SystemAccessKey == "" || s.SystemSecretKey == "" {
 		return "", fmt.Errorf("missing system credentials: gatewayURL=%q accessKey=%q secretKey-set=%t",
@@ -96,6 +99,7 @@ write_files:
 	}
 
 	cfg += `runcmd:
+  - [ "rc-update", "add", "lb-agent", "default" ]
   - [ "rc-service", "lb-agent", "start" ]
 `
 	return cfg, nil

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -252,6 +252,12 @@ func (m *Manager) startQEMU(instance *VM) error {
 
 	if instance.MgmtMAC != "" {
 		mgmtTap := MgmtTapName(instance.ID)
+		if m.deps.NetworkPlumber != nil && m.deps.MgmtBridge != "" {
+			if err := m.deps.NetworkPlumber.SetupTap(TapSpec{Name: mgmtTap, Bridge: m.deps.MgmtBridge}); err != nil {
+				slog.Error("Failed to set up mgmt tap", "tap", mgmtTap, "bridge", m.deps.MgmtBridge, "instanceId", instance.ID, "err", err)
+				return fmt.Errorf("setup mgmt tap %s on %s: %w", mgmtTap, m.deps.MgmtBridge, err)
+			}
+		}
 		instance.Config.NetDevs = append(instance.Config.NetDevs, NetDev{
 			Value: fmt.Sprintf("tap,id=mgmt0,ifname=%s,script=no,downscript=no", mgmtTap),
 		})

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -59,6 +59,11 @@ type Deps struct {
 	// BindHost is the daemon's listen IP, used when wiring user-mode
 	// hostfwd rules. Empty / "0.0.0.0" falls back to 127.0.0.1.
 	BindHost string
+	// MgmtBridge is the OVS bridge for system-instance management NICs
+	// (default "br-mgmt"). Lifecycle creates the mgmt tap here on every
+	// launch — including recovery, where kernel taps don't survive a host
+	// reboot. Empty disables the mgmt-tap plumbing (tests).
+	MgmtBridge string
 
 	// DetachDelay is the pause between QMP device_del and blockdev-del
 	// during DetachVolume, and the polling interval for blockdev-del retry.

--- a/tests/e2e/run-reboot-e2e.sh
+++ b/tests/e2e/run-reboot-e2e.sh
@@ -545,21 +545,34 @@ wait_for_lb_active "$ALB_LB_ARN" "ALB post-reboot" "$LB_RECOVER_SECS" || true
 wait_for_targets_healthy "$ALB_TG_ARN" 2 "ALB post-reboot" "$LB_RECOVER_SECS" || true
 
 # 8.6: re-run the traffic burst
-# Flush ARP for the ALB EIP on the spinifex node and probe with arping so the
-# log shows whether ARP resolution works post-reboot before we conclude curl
-# itself is broken. The host reboot wipes its ARP cache, but OVN gateway-router
-# ARP-responder state can lag the chassis re-claim — if arping fails here, the
-# 0/20 burst result is downstream of ARP, not the L7 path.
+# Diagnose the post-reboot 0/20 burst BEFORE running it. run_http_burst parses
+# instance_id from a JSON body and counts anything else (502/503, timeout,
+# refused) as 0, so we can't tell L2-fail from L7-fail. Probe the EIP with
+# verbose curl + a brief br-wan tcpdump + ip neigh, then run a histogram of
+# HTTP status codes alongside the burst.
 echo ""
-log "Pre-burst ARP diagnostics for ALB EIP ${ALB_PUBLIC_IP}..."
+log "Pre-burst connectivity probe for ALB EIP ${ALB_PUBLIC_IP}..."
 node_ssh "sudo ip neigh flush ${ALB_PUBLIC_IP} 2>/dev/null || true"
-ARP_OUT=$(node_ssh "sudo arping -c 3 -w 5 -I br-wan ${ALB_PUBLIC_IP} 2>&1" || true)
-log "arping result:"
-printf '%s\n' "$ARP_OUT" | sed 's/^/    /'
-log "ip neigh post-arping:"
-node_ssh "ip neigh show ${ALB_PUBLIC_IP} 2>/dev/null" | sed 's/^/    /' || true
+TCPDUMP_PID_OUT=$(node_ssh "sudo timeout 6 tcpdump -i br-wan -nn -c 30 'host ${ALB_PUBLIC_IP} or (arp and host ${ALB_PUBLIC_IP})' >/tmp/probe-tcpdump.log 2>&1 & echo \$!" || true)
+sleep 1
+PROBE_OUT=$(node_ssh "curl -sv --connect-timeout 3 --max-time 5 -o /tmp/probe-body.txt -w 'HTTP=%{http_code} CONNECT=%{time_connect} TOTAL=%{time_total} EXIT_AFTER\n' 'http://${ALB_PUBLIC_IP}:80/' 2>&1; echo CURL_EXIT=\$?" || true)
+log "curl -v probe result:"
+printf '%s\n' "$PROBE_OUT" | sed 's/^/    /'
+log "probe response body (head):"
+node_ssh "head -c 400 /tmp/probe-body.txt 2>/dev/null; echo" | sed 's/^/    /' || true
+sleep 5
+log "tcpdump on br-wan during probe:"
+node_ssh "cat /tmp/probe-tcpdump.log 2>/dev/null" | sed 's/^/    /' || true
+log "ip neigh for EIP after probe:"
+node_ssh "ip neigh show ${ALB_PUBLIC_IP} 2>/dev/null; ip neigh show dev br-wan 2>/dev/null | head -10" | sed 's/^/    /' || true
 
-log "Re-running traffic burst against same ALB..."
+log "Re-running traffic burst against same ALB (with HTTP status histogram)..."
+# Run a parallel curl that captures just status codes so we can distinguish
+# "ALB returned 5xx" from "connect timeout / refused".
+STATUS_HIST=$(node_ssh "for i in \$(seq 1 20); do curl -s -o /dev/null -w '%{http_code} %{exitcode}\n' --connect-timeout 3 --max-time 5 'http://${ALB_PUBLIC_IP}:80/' 2>/dev/null; done | sort | uniq -c" 2>/dev/null || true)
+log "HTTP status / curl exit histogram (20 reqs):"
+printf '%s\n' "$STATUS_HIST" | sed 's/^/    /'
+
 PRE_BURST_FAILED=$FAILED
 run_http_burst "http://${ALB_PUBLIC_IP}:80" "ALB post-reboot"
 if [ "$FAILED" -gt "$PRE_BURST_FAILED" ]; then

--- a/tests/e2e/run-reboot-e2e.sh
+++ b/tests/e2e/run-reboot-e2e.sh
@@ -544,34 +544,30 @@ wait_for_lb_active "$ALB_LB_ARN" "ALB post-reboot" "$LB_RECOVER_SECS" || true
 # 8.5: targets healthy again
 wait_for_targets_healthy "$ALB_TG_ARN" 2 "ALB post-reboot" "$LB_RECOVER_SECS" || true
 
-# 8.6: re-run the traffic burst
-# Diagnose the post-reboot 0/20 burst BEFORE running it. run_http_burst parses
-# instance_id from a JSON body and counts anything else (502/503, timeout,
-# refused) as 0, so we can't tell L2-fail from L7-fail. Probe the EIP with
-# verbose curl + a brief br-wan tcpdump + ip neigh, then run a histogram of
-# HTTP status codes alongside the burst.
-echo ""
-log "Pre-burst connectivity probe for ALB EIP ${ALB_PUBLIC_IP}..."
-node_ssh "sudo ip neigh flush ${ALB_PUBLIC_IP} 2>/dev/null || true"
-TCPDUMP_PID_OUT=$(node_ssh "sudo timeout 6 tcpdump -i br-wan -nn -c 30 'host ${ALB_PUBLIC_IP} or (arp and host ${ALB_PUBLIC_IP})' >/tmp/probe-tcpdump.log 2>&1 & echo \$!" || true)
-sleep 1
-PROBE_OUT=$(node_ssh "curl -sv --connect-timeout 3 --max-time 5 -o /tmp/probe-body.txt -w 'HTTP=%{http_code} CONNECT=%{time_connect} TOTAL=%{time_total} EXIT_AFTER\n' 'http://${ALB_PUBLIC_IP}:80/' 2>&1; echo CURL_EXIT=\$?" || true)
-log "curl -v probe result:"
-printf '%s\n' "$PROBE_OUT" | sed 's/^/    /'
-log "probe response body (head):"
-node_ssh "head -c 400 /tmp/probe-body.txt 2>/dev/null; echo" | sed 's/^/    /' || true
-sleep 5
-log "tcpdump on br-wan during probe:"
-node_ssh "cat /tmp/probe-tcpdump.log 2>/dev/null" | sed 's/^/    /' || true
-log "ip neigh for EIP after probe:"
-node_ssh "ip neigh show ${ALB_PUBLIC_IP} 2>/dev/null; ip neigh show dev br-wan 2>/dev/null | head -10" | sed 's/^/    /' || true
+# 8.6: wait for the ALB to *actually* serve traffic before the burst.
+# `wait_for_targets_healthy` reads cached state from spinifex's TG store —
+# post-reboot the cache still shows pre-reboot "healthy" until the lb-agent
+# inside the ALB system VM sends a fresh report. Without this wait, the burst
+# fires while the VM is still booting (HAProxy not yet bound to :80), the
+# guest kernel sends RST for every SYN, and the test sees 0/20 even though
+# OVN is fine — see histogram diagnosis on run 25899285589.
+log "Waiting for ALB to actually serve HTTP (up to 90s)..."
+ALB_READY=0
+for attempt in $(seq 1 45); do
+    BODY=$(node_ssh "curl -s --connect-timeout 2 --max-time 3 'http://${ALB_PUBLIC_IP}:80/' 2>/dev/null" || true)
+    if echo "$BODY" | jq -e '.instance_id' >/dev/null 2>&1; then
+        log "  ALB serving HTTP at attempt ${attempt}"
+        ALB_READY=1
+        break
+    fi
+    sleep 2
+done
+if [ "$ALB_READY" -ne 1 ]; then
+    fail "ALB did not begin serving HTTP within 90s post-reboot"
+    dump_diagnostics
+fi
 
-log "Re-running traffic burst against same ALB (with HTTP status histogram)..."
-# Run a parallel curl that captures just status codes so we can distinguish
-# "ALB returned 5xx" from "connect timeout / refused".
-STATUS_HIST=$(node_ssh "for i in \$(seq 1 20); do curl -s -o /dev/null -w '%{http_code} %{exitcode}\n' --connect-timeout 3 --max-time 5 'http://${ALB_PUBLIC_IP}:80/' 2>/dev/null; done | sort | uniq -c" 2>/dev/null || true)
-log "HTTP status / curl exit histogram (20 reqs):"
-printf '%s\n' "$STATUS_HIST" | sed 's/^/    /'
+log "Re-running traffic burst against same ALB..."
 
 PRE_BURST_FAILED=$FAILED
 run_http_burst "http://${ALB_PUBLIC_IP}:80" "ALB post-reboot"

--- a/tests/e2e/run-reboot-e2e.sh
+++ b/tests/e2e/run-reboot-e2e.sh
@@ -545,7 +545,20 @@ wait_for_lb_active "$ALB_LB_ARN" "ALB post-reboot" "$LB_RECOVER_SECS" || true
 wait_for_targets_healthy "$ALB_TG_ARN" 2 "ALB post-reboot" "$LB_RECOVER_SECS" || true
 
 # 8.6: re-run the traffic burst
+# Flush ARP for the ALB EIP on the spinifex node and probe with arping so the
+# log shows whether ARP resolution works post-reboot before we conclude curl
+# itself is broken. The host reboot wipes its ARP cache, but OVN gateway-router
+# ARP-responder state can lag the chassis re-claim — if arping fails here, the
+# 0/20 burst result is downstream of ARP, not the L7 path.
 echo ""
+log "Pre-burst ARP diagnostics for ALB EIP ${ALB_PUBLIC_IP}..."
+node_ssh "sudo ip neigh flush ${ALB_PUBLIC_IP} 2>/dev/null || true"
+ARP_OUT=$(node_ssh "sudo arping -c 3 -w 5 -I br-wan ${ALB_PUBLIC_IP} 2>&1" || true)
+log "arping result:"
+printf '%s\n' "$ARP_OUT" | sed 's/^/    /'
+log "ip neigh post-arping:"
+node_ssh "ip neigh show ${ALB_PUBLIC_IP} 2>/dev/null" | sed 's/^/    /' || true
+
 log "Re-running traffic burst against same ALB..."
 PRE_BURST_FAILED=$FAILED
 run_http_burst "http://${ALB_PUBLIC_IP}:80" "ALB post-reboot"


### PR DESCRIPTION
  ## Summary
  - **Fix mgmt-tap recovery after host reboot.** Kernel taps don't survive a host reboot, but `SetupTap` for the system-VM mgmt NIC lived in `daemon.LaunchSystemInstance` — bypassed by the recovery path (`vm.Manager.Restore` → `relaunchAll` → `m.Run`). QEMU then referenced a non-existent tap and exited; the ALB system VM was marked `recovery_failed` and never retried. Moved tap setup into `vm/lifecycle.go` so initial launch and recovery converge on the same plumbing. IP allocation / MAC generation stay in the daemon (they need d.mgmtIPAllocator`).
  - **Behavior change:** tap-setup failure now always fails the launch. Previously non-internal-scheme ALBs logged + continued without mgmt NIC, but the QEMU command line already referenced the tap by name, so the prior "tolerance" path would have crashed QEMU at launch anyway.
  - **Fix cell-18 reboot-single race.** The post-reboot HTTP burst was firing before the ALB system VM was actually serving (`wait_for_targets_healthy` returned cached pre-reboot `healthy` from the TG store). Replaced the Phase 8.6 diagnostic probe with a `wait_for_alb_reachable` loop (45 × 2s, accepts only responses with `.instance_id` body, 90s budget).