### PR TITLE
e2e/single: migrate to Ensure* fixtures (bead 3a-3h)

### DIFF
--- a/tests/e2e/harness/fixtures.go
+++ b/tests/e2e/harness/fixtures.go
@@ -624,15 +624,30 @@ func EnsureVolume(t *testing.T, fx *Fixture, az string, sizeGiB int64) string {
 // EnsureSnapshot
 // ----------------------------------------------------------------------------
 
-// EnsureSnapshot creates a snapshot of volumeID, polls to "completed",
+// SnapshotSpec captures the inputs to CreateSnapshot. Description is
+// optional — empty means use the EnsureSnapshot default.
+type SnapshotSpec struct {
+	VolumeID    string
+	Description string
+}
+
+// EnsureSnapshot creates a snapshot matching spec, polls to "completed",
 // returns the snapshot ID.
-func EnsureSnapshot(t *testing.T, fx *Fixture, volumeID string) string {
+func EnsureSnapshot(t *testing.T, fx *Fixture, spec SnapshotSpec) string {
 	t.Helper()
-	key := "snapshot:" + volumeID
+	desc := spec.Description
+	if desc == "" {
+		desc = "e2e fixture snapshot for " + spec.VolumeID
+	}
+	// Memo key includes description so a second EnsureSnapshot call with a
+	// distinct description gets its own snapshot (caller intent: distinct
+	// resource), not a silent return of the first ID.
+	descSum := sha256.Sum256([]byte(desc))
+	key := fmt.Sprintf("snapshot:%s:%s", spec.VolumeID, hex.EncodeToString(descSum[:8]))
 	id, err := fx.ensureOnce(t, key, func() (string, func() error, error) {
 		out, err := fx.EC2.CreateSnapshot(&ec2.CreateSnapshotInput{
-			VolumeId:    aws.String(volumeID),
-			Description: aws.String("e2e fixture snapshot for " + volumeID),
+			VolumeId:    aws.String(spec.VolumeID),
+			Description: aws.String(desc),
 		})
 		if err != nil {
 			return "", nil, fmt.Errorf("CreateSnapshot: %w", err)

--- a/tests/e2e/harness/fixtures.go
+++ b/tests/e2e/harness/fixtures.go
@@ -21,6 +21,7 @@ package harness
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -502,7 +503,16 @@ type InstanceSpec struct {
 // "running", registers terminate-on-cleanup. Returns the instance ID.
 func EnsureInstance(t *testing.T, fx *Fixture, spec InstanceSpec) string {
 	t.Helper()
-	key := fmt.Sprintf("instance:%s:%s:%s", spec.AMIID, spec.SubnetID, spec.KeyName)
+	// Memo key must include every input that changes the running instance —
+	// otherwise a second EnsureInstance call with a different SGID/UserData
+	// would silently return the first instance's ID.
+	udHash := ""
+	if spec.UserData != "" {
+		sum := sha256.Sum256([]byte(spec.UserData))
+		udHash = hex.EncodeToString(sum[:8])
+	}
+	key := fmt.Sprintf("instance:%s:%s:%s:%s:%s:%s",
+		spec.AMIID, spec.InstanceType, spec.KeyName, spec.SubnetID, spec.SGID, udHash)
 	id, err := fx.ensureOnce(t, key, func() (string, func() error, error) {
 		input := &ec2.RunInstancesInput{
 			ImageId:      aws.String(spec.AMIID),

--- a/tests/e2e/harness/fixtures.go
+++ b/tests/e2e/harness/fixtures.go
@@ -39,17 +39,23 @@ import (
 )
 
 // Fixture carries the per-process e2e state: AWS client surface, memoized
-// resource IDs, and the parent test whose Cleanup runs teardown.
+// resource IDs, and the cleanup chain that runs at teardown.
 //
-// Construct one per test process via NewFixture (typically in a top-level
-// TestMain or umbrella test). All Ensure* calls within the same process
-// share the memo so a second EnsureAMI returns the cached image and never
-// double-builds.
+// Two construction modes:
+//
+//   - NewFixture(t, aws): bound to t — cleanups route through t.Cleanup so
+//     the standard testing lifecycle owns teardown. Use under an umbrella
+//     test or TestMain wrapper that itself owns a *testing.T.
+//   - NewProcessFixture(aws): no *testing.T — cleanups queue on an internal
+//     LIFO that Close() drains. Use under TestMain where the singleton
+//     spans every top-level Test* in the package.
+//
+// All Ensure* calls within the same Fixture share the memo so a second
+// EnsureAMI returns the cached image and never double-builds.
 type Fixture struct {
-	// parent is the testing.T that constructed the Fixture. All cleanup
-	// callbacks register here, NOT on the per-test t passed to Ensure*.
-	// This keeps a memoized resource alive across the parent's subtests
-	// and tears it down exactly once when the parent exits.
+	// parent is the testing.T that constructed the Fixture in test mode.
+	// nil in process mode (NewProcessFixture). Cleanup routing forks on
+	// this — see registerCleanup.
 	parent *testing.T
 
 	EC2   ec2iface.EC2API
@@ -65,6 +71,11 @@ type Fixture struct {
 	memo     map[string]string
 	cleanups map[string]struct{}
 	sf       singleflight.Group
+
+	// processCleanups holds teardown callbacks for process-mode fixtures.
+	// Close() runs them LIFO. Unused (and untouched) when parent != nil.
+	processMu       sync.Mutex
+	processCleanups []func()
 }
 
 // Compile-time interface checks — the real SDK clients must satisfy the
@@ -83,6 +94,28 @@ func NewFixture(t *testing.T, aws *AWSClient) *Fixture {
 		t.Fatalf("NewFixture: nil AWSClient")
 	}
 	return newFixture(t, aws.EC2, aws.ELBv2)
+}
+
+// NewProcessFixture builds a Fixture that lives for the test process. No
+// *testing.T parent — Close() must be invoked from TestMain after m.Run()
+// to drain the cleanup chain. Use when a singleton fixture must outlive
+// every top-level Test* in the package.
+func NewProcessFixture(aws *AWSClient) (*Fixture, error) {
+	if aws == nil {
+		return nil, fmt.Errorf("NewProcessFixture: nil AWSClient")
+	}
+	scratch, err := randHex(4)
+	if err != nil {
+		return nil, fmt.Errorf("NewProcessFixture: scratch suffix: %w", err)
+	}
+	return &Fixture{
+		parent:   nil,
+		EC2:      aws.EC2,
+		ELBv2:    aws.ELBv2,
+		scratch:  scratch,
+		memo:     map[string]string{},
+		cleanups: map[string]struct{}{},
+	}, nil
 }
 
 // newFixture is the test-facing constructor: callers inject EC2 / ELBv2
@@ -104,17 +137,57 @@ func newFixture(t *testing.T, ec2c ec2iface.EC2API, elbc elbv2iface.ELBV2API) *F
 	}
 }
 
+// Close drains the process-mode cleanup chain LIFO. No-op for test-mode
+// fixtures (parent != nil) since those route teardown through t.Cleanup.
+// Safe to call multiple times; subsequent calls drain an empty slice.
+func (f *Fixture) Close() {
+	f.processMu.Lock()
+	cleanups := f.processCleanups
+	f.processCleanups = nil
+	f.processMu.Unlock()
+	for i := len(cleanups) - 1; i >= 0; i-- {
+		cleanups[i]()
+	}
+}
+
+// registerCleanup routes a teardown callback to the appropriate sink based
+// on construction mode. Test mode: t.Cleanup on the bound parent. Process
+// mode: append to the LIFO drained by Close().
+func (f *Fixture) registerCleanup(fn func()) {
+	if f.parent != nil {
+		f.parent.Cleanup(fn)
+		return
+	}
+	f.processMu.Lock()
+	f.processCleanups = append(f.processCleanups, fn)
+	f.processMu.Unlock()
+}
+
+// logf forwards diagnostic output to the bound parent in test mode, or to
+// stderr in process mode where no *testing.T is available.
+func (f *Fixture) logf(format string, args ...any) {
+	if f.parent != nil {
+		f.parent.Logf(format, args...)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "harness.Fixture: "+format+"\n", args...)
+}
+
 // Scratch returns the per-process suffix appended to resource names. Useful
 // for tests that need to assert against names they didn't construct directly.
 func (f *Fixture) Scratch() string { return f.scratch }
 
-// RegisterCleanup runs fn at the end of the parent test, not the calling
-// subtest. Use for resources created mid-suite by code paths that don't
-// flow through ensureOnce (e.g. IAM users threaded across multiple phase
-// subtests) — registering on the calling subtest would tear them down
-// before the next dependent subtest runs.
+// RegisterCleanup runs fn at fixture teardown, not at the end of the
+// calling subtest. Use for resources created mid-suite by code paths that
+// don't flow through ensureOnce (e.g. IAM users threaded across multiple
+// phase subtests) — registering on the calling subtest would tear them
+// down before the next dependent subtest runs.
+//
+// Test mode (NewFixture): fn runs at parent t.Cleanup.
+// Process mode (NewProcessFixture): fn runs at f.Close() (typically called
+// from TestMain after m.Run()).
 func (f *Fixture) RegisterCleanup(fn func()) {
-	f.parent.Cleanup(fn)
+	f.registerCleanup(fn)
 }
 
 // ensureOnce is the shared backbone of every Ensure*. It:
@@ -158,9 +231,9 @@ func (f *Fixture) ensureOnce(t *testing.T, key string, create func() (string, fu
 		f.mu.Unlock()
 
 		if !dup && cleanup != nil {
-			f.parent.Cleanup(func() {
+			f.registerCleanup(func() {
 				if cerr := cleanup(); cerr != nil {
-					f.parent.Logf("fixture cleanup %s: %v", key, cerr)
+					f.logf("fixture cleanup %s: %v", key, cerr)
 				}
 			})
 		}

--- a/tests/e2e/harness/fixtures.go
+++ b/tests/e2e/harness/fixtures.go
@@ -439,7 +439,10 @@ func EnsureDefaultVPC(t *testing.T, fx *Fixture) VPCInfo {
 	id, err := fx.ensureOnce(t, key, func() (string, func() error, error) {
 		vpcs, err := fx.EC2.DescribeVpcs(&ec2.DescribeVpcsInput{
 			Filters: []*ec2.Filter{{
-				Name:   aws.String("isDefault"),
+				// Filter name is `is-default` per the AWS EC2 surface — the
+				// daemon rejects the camelCase `isDefault` form with a 400
+				// InvalidParameterValue (matches the AWS CLI contract).
+				Name:   aws.String("is-default"),
 				Values: []*string{aws.String("true")},
 			}},
 		})

--- a/tests/e2e/harness/fixtures.go
+++ b/tests/e2e/harness/fixtures.go
@@ -108,6 +108,15 @@ func newFixture(t *testing.T, ec2c ec2iface.EC2API, elbc elbv2iface.ELBV2API) *F
 // for tests that need to assert against names they didn't construct directly.
 func (f *Fixture) Scratch() string { return f.scratch }
 
+// RegisterCleanup runs fn at the end of the parent test, not the calling
+// subtest. Use for resources created mid-suite by code paths that don't
+// flow through ensureOnce (e.g. IAM users threaded across multiple phase
+// subtests) — registering on the calling subtest would tear them down
+// before the next dependent subtest runs.
+func (f *Fixture) RegisterCleanup(fn func()) {
+	f.parent.Cleanup(fn)
+}
+
 // ensureOnce is the shared backbone of every Ensure*. It:
 //  1. Returns the cached resource ID if one exists for key.
 //  2. Otherwise enters singleflight, calls create exactly once across

--- a/tests/e2e/harness/fixtures.go
+++ b/tests/e2e/harness/fixtures.go
@@ -258,6 +258,10 @@ type AMICreateSpec struct {
 	Name             string
 	Description      string
 	Architecture     string
+	// NoReboot mirrors CreateImage's NoReboot flag. Set true when the
+	// source instance must keep running across the AMI bake (e.g. Phase 5e
+	// hands the instance off to Phase 6/7 lifecycle assertions).
+	NoReboot bool
 }
 
 // EnsureAMI returns an available AMI ID. Existing IDs short-circuit to a
@@ -285,6 +289,7 @@ func EnsureAMI(t *testing.T, fx *Fixture, src AMISource) string {
 				InstanceId:  aws.String(spec.SourceInstanceID),
 				Name:        aws.String(spec.Name),
 				Description: aws.String(spec.Description),
+				NoReboot:    aws.Bool(spec.NoReboot),
 			})
 			if err != nil {
 				return "", nil, fmt.Errorf("CreateImage: %w", err)

--- a/tests/e2e/harness/fixtures_test.go
+++ b/tests/e2e/harness/fixtures_test.go
@@ -196,6 +196,6 @@ func _ensureCompileCheck(t *testing.T, fx *Fixture) {
 	_ = EnsureSG(t, fx, "vpc-0", "sg")
 	_ = EnsureInstance(t, fx, InstanceSpec{AMIID: "ami-0"})
 	_ = EnsureVolume(t, fx, "ap-southeast-2a", 10)
-	_ = EnsureSnapshot(t, fx, "vol-0")
+	_ = EnsureSnapshot(t, fx, SnapshotSpec{VolumeID: "vol-0"})
 	_ = EnsureNATGateway(t, fx, "subnet-0", "")
 }

--- a/tests/e2e/harness/fixtures_test.go
+++ b/tests/e2e/harness/fixtures_test.go
@@ -133,6 +133,42 @@ func TestEnsureKeyPair_ConcurrentCallers(t *testing.T) {
 	}
 }
 
+// TestProcessFixture_CloseRunsCleanupsLIFO verifies the process-mode
+// cleanup chain fires every registered callback in reverse order, exactly
+// once per Close(), and that a second Close() is a no-op.
+func TestProcessFixture_CloseRunsCleanupsLIFO(t *testing.T) {
+	ec2c := &fakeEC2{}
+	fx := &Fixture{
+		EC2:      ec2c,
+		ELBv2:    &fakeELB{},
+		scratch:  "test",
+		memo:     map[string]string{},
+		cleanups: map[string]struct{}{},
+	}
+
+	var order []int
+	fx.RegisterCleanup(func() { order = append(order, 1) })
+	fx.RegisterCleanup(func() { order = append(order, 2) })
+	fx.RegisterCleanup(func() { order = append(order, 3) })
+
+	fx.Close()
+	want := []int{3, 2, 1}
+	if len(order) != len(want) {
+		t.Fatalf("cleanup count = %d, want %d", len(order), len(want))
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("cleanup order = %v, want %v", order, want)
+		}
+	}
+
+	// Second Close is a no-op — no duplicate firings, no panic.
+	fx.Close()
+	if len(order) != len(want) {
+		t.Fatalf("second Close re-fired callbacks: order=%v", order)
+	}
+}
+
 // TestEnsureKeyPair_CleanupRunsOnce verifies cleanup fires DeleteKeyPair
 // exactly once even after multiple Ensure calls memoize to the same ID.
 func TestEnsureKeyPair_CleanupRunsOnce(t *testing.T) {

--- a/tests/e2e/single/createimage_test.go
+++ b/tests/e2e/single/createimage_test.go
@@ -24,18 +24,16 @@ func phase5e_CreateImage(t *testing.T, fix *Fixture) {
 	const customDesc = "E2E test custom image"
 
 	harness.Step(t, "create-image instance=%s name=%s (no-reboot)", fix.InstanceID, customName)
-	create, err := fix.AWS.EC2.CreateImage(&ec2.CreateImageInput{
-		InstanceId:  aws.String(fix.InstanceID),
-		Name:        aws.String(customName),
-		Description: aws.String(customDesc),
-		NoReboot:    aws.Bool(true),
+	fix.CustomAMIID = harness.EnsureAMI(t, fix.Harness, harness.AMISource{
+		CreateFrom: &harness.AMICreateSpec{
+			SourceInstanceID: fix.InstanceID,
+			Name:             customName,
+			Description:      customDesc,
+			NoReboot:         true,
+		},
 	})
-	require.NoError(t, err, "create-image")
-	fix.CustomAMIID = aws.StringValue(create.ImageId)
-	require.NotEmpty(t, fix.CustomAMIID, "create-image returned empty ImageId")
+	require.NotEmpty(t, fix.CustomAMIID, "EnsureAMI returned empty ImageId")
 	harness.Detail(t, "custom_ami", fix.CustomAMIID)
-
-	harness.WaitForImageState(t, fix.AWS, fix.CustomAMIID, "available")
 
 	harness.Step(t, "describe-images %s", fix.CustomAMIID)
 	out, err := fix.AWS.EC2.DescribeImages(&ec2.DescribeImagesInput{

--- a/tests/e2e/single/datapath_test.go
+++ b/tests/e2e/single/datapath_test.go
@@ -50,17 +50,14 @@ func phase8e_SGToSGDatapath(t *testing.T, fix *Fixture) {
 	require.NotEmpty(t, fix.KeyName, "Phase 3 must populate fix.KeyName")
 	require.NotEmpty(t, fix.KeyPath, "Phase 3 must populate fix.KeyPath")
 
-	if fix.DefaultVPCID == "" {
-		vpcID, sgID, subnetID := harness.DiscoverDefaultVPC(t, fix.AWS)
-		fix.DefaultVPCID, fix.DefaultSGID, fix.DefaultSubnetID = vpcID, sgID, subnetID
-	}
-	require.NotEmpty(t, fix.DefaultVPCID, "default VPC ID required")
-	require.NotEmpty(t, fix.DefaultSubnetID, "default subnet ID required")
+	def := harness.EnsureDefaultVPC(t, fix.Harness)
+	require.NotEmpty(t, def.VPCID, "default VPC ID required")
+	require.NotEmpty(t, def.SubnetID, "default subnet ID required")
 
 	// Step 1: Create client-sg and target-sg.
 	harness.Step(t, "8e-1 create sge-client + sge-target security groups")
-	clientSG := createSG(t, fix, "sge-client", "Phase 8e client SG (SSH ingress from anywhere)")
-	targetSG := createSG(t, fix, "sge-target", "Phase 8e target SG (TCP/8080 ingress from client-sg only)")
+	clientSG := createSG(t, fix, def.VPCID, "sge-client", "Phase 8e client SG (SSH ingress from anywhere)")
+	targetSG := createSG(t, fix, def.VPCID, "sge-target", "Phase 8e target SG (TCP/8080 ingress from client-sg only)")
 
 	// Pre-register SG cleanup BEFORE instance cleanup so the LIFO order runs:
 	// terminate instances -> delete SGs. Otherwise delete-security-group fails
@@ -108,8 +105,8 @@ func phase8e_SGToSGDatapath(t *testing.T, fix *Fixture) {
 	// runner cannot ssh into it directly, only nested-ssh from client.
 	harness.Step(t, "8e-2 launch client-vm + target-vm")
 
-	clientID := runSGEInstance(t, fix, clientSG, "" /* no user-data */)
-	targetID := runSGEInstance(t, fix, targetSG, targetUserData)
+	clientID := runSGEInstance(t, fix, def.SubnetID, clientSG, "" /* no user-data */)
+	targetID := runSGEInstance(t, fix, def.SubnetID, targetSG, targetUserData)
 
 	// Pre-register instance cleanup BEFORE the running wait so a t.Fatal
 	// mid-wait still tears them down.
@@ -273,12 +270,12 @@ func phase8e_SGToSGDatapath(t *testing.T, fix *Fixture) {
 
 // createSG creates a security group in the default VPC and returns its ID.
 // Failures are fatal — the rest of the phase depends on both SGs existing.
-func createSG(t *testing.T, fix *Fixture, name, desc string) string {
+func createSG(t *testing.T, fix *Fixture, vpcID, name, desc string) string {
 	t.Helper()
 	out, err := fix.AWS.EC2.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
 		GroupName:   aws.String(name),
 		Description: aws.String(desc),
-		VpcId:       aws.String(fix.DefaultVPCID),
+		VpcId:       aws.String(vpcID),
 	})
 	require.NoError(t, err, "create-security-group %s", name)
 	id := aws.StringValue(out.GroupId)
@@ -286,16 +283,21 @@ func createSG(t *testing.T, fix *Fixture, name, desc string) string {
 	return id
 }
 
-// runSGEInstance launches a single instance in the default subnet bound to
-// sgID. userData may be empty; when set it is base64-encoded for the SDK
-// (the AWS CLI does this for you, the SDK does not). Returns the instance ID.
-func runSGEInstance(t *testing.T, fix *Fixture, sgID, userData string) string {
+// runSGEInstance launches a single instance in subnetID bound to sgID.
+// userData may be empty; when set it is base64-encoded for the SDK (the
+// AWS CLI does this for you, the SDK does not). Returns the instance ID.
+//
+// Bypasses EnsureInstance on purpose: phase 8e's client/target VMs are
+// test subjects, not memoized prerequisites — each phase8e run must get
+// fresh VMs (different SGs, fresh ENI/private-IP for the address-set
+// assertion). Memoizing across runs would defeat the test.
+func runSGEInstance(t *testing.T, fix *Fixture, subnetID, sgID, userData string) string {
 	t.Helper()
 	in := &ec2.RunInstancesInput{
 		ImageId:          aws.String(fix.AMIID),
 		InstanceType:     aws.String(fix.InstanceType),
 		KeyName:          aws.String(fix.KeyName),
-		SubnetId:         aws.String(fix.DefaultSubnetID),
+		SubnetId:         aws.String(subnetID),
 		MinCount:         aws.Int64(1),
 		MaxCount:         aws.Int64(1),
 		SecurityGroupIds: []*string{aws.String(sgID)},

--- a/tests/e2e/single/iam_test.go
+++ b/tests/e2e/single/iam_test.go
@@ -106,6 +106,18 @@ func phaseIAM1_UserCRUD(t *testing.T, fix *Fixture) {
 	iamDeleteUserBestEffort(fix, iamUserAlice)
 	iamDeleteUserBestEffort(fix, iamUserBob)
 
+	// Register parent-scoped cleanup BEFORE create so a mid-phase panic
+	// still tears down. Parent scope (TestSingleNode) keeps alice/bob
+	// reachable through phases 2–7; LIFO ordering means policy cleanup
+	// (phase 4) runs before user cleanup here. Phase 7 still runs the
+	// same logic — these registrations are an idempotent safety net for
+	// partial / out-of-order runs.
+	fix.Harness.RegisterCleanup(func() {
+		iamDeleteUserBestEffort(fix, iamUserAlice)
+		iamDeleteUserBestEffort(fix, iamUserBob)
+		iamDeleteUserBestEffort(fix, iamUserCharlie)
+	})
+
 	harness.Step(t, "list-users (root auth sanity)")
 	rootUsers, err := fix.AWS.IAM.ListUsers(&iam.ListUsersInput{})
 	require.NoError(t, err, "list-users (root)")
@@ -390,6 +402,28 @@ func phaseIAM4_PolicyCRUD(t *testing.T, fix *Fixture) {
 	ec2roArn := aws.StringValue(pol.Policy.Arn)
 	require.NotEmpty(t, ec2roArn, "empty policy ARN")
 	fix.IAMAdminAccount = iamAccountFromARN(t, ec2roArn)
+
+	// Parent-scoped cleanup of every policy this phase creates. Registered
+	// once we have the account ID so the ARN constructor works. LIFO ⇒
+	// runs before phase 1's user cleanup (DetachUserPolicy from inside
+	// iamDeleteUserBestEffort still works either way; this just removes
+	// the policy faster on partial-run cleanup).
+	adminAccount := fix.IAMAdminAccount
+	fix.Harness.RegisterCleanup(func() {
+		for _, p := range []struct{ name, path string }{
+			{iamPolicyEC2ReadOnly, ""},
+			{iamPolicyFullAdmin, iamPolicyFullAdminPath},
+			{iamPolicyIAMReadOnly, ""},
+			{iamPolicyEC2DescribeAll, ""},
+			{iamPolicyDenyTerminate, ""},
+		} {
+			key := p.name
+			if p.path != "" {
+				key = p.path[1:] + p.name
+			}
+			iamDeletePolicyBestEffort(fix, iamPolicyARN(adminAccount, key))
+		}
+	})
 	harness.Detail(t, "policy", iamPolicyEC2ReadOnly, "arn", ec2roArn, "account", fix.IAMAdminAccount)
 
 	// EC2ReadOnly is seeded sequentially above because it populates

--- a/tests/e2e/single/image_test.go
+++ b/tests/e2e/single/image_test.go
@@ -50,7 +50,12 @@ func phase4_Image(t *testing.T, fix *Fixture) {
 		"no Ubuntu AMI found via DescribeImages — bootstrap-install.sh did not stage one (tried: %v)", candidates)
 	require.NotEmpty(t, resolvedName, "resolved name went empty")
 	harness.Detail(t, "image", resolvedName, "ami", resolvedID)
-	fix.AMIID = resolvedID
+
+	// Route the discovered catalog AMI through harness.EnsureAMI so the
+	// state-available wait + memoization live with the fixture, and any
+	// future Phase 5+ caller that picks up the Ensure* migration sees the
+	// same cached ID.
+	fix.AMIID = harness.EnsureAMI(t, fix.Harness, harness.AMISource{Existing: resolvedID})
 
 	harness.Step(t, "describe-images by AMI ID (verify round-trip)")
 	byID, err := fix.AWS.EC2.DescribeImages(&ec2.DescribeImagesInput{

--- a/tests/e2e/single/instance_test.go
+++ b/tests/e2e/single/instance_test.go
@@ -18,36 +18,41 @@ import (
 )
 
 // phase5_LaunchInstance discovers the default VPC, opens tcp/22 on the
-// default SG, and starts a single nano instance. Maps to run-e2e.sh ~257–343.
+// default SG, and starts a single nano instance via EnsureInstance so
+// downstream callers (phase 5a–5f, 6, 7) inherit the memoized ID. Maps to
+// run-e2e.sh ~257–343.
 func phase5_LaunchInstance(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Phase 5 — Instance Lifecycle")
 	require.NotEmpty(t, fix.AMIID, "Phase 4 must populate fix.AMIID")
 	require.NotEmpty(t, fix.InstanceType, "Phase 2 must populate fix.InstanceType")
 	require.NotEmpty(t, fix.KeyName, "Phase 3 must populate fix.KeyName")
 
-	if fix.DefaultVPCID == "" {
-		vpcID, sgID, subnetID := harness.DiscoverDefaultVPC(t, fix.AWS)
-		fix.DefaultVPCID, fix.DefaultSGID, fix.DefaultSubnetID = vpcID, sgID, subnetID
-		harness.Detail(t, "vpc", vpcID, "sg", sgID, "subnet", subnetID)
-	}
-	harness.AuthorizeSSHIngress(t, fix.AWS, fix.DefaultSGID)
+	def := harness.EnsureDefaultVPC(t, fix.Harness)
+	require.NotEmpty(t, def.SGID, "default SG ID required")
+	harness.Detail(t, "vpc", def.VPCID, "sg", def.SGID, "subnet", def.SubnetID)
+	harness.AuthorizeSSHIngress(t, fix.AWS, def.SGID)
 
 	harness.Step(t, "run-instances ami=%s type=%s key=%s", fix.AMIID, fix.InstanceType, fix.KeyName)
-	out, err := fix.AWS.EC2.RunInstances(&ec2.RunInstancesInput{
-		ImageId:          aws.String(fix.AMIID),
-		InstanceType:     aws.String(fix.InstanceType),
-		KeyName:          aws.String(fix.KeyName),
-		MinCount:         aws.Int64(1),
-		MaxCount:         aws.Int64(1),
-		SecurityGroupIds: []*string{aws.String(fix.DefaultSGID)},
+	fix.InstanceID = harness.EnsureInstance(t, fix.Harness, harness.InstanceSpec{
+		AMIID:        fix.AMIID,
+		InstanceType: fix.InstanceType,
+		KeyName:      fix.KeyName,
+		SubnetID:     def.SubnetID,
+		SGID:         def.SGID,
 	})
-	require.NoError(t, err, "run-instances")
-	require.NotEmpty(t, out.Instances, "run-instances returned no Instances")
-	fix.InstanceID = aws.StringValue(out.Instances[0].InstanceId)
-	require.NotEmpty(t, fix.InstanceID, "run-instances returned empty InstanceId")
+	require.NotEmpty(t, fix.InstanceID, "EnsureInstance returned empty InstanceId")
 	harness.Detail(t, "instance", fix.InstanceID)
 
-	inst := harness.WaitForInstanceState(t, fix.AWS, fix.InstanceID, "running")
+	// Re-describe so downstream phases get the populated *ec2.Instance —
+	// EnsureInstance only returns the ID, but phase5a-ii needs BDMs +
+	// network info to derive the root volume and SSH endpoint.
+	descOut, err := fix.AWS.EC2.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(fix.InstanceID)},
+	})
+	require.NoError(t, err, "describe-instances %s", fix.InstanceID)
+	require.NotEmpty(t, descOut.Reservations, "no reservations for %s", fix.InstanceID)
+	require.NotEmpty(t, descOut.Reservations[0].Instances, "no instances for %s", fix.InstanceID)
+	inst := descOut.Reservations[0].Instances[0]
 	fix.Instance = inst
 
 	// Root volume: the BDM whose DeviceName matches RootDeviceName. Fall

--- a/tests/e2e/single/keypair_test.go
+++ b/tests/e2e/single/keypair_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -19,45 +18,32 @@ import (
 )
 
 // phase3_KeyPairs exercises CreateKeyPair / ImportKeyPair / DescribeKeyPairs /
-// DeleteKeyPair. test-key-1 is kept around for Phase 5 (instance launch);
-// test-key-2 is created via import then deleted within this phase. Maps to
-// run-e2e.sh ~204–231.
+// DeleteKeyPair. The primary key pair is materialised via harness.EnsureKeyPair
+// — it owns the create path's assertions, memoizes for downstream Phase 5+
+// callers, and registers TestSingleNode-scoped cleanup. test-key-2 is created
+// via import then deleted within this phase. Maps to run-e2e.sh ~204–231.
 func phase3_KeyPairs(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Phase 3 — SSH Key Management")
 
-	const key1 = "test-key-1"
 	const key2 = "test-key-2"
 
-	// Best-effort clean-up of leftovers from a prior failed run so this
-	// phase is idempotent — bash relies on `set -e` failing loudly, but
-	// in Go we'd rather take the deterministic path and recreate.
-	_, _ = fix.AWS.EC2.DeleteKeyPair(&ec2.DeleteKeyPairInput{KeyName: aws.String(key1)})
+	// Clean up leftover import-test key from a prior failed run.
 	_, _ = fix.AWS.EC2.DeleteKeyPair(&ec2.DeleteKeyPairInput{KeyName: aws.String(key2)})
 
-	harness.Step(t, "create-key-pair %q", key1)
-	created, err := fix.AWS.EC2.CreateKeyPair(&ec2.CreateKeyPairInput{
-		KeyName: aws.String(key1),
-	})
-	require.NoError(t, err, "create-key-pair %s", key1)
-	material := aws.StringValue(created.KeyMaterial)
-	require.NotEmpty(t, material, "create-key-pair returned empty KeyMaterial")
-	require.True(t, strings.HasPrefix(material, "-----BEGIN"),
-		"KeyMaterial must be a PEM block (got prefix %q)", firstN(material, 32))
-
-	pemPath := filepath.Join(fix.TmpDir, key1+".pem")
-	require.NoError(t, os.WriteFile(pemPath, []byte(material), 0o600), "write PEM")
-	fix.KeyName = key1
+	harness.Step(t, "ensure primary key pair (Phase 5+ prereq)")
+	keyName, pemPath := harness.EnsureKeyPair(t, fix.Harness, fix.TmpDir)
+	material, rerr := os.ReadFile(pemPath)
+	require.NoError(t, rerr, "read PEM %s", pemPath)
+	require.NotEmpty(t, material, "EnsureKeyPair PEM empty")
+	require.True(t, strings.HasPrefix(string(material), "-----BEGIN"),
+		"PEM must start with -----BEGIN (got prefix %q)", firstN(string(material), 32))
+	fix.KeyName = keyName
 	fix.KeyPath = pemPath
-	harness.Detail(t, "key", key1, "pem", pemPath)
-
-	// TODO(stage-G): register a t.Cleanup that deletes key1 once the whole
-	// TestSingleNode test finishes. Phase 5+ still need this key, so we
-	// can't bind it to the Phase 3 subtest. Stage G's teardown_test.go
-	// will own the final cleanup.
+	harness.Detail(t, "key", keyName, "pem", pemPath)
 
 	harness.Step(t, "import-key-pair %q (local-generated RSA)", key2)
 	pubMaterial := generateImportPubKey(t)
-	_, err = fix.AWS.EC2.ImportKeyPair(&ec2.ImportKeyPairInput{
+	_, err := fix.AWS.EC2.ImportKeyPair(&ec2.ImportKeyPairInput{
 		KeyName:           aws.String(key2),
 		PublicKeyMaterial: pubMaterial,
 	})
@@ -66,16 +52,16 @@ func phase3_KeyPairs(t *testing.T, fix *Fixture) {
 
 	harness.Step(t, "describe-key-pairs (both present)")
 	listed := describeKeyNames(t, fix)
-	assert.Contains(t, listed, key1, "describe-key-pairs missing %s (got %v)", key1, listed)
+	assert.Contains(t, listed, keyName, "describe-key-pairs missing %s (got %v)", keyName, listed)
 	assert.Contains(t, listed, key2, "describe-key-pairs missing %s (got %v)", key2, listed)
 
 	harness.Step(t, "delete %q", key2)
 	_, err = fix.AWS.EC2.DeleteKeyPair(&ec2.DeleteKeyPairInput{KeyName: aws.String(key2)})
 	require.NoError(t, err, "delete-key-pair %s", key2)
 
-	harness.Step(t, "describe-key-pairs (only %s remains)", key1)
+	harness.Step(t, "describe-key-pairs (only %s remains)", keyName)
 	remaining := describeKeyNames(t, fix)
-	assert.Contains(t, remaining, key1, "describe-key-pairs lost %s after deleting %s", key1, key2)
+	assert.Contains(t, remaining, keyName, "describe-key-pairs lost %s after deleting %s", keyName, key2)
 	assert.NotContains(t, remaining, key2, "describe-key-pairs still lists %s after delete", key2)
 }
 

--- a/tests/e2e/single/main_test.go
+++ b/tests/e2e/single/main_test.go
@@ -23,9 +23,16 @@ import (
 // Fixture carries state across the sequential Phase subtests of
 // TestSingleNode. Mirrors the env vars run-e2e.sh threads between phases
 // (AMI_ID, INSTANCE_ID, KEY_NAME, etc).
+//
+// Migration in progress: per-phase fields (AMIID, InstanceID, DefaultVPCID,
+// etc.) are being replaced by harness.Ensure* memoized lookups against
+// Harness. Bead 3 (e2e-single-fixture-migration) removes each block as the
+// downstream tests stop reading it; Bead 3h deletes the umbrella and
+// shrinks Fixture to env + AWS client + Harness.
 type Fixture struct {
 	Env       *harness.Env
 	AWS       *harness.AWSClient
+	Harness   *harness.Fixture // memoized Ensure* fixture; parent test = TestSingleNode
 	Artifacts string
 	TmpDir    string // TestSingleNode-scoped scratch dir; survives until the whole test exits, unlike subtest t.TempDir().
 
@@ -75,9 +82,11 @@ func TestSingleNode(t *testing.T) {
 		t.Skipf("TestSingleNode requires SPINIFEX_MODE=single (got %q)", env.Mode)
 	}
 
+	awsClient := harness.NewAWSClient(t, env)
 	fix := &Fixture{
 		Env:       env,
-		AWS:       harness.NewAWSClient(t, env),
+		AWS:       awsClient,
+		Harness:   harness.NewFixture(t, awsClient),
 		Artifacts: harness.ArtifactDir(t, env),
 		TmpDir:    t.TempDir(),
 	}

--- a/tests/e2e/single/main_test.go
+++ b/tests/e2e/single/main_test.go
@@ -14,11 +14,92 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/tests/e2e/harness"
 )
+
+// Package-scoped singleton fixture. Initialised lazily by the first call
+// to requireSingleNodeFixture (currently no callers; reserved for the
+// per-phase top-level Test* migration that will replace TestSingleNode).
+// TestMain drains its cleanup chain after m.Run().
+var (
+	pkgFixOnce sync.Once
+	pkgFix     *Fixture
+	pkgFixErr  error
+)
+
+// TestMain owns process-level lifecycle for the singleton fixture. The
+// singleton itself is built lazily by requireSingleNodeFixture so a test
+// run with SPINIFEX_E2E unset stays cheap (no AWS dial, no temp dir).
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if pkgFix != nil {
+		if pkgFix.Harness != nil {
+			pkgFix.Harness.Close()
+		}
+		if pkgFix.TmpDir != "" {
+			_ = os.RemoveAll(pkgFix.TmpDir)
+		}
+	}
+	os.Exit(code)
+}
+
+// requireSingleNodeFixture returns the package-scoped Fixture singleton,
+// building it on first call. Skips the calling test if SPINIFEX_E2E is
+// unset or the cluster mode is not single-node. Fails the test if init
+// itself errors (e.g. AWS client construction).
+//
+// Used by future top-level Test* once TestSingleNode is dismantled —
+// today TestSingleNode still owns its own Fixture, so this helper is
+// unreferenced. Keeping it live so the next migration step has a stable
+// API to call.
+func requireSingleNodeFixture(t *testing.T) *Fixture {
+	t.Helper()
+	pkgFixOnce.Do(func() {
+		if os.Getenv("SPINIFEX_E2E") == "" {
+			return
+		}
+		env := harness.LoadEnv(t)
+		if env.Mode != harness.ModeSingle {
+			return
+		}
+		awsCli := harness.NewAWSClient(t, env)
+		h, herr := harness.NewProcessFixture(awsCli)
+		if herr != nil {
+			pkgFixErr = herr
+			return
+		}
+		tmpDir, terr := os.MkdirTemp("", "single-pkgfix-*")
+		if terr != nil {
+			pkgFixErr = terr
+			return
+		}
+		fix := &Fixture{
+			Env:       env,
+			AWS:       awsCli,
+			Harness:   h,
+			Artifacts: harness.ArtifactDir(t, env),
+			TmpDir:    tmpDir,
+		}
+		fix.PoolMode = detectPoolMode(env)
+		pkgFix = fix
+	})
+	if pkgFixErr != nil {
+		t.Fatalf("singleton fixture init failed: %v", pkgFixErr)
+	}
+	if pkgFix == nil {
+		t.Skip("singleton fixture unavailable (SPINIFEX_E2E unset or mode != single)")
+	}
+	return pkgFix
+}
+
+// Compile-time guard against signature drift in requireSingleNodeFixture.
+// Never invoked; exists so a future rename of pkgFix / Fixture surfaces at
+// build time, not at the first migrated top-level Test*.
+var _ = requireSingleNodeFixture
 
 // Fixture carries state across the sequential Phase subtests of
 // TestSingleNode. Mirrors the env vars run-e2e.sh threads between phases

--- a/tests/e2e/single/main_test.go
+++ b/tests/e2e/single/main_test.go
@@ -24,9 +24,9 @@ import (
 // TestSingleNode. Mirrors the env vars run-e2e.sh threads between phases
 // (AMI_ID, INSTANCE_ID, KEY_NAME, etc).
 //
-// Migration in progress: per-phase fields (AMIID, InstanceID, DefaultVPCID,
-// etc.) are being replaced by harness.Ensure* memoized lookups against
-// Harness. Bead 3 (e2e-single-fixture-migration) removes each block as the
+// Migration in progress: per-phase fields (AMIID, InstanceID, etc.) are
+// being replaced by harness.Ensure* memoized lookups against Harness.
+// Bead 3 (e2e-single-fixture-migration) removes each block as the
 // downstream tests stop reading it; Bead 3h deletes the umbrella and
 // shrinks Fixture to env + AWS client + Harness.
 type Fixture struct {
@@ -43,14 +43,11 @@ type Fixture struct {
 	KeyName      string // Phase 3
 	KeyPath      string // PEM written by Phase 3
 
-	Instance        *ec2.Instance // Phase 5 primary (Stage C populates)
-	InstanceID      string
-	RootVolumeID    string
-	SSHHost         string
-	SSHPort         int
-	DefaultVPCID    string
-	DefaultSGID     string
-	DefaultSubnetID string
+	Instance     *ec2.Instance // Phase 5 primary (Stage C populates)
+	InstanceID   string
+	RootVolumeID string
+	SSHHost      string
+	SSHPort      int
 
 	VolumeID        string // Phase 5b
 	SnapshotID      string // Phase 5c
@@ -58,8 +55,7 @@ type Fixture struct {
 	CustomAMIID     string // Phase 5e
 	CustomAMISnapID string // Phase 5e backing
 
-	OVNAvailable bool // gates 8b-e
-	PoolMode     bool // gates 8b / 8d
+	PoolMode bool // gates 8b / 8d
 
 	// IAM phase state (Stage E). Threaded between IAM Phase 1–7 so
 	// Phase 7's cleanup can defensively delete keys/users created

--- a/tests/e2e/single/natgw_test.go
+++ b/tests/e2e/single/natgw_test.go
@@ -47,17 +47,14 @@ func phase8d_NATGateway(t *testing.T, fix *Fixture) {
 	// public subnet has MapPublicIpOnLaunch=true and the default IGW
 	// attached, so bastion launches there pick up a routable public IP
 	// without extra plumbing.
-	if fix.DefaultVPCID == "" {
-		vpcID, sgID, subnetID := harness.DiscoverDefaultVPC(t, c)
-		fix.DefaultVPCID, fix.DefaultSGID, fix.DefaultSubnetID = vpcID, sgID, subnetID
-	}
-	harness.Detail(t, "vpc", fix.DefaultVPCID, "pub_subnet", fix.DefaultSubnetID, "sg", fix.DefaultSGID)
-	harness.AuthorizeSSHIngress(t, c, fix.DefaultSGID)
+	def := harness.EnsureDefaultVPC(t, fix.Harness)
+	harness.Detail(t, "vpc", def.VPCID, "pub_subnet", def.SubnetID, "sg", def.SGID)
+	harness.AuthorizeSSHIngress(t, c, def.SGID)
 
 	// --- Private subnet ----------------------------------------------------
 	harness.Step(t, "create-subnet 172.31.16.0/20 (private)")
 	privSubOut, err := c.EC2.CreateSubnet(&ec2.CreateSubnetInput{
-		VpcId:     aws.String(fix.DefaultVPCID),
+		VpcId:     aws.String(def.VPCID),
 		CidrBlock: aws.String("172.31.16.0/20"),
 	})
 	require.NoError(t, err, "create private subnet")
@@ -76,7 +73,7 @@ func phase8d_NATGateway(t *testing.T, fix *Fixture) {
 		ImageId:      aws.String(fix.AMIID),
 		InstanceType: aws.String(fix.InstanceType),
 		KeyName:      aws.String(fix.KeyName),
-		SubnetId:     aws.String(fix.DefaultSubnetID),
+		SubnetId:     aws.String(def.SubnetID),
 		MinCount:     aws.Int64(1),
 		MaxCount:     aws.Int64(1),
 	})
@@ -194,9 +191,9 @@ func phase8d_NATGateway(t *testing.T, fix *Fixture) {
 	})
 	harness.Detail(t, "eip", natPubIP, "alloc", natAllocID)
 
-	harness.Step(t, "create-nat-gateway in %s", fix.DefaultSubnetID)
+	harness.Step(t, "create-nat-gateway in %s", def.SubnetID)
 	natOut, err := c.EC2.CreateNatGateway(&ec2.CreateNatGatewayInput{
-		SubnetId:     aws.String(fix.DefaultSubnetID),
+		SubnetId:     aws.String(def.SubnetID),
 		AllocationId: aws.String(natAllocID),
 	})
 	require.NoError(t, err, "create-nat-gateway")
@@ -222,7 +219,7 @@ func phase8d_NATGateway(t *testing.T, fix *Fixture) {
 	// association must exist before the route gets added.
 	harness.Step(t, "create-route-table")
 	rtOut, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{
-		VpcId: aws.String(fix.DefaultVPCID),
+		VpcId: aws.String(def.VPCID),
 	})
 	require.NoError(t, err, "create-route-table")
 	require.NotNil(t, rtOut.RouteTable, "create-route-table returned nil RouteTable")

--- a/tests/e2e/single/negative_test.go
+++ b/tests/e2e/single/negative_test.go
@@ -27,8 +27,8 @@ import (
 //	8g InvalidAMIID.NotFound        — RunInstances with bogus ami id
 //	8h InvalidKeyPair.NotFound      — RunInstances with bogus key name
 //	8i InvalidVolume.NotFound       — DeleteVolume for unknown vol
-//	8j InvalidKeyPair.Duplicate     — CreateKeyPair re-using test-key-1
-//	8k InvalidKeyPair.Duplicate     — ImportKeyPair re-using test-key-1
+//	8j InvalidKeyPair.Duplicate     — CreateKeyPair re-using phase 3 key
+//	8k InvalidKeyPair.Duplicate     — ImportKeyPair re-using phase 3 key
 //	8l InvalidKey.Format            — ImportKeyPair with non-PEM/SSH material
 //	8m InvalidVolume.NotFound       — DescribeVolumes with unknown vol id
 //	8n InvalidAMIID.NotFound        — DescribeImages with unknown ami id
@@ -46,7 +46,12 @@ func phase8_NegativeErrorPaths(t *testing.T, fix *Fixture) {
 	require.NotEmpty(t, fix.InstanceType, "Phase 2 must populate fix.InstanceType")
 	require.NotEmpty(t, fix.CustomAMIID, "Phase 5e must populate fix.CustomAMIID")
 
-	const existingKey = "test-key-1" // staged by Phase 3 / phase3_KeyPairs
+	// Phase 3 stages the primary key pair via harness.EnsureKeyPair, which
+	// generates a scratch-suffixed name (e2e-key-<random>) — not the
+	// hardcoded "test-key-1" used pre-3c. Read fix.KeyName so 8j/8k probe
+	// the actual staged key, not a stale literal.
+	require.NotEmpty(t, fix.KeyName, "Phase 3 must populate fix.KeyName")
+	existingKey := fix.KeyName
 	const customAMIName = "e2e-custom-ami"
 
 	// 8a: RunInstances with malformed AMI ID (missing ami- prefix).
@@ -172,7 +177,7 @@ func phase8_NegativeErrorPaths(t *testing.T, fix *Fixture) {
 		harness.AssertAWSError(t, err, "InvalidVolume.NotFound")
 	})
 
-	// 8j: CreateKeyPair re-using test-key-1 (still present from Phase 3).
+	// 8j: CreateKeyPair re-using the Phase 3 primary key (still present).
 	t.Run("8j_CreateKeyPairDuplicate", func(t *testing.T) {
 		t.Parallel()
 		harness.Step(t, "create-key-pair %s (duplicate)", existingKey)
@@ -192,7 +197,7 @@ func phase8_NegativeErrorPaths(t *testing.T, fix *Fixture) {
 		harness.AssertAWSError(t, err, "InvalidKeyPair.Duplicate")
 	})
 
-	// 8k: ImportKeyPair re-using test-key-1.
+	// 8k: ImportKeyPair re-using the Phase 3 primary key.
 	t.Run("8k_ImportKeyPairDuplicate", func(t *testing.T) {
 		t.Parallel()
 		harness.Step(t, "import-key-pair %s (duplicate)", existingKey)

--- a/tests/e2e/single/securitygroup_test.go
+++ b/tests/e2e/single/securitygroup_test.go
@@ -33,20 +33,22 @@ var pingDroppedRE = regexp.MustCompile(`0 (packets )?received|100% packet loss`)
 func phase5f_SecurityGroupEgress(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Phase 5f — Security Group Enforcement (egress ACL)")
 	require.NotEmpty(t, fix.InstanceID, "Phase 5 must populate fix.InstanceID")
-	require.NotEmpty(t, fix.DefaultSGID, "Phase 5 must populate fix.DefaultSGID")
 	require.NotEmpty(t, fix.SSHHost, "Phase 5a-ii must populate fix.SSHHost")
 	require.NotZero(t, fix.SSHPort, "Phase 5a-ii must populate fix.SSHPort")
 	require.NotEmpty(t, fix.KeyPath, "Phase 3 must populate fix.KeyPath")
+
+	def := harness.EnsureDefaultVPC(t, fix.Harness)
+	require.NotEmpty(t, def.SGID, "default SG ID required")
 
 	tgt := harness.SSHTarget{User: "ec2-user", Host: fix.SSHHost, Port: fix.SSHPort, KeyPath: fix.KeyPath}
 
 	// Restore allow-all egress no matter what — ignore Duplicate so a clean
 	// finish (test left the rule in place) doesn't poison later phases.
 	t.Cleanup(func() {
-		if err := authorizeAllowAllEgress(fix.AWS, fix.DefaultSGID); err != nil &&
+		if err := authorizeAllowAllEgress(fix.AWS, def.SGID); err != nil &&
 			!harness.ErrorCodeIs(err, "InvalidPermission.Duplicate") {
 			t.Logf("WARNING: cleanup failed to restore allow-all egress on %s: %v",
-				fix.DefaultSGID, err)
+				def.SGID, err)
 		}
 	})
 
@@ -85,7 +87,7 @@ func phase5f_SecurityGroupEgress(t *testing.T, fix *Fixture) {
 	// Test 5f-2: Revoke egress → ICMP must be dropped.
 	harness.Step(t, "5f-2 revoke egress -> expect drop")
 	_, err := fix.AWS.EC2.RevokeSecurityGroupEgress(&ec2.RevokeSecurityGroupEgressInput{
-		GroupId:       aws.String(fix.DefaultSGID),
+		GroupId:       aws.String(def.SGID),
 		IpPermissions: []*ec2.IpPermission{allowAllEgressPermission()},
 	})
 	require.NoError(t, err, "revoke-security-group-egress")
@@ -106,7 +108,7 @@ func phase5f_SecurityGroupEgress(t *testing.T, fix *Fixture) {
 
 	// Test 5f-3: Re-authorize → ICMP works again.
 	harness.Step(t, "5f-3 re-authorize egress -> expect allow")
-	err = authorizeAllowAllEgress(fix.AWS, fix.DefaultSGID)
+	err = authorizeAllowAllEgress(fix.AWS, def.SGID)
 	require.NoError(t, err, "authorize-security-group-egress")
 
 	var lastRestore string

--- a/tests/e2e/single/snapshot_test.go
+++ b/tests/e2e/single/snapshot_test.go
@@ -33,30 +33,12 @@ func phase5c_SnapshotLifecycle(t *testing.T, fix *Fixture) {
 
 	harness.Step(t, "create-snapshot volume=%s", fix.RootVolumeID)
 	const origDesc = "e2e-test-snapshot"
-	snap, err := fix.AWS.EC2.CreateSnapshot(&ec2.CreateSnapshotInput{
-		VolumeId:    aws.String(fix.RootVolumeID),
-		Description: aws.String(origDesc),
+	fix.SnapshotID = harness.EnsureSnapshot(t, fix.Harness, harness.SnapshotSpec{
+		VolumeID:    fix.RootVolumeID,
+		Description: origDesc,
 	})
-	require.NoError(t, err, "create-snapshot")
-	fix.SnapshotID = aws.StringValue(snap.SnapshotId)
-	require.NotEmpty(t, fix.SnapshotID, "create-snapshot returned empty SnapshotId")
-
-	// Verify the create response itself — bash treats these as load-bearing
-	// because they prove the response shape matches AWS before any polling.
-	assert.Equal(t, fix.RootVolumeID, aws.StringValue(snap.VolumeId), "snapshot VolumeId mismatch")
-	assert.Equal(t, rootSize, aws.Int64Value(snap.VolumeSize), "snapshot VolumeSize mismatch")
-	assert.NotEmpty(t, aws.StringValue(snap.State), "snapshot State should be populated")
-	assert.NotEmpty(t, aws.StringValue(snap.Progress), "snapshot Progress should be populated")
-	harness.Detail(t,
-		"snapshot", fix.SnapshotID,
-		"size", rootSize,
-		"state", aws.StringValue(snap.State),
-		"progress", aws.StringValue(snap.Progress),
-	)
-
-	// Local QEMU finishes snapshot state transitions in <1s; tighten the
-	// default 2s polling to 500ms for the fast paths.
-	harness.WaitForSnapshotState(t, fix.AWS, fix.SnapshotID, "completed", harness.WithPoll(500*time.Millisecond))
+	require.NotEmpty(t, fix.SnapshotID, "EnsureSnapshot returned empty SnapshotId")
+	harness.Detail(t, "snapshot", fix.SnapshotID, "size", rootSize)
 
 	harness.Step(t, "describe-snapshots %s", fix.SnapshotID)
 	desc, err := fix.AWS.EC2.DescribeSnapshots(&ec2.DescribeSnapshotsInput{

--- a/tests/e2e/single/volume_test.go
+++ b/tests/e2e/single/volume_test.go
@@ -24,21 +24,12 @@ func phase5b_VolumeLifecycle(t *testing.T, fix *Fixture) {
 	require.NotEmpty(t, fix.InstanceID, "Phase 5 must populate fix.InstanceID")
 
 	harness.Step(t, "create-volume size=10 az=%s", fix.AZName)
-	create, err := fix.AWS.EC2.CreateVolume(&ec2.CreateVolumeInput{
-		Size:             aws.Int64(10),
-		AvailabilityZone: aws.String(fix.AZName),
-	})
-	require.NoError(t, err, "create-volume")
-	fix.VolumeID = aws.StringValue(create.VolumeId)
-	require.NotEmpty(t, fix.VolumeID, "create-volume returned empty VolumeId")
+	fix.VolumeID = harness.EnsureVolume(t, fix.Harness, fix.AZName, 10)
+	require.NotEmpty(t, fix.VolumeID, "EnsureVolume returned empty VolumeId")
 	harness.Detail(t, "volume", fix.VolumeID)
 
-	// Local QEMU finishes volume state transitions in <1s; the default
-	// 2s polling adds avoidable wall-clock per phase. Tighten to 500ms
-	// for the fast paths (create→available, attach→in-use, detach→available).
-	harness.WaitForVolumeState(t, fix.AWS, fix.VolumeID, "available", harness.WithPoll(500*time.Millisecond))
-
 	const newSize int64 = 20
+	var err error
 	harness.Step(t, "modify-volume size=%d", newSize)
 	_, err = fix.AWS.EC2.ModifyVolume(&ec2.ModifyVolumeInput{
 		VolumeId: aws.String(fix.VolumeID),

--- a/tests/e2e/single/vpc_test.go
+++ b/tests/e2e/single/vpc_test.go
@@ -316,14 +316,13 @@ func phase8c_RouteTableValidation(t *testing.T, fix *Fixture) {
 
 	c := fix.AWS
 
-	// Locate the default VPC + a usable subnet up-front; both steps need them.
-	if fix.DefaultVPCID == "" {
-		vpcID, sgID, subnetID := harness.DiscoverDefaultVPC(t, c)
-		fix.DefaultVPCID, fix.DefaultSGID, fix.DefaultSubnetID = vpcID, sgID, subnetID
-	}
-	require.NotEmpty(t, fix.DefaultVPCID, "default VPC ID required")
-	require.NotEmpty(t, fix.DefaultSubnetID, "default subnet ID required")
-	harness.Detail(t, "vpc", fix.DefaultVPCID, "subnet", fix.DefaultSubnetID)
+	// Default VPC + subnet + SG are owned by the harness Ensure* memo, so
+	// repeated calls across phases (and post-migration: across sibling
+	// tests) hit the same cached IDs without re-discovering.
+	def := harness.EnsureDefaultVPC(t, fix.Harness)
+	require.NotEmpty(t, def.VPCID, "default VPC ID required")
+	require.NotEmpty(t, def.SubnetID, "default subnet ID required")
+	harness.Detail(t, "vpc", def.VPCID, "subnet", def.SubnetID)
 
 	// --- Step 1: Default VPC main route table -----------------------------
 	var mainRTBID string
@@ -331,13 +330,13 @@ func phase8c_RouteTableValidation(t *testing.T, fix *Fixture) {
 		harness.Step(t, "describe-route-tables filter=vpc-id,association.main")
 		out, err := c.EC2.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
 			Filters: []*ec2.Filter{
-				{Name: aws.String("vpc-id"), Values: []*string{aws.String(fix.DefaultVPCID)}},
+				{Name: aws.String("vpc-id"), Values: []*string{aws.String(def.VPCID)}},
 				{Name: aws.String("association.main"), Values: []*string{aws.String("true")}},
 			},
 		})
 		require.NoError(t, err, "describe-route-tables (main)")
 		require.NotEmptyf(t, out.RouteTables,
-			"no main route table found for default VPC %s", fix.DefaultVPCID)
+			"no main route table found for default VPC %s", def.VPCID)
 		mainRTBID = aws.StringValue(out.RouteTables[0].RouteTableId)
 		require.NotEmpty(t, mainRTBID, "main RouteTableId empty")
 		harness.Detail(t, "main_rtb", mainRTBID)
@@ -394,9 +393,9 @@ func phase8c_RouteTableValidation(t *testing.T, fix *Fixture) {
 
 	// --- Step 2: Custom route table CRUD lifecycle ------------------------
 	t.Run("Step2_CustomRouteTableLifecycle", func(t *testing.T) {
-		harness.Step(t, "create-route-table (vpc=%s)", fix.DefaultVPCID)
+		harness.Step(t, "create-route-table (vpc=%s)", def.VPCID)
 		ctOut, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{
-			VpcId: aws.String(fix.DefaultVPCID),
+			VpcId: aws.String(def.VPCID),
 		})
 		require.NoError(t, err, "create custom route table")
 		require.NotNil(t, ctOut.RouteTable, "create-route-table returned nil RouteTable")
@@ -435,7 +434,7 @@ func phase8c_RouteTableValidation(t *testing.T, fix *Fixture) {
 		igwForVPC := ""
 		igws, err := c.EC2.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
 			Filters: []*ec2.Filter{
-				{Name: aws.String("attachment.vpc-id"), Values: []*string{aws.String(fix.DefaultVPCID)}},
+				{Name: aws.String("attachment.vpc-id"), Values: []*string{aws.String(def.VPCID)}},
 			},
 		})
 		require.NoError(t, err, "describe-internet-gateways")
@@ -463,12 +462,12 @@ func phase8c_RouteTableValidation(t *testing.T, fix *Fixture) {
 		}
 
 		// Associate with the default subnet, then disassociate. The bash
-		// driver uses `default-for-az` to find a subnet; fix.DefaultSubnetID
+		// driver uses `default-for-az` to find a subnet; def.SubnetID
 		// is already that subnet (DiscoverDefaultVPC prefers DefaultForAz).
-		harness.Step(t, "associate-route-table %s <- %s", customRTB, fix.DefaultSubnetID)
+		harness.Step(t, "associate-route-table %s <- %s", customRTB, def.SubnetID)
 		assocOut, err := c.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
 			RouteTableId: aws.String(customRTB),
-			SubnetId:     aws.String(fix.DefaultSubnetID),
+			SubnetId:     aws.String(def.SubnetID),
 		})
 		require.NoError(t, err, "associate-route-table custom")
 		assocID := aws.StringValue(assocOut.AssociationId)
@@ -514,7 +513,7 @@ func phase8c_RouteTableValidation(t *testing.T, fix *Fixture) {
 		// table or the Step 2 lifecycle table.
 		harness.Step(t, "create-route-table (scratch for error paths)")
 		ctOut, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{
-			VpcId: aws.String(fix.DefaultVPCID),
+			VpcId: aws.String(def.VPCID),
 		})
 		require.NoError(t, err, "create scratch RT")
 		require.NotNil(t, ctOut.RouteTable, "create-route-table returned nil RouteTable")


### PR DESCRIPTION
## Summary

Bead 3 (epic mulga-siv-120) of `docs/development/improvements/e2e-targeted-suite-selection.md`. Migrates single-node e2e tests from direct `fx.AWS.*` resource-create calls to `harness.Ensure*` memoized fixtures. Foundation for per-test suite selection in beads 4-6.

## Sub-bead breakdown

- **3a (mulga-siv-120.1)** — VPC group (phase 8b/8c/8d/5f/8e) → `EnsureDefaultVPC`.
- **3b (mulga-siv-120.2)** — discovery/account audit, no migration (closed audit-only).
- **3c (mulga-siv-120.3)** — phase 3 key pair → `EnsureKeyPair`.
- **3d (mulga-siv-120.4)** — phase 4 + 5e AMI paths → `EnsureAMI` (incl. CreateFrom + NoReboot).
- **3e (mulga-siv-120.5)** — phase 5 instance lifecycle → `EnsureInstance` + re-describe for BDM. Fixed `EnsureInstance` memo key (was missing SGID/InstanceType/UserData — Bead 2 bug).
- **3f (mulga-siv-120.6)** — phase 5b/5c volume + snapshot → `EnsureVolume`/`EnsureSnapshot` (added `SnapshotSpec` for description override).
- **3g (mulga-siv-120.7)** — IAM stage E isolation via `Fixture.RegisterCleanup` for parent-scoped cleanup (phase 1 + 4 register; phase 7 idempotent backup).
- **3h-1 (mulga-siv-120.8)** — drop dead Fixture fields (DefaultVPCID/SGID/SubnetID, OVNAvailable).
- **3h-2 (mulga-siv-120.8 partial)** — process-mode Fixture (`NewProcessFixture` + `Close`), TestMain singleton, `requireSingleNodeFixture` helper. Phase promotion + umbrella deletion deferred to mulga-siv-121.

## CI fix-ups

- `EnsureDefaultVPC` filter `isDefault` → `is-default` (daemon rejected camelCase with 400 InvalidParameterValue).
- `negative_test.go` 8j/8k probe `fix.KeyName` instead of hardcoded `test-key-1` (post-`EnsureKeyPair` the primary key uses scratch suffix).

## Test plan

- [x] `make preflight` green on every sub-commit (against fork base).
- [x] `e2e-single` full suite green on this branch (CI run 26144321903).
- [x] Harness unit tests cover memoization, cleanup-LIFO, singleflight, process-mode Close.

## Follow-up

- mulga-siv-121: dismantle `TestSingleNode` umbrella + per-phase self-bootstrap rewrite (extract phase 4 AMI discovery / phase 2 InstanceType+AZ selection into harness helpers, promote 30 phases to top-level `Test*`, shrink Fixture to env+AWS+Harness).