### PR TITLE
fix(vm): poll for nbd + qmp readiness instead of fixed sleeps

### DIFF
--- a/spinifex/utils/nbd.go
+++ b/spinifex/utils/nbd.go
@@ -73,12 +73,9 @@ func FormatNBDTCPURI(host string, port int) string {
 	return "nbd://" + net.JoinHostPort(host, strconv.Itoa(port))
 }
 
-// WaitForNBDReady polls until the NBD endpoint at uri is reachable, or the
-// timeout expires. Unix-socket URIs use existence-on-disk (matching
-// WaitForUnixSocket so we don't consume the listener's accept queue before
-// QEMU dials); TCP URIs use a brief dial-and-close probe. Used by the launch
-// path to confirm nbdkit finished binding before exec'ing QEMU, replacing
-// the previous fixed 2 s sleep.
+// WaitForNBDReady polls until the NBD endpoint at uri is reachable or the
+// timeout expires. Unix sockets use existence-on-disk to avoid consuming
+// the listener's accept queue before QEMU dials; TCP uses a dial-and-close.
 func WaitForNBDReady(uri string, timeout time.Duration) error {
 	serverType, path, host, port, err := ParseNBDURI(uri)
 	if err != nil {

--- a/spinifex/utils/nbd.go
+++ b/spinifex/utils/nbd.go
@@ -73,6 +73,42 @@ func FormatNBDTCPURI(host string, port int) string {
 	return "nbd://" + net.JoinHostPort(host, strconv.Itoa(port))
 }
 
+// WaitForNBDReady polls until the NBD endpoint at uri is reachable, or the
+// timeout expires. Unix-socket URIs use existence-on-disk (matching
+// WaitForUnixSocket so we don't consume the listener's accept queue before
+// QEMU dials); TCP URIs use a brief dial-and-close probe. Used by the launch
+// path to confirm nbdkit finished binding before exec'ing QEMU, replacing
+// the previous fixed 2 s sleep.
+func WaitForNBDReady(uri string, timeout time.Duration) error {
+	serverType, path, host, port, err := ParseNBDURI(uri)
+	if err != nil {
+		return err
+	}
+	switch serverType {
+	case "unix":
+		return WaitForUnixSocket(path, timeout)
+	case "inet":
+		return waitForTCPListener(net.JoinHostPort(host, strconv.Itoa(port)), timeout)
+	default:
+		return fmt.Errorf("unsupported NBD server type %q for uri %s", serverType, uri)
+	}
+}
+
+func waitForTCPListener(addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for tcp listener %s: %w", addr, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
 // ParseNBDURI parses an NBD URI into its components for QMP blockdev-add.
 // Supported formats:
 //   - "nbd:unix:/path/to/socket.sock" → serverType="unix", path="/path/to/socket.sock"

--- a/spinifex/utils/utils_test.go
+++ b/spinifex/utils/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -218,6 +219,48 @@ func TestWaitForUnixSocket(t *testing.T) {
 		}()
 
 		require.NoError(t, WaitForUnixSocket(path, time.Second))
+	})
+}
+
+func TestWaitForNBDReady(t *testing.T) {
+	t.Run("unix socket ready", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "nbd.sock")
+		ln, err := net.Listen("unix", path)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = ln.Close() })
+
+		require.NoError(t, WaitForNBDReady(FormatNBDSocketURI(path), time.Second))
+	})
+
+	t.Run("unix socket times out", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "missing.sock")
+		err := WaitForNBDReady(FormatNBDSocketURI(path), 100*time.Millisecond)
+		require.Error(t, err)
+	})
+
+	t.Run("tcp listener ready", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = ln.Close() })
+		_, portStr, err := net.SplitHostPort(ln.Addr().String())
+		require.NoError(t, err)
+		port, err := strconv.Atoi(portStr)
+		require.NoError(t, err)
+
+		require.NoError(t, WaitForNBDReady(FormatNBDTCPURI("127.0.0.1", port), time.Second))
+	})
+
+	t.Run("tcp listener times out", func(t *testing.T) {
+		// Port 1 is unprivileged-bind reserved; nothing will be listening.
+		err := WaitForNBDReady(FormatNBDTCPURI("127.0.0.1", 1), 100*time.Millisecond)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects malformed uri", func(t *testing.T) {
+		err := WaitForNBDReady("garbage://nope", time.Second)
+		require.Error(t, err)
 	})
 }
 

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -173,27 +173,18 @@ func (m *Manager) launch(instance *VM) error {
 	return nil
 }
 
-// nbdkitPreExecWait returns how long startQEMU sleeps before exec'ing QEMU to
-// give nbdkit time to bind its sockets. Direct-boot instances have no drives
-// and no nbdkit, so the wait collapses to zero and the boot-time budget is
-// preserved.
-func nbdkitPreExecWait(directBoot bool) time.Duration {
-	if directBoot {
-		return 0
-	}
-	return 2 * time.Second
-}
+// nbdReadyTimeout bounds the per-volume wait for nbdkit's listening
+// socket to appear before exec'ing QEMU. Viperblockd already sleeps 1 s
+// post-fork before responding, so the socket normally exists by the time
+// we get here; the budget covers post-response bind lag under recovery
+// load.
+const nbdReadyTimeout = 5 * time.Second
 
-// qemuStartSettleWait returns the post-fork sleep that lets QEMU surface an
-// immediate-start crash (bad cmdline, missing kernel) before we attempt QMP.
-// Direct-boot binds the QMP socket within a few ms because there is no
-// firmware, ROM, or block layer setup, so a full second is unnecessary.
-func qemuStartSettleWait(directBoot bool) time.Duration {
-	if directBoot {
-		return 50 * time.Millisecond
-	}
-	return time.Second
-}
+// qemuStartupTimeout bounds the post-fork wait for either the QMP socket
+// to appear or the QEMU process to exit. Direct-boot binds QMP within a
+// few ms; PC-machine boots typically take a few hundred ms; recovery-load
+// stragglers can take longer. Past this, treat the launch as wedged.
+const qemuStartupTimeout = 5 * time.Second
 
 // startQEMU launches the QEMU process for instance and waits for startup to
 // confirm.
@@ -340,9 +331,21 @@ func (m *Manager) startQEMU(instance *VM) error {
 	}
 	instance.Config.QMPSocket = qmpSocket
 
-	// Wait briefly for nbdkit to start.
-	// TODO: Improve, confirm nbdkit started for each volume.
-	time.Sleep(nbdkitPreExecWait(instance.DirectBoot))
+	// Confirm each volume's NBD endpoint is reachable before exec'ing QEMU.
+	// Direct-boot has no EBS requests, so the loop is a no-op.
+	instance.EBSRequests.Mu.Lock()
+	nbdEndpoints := make([]struct{ name, uri string }, 0, len(instance.EBSRequests.Requests))
+	for _, req := range instance.EBSRequests.Requests {
+		if req.NBDURI != "" {
+			nbdEndpoints = append(nbdEndpoints, struct{ name, uri string }{req.Name, req.NBDURI})
+		}
+	}
+	instance.EBSRequests.Mu.Unlock()
+	for _, ep := range nbdEndpoints {
+		if err := utils.WaitForNBDReady(ep.uri, nbdReadyTimeout); err != nil {
+			return fmt.Errorf("nbd endpoint not ready for %s: %w", ep.name, err)
+		}
+	}
 
 	processChan := make(chan int, 1)
 	exitChan := make(chan int, 1)
@@ -426,23 +429,37 @@ func (m *Manager) startQEMU(instance *VM) error {
 		return fmt.Errorf("failed to start qemu")
 	}
 
-	// Catch immediate-start crashes (bad cmdline, missing kernel, etc.) before
-	// attempting QMP.
-	time.Sleep(qemuStartSettleWait(instance.DirectBoot))
-
-	select {
-	case exitErr := <-exitChan:
-		startupConfirmed <- false
-		if exitErr != 0 {
-			errorMsg := fmt.Errorf("failed: %v", exitErr)
-			slog.Error("Failed to launch qemu", "err", errorMsg)
-			return errorMsg
+	// Race QMP-socket appearance against early process exit. A bad cmdline
+	// or missing kernel surfaces as a closed exitChan within tens of ms;
+	// a healthy QEMU binds its QMP socket within a few hundred ms. Bounded
+	// at qemuStartupTimeout so a wedged QEMU is killed rather than left to
+	// orphan the tap / volumes indefinitely.
+	timeoutTimer := time.NewTimer(qemuStartupTimeout)
+	defer timeoutTimer.Stop()
+	pollTicker := time.NewTicker(20 * time.Millisecond)
+	defer pollTicker.Stop()
+	for {
+		if _, err := os.Stat(instance.Config.QMPSocket); err == nil {
+			startupConfirmed <- true
+			slog.Info("QEMU started successfully and is running",
+				"console_log", instance.Config.ConsoleLogPath,
+				"serial_socket", instance.Config.SerialSocket)
+			break
 		}
-	default:
-		startupConfirmed <- true
-		slog.Info("QEMU started successfully and is running",
-			"console_log", instance.Config.ConsoleLogPath,
-			"serial_socket", instance.Config.SerialSocket)
+		select {
+		case exitErr := <-exitChan:
+			startupConfirmed <- false
+			errorMsg := fmt.Errorf("qemu exited during startup (code=%d)", exitErr)
+			slog.Error("Failed to launch qemu", "err", errorMsg, "instanceId", instance.ID)
+			return errorMsg
+		case <-timeoutTimer.C:
+			startupConfirmed <- false
+			if proc, findErr := os.FindProcess(pid); findErr == nil {
+				_ = proc.Signal(syscall.SIGKILL)
+			}
+			return fmt.Errorf("timeout waiting for QMP socket %s", instance.Config.QMPSocket)
+		case <-pollTicker.C:
+		}
 	}
 
 	// QEMU writes its pidfile after parsing args and mmap'ing the kernel/initrd/

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -173,18 +173,10 @@ func (m *Manager) launch(instance *VM) error {
 	return nil
 }
 
-// nbdReadyTimeout bounds the per-volume wait for nbdkit's listening
-// socket to appear before exec'ing QEMU. Viperblockd already sleeps 1 s
-// post-fork before responding, so the socket normally exists by the time
-// we get here; the budget covers post-response bind lag under recovery
-// load.
-const nbdReadyTimeout = 5 * time.Second
-
-// qemuStartupTimeout bounds the post-fork wait for either the QMP socket
-// to appear or the QEMU process to exit. Direct-boot binds QMP within a
-// few ms; PC-machine boots typically take a few hundred ms; recovery-load
-// stragglers can take longer. Past this, treat the launch as wedged.
-const qemuStartupTimeout = 5 * time.Second
+const (
+	nbdReadyTimeout    = 5 * time.Second
+	qemuStartupTimeout = 5 * time.Second
+)
 
 // startQEMU launches the QEMU process for instance and waits for startup to
 // confirm.
@@ -331,8 +323,6 @@ func (m *Manager) startQEMU(instance *VM) error {
 	}
 	instance.Config.QMPSocket = qmpSocket
 
-	// Confirm each volume's NBD endpoint is reachable before exec'ing QEMU.
-	// Direct-boot has no EBS requests, so the loop is a no-op.
 	instance.EBSRequests.Mu.Lock()
 	nbdEndpoints := make([]struct{ name, uri string }, 0, len(instance.EBSRequests.Requests))
 	for _, req := range instance.EBSRequests.Requests {
@@ -429,11 +419,8 @@ func (m *Manager) startQEMU(instance *VM) error {
 		return fmt.Errorf("failed to start qemu")
 	}
 
-	// Race QMP-socket appearance against early process exit. A bad cmdline
-	// or missing kernel surfaces as a closed exitChan within tens of ms;
-	// a healthy QEMU binds its QMP socket within a few hundred ms. Bounded
-	// at qemuStartupTimeout so a wedged QEMU is killed rather than left to
-	// orphan the tap / volumes indefinitely.
+	// Race QMP-socket appearance against early process exit; SIGKILL on timeout
+	// so a wedged QEMU does not orphan its tap / volumes.
 	timeoutTimer := time.NewTimer(qemuStartupTimeout)
 	defer timeoutTimer.Stop()
 	pollTicker := time.NewTicker(20 * time.Millisecond)

--- a/spinifex/vm/lifecycle_test.go
+++ b/spinifex/vm/lifecycle_test.go
@@ -797,19 +797,11 @@ func (p *scriptedNetworkPlumber) CleanupTap(_ string) error { return nil }
 
 var _ NetworkPlumber = (*scriptedNetworkPlumber)(nil)
 
-// TestNbdkitPreExecWait locks in the per-mode pre-exec sleep budget: direct-boot
-// is zero (no drives, no nbdkit) and the PC-machine path keeps the 2 s wait that
-// the rest of the launch flow depends on.
-func TestNbdkitPreExecWait(t *testing.T) {
-	assert.Equal(t, time.Duration(0), nbdkitPreExecWait(true))
-	assert.Equal(t, 2*time.Second, nbdkitPreExecWait(false))
-}
-
-// TestQemuStartSettleWait locks in the per-mode post-fork settle: direct-boot
-// trims to 50 ms (QMP socket binds within a few ms when there is no firmware,
-// ROM, or block layer setup) and the PC-machine path retains the historical
-// 1 s buffer that catches bad-cmdline crashes before the QMP dial.
-func TestQemuStartSettleWait(t *testing.T) {
-	assert.Equal(t, 50*time.Millisecond, qemuStartSettleWait(true))
-	assert.Equal(t, time.Second, qemuStartSettleWait(false))
+// TestQemuStartupTimeout pins the post-fork bound. The poll loop races
+// QMP socket appearance against early process exit; the timeout is the
+// outer safety net that prevents a wedged QEMU from orphaning resources
+// indefinitely.
+func TestQemuStartupTimeout(t *testing.T) {
+	assert.Equal(t, 5*time.Second, qemuStartupTimeout)
+	assert.Equal(t, 5*time.Second, nbdReadyTimeout)
 }

--- a/spinifex/vm/lifecycle_test.go
+++ b/spinifex/vm/lifecycle_test.go
@@ -797,11 +797,7 @@ func (p *scriptedNetworkPlumber) CleanupTap(_ string) error { return nil }
 
 var _ NetworkPlumber = (*scriptedNetworkPlumber)(nil)
 
-// TestQemuStartupTimeout pins the post-fork bound. The poll loop races
-// QMP socket appearance against early process exit; the timeout is the
-// outer safety net that prevents a wedged QEMU from orphaning resources
-// indefinitely.
-func TestQemuStartupTimeout(t *testing.T) {
+func TestStartupTimeouts(t *testing.T) {
 	assert.Equal(t, 5*time.Second, qemuStartupTimeout)
 	assert.Equal(t, 5*time.Second, nbdReadyTimeout)
 }


### PR DESCRIPTION
startQEMU previously slept 2 s pre-exec to give nbdkit time to bind, then 1 s post-fork to surface immediate-start crashes. Recovery fan-out at maxConcurrentRecovery=2 makes that 3 s land on the critical path of every restored VM (~75 s extra startup for a 50-VM node).

Replace with bounded polls: per-volume NBD endpoint reachability before exec, and a QMP-socket-vs-exitChan race after fork. Both bounded at 5 s. QMP-side timeout SIGKILLs the captured pid so a wedged QEMU doesn't orphan its tap / volumes.