### PR TITLE
fix: regenerate fw_cfg blobs on ALB system VM relaunch

### DIFF
--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -392,6 +392,43 @@ func (d *Daemon) TerminateSystemInstance(instanceID string) error {
 	return nil
 }
 
+// refreshSystemInstanceState rebuilds any host-local state for a system VM
+// that did not survive a daemon/host restart. Currently this means the
+// per-VM fw_cfg tmpfiles under utils.RuntimeDir() that the direct-boot
+// launch path passes to QEMU via -fw_cfg. utils.RuntimeDir() is a tmpfs on
+// production hosts (XDG_RUNTIME_DIR=/run/spinifex), so the blobs vanish on
+// host reboot while the persisted vm.Config still references them; without
+// this regeneration QEMU exits 1 and the ALB never serves traffic.
+//
+// Non-system VMs (ManagedBy != ELBv2) are a no-op — their QEMU args
+// reference cloud-init ISOs and base AMIs under /var/lib/spinifex/, which
+// survive reboot.
+func (d *Daemon) refreshSystemInstanceState(inst *vm.VM) error {
+	if inst.ManagedBy != tags.ManagedByELBv2 {
+		return nil
+	}
+	if d.elbv2Service == nil {
+		return nil
+	}
+	ctx := handlers_elbv2.RecoveryContext{
+		InstanceID:   inst.ID,
+		InstanceType: inst.InstanceType,
+		ENIMac:       inst.ENIMac,
+		MgmtMAC:      inst.MgmtMAC,
+		MgmtIP:       inst.MgmtIP,
+	}
+	input, err := d.elbv2Service.RebuildSystemInstanceInput(ctx)
+	if err != nil {
+		return fmt.Errorf("rebuild system instance input: %w", err)
+	}
+	if _, err := d.writeFwCfgBlobs(inst.ID, input); err != nil {
+		return fmt.Errorf("rewrite fw_cfg blobs: %w", err)
+	}
+	slog.Info("Refreshed system instance state",
+		"instanceId", inst.ID, "managedBy", inst.ManagedBy)
+	return nil
+}
+
 // cleanupFailedSystemInstance handles cleanup when a system instance launch
 // fails after partial setup (state added, volumes created, etc). Delegates
 // to vm.Manager.MarkFailed which runs the synchronous teardown chain

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -392,23 +392,17 @@ func (d *Daemon) TerminateSystemInstance(instanceID string) error {
 	return nil
 }
 
-// refreshSystemInstanceState rebuilds any host-local state for a system VM
-// that did not survive a daemon/host restart. Currently this means the
-// per-VM fw_cfg tmpfiles under utils.RuntimeDir() that the direct-boot
-// launch path passes to QEMU via -fw_cfg. utils.RuntimeDir() is a tmpfs on
-// production hosts (XDG_RUNTIME_DIR=/run/spinifex), so the blobs vanish on
-// host reboot while the persisted vm.Config still references them; without
-// this regeneration QEMU exits 1 and the ALB never serves traffic.
-//
-// Non-system VMs (ManagedBy != ELBv2) are a no-op — their QEMU args
-// reference cloud-init ISOs and base AMIs under /var/lib/spinifex/, which
-// survive reboot.
+// refreshSystemInstanceState regenerates the tmpfs-backed fw_cfg blobs that
+// QEMU loads at boot. The blobs live under utils.RuntimeDir() (tmpfs on
+// production hosts) and are wiped on host reboot while the persisted
+// vm.Config still references the same paths. Customer VMs use only paths
+// under /var/lib/spinifex/ and are a no-op.
 func (d *Daemon) refreshSystemInstanceState(inst *vm.VM) error {
 	if inst.ManagedBy != tags.ManagedByELBv2 {
 		return nil
 	}
 	if d.elbv2Service == nil {
-		return nil
+		return fmt.Errorf("elbv2 service unavailable: cannot refresh fw_cfg blobs for system VM %s", inst.ID)
 	}
 	ctx := handlers_elbv2.RecoveryContext{
 		InstanceID:   inst.ID,

--- a/spinifex/daemon/daemon_system_instance_test.go
+++ b/spinifex/daemon/daemon_system_instance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -317,81 +318,59 @@ func TestWriteFwCfgBlobs_InvalidNICs_NoDefault(t *testing.T) {
 // refreshSystemInstanceState
 // ---------------------------------------------------------------------------
 
-// TestRefreshSystemInstanceState_NonELBv2IsNoop guards the cheap-path
-// short-circuit: customer VMs (ManagedBy="") have no tmpfs blobs to
-// regenerate, and reaching the lb-record lookup would error pointlessly.
-func TestRefreshSystemInstanceState_NonELBv2IsNoop(t *testing.T) {
-	d := &Daemon{vmMgr: vm.NewManager()}
-	inst := &vm.VM{ID: "i-customer", ManagedBy: ""}
-
-	err := d.refreshSystemInstanceState(inst)
-	require.NoError(t, err, "non-ELBv2 VMs must short-circuit before the service lookup — customer instances do not need fw_cfg blob regeneration")
-}
-
-// TestRefreshSystemInstanceState_NilELBv2ServiceIsNoop covers the early
-// daemon-startup window where vmMgr.Restore runs before elbv2Service is
-// wired. The hook must not panic; the VM stays Pending and a later
-// recovery cycle (or operator retry) reaches the regen path with the
-// service available.
-func TestRefreshSystemInstanceState_NilELBv2ServiceIsNoop(t *testing.T) {
-	d := &Daemon{vmMgr: vm.NewManager(), elbv2Service: nil}
-	inst := &vm.VM{ID: "i-no-svc", ManagedBy: tags.ManagedByELBv2}
-
-	err := d.refreshSystemInstanceState(inst)
-	require.NoError(t, err, "an unwired elbv2Service must NOT block recovery with a hard error — the service finishes wiring later in Daemon.Start")
-}
-
-// TestRefreshSystemInstanceState_NoLBRecord verifies the failure-mode path:
-// the VM record survived but the LB record was wiped from KV (manual
-// admin deletion, KV corruption). Recovery must surface the error so the
-// caller flips the instance to recovery_failed rather than booting it
-// against guessed inputs.
-func TestRefreshSystemInstanceState_NoLBRecord(t *testing.T) {
+// newRefreshTestDaemon returns a Daemon wired with vmMgr + a fresh ELBv2
+// service, with XDG_RUNTIME_DIR pointed at a per-test tmpdir so
+// writeFwCfgBlobs is sandboxed. The returned nats.Conn lets the caller seed
+// LB records via a separate Store handle sharing the same KV bucket.
+func newRefreshTestDaemon(t *testing.T) (*Daemon, *nats.Conn, string) {
+	t.Helper()
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
-
 	_, nc, _ := testutil.StartTestJetStream(t)
 	svc, err := handlers_elbv2.NewELBv2ServiceImplWithNATS(nil, nc)
 	require.NoError(t, err)
 	t.Cleanup(svc.Close)
+	return &Daemon{vmMgr: vm.NewManager(), elbv2Service: svc}, nc, tmpDir
+}
 
-	d := &Daemon{vmMgr: vm.NewManager(), elbv2Service: svc}
+func TestRefreshSystemInstanceState_NonELBv2IsNoop(t *testing.T) {
+	d := &Daemon{vmMgr: vm.NewManager()}
+	require.NoError(t, d.refreshSystemInstanceState(&vm.VM{ID: "i-customer", ManagedBy: ""}))
+}
+
+func TestRefreshSystemInstanceState_NilELBv2ServiceErrors(t *testing.T) {
+	d := &Daemon{vmMgr: vm.NewManager(), elbv2Service: nil}
+	err := d.refreshSystemInstanceState(&vm.VM{ID: "i-no-svc", ManagedBy: tags.ManagedByELBv2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "elbv2 service unavailable")
+}
+
+func TestRefreshSystemInstanceState_NoLBRecord(t *testing.T) {
+	d, _, tmpDir := newRefreshTestDaemon(t)
 	inst := &vm.VM{ID: "i-orphan-alb", ManagedBy: tags.ManagedByELBv2, InstanceType: "sys.micro"}
 
-	err = d.refreshSystemInstanceState(inst)
+	err := d.refreshSystemInstanceState(inst)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rebuild system instance input")
-	assert.Contains(t, err.Error(), "no LB record references instance i-orphan-alb",
-		"the wrapped error must identify the missing LB so journal grep finds the orphaned VM record")
+	assert.Contains(t, err.Error(), "no LB record references instance i-orphan-alb")
 
-	// No tmpfiles must be created when rebuild fails — leaving stale blobs
-	// behind would mask the failure on the next recovery attempt.
 	entries, _ := os.ReadDir(tmpDir)
 	for _, e := range entries {
 		assert.False(t, strings.HasPrefix(e.Name(), "fwcfg-i-orphan-alb"),
-			"unexpected tmpfile left behind on rebuild failure: %s", e.Name())
+			"stale tmpfile left behind on rebuild failure: %s", e.Name())
 	}
 }
 
-// TestRefreshSystemInstanceState_RewritesBlobs covers the success path —
-// the bug's actual fix. Given an ELBv2-managed VM whose tmpfs blobs were
-// wiped (simulated by deleting the files after CreateLoadBalancer), the
-// hook must regenerate all three blobs at the deterministic paths the
-// persisted vm.Config.FwCfg references.
 func TestRefreshSystemInstanceState_RewritesBlobs(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+	d, nc, tmpDir := newRefreshTestDaemon(t)
+	d.elbv2Service.SystemAccessKey = "AKID-recover"
+	d.elbv2Service.SystemSecretKey = "SECRET-recover"
+	d.elbv2Service.GatewayURL = "https://10.0.0.1:9999"
+	d.elbv2Service.CACert = "-----BEGIN CERTIFICATE-----\nfake-ca\n-----END CERTIFICATE-----\n"
 
-	_, nc, _ := testutil.StartTestJetStream(t)
-	svc, err := handlers_elbv2.NewELBv2ServiceImplWithNATS(nil, nc)
+	seedStore, err := handlers_elbv2.NewStore(nc)
 	require.NoError(t, err)
-	t.Cleanup(svc.Close)
-
-	// Pre-populate an LB record that references the recovery instance. We
-	// bypass CreateLoadBalancer (which would require a VPC service + mock
-	// launcher) by writing the record straight into the store — the
-	// rebuild path's only requirement is that some LB.InstanceID matches.
-	record := &handlers_elbv2.LoadBalancerRecord{
+	require.NoError(t, seedStore.PutLoadBalancer(&handlers_elbv2.LoadBalancerRecord{
 		LoadBalancerID: "lb-recover",
 		Name:           "recover-alb",
 		Scheme:         handlers_elbv2.SchemeInternal,
@@ -402,14 +381,8 @@ func TestRefreshSystemInstanceState_RewritesBlobs(t *testing.T) {
 		InstanceID:     "i-recover-blobs",
 		VPCIP:          "10.0.1.5",
 		AccountID:      "123456789012",
-	}
-	// Both store instances share the same JetStream KV bucket, so a Put
-	// here is visible to svc.store on the next List call.
-	seedStore, err := handlers_elbv2.NewStore(nc)
-	require.NoError(t, err)
-	require.NoError(t, seedStore.PutLoadBalancer(record))
+	}))
 
-	d := &Daemon{vmMgr: vm.NewManager(), elbv2Service: svc}
 	inst := &vm.VM{
 		ID:           "i-recover-blobs",
 		ManagedBy:    tags.ManagedByELBv2,
@@ -418,15 +391,61 @@ func TestRefreshSystemInstanceState_RewritesBlobs(t *testing.T) {
 		MgmtMAC:      "02:a0:00:11:22:33",
 		MgmtIP:       "172.31.0.7",
 	}
-
 	require.NoError(t, d.refreshSystemInstanceState(inst))
 
-	// Three blobs at deterministic paths — these are the exact filenames
-	// writeFwCfgBlobs bakes into vm.Config.FwCfg, so the persisted QEMU
-	// command line will reference the same paths after the rewrite.
-	for _, suffix := range []string{"netcfg", "lbenv", "cacert"} {
-		path := filepath.Join(tmpDir, fmt.Sprintf("fwcfg-%s-%s.tmp", inst.ID, suffix))
-		_, statErr := os.Stat(path)
-		assert.NoError(t, statErr, "expected fw_cfg blob at %s after refresh — the persisted -fw_cfg arg in vm.Config references this exact path", path)
+	netcfg, err := os.ReadFile(filepath.Join(tmpDir, "fwcfg-i-recover-blobs-netcfg.tmp"))
+	require.NoError(t, err)
+	assert.Contains(t, string(netcfg), "NIC0_MAC=02:aa:bb:cc:dd:01")
+	assert.Contains(t, string(netcfg), "NIC1_MAC=02:a0:00:11:22:33")
+
+	lbenv, err := os.ReadFile(filepath.Join(tmpDir, "fwcfg-i-recover-blobs-lbenv.tmp"))
+	require.NoError(t, err)
+	assert.Contains(t, string(lbenv), "LB_LB_ID=lb-recover")
+	assert.Contains(t, string(lbenv), "LB_ACCESS_KEY=AKID-recover")
+
+	cacert, err := os.ReadFile(filepath.Join(tmpDir, "fwcfg-i-recover-blobs-cacert.tmp"))
+	require.NoError(t, err)
+	assert.Contains(t, string(cacert), "fake-ca")
+}
+
+// TestRefreshSystemInstanceState_WriteErrorPropagates exercises the
+// writeFwCfgBlobs error path (plan §3): a write failure under the tmpfs
+// path must surface as a wrapped error so MarkRecoveryFailed gets called.
+func TestRefreshSystemInstanceState_WriteErrorPropagates(t *testing.T) {
+	d, nc, tmpDir := newRefreshTestDaemon(t)
+
+	seedStore, err := handlers_elbv2.NewStore(nc)
+	require.NoError(t, err)
+	require.NoError(t, seedStore.PutLoadBalancer(&handlers_elbv2.LoadBalancerRecord{
+		LoadBalancerID: "lb-werr",
+		Name:           "werr-alb",
+		Scheme:         handlers_elbv2.SchemeInternal,
+		Type:           handlers_elbv2.LoadBalancerTypeApplication,
+		State:          handlers_elbv2.StateActive,
+		Subnets:        []string{"subnet-aaa"},
+		ENIs:           []string{"eni-primary"},
+		InstanceID:     "i-werr",
+		VPCIP:          "10.0.1.5",
+		AccountID:      "123456789012",
+	}))
+
+	// Replace XDG_RUNTIME_DIR with a regular file so os.WriteFile in
+	// writeFwCfgBlobs fails with ENOTDIR. tmpDir from the helper is no
+	// longer the runtime dir for this test.
+	_ = tmpDir
+	notADir := filepath.Join(t.TempDir(), "blocking-file")
+	require.NoError(t, os.WriteFile(notADir, nil, 0600))
+	t.Setenv("XDG_RUNTIME_DIR", notADir)
+
+	inst := &vm.VM{
+		ID:           "i-werr",
+		ManagedBy:    tags.ManagedByELBv2,
+		InstanceType: "sys.micro",
+		ENIMac:       "02:aa:bb:cc:dd:01",
+		MgmtMAC:      "02:a0:00:11:22:33",
+		MgmtIP:       "172.31.0.7",
 	}
+	err = d.refreshSystemInstanceState(inst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rewrite fw_cfg blobs")
 }

--- a/spinifex/daemon/daemon_system_instance_test.go
+++ b/spinifex/daemon/daemon_system_instance_test.go
@@ -3,11 +3,14 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
+	"github.com/mulgadc/spinifex/spinifex/tags"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -307,5 +310,123 @@ func TestWriteFwCfgBlobs_InvalidNICs_NoDefault(t *testing.T) {
 	for _, e := range entries {
 		assert.False(t, strings.HasPrefix(e.Name(), "fwcfg-i-bad-nics"),
 			"unexpected tmpfile left behind: %s", e.Name())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// refreshSystemInstanceState
+// ---------------------------------------------------------------------------
+
+// TestRefreshSystemInstanceState_NonELBv2IsNoop guards the cheap-path
+// short-circuit: customer VMs (ManagedBy="") have no tmpfs blobs to
+// regenerate, and reaching the lb-record lookup would error pointlessly.
+func TestRefreshSystemInstanceState_NonELBv2IsNoop(t *testing.T) {
+	d := &Daemon{vmMgr: vm.NewManager()}
+	inst := &vm.VM{ID: "i-customer", ManagedBy: ""}
+
+	err := d.refreshSystemInstanceState(inst)
+	require.NoError(t, err, "non-ELBv2 VMs must short-circuit before the service lookup — customer instances do not need fw_cfg blob regeneration")
+}
+
+// TestRefreshSystemInstanceState_NilELBv2ServiceIsNoop covers the early
+// daemon-startup window where vmMgr.Restore runs before elbv2Service is
+// wired. The hook must not panic; the VM stays Pending and a later
+// recovery cycle (or operator retry) reaches the regen path with the
+// service available.
+func TestRefreshSystemInstanceState_NilELBv2ServiceIsNoop(t *testing.T) {
+	d := &Daemon{vmMgr: vm.NewManager(), elbv2Service: nil}
+	inst := &vm.VM{ID: "i-no-svc", ManagedBy: tags.ManagedByELBv2}
+
+	err := d.refreshSystemInstanceState(inst)
+	require.NoError(t, err, "an unwired elbv2Service must NOT block recovery with a hard error — the service finishes wiring later in Daemon.Start")
+}
+
+// TestRefreshSystemInstanceState_NoLBRecord verifies the failure-mode path:
+// the VM record survived but the LB record was wiped from KV (manual
+// admin deletion, KV corruption). Recovery must surface the error so the
+// caller flips the instance to recovery_failed rather than booting it
+// against guessed inputs.
+func TestRefreshSystemInstanceState_NoLBRecord(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	_, nc, _ := testutil.StartTestJetStream(t)
+	svc, err := handlers_elbv2.NewELBv2ServiceImplWithNATS(nil, nc)
+	require.NoError(t, err)
+	t.Cleanup(svc.Close)
+
+	d := &Daemon{vmMgr: vm.NewManager(), elbv2Service: svc}
+	inst := &vm.VM{ID: "i-orphan-alb", ManagedBy: tags.ManagedByELBv2, InstanceType: "sys.micro"}
+
+	err = d.refreshSystemInstanceState(inst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rebuild system instance input")
+	assert.Contains(t, err.Error(), "no LB record references instance i-orphan-alb",
+		"the wrapped error must identify the missing LB so journal grep finds the orphaned VM record")
+
+	// No tmpfiles must be created when rebuild fails — leaving stale blobs
+	// behind would mask the failure on the next recovery attempt.
+	entries, _ := os.ReadDir(tmpDir)
+	for _, e := range entries {
+		assert.False(t, strings.HasPrefix(e.Name(), "fwcfg-i-orphan-alb"),
+			"unexpected tmpfile left behind on rebuild failure: %s", e.Name())
+	}
+}
+
+// TestRefreshSystemInstanceState_RewritesBlobs covers the success path —
+// the bug's actual fix. Given an ELBv2-managed VM whose tmpfs blobs were
+// wiped (simulated by deleting the files after CreateLoadBalancer), the
+// hook must regenerate all three blobs at the deterministic paths the
+// persisted vm.Config.FwCfg references.
+func TestRefreshSystemInstanceState_RewritesBlobs(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	_, nc, _ := testutil.StartTestJetStream(t)
+	svc, err := handlers_elbv2.NewELBv2ServiceImplWithNATS(nil, nc)
+	require.NoError(t, err)
+	t.Cleanup(svc.Close)
+
+	// Pre-populate an LB record that references the recovery instance. We
+	// bypass CreateLoadBalancer (which would require a VPC service + mock
+	// launcher) by writing the record straight into the store — the
+	// rebuild path's only requirement is that some LB.InstanceID matches.
+	record := &handlers_elbv2.LoadBalancerRecord{
+		LoadBalancerID: "lb-recover",
+		Name:           "recover-alb",
+		Scheme:         handlers_elbv2.SchemeInternal,
+		Type:           handlers_elbv2.LoadBalancerTypeApplication,
+		State:          handlers_elbv2.StateActive,
+		Subnets:        []string{"subnet-aaa"},
+		ENIs:           []string{"eni-primary"},
+		InstanceID:     "i-recover-blobs",
+		VPCIP:          "10.0.1.5",
+		AccountID:      "123456789012",
+	}
+	// Both store instances share the same JetStream KV bucket, so a Put
+	// here is visible to svc.store on the next List call.
+	seedStore, err := handlers_elbv2.NewStore(nc)
+	require.NoError(t, err)
+	require.NoError(t, seedStore.PutLoadBalancer(record))
+
+	d := &Daemon{vmMgr: vm.NewManager(), elbv2Service: svc}
+	inst := &vm.VM{
+		ID:           "i-recover-blobs",
+		ManagedBy:    tags.ManagedByELBv2,
+		InstanceType: "sys.micro",
+		ENIMac:       "02:aa:bb:cc:dd:01",
+		MgmtMAC:      "02:a0:00:11:22:33",
+		MgmtIP:       "172.31.0.7",
+	}
+
+	require.NoError(t, d.refreshSystemInstanceState(inst))
+
+	// Three blobs at deterministic paths — these are the exact filenames
+	// writeFwCfgBlobs bakes into vm.Config.FwCfg, so the persisted QEMU
+	// command line will reference the same paths after the rewrite.
+	for _, suffix := range []string{"netcfg", "lbenv", "cacert"} {
+		path := filepath.Join(tmpDir, fmt.Sprintf("fwcfg-%s-%s.tmp", inst.ID, suffix))
+		_, statErr := os.Stat(path)
+		assert.NoError(t, statErr, "expected fw_cfg blob at %s after refresh — the persisted -fw_cfg arg in vm.Config references this exact path", path)
 	}
 }

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -479,9 +479,10 @@ func (d *Daemon) buildVMManagerDeps() vm.Deps {
 		VolumeStateUpdater: d.volumeService,
 		InstanceCleaner:    newInstanceCleanerAdapter(d),
 		Hooks: vm.ManagerHooks{
-			OnInstanceUp:         d.onInstanceUpHook(),
-			OnInstanceDown:       d.onInstanceDownHook(),
-			OnInstanceRecovering: d.onInstanceRecoveringHook(),
+			OnInstanceUp:           d.onInstanceUpHook(),
+			OnInstanceDown:         d.onInstanceDownHook(),
+			OnInstanceRecovering:   d.onInstanceRecoveringHook(),
+			BeforeInstanceRelaunch: d.refreshSystemInstanceState,
 		},
 		ShutdownSignal:             d.shuttingDown.Load,
 		CrashHandler:               d.vmMgr.HandleCrash,

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -2,9 +2,12 @@ package daemon
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
+	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/gpu"
+	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
@@ -294,4 +297,22 @@ func TestReleaseGPU_ManagerError_LogsWarning(t *testing.T) {
 	instance := &vm.VM{ID: "i-unclaimed", GPUPCIAddresses: []string{"0000:03:00.0"}}
 	// Must not panic; the error is logged as a warning.
 	a.ReleaseGPU(instance)
+}
+
+// TestBuildVMManagerDeps_WiresBeforeInstanceRelaunch guards the single line
+// in buildVMManagerDeps that routes the recovery hook to
+// refreshSystemInstanceState. Dropping it would surface only in cell-18.
+func TestBuildVMManagerDeps_WiresBeforeInstanceRelaunch(t *testing.T) {
+	d := &Daemon{config: &config.Config{}, vmMgr: vm.NewManager()}
+	deps := d.buildVMManagerDeps()
+	require.NotNil(t, deps.Hooks.BeforeInstanceRelaunch)
+
+	wantPC := reflect.ValueOf(d.refreshSystemInstanceState).Pointer()
+	gotPC := reflect.ValueOf(deps.Hooks.BeforeInstanceRelaunch).Pointer()
+	assert.Equal(t, wantPC, gotPC, "hook must point at refreshSystemInstanceState")
+
+	// Sanity: the wired hook is callable and returns nil for non-ELBv2 VMs.
+	require.NoError(t, deps.Hooks.BeforeInstanceRelaunch(&vm.VM{ID: "i-noop", ManagedBy: ""}))
+	require.Error(t, deps.Hooks.BeforeInstanceRelaunch(&vm.VM{ID: "i-svc", ManagedBy: tags.ManagedByELBv2}),
+		"ELBv2 VM with nil elbv2Service must error rather than silently no-op")
 }

--- a/spinifex/handlers/elbv2/launcher.go
+++ b/spinifex/handlers/elbv2/launcher.go
@@ -82,6 +82,20 @@ type NICConfig struct {
 	RouteVia  string // next-hop for RouteDst
 }
 
+// RecoveryContext carries the per-VM fields the ELBv2 service needs to
+// reconstruct a SystemInstanceInput during host-reboot recovery, without
+// importing the vm package (which would cycle back through daemon).
+// MgmtMAC / MgmtIP are the values the daemon already allocated for this
+// instance on a prior launch; the service injects them back into NIC[1]
+// rather than re-allocating from the mgmt IPAM.
+type RecoveryContext struct {
+	InstanceID   string
+	InstanceType string
+	ENIMac       string
+	MgmtMAC      string
+	MgmtIP       string
+}
+
 // SystemInstanceOutput contains the result of a successful launch.
 type SystemInstanceOutput struct {
 	InstanceID string // e.g. "i-xxxxx"

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -290,6 +290,121 @@ func (s *ELBv2ServiceImpl) buildMicrovmNICs(primaryIP, primaryMAC, primarySubnet
 	return nics
 }
 
+// describeENIs resolves the supplied ENI IDs in one VPC describe call and
+// returns them keyed by NetworkInterfaceId. Returns an empty map when the
+// VPC service is unwired or the describe errors — callers must tolerate
+// missing entries.
+func (s *ELBv2ServiceImpl) describeENIs(eniIDs []string, accountID string) map[string]*ec2.NetworkInterface {
+	eniDetails := make(map[string]*ec2.NetworkInterface, len(eniIDs))
+	if s.VPCService == nil || len(eniIDs) == 0 {
+		return eniDetails
+	}
+	eniPtrs := make([]*string, 0, len(eniIDs))
+	for _, id := range eniIDs {
+		eniPtrs = append(eniPtrs, aws.String(id))
+	}
+	result, err := s.VPCService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: eniPtrs,
+	}, accountID)
+	if err != nil {
+		slog.Debug("describeENIs: VPC describe failed", "count", len(eniIDs), "err", err)
+		return eniDetails
+	}
+	for _, eni := range result.NetworkInterfaces {
+		if eni.NetworkInterfaceId != nil {
+			eniDetails[*eni.NetworkInterfaceId] = eni
+		}
+	}
+	return eniDetails
+}
+
+// buildExtraENIInputs threads every non-primary ENI in eniIDs into an
+// ExtraENIInput, using eniDetails as the MAC/IP/SubnetID source. eniIDs[0]
+// is the primary ENI and is intentionally excluded. ENIs missing from
+// eniDetails are skipped (matching CreateLoadBalancer's original behaviour
+// when DescribeNetworkInterfaces drops an entry).
+func buildExtraENIInputs(eniIDs []string, eniDetails map[string]*ec2.NetworkInterface) []ExtraENIInput {
+	if len(eniIDs) <= 1 {
+		return nil
+	}
+	extras := make([]ExtraENIInput, 0, len(eniIDs)-1)
+	for i := 1; i < len(eniIDs); i++ {
+		eni := eniDetails[eniIDs[i]]
+		if eni == nil {
+			continue
+		}
+		extras = append(extras, ExtraENIInput{
+			ENIID:    eniIDs[i],
+			ENIMac:   aws.StringValue(eni.MacAddress),
+			ENIIP:    aws.StringValue(eni.PrivateIpAddress),
+			SubnetID: aws.StringValue(eni.SubnetId),
+		})
+	}
+	return extras
+}
+
+// RebuildSystemInstanceInput reconstructs the launch input for an existing
+// system instance during host-reboot recovery. It locates the LB record by
+// instance ID, re-derives NICs (including the mgmt NIC, using the MAC/IP
+// already allocated on the VM), and regenerates the LBAgentEnv/CACert blobs
+// from current service state. Returns an error when no LB record references
+// ctx.InstanceID — the caller treats that as a recovery failure rather than
+// guess at a launch input.
+func (s *ELBv2ServiceImpl) RebuildSystemInstanceInput(ctx RecoveryContext) (*SystemInstanceInput, error) {
+	lbs, err := s.store.ListLoadBalancers()
+	if err != nil {
+		return nil, fmt.Errorf("list lb records: %w", err)
+	}
+	var lb *LoadBalancerRecord
+	for _, r := range lbs {
+		if r.InstanceID == ctx.InstanceID {
+			lb = r
+			break
+		}
+	}
+	if lb == nil {
+		return nil, fmt.Errorf("no LB record references instance %s", ctx.InstanceID)
+	}
+	if len(lb.Subnets) == 0 || len(lb.ENIs) == 0 {
+		return nil, fmt.Errorf("lb %s has no subnets/ENIs to rebuild from", lb.LoadBalancerID)
+	}
+
+	eniDetails := s.describeENIs(lb.ENIs, lb.AccountID)
+	primaryMAC := ctx.ENIMac
+	if primary := eniDetails[lb.ENIs[0]]; primary != nil {
+		if mac := aws.StringValue(primary.MacAddress); mac != "" {
+			primaryMAC = mac
+		}
+	}
+	extraENIs := buildExtraENIInputs(lb.ENIs, eniDetails)
+
+	nics := s.buildMicrovmNICs(lb.VPCIP, primaryMAC, lb.Subnets[0], lb.ENIs[0], lb.Scheme, extraENIs, lb.AccountID)
+	// Re-inject the daemon-allocated mgmt NIC values so writeFwCfgBlobs
+	// emits the same netcfg the original launch produced — buildMicrovmNICs
+	// leaves NIC[1] MAC/CIDR blank because they are only known after the
+	// daemon's per-instance mgmt IP allocation.
+	if len(nics) > 1 && ctx.MgmtMAC != "" {
+		nics[1].MAC = ctx.MgmtMAC
+		if ctx.MgmtIP != "" {
+			nics[1].CIDR = ctx.MgmtIP + "/24"
+		}
+	}
+
+	return &SystemInstanceInput{
+		InstanceType: ctx.InstanceType,
+		SubnetID:     lb.Subnets[0],
+		ENIID:        lb.ENIs[0],
+		ENIMac:       primaryMAC,
+		ENIIP:        lb.VPCIP,
+		ExtraENIs:    extraENIs,
+		Scheme:       lb.Scheme,
+		AccountID:    lb.AccountID,
+		NICs:         nics,
+		LBAgentEnv:   s.buildLBAgentEnv(lb.LoadBalancerID),
+		CACert:       s.CACert,
+	}, nil
+}
+
 // resolveENIBindAddr looks up the private IP of the first ENI belonging to the ALB.
 // Returns empty string if VPC service is unavailable or no ENIs exist.
 func (s *ELBv2ServiceImpl) resolveENIBindAddr(lb *LoadBalancerRecord) string {
@@ -706,24 +821,7 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 	var hostPorts map[int]int
 	var launchFailed bool
 	if s.InstanceLauncher != nil && len(eniIDs) > 0 && len(subnets) > 0 {
-		// Resolve MAC/IP for every ENI in one describe call.
-		eniDetails := make(map[string]*ec2.NetworkInterface, len(eniIDs))
-		if s.VPCService != nil {
-			eniPtrs := make([]*string, 0, len(eniIDs))
-			for _, id := range eniIDs {
-				eniPtrs = append(eniPtrs, aws.String(id))
-			}
-			result, descErr := s.VPCService.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
-				NetworkInterfaceIds: eniPtrs,
-			}, accountID)
-			if descErr == nil {
-				for _, eni := range result.NetworkInterfaces {
-					if eni.NetworkInterfaceId != nil {
-						eniDetails[*eni.NetworkInterfaceId] = eni
-					}
-				}
-			}
-		}
+		eniDetails := s.describeENIs(eniIDs, accountID)
 
 		primary := eniDetails[eniIDs[0]]
 		primaryIP := ""
@@ -733,19 +831,7 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 			primaryMAC = aws.StringValue(primary.MacAddress)
 		}
 
-		extraENIInputs := make([]ExtraENIInput, 0, len(eniIDs)-1)
-		for i := 1; i < len(eniIDs); i++ {
-			eni := eniDetails[eniIDs[i]]
-			if eni == nil {
-				continue
-			}
-			extraENIInputs = append(extraENIInputs, ExtraENIInput{
-				ENIID:    eniIDs[i],
-				ENIMac:   aws.StringValue(eni.MacAddress),
-				ENIIP:    aws.StringValue(eni.PrivateIpAddress),
-				SubnetID: aws.StringValue(eni.SubnetId),
-			})
-		}
+		extraENIInputs := buildExtraENIInputs(eniIDs, eniDetails)
 
 		var launchInput *SystemInstanceInput
 		if s.GatewayURL == "" || s.SystemAccessKey == "" || s.SystemSecretKey == "" {

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -118,9 +118,8 @@ type ELBv2ServiceImpl struct {
 	cancel                     context.CancelFunc
 	hc                         *healthChecker
 
-	recoveryLBIndexOnce sync.Once
-	recoveryLBIndex     map[string]*LoadBalancerRecord
-	recoveryLBIndexErr  error
+	recoveryLBIndexMu sync.Mutex
+	recoveryLBIndex   map[string]*LoadBalancerRecord
 }
 
 // NewELBv2ServiceImplWithNATS creates an ELBv2 service backed by JetStream KV.
@@ -347,25 +346,28 @@ func buildExtraENIInputs(eniIDs []string, eniDetails map[string]*ec2.NetworkInte
 	return extras
 }
 
-// loadRecoveryLBIndex returns the instanceID->LB map, populated once on
-// first call. Recovery is a daemon-startup-only flow so a process-lifetime
-// cache is appropriate; each daemon process constructs a fresh service.
+// loadRecoveryLBIndex returns the instanceID->LB map, populated lazily on
+// first successful call. Errors are not cached: a transient JetStream
+// failure at startup must not condemn every subsequent recovery candidate
+// in the same batch — the next caller retries.
 func (s *ELBv2ServiceImpl) loadRecoveryLBIndex() (map[string]*LoadBalancerRecord, error) {
-	s.recoveryLBIndexOnce.Do(func() {
-		lbs, err := s.store.ListLoadBalancers()
-		if err != nil {
-			s.recoveryLBIndexErr = fmt.Errorf("list lb records: %w", err)
-			return
+	s.recoveryLBIndexMu.Lock()
+	defer s.recoveryLBIndexMu.Unlock()
+	if s.recoveryLBIndex != nil {
+		return s.recoveryLBIndex, nil
+	}
+	lbs, err := s.store.ListLoadBalancers()
+	if err != nil {
+		return nil, fmt.Errorf("list lb records: %w", err)
+	}
+	index := make(map[string]*LoadBalancerRecord, len(lbs))
+	for _, r := range lbs {
+		if r.InstanceID != "" {
+			index[r.InstanceID] = r
 		}
-		index := make(map[string]*LoadBalancerRecord, len(lbs))
-		for _, r := range lbs {
-			if r.InstanceID != "" {
-				index[r.InstanceID] = r
-			}
-		}
-		s.recoveryLBIndex = index
-	})
-	return s.recoveryLBIndex, s.recoveryLBIndexErr
+	}
+	s.recoveryLBIndex = index
+	return s.recoveryLBIndex, nil
 }
 
 // RebuildSystemInstanceInput reconstructs the launch input for an existing

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -117,6 +117,10 @@ type ELBv2ServiceImpl struct {
 	ctx                        context.Context
 	cancel                     context.CancelFunc
 	hc                         *healthChecker
+
+	recoveryLBIndexOnce sync.Once
+	recoveryLBIndex     map[string]*LoadBalancerRecord
+	recoveryLBIndexErr  error
 }
 
 // NewELBv2ServiceImplWithNATS creates an ELBv2 service backed by JetStream KV.
@@ -307,7 +311,7 @@ func (s *ELBv2ServiceImpl) describeENIs(eniIDs []string, accountID string) map[s
 		NetworkInterfaceIds: eniPtrs,
 	}, accountID)
 	if err != nil {
-		slog.Debug("describeENIs: VPC describe failed", "count", len(eniIDs), "err", err)
+		slog.Error("VPC describe ENIs failed", "count", len(eniIDs), "err", err)
 		return eniDetails
 	}
 	for _, eni := range result.NetworkInterfaces {
@@ -343,25 +347,37 @@ func buildExtraENIInputs(eniIDs []string, eniDetails map[string]*ec2.NetworkInte
 	return extras
 }
 
-// RebuildSystemInstanceInput reconstructs the launch input for an existing
-// system instance during host-reboot recovery. It locates the LB record by
-// instance ID, re-derives NICs (including the mgmt NIC, using the MAC/IP
-// already allocated on the VM), and regenerates the LBAgentEnv/CACert blobs
-// from current service state. Returns an error when no LB record references
-// ctx.InstanceID — the caller treats that as a recovery failure rather than
-// guess at a launch input.
-func (s *ELBv2ServiceImpl) RebuildSystemInstanceInput(ctx RecoveryContext) (*SystemInstanceInput, error) {
-	lbs, err := s.store.ListLoadBalancers()
-	if err != nil {
-		return nil, fmt.Errorf("list lb records: %w", err)
-	}
-	var lb *LoadBalancerRecord
-	for _, r := range lbs {
-		if r.InstanceID == ctx.InstanceID {
-			lb = r
-			break
+// loadRecoveryLBIndex returns the instanceID->LB map, populated once on
+// first call. Recovery is a daemon-startup-only flow so a process-lifetime
+// cache is appropriate; each daemon process constructs a fresh service.
+func (s *ELBv2ServiceImpl) loadRecoveryLBIndex() (map[string]*LoadBalancerRecord, error) {
+	s.recoveryLBIndexOnce.Do(func() {
+		lbs, err := s.store.ListLoadBalancers()
+		if err != nil {
+			s.recoveryLBIndexErr = fmt.Errorf("list lb records: %w", err)
+			return
 		}
+		index := make(map[string]*LoadBalancerRecord, len(lbs))
+		for _, r := range lbs {
+			if r.InstanceID != "" {
+				index[r.InstanceID] = r
+			}
+		}
+		s.recoveryLBIndex = index
+	})
+	return s.recoveryLBIndex, s.recoveryLBIndexErr
+}
+
+// RebuildSystemInstanceInput reconstructs the launch input for an existing
+// system instance during host-reboot recovery. The instance->LB map is
+// memoised in s.recoveryLBIndex so N concurrent recovery candidates share a
+// single ListLoadBalancers call instead of issuing N×L JetStream round-trips.
+func (s *ELBv2ServiceImpl) RebuildSystemInstanceInput(ctx RecoveryContext) (*SystemInstanceInput, error) {
+	index, err := s.loadRecoveryLBIndex()
+	if err != nil {
+		return nil, err
 	}
+	lb := index[ctx.InstanceID]
 	if lb == nil {
 		return nil, fmt.Errorf("no LB record references instance %s", ctx.InstanceID)
 	}
@@ -370,11 +386,21 @@ func (s *ELBv2ServiceImpl) RebuildSystemInstanceInput(ctx RecoveryContext) (*Sys
 	}
 
 	eniDetails := s.describeENIs(lb.ENIs, lb.AccountID)
+	// Multi-ENI rebuild needs an authoritative MAC/IP/subnet per extra, which
+	// only the VPC store supplies. Single-ENI ALBs can fall back to ctx.ENIMac
+	// + lb.VPCIP for the primary, so we only enforce the strict count match
+	// when extras are present.
+	if len(lb.ENIs) > 1 && len(eniDetails) < len(lb.ENIs) {
+		return nil, fmt.Errorf("describe lb %s ENIs: got %d/%d", lb.LoadBalancerID, len(eniDetails), len(lb.ENIs))
+	}
 	primaryMAC := ctx.ENIMac
 	if primary := eniDetails[lb.ENIs[0]]; primary != nil {
 		if mac := aws.StringValue(primary.MacAddress); mac != "" {
 			primaryMAC = mac
 		}
+	}
+	if primaryMAC == "" {
+		return nil, fmt.Errorf("no MAC for primary ENI %s of lb %s", lb.ENIs[0], lb.LoadBalancerID)
 	}
 	extraENIs := buildExtraENIInputs(lb.ENIs, eniDetails)
 

--- a/spinifex/handlers/elbv2/service_impl_vpc_test.go
+++ b/spinifex/handlers/elbv2/service_impl_vpc_test.go
@@ -769,17 +769,13 @@ func TestRebuildSystemInstanceInput_HappyPath(t *testing.T) {
 	assert.Equal(t, "10.0.1.42", rebuilt.ENIIP)
 	assert.Equal(t, originalInput.Scheme, rebuilt.Scheme)
 	assert.Equal(t, originalInput.AccountID, rebuilt.AccountID)
-	assert.Equal(t, originalInput.LBAgentEnv, rebuilt.LBAgentEnv,
-		"buildLBAgentEnv is deterministic on lbID + system creds — recovery must regenerate the exact same env or HAProxy comes up with a different SigV4 identity")
-	assert.Equal(t, originalInput.CACert, rebuilt.CACert,
-		"a different CACert at recovery time would mean a TLS chain mismatch vs the one the running guest already trusted")
+	assert.Equal(t, originalInput.LBAgentEnv, rebuilt.LBAgentEnv)
+	assert.Equal(t, originalInput.CACert, rebuilt.CACert)
 
-	require.GreaterOrEqual(t, len(rebuilt.NICs), 2, "ALB recovery input must carry at least NIC[0] primary + NIC[1] mgmt")
-	assert.True(t, rebuilt.NICs[0].IsDefault, "NIC[0] must be the default-route owner — flipping this breaks egress to the gateway")
-	assert.Equal(t, "02:a0:00:11:22:33", rebuilt.NICs[1].MAC,
-		"NIC[1] MAC must come from the recovery context — re-allocating from mgmt IPAM would orphan the existing tap on br-mgmt")
-	assert.Equal(t, "172.31.0.7/24", rebuilt.NICs[1].CIDR,
-		"NIC[1] CIDR must mirror the daemon's prior allocation; otherwise the guest's lb-agent route to AWSGW points at the wrong source")
+	require.GreaterOrEqual(t, len(rebuilt.NICs), 2)
+	assert.True(t, rebuilt.NICs[0].IsDefault)
+	assert.Equal(t, "02:a0:00:11:22:33", rebuilt.NICs[1].MAC, "mgmt NIC MAC must come from RecoveryContext")
+	assert.Equal(t, "172.31.0.7/24", rebuilt.NICs[1].CIDR, "mgmt NIC CIDR must come from RecoveryContext")
 }
 
 // TestRebuildSystemInstanceInput_NoLBRecord verifies the error path used by
@@ -832,16 +828,17 @@ func TestRebuildSystemInstanceInput_MultiENI(t *testing.T) {
 		ENIMac:       originalInput.ENIMac,
 	})
 	require.NoError(t, err)
-	require.Len(t, rebuilt.ExtraENIs, len(originalInput.ExtraENIs),
-		"every extra ENI from the original launch must reappear on rebuild — dropping one would leave a tap on br-int with no QEMU NIC to feed it")
+	require.Len(t, rebuilt.ExtraENIs, len(originalInput.ExtraENIs))
 
-	originalSubs := map[string]bool{}
+	originalByENI := map[string]ExtraENIInput{}
 	for _, e := range originalInput.ExtraENIs {
-		originalSubs[e.SubnetID] = true
+		originalByENI[e.ENIID] = e
 	}
 	for _, e := range rebuilt.ExtraENIs {
-		assert.True(t, originalSubs[e.SubnetID], "extra ENI on subnet %s was not in the original launch — wrong subnet means wrong CIDR for guest routing", e.SubnetID)
-		assert.NotEmpty(t, e.ENIMac)
-		assert.NotEmpty(t, e.ENIIP)
+		orig, ok := originalByENI[e.ENIID]
+		require.True(t, ok, "extra ENI %s not in original launch", e.ENIID)
+		assert.Equal(t, orig.SubnetID, e.SubnetID)
+		assert.Equal(t, orig.ENIMac, e.ENIMac)
+		assert.Equal(t, orig.ENIIP, e.ENIIP)
 	}
 }

--- a/spinifex/handlers/elbv2/service_impl_vpc_test.go
+++ b/spinifex/handlers/elbv2/service_impl_vpc_test.go
@@ -712,3 +712,136 @@ func TestCreateLoadBalancer_NoSecurityGroupsFallsBackToDefault(t *testing.T) {
 	require.Len(t, albENI.Groups, 1)
 	assert.Equal(t, defaultSGID, *albENI.Groups[0].GroupId)
 }
+
+// TestRebuildSystemInstanceInput_HappyPath verifies that a recovering ALB
+// VM gets the same SystemInstanceInput shape the launch path produced —
+// otherwise writeFwCfgBlobs would emit a different netcfg/cacert blob than
+// the persisted QEMU command line references, and the relaunch would fail
+// at fw_cfg load time the same way the tmpfs wipe does today.
+func TestRebuildSystemInstanceInput_HappyPath(t *testing.T) {
+	svc, vpcSvc := setupTestServiceWithVPC(t)
+
+	subnets, err := vpcSvc.DescribeSubnets(&ec2.DescribeSubnetsInput{}, testAccountID)
+	require.NoError(t, err)
+	subnetID := *subnets.Subnets[0].SubnetId
+
+	mock := &mockSystemInstanceLauncher{
+		launchResult: &SystemInstanceOutput{
+			InstanceID: "i-recover-1",
+			PrivateIP:  "10.0.1.42",
+		},
+	}
+	svc.InstanceLauncher = mock
+	svc.GatewayURL = "https://10.0.0.1:9999"
+	svc.SystemAccessKey = "AKID"
+	svc.SystemSecretKey = "SECRET"
+	svc.CACert = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
+
+	_, err = svc.CreateLoadBalancer(&elbv2.CreateLoadBalancerInput{
+		Name:    aws.String("recover-alb"),
+		Subnets: []*string{aws.String(subnetID)},
+		Scheme:  aws.String("internal"),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, mock.launchCalls, 1)
+	originalInput := mock.launchCalls[0]
+
+	ctx := RecoveryContext{
+		InstanceID:   "i-recover-1",
+		InstanceType: originalInput.InstanceType,
+		ENIMac:       originalInput.ENIMac,
+		MgmtMAC:      "02:a0:00:11:22:33",
+		MgmtIP:       "172.31.0.7",
+	}
+
+	rebuilt, err := svc.RebuildSystemInstanceInput(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rebuilt)
+
+	assert.Equal(t, originalInput.InstanceType, rebuilt.InstanceType)
+	assert.Equal(t, originalInput.SubnetID, rebuilt.SubnetID)
+	assert.Equal(t, originalInput.ENIID, rebuilt.ENIID)
+	assert.Equal(t, originalInput.ENIMac, rebuilt.ENIMac)
+	// ENIIP comes from the persisted lb.VPCIP (which the launcher's PrivateIP
+	// return value sets); in production the launcher echoes back the ENI's
+	// private IP, so this matches the original launch input. The test mock
+	// returns a synthetic value, so assert against the mock's PrivateIP.
+	assert.Equal(t, "10.0.1.42", rebuilt.ENIIP)
+	assert.Equal(t, originalInput.Scheme, rebuilt.Scheme)
+	assert.Equal(t, originalInput.AccountID, rebuilt.AccountID)
+	assert.Equal(t, originalInput.LBAgentEnv, rebuilt.LBAgentEnv,
+		"buildLBAgentEnv is deterministic on lbID + system creds — recovery must regenerate the exact same env or HAProxy comes up with a different SigV4 identity")
+	assert.Equal(t, originalInput.CACert, rebuilt.CACert,
+		"a different CACert at recovery time would mean a TLS chain mismatch vs the one the running guest already trusted")
+
+	require.GreaterOrEqual(t, len(rebuilt.NICs), 2, "ALB recovery input must carry at least NIC[0] primary + NIC[1] mgmt")
+	assert.True(t, rebuilt.NICs[0].IsDefault, "NIC[0] must be the default-route owner — flipping this breaks egress to the gateway")
+	assert.Equal(t, "02:a0:00:11:22:33", rebuilt.NICs[1].MAC,
+		"NIC[1] MAC must come from the recovery context — re-allocating from mgmt IPAM would orphan the existing tap on br-mgmt")
+	assert.Equal(t, "172.31.0.7/24", rebuilt.NICs[1].CIDR,
+		"NIC[1] CIDR must mirror the daemon's prior allocation; otherwise the guest's lb-agent route to AWSGW points at the wrong source")
+}
+
+// TestRebuildSystemInstanceInput_NoLBRecord verifies the error path used by
+// refreshSystemInstanceState to flag the instance recovery_failed when the
+// LB record was wiped from KV but the VM record survived — recovery must
+// not invent a fake input and silently boot the VM into an unowned state.
+func TestRebuildSystemInstanceInput_NoLBRecord(t *testing.T) {
+	svc := setupTestService(t)
+
+	_, err := svc.RebuildSystemInstanceInput(RecoveryContext{
+		InstanceID:   "i-ghost",
+		InstanceType: "sys.micro",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no LB record references instance i-ghost")
+}
+
+// TestRebuildSystemInstanceInput_MultiENI verifies that extras survive the
+// rebuild for multi-subnet ALBs — the create path passes one ExtraENIInput
+// per non-primary subnet, and recovery must produce the same shape so the
+// daemon wires the same set of taps and NICs the persisted QEMU args
+// reference.
+func TestRebuildSystemInstanceInput_MultiENI(t *testing.T) {
+	svc, vpcSvc := setupTestServiceWithVPC(t)
+
+	vpcs, _ := vpcSvc.DescribeVpcs(&ec2.DescribeVpcsInput{}, testAccountID)
+	vpcID := *vpcs.Vpcs[0].VpcId
+	sub1 := getTestSubnetID(t, vpcSvc, vpcID, "10.0.20.0/24", "us-east-1a")
+	sub2 := getTestSubnetID(t, vpcSvc, vpcID, "10.0.21.0/24", "us-east-1b")
+
+	mock := &mockSystemInstanceLauncher{
+		launchResult: &SystemInstanceOutput{InstanceID: "i-recover-multi", PrivateIP: "10.0.20.4"},
+	}
+	svc.InstanceLauncher = mock
+	svc.GatewayURL = "https://10.0.0.1:9999"
+	svc.SystemAccessKey = "AKID"
+	svc.SystemSecretKey = "SECRET"
+
+	_, err := svc.CreateLoadBalancer(&elbv2.CreateLoadBalancerInput{
+		Name:    aws.String("recover-multi-alb"),
+		Subnets: []*string{aws.String(sub1), aws.String(sub2)},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, mock.launchCalls, 1)
+	originalInput := mock.launchCalls[0]
+
+	rebuilt, err := svc.RebuildSystemInstanceInput(RecoveryContext{
+		InstanceID:   "i-recover-multi",
+		InstanceType: originalInput.InstanceType,
+		ENIMac:       originalInput.ENIMac,
+	})
+	require.NoError(t, err)
+	require.Len(t, rebuilt.ExtraENIs, len(originalInput.ExtraENIs),
+		"every extra ENI from the original launch must reappear on rebuild — dropping one would leave a tap on br-int with no QEMU NIC to feed it")
+
+	originalSubs := map[string]bool{}
+	for _, e := range originalInput.ExtraENIs {
+		originalSubs[e.SubnetID] = true
+	}
+	for _, e := range rebuilt.ExtraENIs {
+		assert.True(t, originalSubs[e.SubnetID], "extra ENI on subnet %s was not in the original launch — wrong subnet means wrong CIDR for guest routing", e.SubnetID)
+		assert.NotEmpty(t, e.ENIMac)
+		assert.NotEmpty(t, e.ENIIP)
+	}
+}

--- a/spinifex/utils/pidfile.go
+++ b/spinifex/utils/pidfile.go
@@ -199,6 +199,27 @@ func WaitForProcessExit(pid int, timeout time.Duration) error {
 	}
 }
 
+// WaitForPidFile polls until QEMU writes its pidfile or the timeout expires.
+// Direct-boot microvms need ~50ms in the happy path, but under post-reboot
+// recovery load (multiple VMs launching, nbdkit binding sockets, fwcfg blobs
+// being written) the kernel may not schedule QEMU's pidfile write within a
+// single settle window. A short blocking poll keeps the fast-start latency
+// intact while avoiding premature launch-failure cascades that tear down the
+// tap before QEMU finishes opening it.
+func WaitForPidFile(instanceID string, timeout time.Duration) (int, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		pid, err := ReadPidFile(instanceID)
+		if err == nil {
+			return pid, nil
+		}
+		if time.Now().After(deadline) {
+			return 0, err
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 func WaitForPidFileRemoval(instanceID string, timeout time.Duration) error {
 	timeoutCh := time.After(timeout)
 	ticker := time.NewTicker(100 * time.Millisecond)

--- a/spinifex/utils/utils_test.go
+++ b/spinifex/utils/utils_test.go
@@ -148,6 +148,43 @@ func TestExecProcessAndKill(t *testing.T) {
 	assert.Error(t, err) // Should return an error since process is killed
 }
 
+func TestWaitForPidFile(t *testing.T) {
+	t.Run("returns pid when file appears within timeout", func(t *testing.T) {
+		const name = "wait-pidfile-appears"
+		_ = RemovePidFile(name)
+		t.Cleanup(func() { _ = RemovePidFile(name) })
+
+		go func() {
+			time.Sleep(150 * time.Millisecond)
+			_ = WritePidFile(name, 4242)
+		}()
+
+		pid, err := WaitForPidFile(name, time.Second)
+		require.NoError(t, err)
+		assert.Equal(t, 4242, pid)
+	})
+
+	t.Run("returns error when timeout expires", func(t *testing.T) {
+		const name = "wait-pidfile-missing"
+		_ = RemovePidFile(name)
+
+		_, err := WaitForPidFile(name, 100*time.Millisecond)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns immediately when file already present", func(t *testing.T) {
+		const name = "wait-pidfile-present"
+		require.NoError(t, WritePidFile(name, 7777))
+		t.Cleanup(func() { _ = RemovePidFile(name) })
+
+		start := time.Now()
+		pid, err := WaitForPidFile(name, time.Second)
+		require.NoError(t, err)
+		assert.Equal(t, 7777, pid)
+		assert.Less(t, time.Since(start), 50*time.Millisecond)
+	})
+}
+
 func TestUnmarshalJsonPayload(t *testing.T) {
 	type TestStruct struct {
 		Name  string `json:"name"`

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -171,14 +171,14 @@ func (m *Manager) launch(instance *VM) error {
 	return nil
 }
 
-// preQEMUExecWait returns how long startQEMU sleeps before exec'ing QEMU.
-// Non-direct-boot needs 2 s so nbdkit can bind its sockets. Direct-boot has no
-// nbdkit but reuses the same window: post-host-reboot recovery has shown
-// qemu's TUNSETIFF returning EPERM ("could not configure /dev/net/tun:
-// Operation not permitted") when exec'd ~1 s after `ip tuntap add ... user X
-// group Y`, while a 2 s gap reliably succeeds for the same daemon/uid against
-// an identically owned tap on the q35 (nbdkit) path.
-func preQEMUExecWait() time.Duration {
+// nbdkitPreExecWait returns how long startQEMU sleeps before exec'ing QEMU to
+// give nbdkit time to bind its sockets. Direct-boot instances have no drives
+// and no nbdkit, so the wait collapses to zero and the boot-time budget is
+// preserved.
+func nbdkitPreExecWait(directBoot bool) time.Duration {
+	if directBoot {
+		return 0
+	}
 	return 2 * time.Second
 }
 
@@ -340,7 +340,7 @@ func (m *Manager) startQEMU(instance *VM) error {
 
 	// Wait briefly for nbdkit to start.
 	// TODO: Improve, confirm nbdkit started for each volume.
-	time.Sleep(preQEMUExecWait())
+	time.Sleep(nbdkitPreExecWait(instance.DirectBoot))
 
 	processChan := make(chan int, 1)
 	exitChan := make(chan int, 1)

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -443,7 +443,11 @@ func (m *Manager) startQEMU(instance *VM) error {
 			"serial_socket", instance.Config.SerialSocket)
 	}
 
-	if _, err := utils.ReadPidFile(instance.ID); err != nil {
+	// QEMU writes its pidfile after parsing args and mmap'ing the kernel/initrd/
+	// fwcfg blobs. Direct-boot is usually <50ms, but under post-reboot recovery
+	// load it can exceed the settle wait — block briefly so we don't tear down
+	// the tap before QEMU finishes attaching to it.
+	if _, err := utils.WaitForPidFile(instance.ID, 3*time.Second); err != nil {
 		slog.Error("Failed to read PID file", "err", err)
 		return err
 	}

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -171,18 +171,14 @@ func (m *Manager) launch(instance *VM) error {
 	return nil
 }
 
-// nbdkitPreExecWait returns how long startQEMU sleeps before exec'ing QEMU.
-// Non-direct-boot waits 2 s so nbdkit can bind its sockets. Direct-boot has no
-// nbdkit but still waits 1 s so the kernel commits the just-created tap
-// owner (set via `ip tuntap add ... user X group Y`) before QEMU's TUNSETIFF
-// — post-host-reboot recovery has shown the ioctl racing the tap commit and
-// returning EPERM ("could not configure /dev/net/tun: Operation not
-// permitted"). The non-direct-boot path masks the same race incidentally
-// with its longer nbdkit wait.
-func nbdkitPreExecWait(directBoot bool) time.Duration {
-	if directBoot {
-		return time.Second
-	}
+// preQEMUExecWait returns how long startQEMU sleeps before exec'ing QEMU.
+// Non-direct-boot needs 2 s so nbdkit can bind its sockets. Direct-boot has no
+// nbdkit but reuses the same window: post-host-reboot recovery has shown
+// qemu's TUNSETIFF returning EPERM ("could not configure /dev/net/tun:
+// Operation not permitted") when exec'd ~1 s after `ip tuntap add ... user X
+// group Y`, while a 2 s gap reliably succeeds for the same daemon/uid against
+// an identically owned tap on the q35 (nbdkit) path.
+func preQEMUExecWait() time.Duration {
 	return 2 * time.Second
 }
 
@@ -344,7 +340,7 @@ func (m *Manager) startQEMU(instance *VM) error {
 
 	// Wait briefly for nbdkit to start.
 	// TODO: Improve, confirm nbdkit started for each volume.
-	time.Sleep(nbdkitPreExecWait(instance.DirectBoot))
+	time.Sleep(preQEMUExecWait())
 
 	processChan := make(chan int, 1)
 	exitChan := make(chan int, 1)

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -171,13 +171,17 @@ func (m *Manager) launch(instance *VM) error {
 	return nil
 }
 
-// nbdkitPreExecWait returns how long startQEMU sleeps before exec'ing QEMU to
-// give nbdkit time to bind its sockets. Direct-boot instances have no drives
-// and no nbdkit, so the wait collapses to zero and the boot-time budget is
-// preserved.
+// nbdkitPreExecWait returns how long startQEMU sleeps before exec'ing QEMU.
+// Non-direct-boot waits 2 s so nbdkit can bind its sockets. Direct-boot has no
+// nbdkit but still waits 1 s so the kernel commits the just-created tap
+// owner (set via `ip tuntap add ... user X group Y`) before QEMU's TUNSETIFF
+// — post-host-reboot recovery has shown the ioctl racing the tap commit and
+// returning EPERM ("could not configure /dev/net/tun: Operation not
+// permitted"). The non-direct-boot path masks the same race incidentally
+// with its longer nbdkit wait.
 func nbdkitPreExecWait(directBoot bool) time.Duration {
 	if directBoot {
-		return 0
+		return time.Second
 	}
 	return 2 * time.Second
 }

--- a/spinifex/vm/lifecycle_test.go
+++ b/spinifex/vm/lifecycle_test.go
@@ -763,10 +763,10 @@ func (p *scriptedNetworkPlumber) CleanupTap(_ string) error { return nil }
 var _ NetworkPlumber = (*scriptedNetworkPlumber)(nil)
 
 // TestNbdkitPreExecWait locks in the per-mode pre-exec sleep budget: direct-boot
-// is zero (no drives, no nbdkit) and the PC-machine path keeps the 2 s wait that
-// the rest of the launch flow depends on.
+// is 1 s (tap-owner settle floor for TUNSETIFF, no nbdkit) and the PC-machine
+// path keeps the 2 s wait that the rest of the launch flow depends on.
 func TestNbdkitPreExecWait(t *testing.T) {
-	assert.Equal(t, time.Duration(0), nbdkitPreExecWait(true))
+	assert.Equal(t, time.Second, nbdkitPreExecWait(true))
 	assert.Equal(t, 2*time.Second, nbdkitPreExecWait(false))
 }
 

--- a/spinifex/vm/lifecycle_test.go
+++ b/spinifex/vm/lifecycle_test.go
@@ -762,12 +762,12 @@ func (p *scriptedNetworkPlumber) CleanupTap(_ string) error { return nil }
 
 var _ NetworkPlumber = (*scriptedNetworkPlumber)(nil)
 
-// TestPreQEMUExecWait locks in the 2 s sleep before QEMU exec. The non-direct
-// path needs it for nbdkit socket binding; the direct path needs it because
-// TUNSETIFF returns EPERM when exec'd ~1 s after `ip tuntap add ... user X
-// group Y` on the post-host-reboot recovery path.
-func TestPreQEMUExecWait(t *testing.T) {
-	assert.Equal(t, 2*time.Second, preQEMUExecWait())
+// TestNbdkitPreExecWait locks in the per-mode pre-exec sleep budget: direct-boot
+// is zero (no drives, no nbdkit) and the PC-machine path keeps the 2 s wait that
+// the rest of the launch flow depends on.
+func TestNbdkitPreExecWait(t *testing.T) {
+	assert.Equal(t, time.Duration(0), nbdkitPreExecWait(true))
+	assert.Equal(t, 2*time.Second, nbdkitPreExecWait(false))
 }
 
 // TestQemuStartSettleWait locks in the per-mode post-fork settle: direct-boot

--- a/spinifex/vm/lifecycle_test.go
+++ b/spinifex/vm/lifecycle_test.go
@@ -762,12 +762,12 @@ func (p *scriptedNetworkPlumber) CleanupTap(_ string) error { return nil }
 
 var _ NetworkPlumber = (*scriptedNetworkPlumber)(nil)
 
-// TestNbdkitPreExecWait locks in the per-mode pre-exec sleep budget: direct-boot
-// is 1 s (tap-owner settle floor for TUNSETIFF, no nbdkit) and the PC-machine
-// path keeps the 2 s wait that the rest of the launch flow depends on.
-func TestNbdkitPreExecWait(t *testing.T) {
-	assert.Equal(t, time.Second, nbdkitPreExecWait(true))
-	assert.Equal(t, 2*time.Second, nbdkitPreExecWait(false))
+// TestPreQEMUExecWait locks in the 2 s sleep before QEMU exec. The non-direct
+// path needs it for nbdkit socket binding; the direct path needs it because
+// TUNSETIFF returns EPERM when exec'd ~1 s after `ip tuntap add ... user X
+// group Y` on the post-host-reboot recovery path.
+func TestPreQEMUExecWait(t *testing.T) {
+	assert.Equal(t, 2*time.Second, preQEMUExecWait())
 }
 
 // TestQemuStartSettleWait locks in the per-mode post-fork settle: direct-boot

--- a/spinifex/vm/manager.go
+++ b/spinifex/vm/manager.go
@@ -24,6 +24,13 @@ type ManagerHooks struct {
 	// OnInstanceUp on launch success is idempotent and reinstalls both
 	// the command and console subscriptions.
 	OnInstanceRecovering func(*VM)
+	// BeforeInstanceRelaunch fires from Restore once per recovery
+	// candidate, after OnInstanceRecovering and immediately before
+	// m.Run. Daemons use this to refresh ephemeral on-host state
+	// (tmpfs-backed config blobs, dynamic firmware files) that did not
+	// survive a host reboot. A non-nil error aborts the relaunch and
+	// marks the instance recovery_failed.
+	BeforeInstanceRelaunch func(*VM) error
 }
 
 // Deps bundles every collaborator the manager uses to drive lifecycle.

--- a/spinifex/vm/restore.go
+++ b/spinifex/vm/restore.go
@@ -300,6 +300,15 @@ func (m *Manager) relaunchAll(toLaunch []*VM) {
 					"instanceId", inst.ID, "status", string(status))
 				return
 			}
+			if m.deps.Hooks.BeforeInstanceRelaunch != nil {
+				if err := m.deps.Hooks.BeforeInstanceRelaunch(inst); err != nil {
+					slog.Error("Pre-relaunch hook failed",
+						"instanceId", inst.ID, "managedBy", inst.ManagedBy,
+						"instanceType", inst.InstanceType, "err", err)
+					m.MarkRecoveryFailed(inst, "pre_relaunch_hook_failed")
+					return
+				}
+			}
 			slog.Info("Launching instance (recovery)",
 				"instance", inst.ID, "managedBy", inst.ManagedBy, "instanceType", inst.InstanceType)
 			if err := m.Run(inst); err != nil {

--- a/spinifex/vm/restore_test.go
+++ b/spinifex/vm/restore_test.go
@@ -630,6 +630,89 @@ func TestRelaunchAll(t *testing.T) {
 			"recovery failure preserves per-id subscriptions: OnInstanceDown must not fire")
 	})
 
+	t.Run("BeforeInstanceRelaunch fires once before Run on success", func(t *testing.T) {
+		m, mounter, _, _ := relaunchTestManager(t)
+		var hookOrder []string
+		var mu sync.Mutex
+		m.deps.Hooks.BeforeInstanceRelaunch = func(v *VM) error {
+			mu.Lock()
+			hookOrder = append(hookOrder, "hook:"+v.ID)
+			mu.Unlock()
+			return nil
+		}
+		mounter.behavior["i-hook-ok"] = func(v *VM) error {
+			mu.Lock()
+			hookOrder = append(hookOrder, "mount:"+v.ID)
+			mu.Unlock()
+			return nil
+		}
+
+		instance := &VM{
+			ID:           "i-hook-ok",
+			Status:       StatePending,
+			InstanceType: "t3.micro",
+			Instance:     &ec2.Instance{},
+		}
+		m.Insert(instance)
+
+		m.relaunchAll([]*VM{instance})
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, []string{"hook:i-hook-ok", "mount:i-hook-ok"}, hookOrder,
+			"BeforeInstanceRelaunch must fire before Run's Mount — otherwise the host-local state Run consumes is still stale from the tmpfs wipe")
+	})
+
+	t.Run("BeforeInstanceRelaunch error marks recovery_failed and skips Run", func(t *testing.T) {
+		t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+		mounter := &recoveryMounter{behavior: map[string]func(*VM) error{}}
+		cleaner := &recordingInstanceCleaner{}
+		rt := &recordedTransitions{}
+		m := NewManager()
+		rt.bind(m)
+		m.SetDeps(Deps{
+			NodeID:          "test-node",
+			StateStore:      newFakeStateStore(),
+			VolumeMounter:   mounter,
+			InstanceCleaner: cleaner,
+			TransitionState: rt.apply,
+			ShutdownSignal:  func() bool { return false },
+			Hooks: ManagerHooks{
+				BeforeInstanceRelaunch: func(*VM) error {
+					return errors.New("blob regeneration failed")
+				},
+			},
+		})
+
+		instance := &VM{
+			ID:           "i-hook-fail",
+			Status:       StatePending,
+			InstanceType: "t3.micro",
+			Instance:     &ec2.Instance{},
+		}
+		m.Insert(instance)
+		errored := rt.waitFor(instance.ID, StateError)
+
+		m.relaunchAll([]*VM{instance})
+
+		select {
+		case <-errored:
+		case <-time.After(markFailedDeadline):
+			t.Fatalf("MarkRecoveryFailed did not record StateError transition within %s", markFailedDeadline)
+		}
+
+		assert.Equal(t, StateError, m.Status(instance),
+			"a pre-relaunch hook error must drive the instance into StateError via MarkRecoveryFailed — without this the failure is silent and the LB never recovers")
+		require.NotNil(t, instance.Instance.StateReason)
+		assert.Equal(t, "pre_relaunch_hook_failed", *instance.Instance.StateReason.Message,
+			"the reason must identify the hook failure class so the journal/audit log captures why launch was aborted before Run")
+
+		mounter.mu.Lock()
+		defer mounter.mu.Unlock()
+		assert.Empty(t, mounter.mounted,
+			"a failing hook must short-circuit before Run; otherwise QEMU launches against the missing fw_cfg blobs we tried to regenerate")
+	})
+
 	t.Run("status check skips instances flipped before launch", func(t *testing.T) {
 		m, mounter, _, _ := relaunchTestManager(t)
 		const total = 5

--- a/spinifex/vm/restore_test.go
+++ b/spinifex/vm/restore_test.go
@@ -660,7 +660,7 @@ func TestRelaunchAll(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		assert.Equal(t, []string{"hook:i-hook-ok", "mount:i-hook-ok"}, hookOrder,
-			"BeforeInstanceRelaunch must fire before Run's Mount — otherwise the host-local state Run consumes is still stale from the tmpfs wipe")
+			"hook must fire before Run's Mount")
 	})
 
 	t.Run("BeforeInstanceRelaunch error marks recovery_failed and skips Run", func(t *testing.T) {
@@ -701,16 +701,13 @@ func TestRelaunchAll(t *testing.T) {
 			t.Fatalf("MarkRecoveryFailed did not record StateError transition within %s", markFailedDeadline)
 		}
 
-		assert.Equal(t, StateError, m.Status(instance),
-			"a pre-relaunch hook error must drive the instance into StateError via MarkRecoveryFailed — without this the failure is silent and the LB never recovers")
+		assert.Equal(t, StateError, m.Status(instance))
 		require.NotNil(t, instance.Instance.StateReason)
-		assert.Equal(t, "pre_relaunch_hook_failed", *instance.Instance.StateReason.Message,
-			"the reason must identify the hook failure class so the journal/audit log captures why launch was aborted before Run")
+		assert.Equal(t, "pre_relaunch_hook_failed", *instance.Instance.StateReason.Message)
 
 		mounter.mu.Lock()
 		defer mounter.mu.Unlock()
-		assert.Empty(t, mounter.mounted,
-			"a failing hook must short-circuit before Run; otherwise QEMU launches against the missing fw_cfg blobs we tried to regenerate")
+		assert.Empty(t, mounter.mounted, "Run must not fire when hook errors")
 	})
 
 	t.Run("status check skips instances flipped before launch", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- After a host reboot, the ALB's system VM failed to relaunch because three `-fw_cfg name=...,file=/run/spinifex/...` paths sit on tmpfs and are wiped. QEMU exited 1, the instance flipped to `recovery_failed`, and the LB stopped serving traffic.
- Adds a `BeforeInstanceRelaunch` hook to `vm.ManagerHooks` that fires from `relaunchAll` immediately before `m.Run`. The daemon implements it by rebuilding `SystemInstanceInput` from the persisted LB record + recovery context, then re-running the existing `writeFwCfgBlobs` to recreate the three tmpfiles at the same paths the persisted `vm.Config.FwCfg` already references.
- Hook errors flip the instance to `recovery_failed` with reason pre_relaunch_hook_failed` and skip `m.Run` — no QEMU launch against half-rebuilt state. ELBv2-service-unavailable on an ELBv2 VM is a hard error, not a silent no-op. Multi-ENI rebuilds fail closed on partial VPC describes. The per-recovery `ListLoadBalancers` is memoised once via `sync.Once` so N concurrent candidates share a single KV scan.