### PR TITLE
feat(network/external): restore source=dhcp on external pools

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -294,6 +294,7 @@ func init() {
 	adminInitCmd.Flags().String("external-mode", "", "External network mode: 'pool' (default when WAN detected) or '' (disabled)")
 	adminInitCmd.Flags().String("external-iface", "", "WAN NIC for br-external (auto-detected from default route)")
 	adminInitCmd.Flags().String("external-source", "", "Pool IP source: 'dhcp' (default when no --external-pool) or 'static' (uses --external-pool range)")
+	adminInitCmd.Flags().String("external-bind-bridge", "", "Linux bridge for upstream DHCP DORA (default 'br-wan' when --external-source=dhcp)")
 	adminInitCmd.Flags().String("external-pool", "", "External IP pool range as start-end (e.g., 192.168.1.150-192.168.1.250)")
 	adminInitCmd.Flags().String("external-gateway", "", "WAN gateway IP (auto-detected from default route)")
 	adminInitCmd.Flags().String("gateway-ip", "", "OVN gateway router's external IP for SNAT (default: pool range_start for pool mode, required for nat mode without DHCP)")
@@ -839,6 +840,7 @@ func runAdminInit(cmd *cobra.Command, args []string) {
 	externalMode, _ := cmd.Flags().GetString("external-mode")
 	externalIface, _ := cmd.Flags().GetString("external-iface")
 	externalSource, _ := cmd.Flags().GetString("external-source")
+	externalBindBridge, _ := cmd.Flags().GetString("external-bind-bridge")
 	externalPool, _ := cmd.Flags().GetString("external-pool")
 	externalGateway, _ := cmd.Flags().GetString("external-gateway")
 	externalPrefixLen, _ := cmd.Flags().GetInt("external-prefix-len")
@@ -928,29 +930,50 @@ func runAdminInit(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	if externalMode == "pool" {
-		if externalSource != "" && externalSource != "static" {
-			fmt.Fprintf(os.Stderr, "❌ Error: --external-source must be 'static' (only supported value), got: %s\n", externalSource)
-			os.Exit(1)
-		}
-		externalSource = "static"
-		if externalPool == "" {
-			fmt.Fprintf(os.Stderr, "❌ Error: --external-pool is required when --external-mode=pool (e.g., 192.168.1.150-192.168.1.250)\n")
-			if detectedNet != nil && detectedNet.WAN != nil {
-				sugStart, sugEnd := admin.SuggestPoolRange(detectedNet.WAN)
-				fmt.Fprintf(os.Stderr, "   Suggested: --external-pool=%s-%s\n", sugStart, sugEnd)
+		// Default source: dhcp when no --external-pool, else static.
+		if externalSource == "" {
+			if externalPool == "" {
+				externalSource = "dhcp"
+			} else {
+				externalSource = "static"
 			}
+		}
+		switch externalSource {
+		case "dhcp":
+			if externalPool != "" {
+				fmt.Fprintf(os.Stderr, "❌ Error: --external-pool not allowed with --external-source=dhcp (addresses come from upstream DHCP server)\n")
+				os.Exit(1)
+			}
+			if externalBindBridge == "" {
+				externalBindBridge = "br-wan"
+			}
+		case "static":
+			if externalBindBridge != "" {
+				fmt.Fprintf(os.Stderr, "❌ Error: --external-bind-bridge only valid with --external-source=dhcp\n")
+				os.Exit(1)
+			}
+			if externalPool == "" {
+				fmt.Fprintf(os.Stderr, "❌ Error: --external-pool is required with --external-source=static (e.g., 192.168.1.150-192.168.1.250)\n")
+				if detectedNet != nil && detectedNet.WAN != nil {
+					sugStart, sugEnd := admin.SuggestPoolRange(detectedNet.WAN)
+					fmt.Fprintf(os.Stderr, "   Suggested: --external-pool=%s-%s\n", sugStart, sugEnd)
+				}
+				os.Exit(1)
+			}
+			if externalGateway == "" {
+				fmt.Fprintf(os.Stderr, "❌ Error: --external-gateway is required with --external-source=static\n")
+				os.Exit(1)
+			}
+			parts := strings.SplitN(externalPool, "-", 2)
+			if len(parts) != 2 || net.ParseIP(parts[0]) == nil || net.ParseIP(parts[1]) == nil {
+				fmt.Fprintf(os.Stderr, "❌ Error: --external-pool must be start-end IPs (e.g., 192.168.1.150-192.168.1.250), got: %s\n", externalPool)
+				os.Exit(1)
+			}
+			poolStart, poolEnd = parts[0], parts[1]
+		default:
+			fmt.Fprintf(os.Stderr, "❌ Error: --external-source must be 'static' or 'dhcp', got: %s\n", externalSource)
 			os.Exit(1)
 		}
-		if externalGateway == "" {
-			fmt.Fprintf(os.Stderr, "❌ Error: --external-gateway is required when --external-mode=pool\n")
-			os.Exit(1)
-		}
-		parts := strings.SplitN(externalPool, "-", 2)
-		if len(parts) != 2 || net.ParseIP(parts[0]) == nil || net.ParseIP(parts[1]) == nil {
-			fmt.Fprintf(os.Stderr, "❌ Error: --external-pool must be start-end IPs (e.g., 192.168.1.150-192.168.1.250), got: %s\n", externalPool)
-			os.Exit(1)
-		}
-		poolStart, poolEnd = parts[0], parts[1]
 	}
 	if externalGateway != "" && net.ParseIP(externalGateway) == nil {
 		fmt.Fprintf(os.Stderr, "❌ Error: --external-gateway is not a valid IP: %s\n", externalGateway)
@@ -1133,6 +1156,7 @@ func runAdminInit(cmd *cobra.Command, args []string) {
 			networkConfig.ExternalMode = externalMode
 			networkConfig.PoolName = "wan"
 			networkConfig.PoolSource = externalSource
+			networkConfig.PoolBindBridge = externalBindBridge
 			networkConfig.PoolStart = poolStart
 			networkConfig.PoolEnd = poolEnd
 			networkConfig.PoolGateway = externalGateway
@@ -1246,6 +1270,7 @@ func runAdminInit(cmd *cobra.Command, args []string) {
 		ExternalIface:  externalIface,
 		PoolName:       "wan",
 		PoolSource:     externalSource,
+		PoolBindBridge: externalBindBridge,
 		PoolStart:      poolStart,
 		PoolEnd:        poolEnd,
 		PoolGateway:    externalGateway,
@@ -1269,10 +1294,14 @@ func runAdminInit(cmd *cobra.Command, args []string) {
 	if externalMode != "" {
 		fmt.Printf("\n📡 External networking: %s\n", externalMode)
 		fmt.Printf("  WAN interface: %s\n", externalIface)
-		if poolStart != "" {
+		switch externalSource {
+		case "static":
 			fmt.Printf("  Source:        static (IP range)\n")
 			fmt.Printf("  IP pool:       %s - %s\n", poolStart, poolEnd)
 			fmt.Printf("  ⚠️  Ensure %s-%s is excluded from your router's DHCP range.\n", poolStart, poolEnd)
+		case "dhcp":
+			fmt.Printf("  Source:        dhcp (upstream DHCP server)\n")
+			fmt.Printf("  Bind bridge:   %s\n", externalBindBridge)
 		}
 		if gatewayIP != "" {
 			fmt.Printf("  Gateway IP:    %s (static)\n", gatewayIP)
@@ -2285,6 +2314,7 @@ func applyNetworkConfig(settings *admin.ConfigSettings, nc *formation.NetworkCon
 	settings.ExternalMode = nc.ExternalMode
 	settings.PoolName = nc.PoolName
 	settings.PoolSource = nc.PoolSource
+	settings.PoolBindBridge = nc.PoolBindBridge
 	settings.PoolStart = nc.PoolStart
 	settings.PoolEnd = nc.PoolEnd
 	settings.PoolGateway = nc.PoolGateway

--- a/cmd/spinifex/cmd/admin_test.go
+++ b/cmd/spinifex/cmd/admin_test.go
@@ -288,3 +288,101 @@ func TestImagesRemoveCmd_FlagSchema(t *testing.T) {
 
 // cobraRequiredAnnotation is the annotation key cobra uses to mark required flags.
 const cobraRequiredAnnotation = "cobra_annotation_bash_completion_one_required_flag"
+
+// `spx admin init` must expose --external-source and --external-bind-bridge so
+// operators can pick the DHCP path for [[network.external_pools]].
+func TestAdminInitCmd_ExternalDHCPFlagSchema(t *testing.T) {
+	sourceFlag := adminInitCmd.Flags().Lookup("external-source")
+	require.NotNil(t, sourceFlag, "--external-source must be defined")
+	assert.Equal(t, "", sourceFlag.DefValue)
+
+	bindFlag := adminInitCmd.Flags().Lookup("external-bind-bridge")
+	require.NotNil(t, bindFlag, "--external-bind-bridge must be defined")
+	assert.Equal(t, "", bindFlag.DefValue)
+
+	poolFlag := adminInitCmd.Flags().Lookup("external-pool")
+	require.NotNil(t, poolFlag)
+	assert.Equal(t, "", poolFlag.DefValue)
+}
+
+// DHCP-sourced pool must emit source + bind_bridge into spinifex.toml so the
+// daemon's validator and vpcd's DHCPManager find the bridge they DORA on.
+func TestSpinifexTomlTemplate_ExternalPoolDHCPSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+	settings := admin.ConfigSettings{
+		Node:           "node1",
+		Az:             "ap-southeast-2a",
+		Port:           "4432",
+		Region:         "ap-southeast-2",
+		BindIP:         "10.11.12.1",
+		ConfigDir:      dir,
+		OVNNBAddr:      "tcp:127.0.0.1:6641",
+		OVNSBAddr:      "tcp:127.0.0.1:6642",
+		ExternalMode:   "pool",
+		ExternalIface:  "eth0",
+		PoolName:       "wan",
+		PoolSource:     "dhcp",
+		PoolBindBridge: "br-wan",
+		PoolPrefixLen:  24,
+	}
+	require.NoError(t, admin.GenerateConfigFile(path, spinifexTomlTemplate, settings))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, `source      = "dhcp"`)
+	assert.Contains(t, content, `bind_bridge = "br-wan"`)
+	assert.NotContains(t, content, "range_start", "dhcp pool must not emit range_start")
+	assert.NotContains(t, content, "range_end", "dhcp pool must not emit range_end")
+	assert.NotContains(t, content, "gateway     =", "gateway omitted for dhcp pool (discovered from OFFER)")
+}
+
+// Static-sourced pool must not emit bind_bridge — the validator rejects it.
+func TestSpinifexTomlTemplate_ExternalPoolStaticSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+	settings := admin.ConfigSettings{
+		Node:          "node1",
+		Az:            "ap-southeast-2a",
+		Port:          "4432",
+		Region:        "ap-southeast-2",
+		BindIP:        "10.11.12.1",
+		ConfigDir:     dir,
+		OVNNBAddr:     "tcp:127.0.0.1:6641",
+		OVNSBAddr:     "tcp:127.0.0.1:6642",
+		ExternalMode:  "pool",
+		ExternalIface: "eth0",
+		PoolName:      "wan",
+		PoolSource:    "static",
+		PoolStart:     "192.168.1.150",
+		PoolEnd:       "192.168.1.250",
+		PoolGateway:   "192.168.1.1",
+		PoolPrefixLen: 24,
+	}
+	require.NoError(t, admin.GenerateConfigFile(path, spinifexTomlTemplate, settings))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, `source      = "static"`)
+	assert.NotContains(t, content, "bind_bridge", "static pool must not emit bind_bridge")
+	assert.Contains(t, content, `range_start = "192.168.1.150"`)
+	assert.Contains(t, content, `gateway     = "192.168.1.1"`)
+}
+
+// Formation joiners must receive PoolBindBridge from the init node so the
+// cluster-wide config reaches every chassis intact.
+func TestApplyNetworkConfig_PropagatesPoolBindBridge(t *testing.T) {
+	settings := &admin.ConfigSettings{}
+	nc := &formation.NetworkConfig{
+		ExternalMode:   "pool",
+		PoolName:       "wan",
+		PoolSource:     "dhcp",
+		PoolBindBridge: "br-wan",
+		PoolPrefixLen:  24,
+	}
+	applyNetworkConfig(settings, nc)
+	assert.Equal(t, "dhcp", settings.PoolSource)
+	assert.Equal(t, "br-wan", settings.PoolBindBridge)
+}

--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -728,6 +728,8 @@ var vpcdStartCmd = &cobra.Command{
 		for _, p := range clusterConfig.Network.ExternalPools {
 			extPools = append(extPools, vpcd.ExternalPoolConfig{
 				Name:            p.Name,
+				Source:          p.Source,
+				BindBridge:      p.BindBridge,
 				RangeStart:      p.RangeStart,
 				RangeEnd:        p.RangeEnd,
 				Gateway:         p.Gateway,

--- a/cmd/spinifex/cmd/templates/spinifex.toml
+++ b/cmd/spinifex/cmd/templates/spinifex.toml
@@ -18,11 +18,16 @@ name        = "{{.PoolName}}"
 {{- if .PoolSource}}
 source      = "{{.PoolSource}}"
 {{- end}}
+{{- if .PoolBindBridge}}
+bind_bridge = "{{.PoolBindBridge}}"
+{{- end}}
 {{- if .PoolStart}}
 range_start = "{{.PoolStart}}"
 range_end   = "{{.PoolEnd}}"
 {{- end}}
+{{- if .PoolGateway}}
 gateway     = "{{.PoolGateway}}"
+{{- end}}
 {{- if .PoolGatewayIP}}
 gateway_ip  = "{{.PoolGatewayIP}}"
 {{- end}}

--- a/spinifex/admin/admin.go
+++ b/spinifex/admin/admin.go
@@ -73,9 +73,10 @@ type ConfigSettings struct {
 	ExternalMode   string   // "pool" or "" (disabled)
 	ExternalIface  string   // WAN NIC name (e.g., "eth0", "eth1")
 	PoolName       string   // External pool name (e.g., "wan")
-	PoolSource     string   // IP source: "static" (default; only valid value)
-	PoolStart      string   // First IP in external pool range
-	PoolEnd        string   // Last IP in external pool range
+	PoolSource     string   // IP source: "static" or "dhcp"
+	PoolBindBridge string   // Linux bridge for upstream DORA (source=dhcp only)
+	PoolStart      string   // First IP in external pool range (static only)
+	PoolEnd        string   // Last IP in external pool range (static only)
 	PoolGateway    string   // WAN gateway IP
 	PoolGatewayIP  string   // Explicit SNAT IP (overrides default of first IP in range)
 	PoolPrefixLen  int      // Subnet prefix length (default 24)

--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -23,7 +23,8 @@ type ClusterConfig struct {
 // ExternalPool defines a range of routable IPs that Spinifex manages for public subnets.
 type ExternalPool struct {
 	Name       string   `mapstructure:"name"`        // Pool identifier (e.g., "wan", "dc1-primary")
-	Source     string   `mapstructure:"source"`      // IP source: "static" (default; only valid value)
+	Source     string   `mapstructure:"source"`      // IP source: "static" (default) or "dhcp"
+	BindBridge string   `mapstructure:"bind_bridge"` // Linux bridge for DHCP DORA (source=dhcp only)
 	RangeStart string   `mapstructure:"range_start"` // First IP in range (static source only)
 	RangeEnd   string   `mapstructure:"range_end"`   // Last IP in range (static source only)
 	Gateway    string   `mapstructure:"gateway"`     // WAN default gateway (next hop for 0.0.0.0/0)
@@ -279,8 +280,24 @@ func validateClusterConfig(cc *ClusterConfig) error {
 	}
 	var ranges []poolRange
 	for _, p := range cc.Network.ExternalPools {
-		if p.Source != "" && p.Source != "static" {
-			return fmt.Errorf("config: [[network.external_pools]] %q: source=%q is no longer supported; use source=\"static\" with explicit range_start/range_end", p.Name, p.Source)
+		switch p.Source {
+		case "", "static":
+			if p.BindBridge != "" {
+				return fmt.Errorf("config: [[network.external_pools]] %q: bind_bridge is only valid with source=\"dhcp\"", p.Name)
+			}
+		case "dhcp":
+			if p.BindBridge == "" {
+				return fmt.Errorf("config: [[network.external_pools]] %q: source=\"dhcp\" requires bind_bridge (Linux bridge for DHCP DORA)", p.Name)
+			}
+			if p.RangeStart != "" || p.RangeEnd != "" {
+				return fmt.Errorf("config: [[network.external_pools]] %q: range_start/range_end not allowed with source=\"dhcp\" (addresses come from upstream)", p.Name)
+			}
+			if p.GwLrpRangeStart != "" || p.GwLrpRangeEnd != "" {
+				return fmt.Errorf("config: [[network.external_pools]] %q: gw_lrp_range_start/gw_lrp_range_end not allowed with source=\"dhcp\" (gateway LRP IP is DORA'd per VPC)", p.Name)
+			}
+			continue
+		default:
+			return fmt.Errorf("config: [[network.external_pools]] %q: source=%q unsupported; use \"static\" or \"dhcp\"", p.Name, p.Source)
 		}
 		if p.RangeStart == "" || p.RangeEnd == "" {
 			continue

--- a/spinifex/config/config_test.go
+++ b/spinifex/config/config_test.go
@@ -417,7 +417,38 @@ region = "us-east-1"
 	assert.False(t, cfg.Network.IPSecEnabled)
 }
 
-func TestLoadConfig_NetworkPoolDHCPSourceRejected(t *testing.T) {
+func TestLoadConfig_NetworkPoolDHCPSourceAccepted(t *testing.T) {
+	resetViper(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+
+	toml := `
+node = "n1"
+
+[network]
+external_mode = "pool"
+
+[[network.external_pools]]
+name = "wan"
+source = "dhcp"
+bind_bridge = "br-wan"
+gateway = "192.168.1.1"
+prefix_len = 24
+
+[nodes.n1]
+region = "us-east-1"
+`
+	require.NoError(t, os.WriteFile(path, []byte(toml), 0600))
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Network.ExternalPools, 1)
+	assert.Equal(t, "dhcp", cfg.Network.ExternalPools[0].Source)
+	assert.Equal(t, "br-wan", cfg.Network.ExternalPools[0].BindBridge)
+}
+
+func TestLoadConfig_NetworkPoolDHCPSourceRequiresBindBridge(t *testing.T) {
 	resetViper(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "spinifex.toml")
@@ -432,7 +463,63 @@ external_mode = "pool"
 name = "wan"
 source = "dhcp"
 gateway = "192.168.1.1"
-gateway_ip = "192.168.1.100"
+prefix_len = 24
+
+[nodes.n1]
+region = "us-east-1"
+`
+	require.NoError(t, os.WriteFile(path, []byte(toml), 0600))
+
+	cfg, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "bind_bridge")
+}
+
+func TestLoadConfig_NetworkPoolDHCPRejectsRange(t *testing.T) {
+	resetViper(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+
+	toml := `
+node = "n1"
+
+[network]
+external_mode = "pool"
+
+[[network.external_pools]]
+name = "wan"
+source = "dhcp"
+bind_bridge = "br-wan"
+range_start = "192.168.1.150"
+range_end = "192.168.1.200"
+
+[nodes.n1]
+region = "us-east-1"
+`
+	require.NoError(t, os.WriteFile(path, []byte(toml), 0600))
+
+	cfg, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "range_start")
+}
+
+func TestLoadConfig_NetworkPoolUnknownSourceRejected(t *testing.T) {
+	resetViper(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+
+	toml := `
+node = "n1"
+
+[network]
+external_mode = "pool"
+
+[[network.external_pools]]
+name = "wan"
+source = "magic"
+gateway = "192.168.1.1"
 prefix_len = 24
 
 [nodes.n1]
@@ -444,7 +531,7 @@ region = "us-east-1"
 	require.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "source=")
-	assert.Contains(t, err.Error(), "dhcp")
+	assert.Contains(t, err.Error(), "magic")
 }
 
 func TestLoadConfig_ExternalDHCPRejected(t *testing.T) {

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -49,6 +49,7 @@ import (
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
 	"github.com/mulgadc/spinifex/spinifex/instancetypes"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
 	"github.com/mulgadc/spinifex/spinifex/network/host"
 	"github.com/mulgadc/spinifex/spinifex/objectstore"
 	"github.com/mulgadc/spinifex/spinifex/types"
@@ -1122,9 +1123,12 @@ func (d *Daemon) startCluster() error {
 			slog.Warn("Failed to get JetStream for external IPAM", "err", jsErr)
 		} else {
 			var pools []handlers_ec2_vpc.ExternalPoolConfig
+			anyDHCP := false
 			for _, p := range d.clusterConfig.Network.ExternalPools {
 				pools = append(pools, handlers_ec2_vpc.ExternalPoolConfig{
 					Name:            p.Name,
+					Source:          p.Source,
+					BindBridge:      p.BindBridge,
 					RangeStart:      p.RangeStart,
 					RangeEnd:        p.RangeEnd,
 					Gateway:         p.Gateway,
@@ -1135,12 +1139,21 @@ func (d *Daemon) startCluster() error {
 					GwLrpRangeStart: p.GwLrpRangeStart,
 					GwLrpRangeEnd:   p.GwLrpRangeEnd,
 				})
+				if p.Source == "dhcp" {
+					anyDHCP = true
+				}
 			}
 			d.externalIPAM, err = handlers_ec2_vpc.NewExternalIPAM(js, pools)
 			if err != nil {
 				slog.Warn("Failed to initialize external IPAM", "err", err)
 			} else {
-				slog.Info("External IPAM initialized", "mode", d.clusterConfig.Network.ExternalMode, "pools", len(pools))
+				if anyDHCP {
+					dhcpClient := dhcp.NewNATSClient(d.natsConn, 0)
+					if dhcpErr := d.externalIPAM.EnableDHCP(dhcpClient); dhcpErr != nil {
+						slog.Warn("Failed to enable DHCP allocator on external IPAM", "err", dhcpErr)
+					}
+				}
+				slog.Info("External IPAM initialized", "mode", d.clusterConfig.Network.ExternalMode, "pools", len(pools), "dhcp", anyDHCP)
 			}
 		}
 	}

--- a/spinifex/formation/formation.go
+++ b/spinifex/formation/formation.go
@@ -64,6 +64,7 @@ type NetworkConfig struct {
 	ExternalMode   string   `json:"external_mode"`
 	PoolName       string   `json:"pool_name"`
 	PoolSource     string   `json:"pool_source,omitempty"`
+	PoolBindBridge string   `json:"pool_bind_bridge,omitempty"`
 	PoolStart      string   `json:"pool_start,omitempty"`
 	PoolEnd        string   `json:"pool_end,omitempty"`
 	PoolGateway    string   `json:"pool_gateway"`

--- a/spinifex/handlers/ec2/vpc/external_ipam.go
+++ b/spinifex/handlers/ec2/vpc/external_ipam.go
@@ -2,11 +2,13 @@ package handlers_ec2_vpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
 
 	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
 	"github.com/nats-io/nats.go"
 )
 
@@ -29,6 +31,8 @@ const (
 // cleanup tracked separately).
 type ExternalPoolConfig struct {
 	Name       string
+	Source     string // "static" (default) or "dhcp"
+	BindBridge string // Linux bridge for DHCP DORA (source=dhcp only)
 	RangeStart string
 	RangeEnd   string
 	Gateway    string
@@ -44,29 +48,56 @@ type ExternalPoolConfig struct {
 }
 
 // ExternalIPAM is the AWS-facing entry point for external IP allocation.
-// State + CAS logic now lives in external.StaticPoolAllocator; this type
-// is a thin facade that preserves the existing call surface (AllocateIP /
-// AllocateFromPool / ReleaseIP / GetPoolRecord) for handlers and tests.
+// State + CAS logic lives in external.StaticPoolAllocator for static
+// pools and dhcp.DHCPPoolAllocator (via vpcd RPC) for dhcp-sourced
+// pools; ExternalIPAM dispatches by pool name.
 type ExternalIPAM struct {
-	kv        nats.KeyValue
-	pools     []ExternalPoolConfig
-	allocator external.Allocator
+	kv      nats.KeyValue
+	pools   []ExternalPoolConfig
+	static  *external.StaticPoolAllocator
+	perPool map[string]external.Allocator // dhcp overrides; static pools fall through to `static`
 }
 
-// NewExternalIPAM creates a new ExternalIPAM backed by a static pool
-// allocator on NATS JetStream KV.
+// NewExternalIPAM creates a new ExternalIPAM. Static pools wire through
+// external.StaticPoolAllocator; DHCP-sourced pools wait for EnableDHCP
+// to install the per-pool dhcp.DHCPPoolAllocator.
 func NewExternalIPAM(js nats.JetStreamContext, pools []ExternalPoolConfig) (*ExternalIPAM, error) {
-	alloc, err := external.NewStaticPoolAllocator(js, toExternalPools(pools))
-	if err != nil {
-		return nil, err
+	staticPools := filterStatic(pools)
+	var (
+		alloc *external.StaticPoolAllocator
+		kv    nats.KeyValue
+	)
+	if len(staticPools) > 0 {
+		var err error
+		alloc, err = external.NewStaticPoolAllocator(js, toExternalPools(staticPools))
+		if err != nil {
+			return nil, err
+		}
+		kv = alloc.KV()
 	}
-	return &ExternalIPAM{kv: alloc.KV(), pools: pools, allocator: alloc}, nil
+	return &ExternalIPAM{kv: kv, pools: pools, static: alloc, perPool: map[string]external.Allocator{}}, nil
 }
 
 // NewExternalIPAMWithKV creates an ExternalIPAM with an existing KV bucket (for testing).
 func NewExternalIPAMWithKV(kv nats.KeyValue, pools []ExternalPoolConfig) *ExternalIPAM {
-	alloc := external.NewStaticPoolAllocatorWithKV(kv, toExternalPools(pools))
-	return &ExternalIPAM{kv: kv, pools: pools, allocator: alloc}
+	alloc := external.NewStaticPoolAllocatorWithKV(kv, toExternalPools(filterStatic(pools)))
+	return &ExternalIPAM{kv: kv, pools: pools, static: alloc, perPool: map[string]external.Allocator{}}
+}
+
+// EnableDHCP installs a DHCPPoolAllocator for every pool with
+// Source="dhcp". client is the daemon-side NATS wrapper that fans out
+// to vpcd. Idempotent — repeated calls overwrite existing dhcp entries.
+func (m *ExternalIPAM) EnableDHCP(client *dhcp.NATSClient) error {
+	if client == nil {
+		return errors.New("ExternalIPAM EnableDHCP: nil NATSClient")
+	}
+	for _, p := range m.pools {
+		if p.Source != external.SourceDHCP {
+			continue
+		}
+		m.perPool[p.Name] = dhcp.NewDHCPPoolAllocator(client, toExternalPools([]ExternalPoolConfig{p})[0])
+	}
+	return nil
 }
 
 // AllocateIP allocates the next available external IP from the best pool
@@ -89,7 +120,11 @@ func (m *ExternalIPAM) AllocateFromPool(poolName, purpose, allocID, eniID, insta
 }
 
 func (m *ExternalIPAM) allocateFromPool(poolName, purpose, allocID, eniID, instanceID string) (string, error) {
-	addr, err := m.allocator.Allocate(context.Background(), external.AllocateRequest{
+	alloc, err := m.allocatorFor(poolName)
+	if err != nil {
+		return "", err
+	}
+	addr, err := alloc.Allocate(context.Background(), external.AllocateRequest{
 		PoolName:     poolName,
 		Purpose:      purpose,
 		AllocationID: allocID,
@@ -108,16 +143,30 @@ func (m *ExternalIPAM) ReleaseIP(poolName, ip string) error {
 	if err != nil {
 		return fmt.Errorf("parse release IP %q: %w", ip, err)
 	}
-	return m.allocator.Release(context.Background(), poolName, addr)
+	alloc, err := m.allocatorFor(poolName)
+	if err != nil {
+		return err
+	}
+	return alloc.Release(context.Background(), poolName, addr)
 }
 
-// GetPoolRecord returns the current IPAM record for a pool.
+// GetPoolRecord returns the current IPAM record for a pool. DHCP-sourced
+// pools have no static record — the per-AZ lease bucket is authoritative.
 func (m *ExternalIPAM) GetPoolRecord(poolName string) (*ExternalIPAMRecord, error) {
-	sp, ok := m.allocator.(*external.StaticPoolAllocator)
-	if !ok {
-		return nil, fmt.Errorf("pool record unavailable: allocator is not static")
+	if m.static == nil {
+		return nil, fmt.Errorf("pool record unavailable: no static allocator")
 	}
-	return sp.GetPoolRecord(poolName)
+	return m.static.GetPoolRecord(poolName)
+}
+
+func (m *ExternalIPAM) allocatorFor(poolName string) (external.Allocator, error) {
+	if a, ok := m.perPool[poolName]; ok {
+		return a, nil
+	}
+	if m.static == nil {
+		return nil, fmt.Errorf("no allocator for pool %q (static disabled, dhcp not enabled)", poolName)
+	}
+	return m.static, nil
 }
 
 // findPool returns the best pool for the given region/AZ using the same
@@ -152,6 +201,8 @@ func toExternalPools(pools []ExternalPoolConfig) []external.ExternalPoolConfig {
 	for i, p := range pools {
 		out[i] = external.ExternalPoolConfig{
 			Name:            p.Name,
+			Source:          p.Source,
+			BindBridge:      p.BindBridge,
 			RangeStart:      p.RangeStart,
 			RangeEnd:        p.RangeEnd,
 			Gateway:         p.Gateway,
@@ -162,6 +213,17 @@ func toExternalPools(pools []ExternalPoolConfig) []external.ExternalPoolConfig {
 			AZ:              p.AZ,
 			GwLrpRangeStart: p.GwLrpRangeStart,
 			GwLrpRangeEnd:   p.GwLrpRangeEnd,
+		}
+	}
+	return out
+}
+
+// filterStatic returns only the static pools (Source unset or "static").
+func filterStatic(pools []ExternalPoolConfig) []ExternalPoolConfig {
+	out := make([]ExternalPoolConfig, 0, len(pools))
+	for _, p := range pools {
+		if p.Source == "" || p.Source == external.SourceStatic {
+			out = append(out, p)
 		}
 	}
 	return out

--- a/spinifex/handlers/ec2/vpc/external_ipam.go
+++ b/spinifex/handlers/ec2/vpc/external_ipam.go
@@ -1,53 +1,32 @@
 package handlers_ec2_vpc
 
 import (
-	"encoding/json"
-	"errors"
+	"context"
 	"fmt"
-	"log/slog"
-	"math/big"
 	"net"
+	"net/netip"
 
-	"github.com/mulgadc/spinifex/spinifex/migrate"
-	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/network/external"
 	"github.com/nats-io/nats.go"
 )
 
-const (
-	KVBucketExternalIPAM        = "spinifex-external-ipam"
-	KVBucketExternalIPAMVersion = 2
+// Backward-compatible aliases so callers (daemon, EIP, EC2 handlers, tests)
+// keep importing record + allocation shapes from this package while the
+// allocator implementation lives in network/external.
+type (
+	ExternalIPAllocation = external.ExternalIPAllocation
+	ExternalIPAMRecord   = external.PoolRecord
 )
 
-// ExternalIPAllocation describes how an external IP is being used. Purpose
-// values come from the Purpose enum in purpose.go.
-type ExternalIPAllocation struct {
-	Purpose      string `json:"purpose"`                 // Purpose enum: igw-lrp, eni-public, eip, natgw-external
-	AllocationID string `json:"allocation_id,omitempty"` // For elastic IPs
-	Association  string `json:"association,omitempty"`   // ENI ID for elastic IPs
-	ENIId        string `json:"eni_id,omitempty"`        // ENI owning this IP
-	InstanceId   string `json:"instance_id,omitempty"`   // Instance owning this IP
-	Note         string `json:"note,omitempty"`          // Human-readable note
-}
-
-// ExternalIPAMRecord tracks allocated external IPs for a single pool.
-type ExternalIPAMRecord struct {
-	PoolName   string `json:"pool_name"`
-	RangeStart string `json:"range_start"`
-	RangeEnd   string `json:"range_end"`
-	Gateway    string `json:"gateway"`
-	GatewayIP  string `json:"gateway_ip"`
-	PrefixLen  int    `json:"prefix_len"`
-	Region     string `json:"region,omitempty"`
-	AZ         string `json:"az,omitempty"`
-	// GwLrpRangeStart/End mirrors ExternalPoolConfig — IPAM skips this
-	// sub-range so it doesn't collide with vpcd's gateway LRP IPs in
-	// centralized NAT.
-	GwLrpRangeStart string                          `json:"gw_lrp_range_start,omitempty"`
-	GwLrpRangeEnd   string                          `json:"gw_lrp_range_end,omitempty"`
-	Allocated       map[string]ExternalIPAllocation `json:"allocated"`
-}
+const (
+	KVBucketExternalIPAM        = external.KVBucketStaticPool
+	KVBucketExternalIPAMVersion = external.KVBucketStaticPoolVersion
+)
 
 // ExternalPoolConfig is the admin-defined pool from spinifex.toml.
+// Duplicated against network/external.ExternalPoolConfig — the duplicate
+// stays until ExternalIPAM moves into network/external (deferred L5
+// cleanup tracked separately).
 type ExternalPoolConfig struct {
 	Name       string
 	RangeStart string
@@ -64,124 +43,34 @@ type ExternalPoolConfig struct {
 	GwLrpRangeEnd   string
 }
 
-// ExternalIPAM manages external IP allocation from admin-defined pools using NATS KV with CAS.
+// ExternalIPAM is the AWS-facing entry point for external IP allocation.
+// State + CAS logic now lives in external.StaticPoolAllocator; this type
+// is a thin facade that preserves the existing call surface (AllocateIP /
+// AllocateFromPool / ReleaseIP / GetPoolRecord) for handlers and tests.
 type ExternalIPAM struct {
-	kv    nats.KeyValue
-	pools []ExternalPoolConfig
+	kv        nats.KeyValue
+	pools     []ExternalPoolConfig
+	allocator external.Allocator
 }
 
-// NewExternalIPAM creates a new ExternalIPAM backed by NATS JetStream KV.
+// NewExternalIPAM creates a new ExternalIPAM backed by a static pool
+// allocator on NATS JetStream KV.
 func NewExternalIPAM(js nats.JetStreamContext, pools []ExternalPoolConfig) (*ExternalIPAM, error) {
-	kv, err := utils.GetOrCreateKVBucket(js, KVBucketExternalIPAM, 5)
+	alloc, err := external.NewStaticPoolAllocator(js, toExternalPools(pools))
 	if err != nil {
-		return nil, fmt.Errorf("create external IPAM KV bucket: %w", err)
+		return nil, err
 	}
-	if err := migrate.DefaultRegistry.RunKV(KVBucketExternalIPAM, kv, KVBucketExternalIPAMVersion); err != nil {
-		return nil, fmt.Errorf("migrate %s: %w", KVBucketExternalIPAM, err)
-	}
-	ipam := &ExternalIPAM{kv: kv, pools: pools}
-	if err := ipam.initPools(); err != nil {
-		return nil, fmt.Errorf("init external IPAM pools: %w", err)
-	}
-	return ipam, nil
+	return &ExternalIPAM{kv: alloc.KV(), pools: pools, allocator: alloc}, nil
 }
 
 // NewExternalIPAMWithKV creates an ExternalIPAM with an existing KV bucket (for testing).
 func NewExternalIPAMWithKV(kv nats.KeyValue, pools []ExternalPoolConfig) *ExternalIPAM {
-	return &ExternalIPAM{kv: kv, pools: pools}
-}
-
-// initPools ensures each configured pool has a KV record. Idempotent — safe to call
-// on every vpcd startup. Reserves the gateway IP in each pool.
-func (m *ExternalIPAM) initPools() error {
-	for _, pool := range m.pools {
-		if err := m.initPool(pool); err != nil {
-			return fmt.Errorf("init pool %q: %w", pool.Name, err)
-		}
-	}
-	return nil
-}
-
-func (m *ExternalIPAM) initPool(pool ExternalPoolConfig) error {
-	chk, revision, err := m.getRecord(pool.Name)
-
-	if err != nil && !errors.Is(err, nats.ErrKeyNotFound) {
-		return err
-	}
-
-	if err == nil {
-		if chk.RangeStart != pool.RangeStart || chk.RangeEnd != pool.RangeEnd ||
-			chk.GwLrpRangeStart != pool.GwLrpRangeStart || chk.GwLrpRangeEnd != pool.GwLrpRangeEnd {
-			slog.Info("external IPAM pool config drift, reconciling KV",
-				"pool", pool.Name,
-				"old_range", chk.RangeStart+"-"+chk.RangeEnd, "new_range", pool.RangeStart+"-"+pool.RangeEnd,
-				"old_gw_lrp_range", chk.GwLrpRangeStart+"-"+chk.GwLrpRangeEnd,
-				"new_gw_lrp_range", pool.GwLrpRangeStart+"-"+pool.GwLrpRangeEnd)
-
-			chk.RangeStart = pool.RangeStart
-			chk.RangeEnd = pool.RangeEnd
-			chk.GwLrpRangeStart = pool.GwLrpRangeStart
-			chk.GwLrpRangeEnd = pool.GwLrpRangeEnd
-
-			data, err := json.Marshal(chk)
-			if err != nil {
-				return fmt.Errorf("marshal external IPAM record: %w", err)
-			}
-
-			if _, err := m.kv.Update(pool.Name, data, revision); err != nil {
-				slog.Warn("external IPAM update failed", "pool", pool.Name, "err", err)
-				return err
-			}
-			return nil
-		}
-		slog.Debug("external IPAM pool already initialized", "pool", pool.Name)
-		return nil
-	}
-
-	slog.Info("external IPAM pool not found, creating", "pool", pool.Name)
-
-	gwIP := pool.GatewayIP
-	if gwIP == "" {
-		gwIP = pool.RangeStart
-	}
-
-	record := &ExternalIPAMRecord{
-		PoolName:        pool.Name,
-		RangeStart:      pool.RangeStart,
-		RangeEnd:        pool.RangeEnd,
-		Gateway:         pool.Gateway,
-		GatewayIP:       gwIP,
-		PrefixLen:       pool.PrefixLen,
-		Region:          pool.Region,
-		AZ:              pool.AZ,
-		GwLrpRangeStart: pool.GwLrpRangeStart,
-		GwLrpRangeEnd:   pool.GwLrpRangeEnd,
-		Allocated: map[string]ExternalIPAllocation{
-			gwIP: {Purpose: PurposeIGWLRP, Note: "OVN router SNAT address"},
-		},
-	}
-
-	data, err := json.Marshal(record)
-	if err != nil {
-		return fmt.Errorf("marshal pool record: %w", err)
-	}
-
-	if _, err := m.kv.Create(pool.Name, data); err != nil {
-		// Another instance may have initialized concurrently — that's fine.
-		if errors.Is(err, nats.ErrKeyExists) {
-			return nil
-		}
-		return fmt.Errorf("create pool KV entry: %w", err)
-	}
-
-	slog.Info("external IPAM pool initialized", "pool", pool.Name, "gateway_ip", gwIP)
-	return nil
+	alloc := external.NewStaticPoolAllocatorWithKV(kv, toExternalPools(pools))
+	return &ExternalIPAM{kv: kv, pools: pools, allocator: alloc}
 }
 
 // AllocateIP allocates the next available external IP from the best pool
 // matching the given region/AZ. Returns the allocated IP and pool name.
-// purpose is one of the Purpose* constants in purpose.go; allocID is the
-// EIP allocation ID (for PurposeEIP) and "" otherwise.
 func (m *ExternalIPAM) AllocateIP(region, az, purpose, allocID, eniID, instanceID string) (string, string, error) {
 	pool := m.findPool(region, az)
 	if pool == nil {
@@ -200,100 +89,52 @@ func (m *ExternalIPAM) AllocateFromPool(poolName, purpose, allocID, eniID, insta
 }
 
 func (m *ExternalIPAM) allocateFromPool(poolName, purpose, allocID, eniID, instanceID string) (string, error) {
-	for attempt := range 5 {
-		record, revision, err := m.getRecord(poolName)
-		if err != nil {
-			return "", fmt.Errorf("get external IPAM record: %w", err)
-		}
-
-		ip, err := nextAvailableExternalIP(record)
-		if err != nil {
-			return "", err
-		}
-
-		record.Allocated[ip] = ExternalIPAllocation{
-			Purpose:      purpose,
-			AllocationID: allocID,
-			ENIId:        eniID,
-			InstanceId:   instanceID,
-		}
-
-		data, err := json.Marshal(record)
-		if err != nil {
-			return "", fmt.Errorf("marshal external IPAM record: %w", err)
-		}
-
-		if _, err := m.kv.Update(poolName, data, revision); err != nil {
-			slog.Debug("external IPAM CAS conflict, retrying", "pool", poolName, "attempt", attempt)
-			continue
-		}
-
-		slog.Info("external IPAM allocated IP", "pool", poolName, "ip", ip, "purpose", purpose)
-		return ip, nil
+	addr, err := m.allocator.Allocate(context.Background(), external.AllocateRequest{
+		PoolName:     poolName,
+		Purpose:      purpose,
+		AllocationID: allocID,
+		ENIID:        eniID,
+		InstanceID:   instanceID,
+	})
+	if err != nil {
+		return "", err
 	}
-
-	return "", fmt.Errorf("external IPAM allocation failed after CAS retries for pool %s", poolName)
+	return addr.String(), nil
 }
 
 // ReleaseIP releases a previously allocated external IP back to its pool.
 func (m *ExternalIPAM) ReleaseIP(poolName, ip string) error {
-	for attempt := range 5 {
-		record, revision, err := m.getRecord(poolName)
-		if err != nil {
-			return fmt.Errorf("get external IPAM record for release: %w", err)
-		}
-
-		alloc, ok := record.Allocated[ip]
-		if !ok {
-			return fmt.Errorf("IP %s not allocated in pool %s", ip, poolName)
-		}
-		if alloc.Purpose == PurposeIGWLRP {
-			return fmt.Errorf("cannot release gateway IP %s in pool %s", ip, poolName)
-		}
-
-		delete(record.Allocated, ip)
-
-		data, err := json.Marshal(record)
-		if err != nil {
-			return fmt.Errorf("marshal external IPAM record: %w", err)
-		}
-
-		if _, err := m.kv.Update(poolName, data, revision); err != nil {
-			slog.Debug("external IPAM release CAS conflict, retrying", "pool", poolName, "attempt", attempt)
-			continue
-		}
-
-		slog.Info("external IPAM released IP", "pool", poolName, "ip", ip)
-		return nil
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return fmt.Errorf("parse release IP %q: %w", ip, err)
 	}
-
-	return fmt.Errorf("external IPAM release failed after CAS retries for pool %s", poolName)
+	return m.allocator.Release(context.Background(), poolName, addr)
 }
 
 // GetPoolRecord returns the current IPAM record for a pool.
 func (m *ExternalIPAM) GetPoolRecord(poolName string) (*ExternalIPAMRecord, error) {
-	record, _, err := m.getRecord(poolName)
-	return record, err
+	sp, ok := m.allocator.(*external.StaticPoolAllocator)
+	if !ok {
+		return nil, fmt.Errorf("pool record unavailable: allocator is not static")
+	}
+	return sp.GetPoolRecord(poolName)
 }
 
 // findPool returns the best pool for the given region/AZ using the same
 // fallback order as topology.go: AZ-scoped → region-scoped → unscoped.
 func (m *ExternalIPAM) findPool(region, az string) *ExternalPoolConfig {
-	// 1. AZ-scoped match
 	for i := range m.pools {
 		p := &m.pools[i]
 		if p.AZ != "" && p.AZ == az && p.Region == region {
 			return p
 		}
 	}
-	// 2. Region-scoped (no AZ)
 	for i := range m.pools {
 		p := &m.pools[i]
 		if p.AZ == "" && p.Region != "" && p.Region == region {
 			return p
 		}
 	}
-	// 3. Unscoped (global pool)
 	for i := range m.pools {
 		p := &m.pools[i]
 		if p.Region == "" && p.AZ == "" {
@@ -303,54 +144,27 @@ func (m *ExternalIPAM) findPool(region, az string) *ExternalPoolConfig {
 	return nil
 }
 
-func (m *ExternalIPAM) getRecord(poolName string) (*ExternalIPAMRecord, uint64, error) {
-	entry, err := m.kv.Get(poolName)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	var record ExternalIPAMRecord
-	if err := json.Unmarshal(entry.Value(), &record); err != nil {
-		return nil, 0, fmt.Errorf("unmarshal external IPAM record: %w", err)
-	}
-
-	return &record, entry.Revision(), nil
-}
-
-// nextAvailableExternalIP finds the next unallocated IP in the pool's
-// range. Addresses inside [GwLrpRangeStart, GwLrpRangeEnd] are skipped —
-// vpcd reserves them for OVN gateway LRPs.
-func nextAvailableExternalIP(record *ExternalIPAMRecord) (string, error) {
-	startIP := net.ParseIP(record.RangeStart).To4()
-	endIP := net.ParseIP(record.RangeEnd).To4()
-	if startIP == nil || endIP == nil {
-		return "", fmt.Errorf("invalid IP range: %s - %s", record.RangeStart, record.RangeEnd)
-	}
-
-	var gwLrpStart, gwLrpEnd int64 = -1, -1
-	if record.GwLrpRangeStart != "" && record.GwLrpRangeEnd != "" {
-		s := net.ParseIP(record.GwLrpRangeStart).To4()
-		e := net.ParseIP(record.GwLrpRangeEnd).To4()
-		if s != nil && e != nil {
-			gwLrpStart = ipToInt(s).Int64()
-			gwLrpEnd = ipToInt(e).Int64()
+// toExternalPools converts the handlers-side ExternalPoolConfig into the
+// network/external mirror. The duplicate type goes away in the deferred
+// L5 cleanup.
+func toExternalPools(pools []ExternalPoolConfig) []external.ExternalPoolConfig {
+	out := make([]external.ExternalPoolConfig, len(pools))
+	for i, p := range pools {
+		out[i] = external.ExternalPoolConfig{
+			Name:            p.Name,
+			RangeStart:      p.RangeStart,
+			RangeEnd:        p.RangeEnd,
+			Gateway:         p.Gateway,
+			GatewayIP:       p.GatewayIP,
+			PrefixLen:       p.PrefixLen,
+			DNSServers:      nil,
+			Region:          p.Region,
+			AZ:              p.AZ,
+			GwLrpRangeStart: p.GwLrpRangeStart,
+			GwLrpRangeEnd:   p.GwLrpRangeEnd,
 		}
 	}
-
-	startInt := ipToInt(startIP)
-	endInt := ipToInt(endIP)
-
-	for i := startInt.Int64(); i <= endInt.Int64(); i++ {
-		if gwLrpStart >= 0 && i >= gwLrpStart && i <= gwLrpEnd {
-			continue
-		}
-		candidate := intToIP(intFromInt64(i)).String()
-		if _, taken := record.Allocated[candidate]; !taken {
-			return candidate, nil
-		}
-	}
-
-	return "", fmt.Errorf("InsufficientAddressCapacity: pool %s exhausted", record.PoolName)
+	return out
 }
 
 // ValidatePoolConfig checks that a pool config is valid.
@@ -375,12 +189,9 @@ func ValidatePoolConfig(pool ExternalPoolConfig) error {
 	if endIP == nil {
 		return fmt.Errorf("invalid range_end: %q", pool.RangeEnd)
 	}
-	if ipToInt(startIP.To4()).Cmp(ipToInt(endIP.To4())) > 0 {
+	if compareIPs(startIP, endIP) > 0 {
 		return fmt.Errorf("range_start %s is greater than range_end %s", pool.RangeStart, pool.RangeEnd)
 	}
-	// gw_lrp_range must be valid IPs and must NOT overlap range_start/end
-	// — otherwise vpcd's gateway LRP allocator and per-VM EIP allocator
-	// would fight over the same address.
 	if pool.GwLrpRangeStart != "" || pool.GwLrpRangeEnd != "" {
 		gwS := net.ParseIP(pool.GwLrpRangeStart)
 		gwE := net.ParseIP(pool.GwLrpRangeEnd)
@@ -390,16 +201,12 @@ func ValidatePoolConfig(pool ExternalPoolConfig) error {
 		if gwE == nil {
 			return fmt.Errorf("invalid gw_lrp_range_end: %q", pool.GwLrpRangeEnd)
 		}
-		gwSi := ipToInt(gwS.To4())
-		gwEi := ipToInt(gwE.To4())
-		if gwSi.Cmp(gwEi) > 0 {
+		if compareIPs(gwS, gwE) > 0 {
 			return fmt.Errorf("gw_lrp_range_start %s is greater than gw_lrp_range_end %s",
 				pool.GwLrpRangeStart, pool.GwLrpRangeEnd)
 		}
-		rangeSi := ipToInt(startIP.To4())
-		rangeEi := ipToInt(endIP.To4())
 		// Overlap test: !(gwE < rangeS || gwS > rangeE)
-		if gwEi.Cmp(rangeSi) >= 0 && gwSi.Cmp(rangeEi) <= 0 {
+		if compareIPs(gwE, startIP) >= 0 && compareIPs(gwS, endIP) <= 0 {
 			return fmt.Errorf("gw_lrp_range %s-%s overlaps range %s-%s",
 				pool.GwLrpRangeStart, pool.GwLrpRangeEnd, pool.RangeStart, pool.RangeEnd)
 		}
@@ -407,7 +214,8 @@ func ValidatePoolConfig(pool ExternalPoolConfig) error {
 	return nil
 }
 
-// intFromInt64 wraps a plain int64 into a *big.Int-compatible IP conversion.
-func intFromInt64(v int64) *big.Int {
-	return big.NewInt(v)
+func compareIPs(a, b net.IP) int {
+	ai := ipToInt(a.To4())
+	bi := ipToInt(b.To4())
+	return ai.Cmp(bi)
 }

--- a/spinifex/handlers/ec2/vpc/external_ipam_test.go
+++ b/spinifex/handlers/ec2/vpc/external_ipam_test.go
@@ -392,29 +392,6 @@ func TestExternalIPAM_FindPoolByName_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestNextAvailableExternalIP_SkipsGwLrpRange verifies the per-VM EIP allocator
-// honors gw_lrp_range by skipping IPs reserved for vpcd's gateway LRPs (siv-36).
-func TestNextAvailableExternalIP_SkipsGwLrpRange(t *testing.T) {
-	rec := &ExternalIPAMRecord{
-		PoolName:        "wan",
-		RangeStart:      "192.168.1.10",
-		RangeEnd:        "192.168.1.14",
-		GwLrpRangeStart: "192.168.1.11",
-		GwLrpRangeEnd:   "192.168.1.13",
-		Allocated:       map[string]ExternalIPAllocation{},
-	}
-	ip, err := nextAvailableExternalIP(rec)
-	require.NoError(t, err)
-	assert.Equal(t, "192.168.1.10", ip)
-	rec.Allocated[ip] = ExternalIPAllocation{}
-	ip, err = nextAvailableExternalIP(rec)
-	require.NoError(t, err)
-	assert.Equal(t, "192.168.1.14", ip)
-	rec.Allocated[ip] = ExternalIPAllocation{}
-	_, err = nextAvailableExternalIP(rec)
-	require.Error(t, err)
-}
-
 func TestValidatePoolConfig(t *testing.T) {
 	base := func() ExternalPoolConfig {
 		return ExternalPoolConfig{

--- a/spinifex/network/external/allocator.go
+++ b/spinifex/network/external/allocator.go
@@ -1,0 +1,26 @@
+package external
+
+import (
+	"context"
+	"net/netip"
+)
+
+// AllocateRequest carries the per-allocation identity used by both static
+// and DHCP-backed allocators. PoolName picks the pool; the AWS identity
+// (AllocationID / ENIID / InstanceID) is recorded on the IPAM entry for
+// static pools and used as the DHCP client-ID for DHCP pools.
+type AllocateRequest struct {
+	PoolName     string
+	Purpose      string
+	AllocationID string
+	ENIID        string
+	InstanceID   string
+}
+
+// Allocator hands out a single external IP per AWS identity from a named
+// pool. Implementations: StaticPoolAllocator (range math + KV CAS) and
+// DHCPPoolAllocator (RFC 2131 DORA via vpcd, Q4).
+type Allocator interface {
+	Allocate(ctx context.Context, req AllocateRequest) (netip.Addr, error)
+	Release(ctx context.Context, poolName string, ip netip.Addr) error
+}

--- a/spinifex/network/external/dhcp/client.go
+++ b/spinifex/network/external/dhcp/client.go
@@ -1,0 +1,76 @@
+// Package dhcp provides an in-process DHCPv4 client used by spinifex-vpcd
+// to obtain, renew and release real server-bound leases on behalf of the
+// external IPAM pool.
+//
+// The production client (NewNClient4) opens an AF_PACKET socket per DORA
+// on the target bridge via github.com/insomniacslk/dhcp/dhcpv4/nclient4.
+// Tests inject Fake instead.
+//
+// Retransmission lives one layer up (DHCPManager in vpcd, Q3) — this
+// package performs single-attempt DORA/RENEW/RELEASE and persists
+// server-bound leases to a per-AZ KV bucket.
+package dhcp
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// Client is the per-handshake DHCP surface. Backed by NewNClient4 in
+// production; Fake satisfies this for unit tests.
+type Client interface {
+	Acquire(ctx context.Context, req AcquireRequest) (*Lease, error)
+	Renew(ctx context.Context, lease *Lease) (*Lease, error)
+	Release(ctx context.Context, lease *Lease) error
+}
+
+// AcquireRequest identifies a new DHCP lease. Fields map 1:1 to DHCP
+// options and the payload chaddr.
+type AcquireRequest struct {
+	Bridge      string           // bridge carrying the AF_PACKET socket
+	ClientID    string           // option 61 — client-identifier
+	Hostname    string           // option 12 — host-name
+	VendorClass string           // option 60 — vendor-class-identifier
+	HWAddr      net.HardwareAddr // chaddr in the DHCP payload
+}
+
+// Lease is a server-bound DHCPv4 lease. Carries enough state for Renew
+// and Release, plus the raw Offer/ACK packets so that DHCPManager (Q3)
+// can resume after a daemon restart.
+type Lease struct {
+	Bridge      string
+	ClientID    string
+	Hostname    string
+	VendorClass string
+	HWAddr      net.HardwareAddr
+
+	IP         net.IP
+	SubnetMask net.IPMask
+	Routers    []net.IP
+	DNS        []net.IP
+	ServerID   net.IP
+
+	AcquiredAt    time.Time
+	LeaseDuration time.Duration
+	T1            time.Duration
+	T2            time.Duration
+
+	// Raw wire packets. Opaque to callers; nclient4 needs them to build
+	// RENEW / RELEASE messages that hit the same server binding. Persisted
+	// in KV for crash recovery.
+	RawOffer []byte
+	RawACK   []byte
+}
+
+// ExpiresAt returns the absolute deadline at which the upstream server is
+// free to reassign this IP.
+func (l *Lease) ExpiresAt() time.Time { return l.AcquiredAt.Add(l.LeaseDuration) }
+
+// RenewAt returns the absolute time the Manager should attempt a RENEW
+// (option 58 / T1).
+func (l *Lease) RenewAt() time.Time { return l.AcquiredAt.Add(l.T1) }
+
+// RebindAt returns the absolute time the Manager should attempt a REBIND
+// (option 59 / T2).
+func (l *Lease) RebindAt() time.Time { return l.AcquiredAt.Add(l.T2) }

--- a/spinifex/network/external/dhcp/client_test.go
+++ b/spinifex/network/external/dhcp/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,8 +141,42 @@ func TestNClient4ValidatesInputs(t *testing.T) {
 	if _, err := c.Acquire(context.Background(), dhcp.AcquireRequest{}); err == nil {
 		t.Fatal("expected bridge-required error")
 	}
-	if _, err := c.Acquire(context.Background(), dhcp.AcquireRequest{Bridge: "br-wan"}); err == nil {
-		t.Fatal("expected hw_addr-required error")
+	// Neither HWAddr nor ClientID — allocator can't derive a MAC, must fail.
+	_, err := c.Acquire(context.Background(), dhcp.AcquireRequest{Bridge: "br-wan"})
+	if err == nil {
+		t.Fatal("expected client_id-or-hw_addr-required error")
+	}
+	if !strings.Contains(err.Error(), "client_id or hw_addr is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Regression: nightly cell 1 failed with "dhcp acquire: hw_addr is required"
+// because DHCPGatewayLRPAllocator passes only ClientID, never HWAddr. The
+// real client must derive chaddr from the client-id rather than rejecting
+// the request.
+func TestDeriveMAC_StableAndLocallyAdministered(t *testing.T) {
+	got1, err := dhcp.DeriveMAC("dhcp-gw-lrp-vpc-1")
+	if err != nil {
+		t.Fatalf("DeriveMAC: %v", err)
+	}
+	got2, err := dhcp.DeriveMAC("dhcp-gw-lrp-vpc-1")
+	if err != nil {
+		t.Fatalf("DeriveMAC second call: %v", err)
+	}
+	if got1.String() != got2.String() {
+		t.Fatalf("DeriveMAC not deterministic: %s vs %s", got1, got2)
+	}
+	if got1[0] != 0x02 {
+		t.Fatalf("first octet must be 0x02 (LAA, unicast), got %02x", got1[0])
+	}
+
+	other, err := dhcp.DeriveMAC("dhcp-gw-lrp-vpc-2")
+	if err != nil {
+		t.Fatalf("DeriveMAC vpc-2: %v", err)
+	}
+	if got1.String() == other.String() {
+		t.Fatal("distinct client-ids must produce distinct MACs")
 	}
 }
 

--- a/spinifex/network/external/dhcp/client_test.go
+++ b/spinifex/network/external/dhcp/client_test.go
@@ -1,0 +1,172 @@
+package dhcp_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+)
+
+func TestLeaseTimers(t *testing.T) {
+	acq := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	l := &dhcp.Lease{
+		AcquiredAt:    acq,
+		LeaseDuration: time.Hour,
+		T1:            30 * time.Minute,
+		T2:            52*time.Minute + 30*time.Second,
+	}
+
+	if got := l.RenewAt(); !got.Equal(acq.Add(30 * time.Minute)) {
+		t.Errorf("RenewAt: got %v, want %v", got, acq.Add(30*time.Minute))
+	}
+	if got := l.RebindAt(); !got.Equal(acq.Add(52*time.Minute + 30*time.Second)) {
+		t.Errorf("RebindAt: got %v, want %v", got, acq.Add(52*time.Minute+30*time.Second))
+	}
+	if got := l.ExpiresAt(); !got.Equal(acq.Add(time.Hour)) {
+		t.Errorf("ExpiresAt: got %v, want %v", got, acq.Add(time.Hour))
+	}
+}
+
+func TestFakeAcquireReturnsLeaseAndTracksCount(t *testing.T) {
+	f := dhcp.NewFake()
+	mac, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+
+	lease, err := f.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eni-1", HWAddr: mac,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if lease == nil || lease.IP == nil {
+		t.Fatalf("expected lease with IP, got %+v", lease)
+	}
+	if f.AcquireCount() != 1 {
+		t.Errorf("acquire count = %d, want 1", f.AcquireCount())
+	}
+	if held, ok := f.HeldLease("eni-1"); !ok || held.IP.String() != lease.IP.String() {
+		t.Errorf("held lease = %v/%v, want match", held, ok)
+	}
+}
+
+func TestFakeAcquireHookOverridesDefault(t *testing.T) {
+	f := dhcp.NewFake()
+	f.AcquireHook = func(dhcp.AcquireRequest) (*dhcp.Lease, error) {
+		return nil, errors.New("injected")
+	}
+	_, err := f.Acquire(context.Background(), dhcp.AcquireRequest{Bridge: "br-wan", ClientID: "x"})
+	if err == nil || err.Error() != "injected" {
+		t.Fatalf("expected injected error, got %v", err)
+	}
+}
+
+func TestFakeRenewRefreshesAcquiredAt(t *testing.T) {
+	f := dhcp.NewFake()
+	lease, err := f.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eni-2",
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	firstAcq := lease.AcquiredAt
+
+	time.Sleep(10 * time.Millisecond)
+	renewed, err := f.Renew(context.Background(), lease)
+	if err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if !renewed.AcquiredAt.After(firstAcq) {
+		t.Errorf("renewed AcquiredAt %v not after original %v", renewed.AcquiredAt, firstAcq)
+	}
+	if f.RenewCount() != 1 {
+		t.Errorf("renew count = %d, want 1", f.RenewCount())
+	}
+}
+
+func TestFakeReleaseClearsTrackedLease(t *testing.T) {
+	f := dhcp.NewFake()
+	lease, _ := f.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eni-3",
+	})
+	if err := f.Release(context.Background(), lease); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, ok := f.HeldLease("eni-3"); ok {
+		t.Errorf("expected lease removed after Release")
+	}
+	if f.ReleaseCount() != 1 {
+		t.Errorf("release count = %d, want 1", f.ReleaseCount())
+	}
+}
+
+func TestFakeRenewHookSurfacesError(t *testing.T) {
+	f := dhcp.NewFake()
+	f.RenewHook = func(*dhcp.Lease) (*dhcp.Lease, error) {
+		return nil, errors.New("server NAK")
+	}
+	lease, _ := f.Acquire(context.Background(), dhcp.AcquireRequest{Bridge: "br-wan", ClientID: "eni-4"})
+	if _, err := f.Renew(context.Background(), lease); err == nil {
+		t.Fatal("expected hook error")
+	}
+}
+
+func TestFakeReleaseHookSurfacesError(t *testing.T) {
+	f := dhcp.NewFake()
+	f.ReleaseHook = func(*dhcp.Lease) error { return errors.New("server unreachable") }
+	lease, _ := f.Acquire(context.Background(), dhcp.AcquireRequest{Bridge: "br-wan", ClientID: "eni-rel"})
+	if err := f.Release(context.Background(), lease); err == nil {
+		t.Fatal("expected hook error")
+	}
+}
+
+func TestFakeRenewNilLease(t *testing.T) {
+	f := dhcp.NewFake()
+	if _, err := f.Renew(context.Background(), nil); err == nil {
+		t.Fatal("expected error for nil lease")
+	}
+}
+
+func TestFakeReleaseNilIsNoop(t *testing.T) {
+	f := dhcp.NewFake()
+	if err := f.Release(context.Background(), nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestNClient4ValidatesInputs(t *testing.T) {
+	c := dhcp.NewNClient4(0)
+	if _, err := c.Acquire(context.Background(), dhcp.AcquireRequest{}); err == nil {
+		t.Fatal("expected bridge-required error")
+	}
+	if _, err := c.Acquire(context.Background(), dhcp.AcquireRequest{Bridge: "br-wan"}); err == nil {
+		t.Fatal("expected hw_addr-required error")
+	}
+}
+
+func TestNClient4RenewRejectsNilAndMissingRaw(t *testing.T) {
+	c := dhcp.NewNClient4(0)
+	if _, err := c.Renew(context.Background(), nil); err == nil {
+		t.Fatal("expected nil-lease error")
+	}
+	lease := &dhcp.Lease{Bridge: "br-wan", ClientID: "x"}
+	if _, err := c.Renew(context.Background(), lease); err == nil {
+		t.Fatal("expected missing-raw-bytes error")
+	}
+}
+
+func TestNClient4ReleaseNilIsNoop(t *testing.T) {
+	c := dhcp.NewNClient4(0)
+	if err := c.Release(context.Background(), nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestNClient4ReleaseRejectsMissingRaw(t *testing.T) {
+	c := dhcp.NewNClient4(0)
+	lease := &dhcp.Lease{Bridge: "br-wan", ClientID: "x"}
+	if err := c.Release(context.Background(), lease); err == nil {
+		t.Fatal("expected missing-raw-bytes error")
+	}
+}

--- a/spinifex/network/external/dhcp/fake.go
+++ b/spinifex/network/external/dhcp/fake.go
@@ -1,0 +1,171 @@
+package dhcp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// Fake is a configurable in-memory Client for unit tests. It mimics the
+// DORA / RENEW / RELEASE lifecycle well enough to exercise DHCPManager
+// (Q3) and DHCPPoolAllocator (Q4) without opening real sockets. Hooks
+// let tests inject errors or custom responses at each step.
+type Fake struct {
+	mu sync.Mutex
+
+	defaultLease LeaseTemplate
+
+	// Optional hooks — if non-nil the fake calls the hook instead of
+	// synthesising a response. Useful for fault injection.
+	AcquireHook func(AcquireRequest) (*Lease, error)
+	RenewHook   func(*Lease) (*Lease, error)
+	ReleaseHook func(*Lease) error
+
+	leases       map[string]*Lease // keyed by ClientID
+	acquireCount int
+	renewCount   int
+	releaseCount int
+}
+
+var _ Client = (*Fake)(nil)
+
+// LeaseTemplate configures the synthetic lease Fake returns from Acquire
+// when no AcquireHook is set.
+type LeaseTemplate struct {
+	IP            net.IP
+	SubnetMask    net.IPMask
+	Routers       []net.IP
+	DNS           []net.IP
+	ServerID      net.IP
+	LeaseDuration time.Duration
+}
+
+// DefaultLeaseTemplate returns a reasonable template for tests (RFC 5737
+// TEST-NET-1, 1 h lease).
+func DefaultLeaseTemplate() LeaseTemplate {
+	return LeaseTemplate{
+		IP:            net.IPv4(192, 0, 2, 100),
+		SubnetMask:    net.CIDRMask(24, 32),
+		Routers:       []net.IP{net.IPv4(192, 0, 2, 1)},
+		DNS:           []net.IP{net.IPv4(192, 0, 2, 1)},
+		ServerID:      net.IPv4(192, 0, 2, 1),
+		LeaseDuration: time.Hour,
+	}
+}
+
+// NewFake creates a Fake pre-loaded with DefaultLeaseTemplate.
+func NewFake() *Fake {
+	return &Fake{
+		defaultLease: DefaultLeaseTemplate(),
+		leases:       map[string]*Lease{},
+	}
+}
+
+// SetDefaultLease overrides the template used for subsequent Acquire calls.
+func (f *Fake) SetDefaultLease(tmpl LeaseTemplate) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.defaultLease = tmpl
+}
+
+func (f *Fake) AcquireCount() int { f.mu.Lock(); defer f.mu.Unlock(); return f.acquireCount }
+func (f *Fake) RenewCount() int   { f.mu.Lock(); defer f.mu.Unlock(); return f.renewCount }
+func (f *Fake) ReleaseCount() int { f.mu.Lock(); defer f.mu.Unlock(); return f.releaseCount }
+
+// HeldLease returns the last lease Fake synthesised for the given ClientID.
+func (f *Fake) HeldLease(clientID string) (*Lease, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	l, ok := f.leases[clientID]
+	return l, ok
+}
+
+func (f *Fake) Acquire(_ context.Context, req AcquireRequest) (*Lease, error) {
+	f.mu.Lock()
+	f.acquireCount++
+	hook := f.AcquireHook
+	tmpl := f.defaultLease
+	f.mu.Unlock()
+
+	if hook != nil {
+		lease, err := hook(req)
+		if err == nil && lease != nil {
+			f.mu.Lock()
+			f.leases[req.ClientID] = lease
+			f.mu.Unlock()
+		}
+		return lease, err
+	}
+
+	lease := &Lease{
+		Bridge:        req.Bridge,
+		ClientID:      req.ClientID,
+		Hostname:      req.Hostname,
+		VendorClass:   req.VendorClass,
+		HWAddr:        append(net.HardwareAddr(nil), req.HWAddr...),
+		IP:            tmpl.IP,
+		SubnetMask:    tmpl.SubnetMask,
+		Routers:       tmpl.Routers,
+		DNS:           tmpl.DNS,
+		ServerID:      tmpl.ServerID,
+		AcquiredAt:    time.Now(),
+		LeaseDuration: tmpl.LeaseDuration,
+		T1:            tmpl.LeaseDuration / 2,
+		T2:            tmpl.LeaseDuration * 7 / 8,
+		// Synthetic raw packets — opaque marker bytes so Renew/Release
+		// distinguish a fake lease from a nil-bytes one.
+		RawOffer: []byte("fake-offer-" + req.ClientID),
+		RawACK:   []byte("fake-ack-" + req.ClientID),
+	}
+
+	f.mu.Lock()
+	f.leases[req.ClientID] = lease
+	f.mu.Unlock()
+	return lease, nil
+}
+
+func (f *Fake) Renew(_ context.Context, lease *Lease) (*Lease, error) {
+	if lease == nil {
+		return nil, fmt.Errorf("fake renew: lease is nil")
+	}
+	f.mu.Lock()
+	f.renewCount++
+	hook := f.RenewHook
+	f.mu.Unlock()
+
+	if hook != nil {
+		renewed, err := hook(lease)
+		if err == nil && renewed != nil {
+			f.mu.Lock()
+			f.leases[lease.ClientID] = renewed
+			f.mu.Unlock()
+		}
+		return renewed, err
+	}
+
+	renewed := *lease
+	renewed.AcquiredAt = time.Now()
+	f.mu.Lock()
+	f.leases[lease.ClientID] = &renewed
+	f.mu.Unlock()
+	return &renewed, nil
+}
+
+func (f *Fake) Release(_ context.Context, lease *Lease) error {
+	if lease == nil {
+		return nil
+	}
+	f.mu.Lock()
+	f.releaseCount++
+	hook := f.ReleaseHook
+	f.mu.Unlock()
+	if hook != nil {
+		return hook(lease)
+	}
+	f.mu.Lock()
+	delete(f.leases, lease.ClientID)
+	f.mu.Unlock()
+	return nil
+}

--- a/spinifex/network/external/dhcp/kv.go
+++ b/spinifex/network/external/dhcp/kv.go
@@ -113,6 +113,33 @@ func (s *Store) Delete(clientID string) error {
 	return nil
 }
 
+// LookupByIP scans the bucket for an entry whose lease IP matches ip
+// (and pool name, when non-empty). Returns (nil, nats.ErrKeyNotFound)
+// when no match. O(N) over leases — release is the only caller and
+// runs at allocation-lifecycle frequency, not on the hot path.
+func (s *Store) LookupByIP(poolName, ip string) (*Entry, error) {
+	if ip == "" {
+		return nil, errors.New("dhcp store lookup: ip required")
+	}
+	entries, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	for i := range entries {
+		e := &entries[i]
+		if e.Lease == nil || e.Lease.IP == nil {
+			continue
+		}
+		if poolName != "" && e.PoolName != poolName {
+			continue
+		}
+		if e.Lease.IP.String() == ip {
+			return e, nil
+		}
+	}
+	return nil, nats.ErrKeyNotFound
+}
+
 // List returns every entry currently in the bucket. Skips the internal
 // version key written by utils.GetOrCreateKVBucket.
 func (s *Store) List() ([]Entry, error) {

--- a/spinifex/network/external/dhcp/kv.go
+++ b/spinifex/network/external/dhcp/kv.go
@@ -1,0 +1,296 @@
+package dhcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// KVBucketPrefix is the lease bucket's name prefix. The full bucket name
+// is BucketName(az), per-AZ to keep chassis-failover within the AZ scope
+// (D7 in the design doc).
+const KVBucketPrefix = "spinifex-dhcp-leases"
+
+// BucketName returns the per-AZ lease bucket name. Empty az is allowed
+// (single-AZ deployments collapse to "spinifex-dhcp-leases").
+func BucketName(az string) string {
+	if az == "" {
+		return KVBucketPrefix
+	}
+	return KVBucketPrefix + "-" + az
+}
+
+// Entry is one persisted lease: the wire Lease plus the allocator-side
+// bookkeeping (purpose, pool name, vpc id) the manager needs to reconcile
+// state after a restart.
+type Entry struct {
+	Purpose  string // "eip" | "eni-public" | "natgw-external" | "gw-lrp"
+	PoolName string
+	VPCID    string // populated for purpose=gw-lrp
+	Lease    *Lease
+}
+
+// Store is the persistence surface for active DHCP leases. Backed by
+// NATS JetStream KV in production; tests can substitute via the
+// NewStoreWithKV constructor.
+type Store struct {
+	kv nats.KeyValue
+	az string
+}
+
+// NewStore creates/opens the per-AZ lease bucket and returns a Store.
+func NewStore(js nats.JetStreamContext, az string) (*Store, error) {
+	kv, err := utils.GetOrCreateKVBucket(js, BucketName(az), 5)
+	if err != nil {
+		return nil, fmt.Errorf("create dhcp lease KV bucket: %w", err)
+	}
+	return &Store{kv: kv, az: az}, nil
+}
+
+// NewStoreWithKV is the test constructor — caller owns the bucket.
+func NewStoreWithKV(kv nats.KeyValue, az string) *Store {
+	return &Store{kv: kv, az: az}
+}
+
+// AZ returns the AZ this store is scoped to.
+func (s *Store) AZ() string { return s.az }
+
+// KV exposes the underlying bucket. Used by tests that share buckets.
+func (s *Store) KV() nats.KeyValue { return s.kv }
+
+// Put persists an entry keyed by Lease.ClientID. Overwrites any existing
+// entry for the same client-id.
+func (s *Store) Put(e Entry) error {
+	if e.Lease == nil {
+		return errors.New("dhcp store put: lease is nil")
+	}
+	if e.Lease.ClientID == "" {
+		return errors.New("dhcp store put: client_id is empty")
+	}
+	data, err := json.Marshal(toWireEntry(e))
+	if err != nil {
+		return fmt.Errorf("marshal lease entry: %w", err)
+	}
+	if _, err := s.kv.Put(e.Lease.ClientID, data); err != nil {
+		return fmt.Errorf("put lease entry: %w", err)
+	}
+	return nil
+}
+
+// Get returns the entry for clientID. Returns (nil, nats.ErrKeyNotFound)
+// when absent.
+func (s *Store) Get(clientID string) (*Entry, error) {
+	raw, err := s.kv.Get(clientID)
+	if err != nil {
+		return nil, err
+	}
+	var w wireEntry
+	if err := json.Unmarshal(raw.Value(), &w); err != nil {
+		return nil, fmt.Errorf("unmarshal lease entry %q: %w", clientID, err)
+	}
+	e, err := fromWireEntry(w)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+// Delete removes the entry. Idempotent: missing keys return nil.
+func (s *Store) Delete(clientID string) error {
+	if err := s.kv.Delete(clientID); err != nil {
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return nil
+		}
+		return fmt.Errorf("delete lease entry %q: %w", clientID, err)
+	}
+	return nil
+}
+
+// List returns every entry currently in the bucket. Skips the internal
+// version key written by utils.GetOrCreateKVBucket.
+func (s *Store) List() ([]Entry, error) {
+	keys, err := s.kv.Keys()
+	if err != nil {
+		if errors.Is(err, nats.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list lease keys: %w", err)
+	}
+	var out []Entry
+	for _, k := range keys {
+		if k == utils.VersionKey {
+			continue
+		}
+		e, err := s.Get(k)
+		if err != nil {
+			if errors.Is(err, nats.ErrKeyNotFound) {
+				continue
+			}
+			slog.Warn("dhcp store list: skipping unreadable entry", "key", k, "err", err)
+			continue
+		}
+		out = append(out, *e)
+	}
+	return out, nil
+}
+
+// wireEntry is the on-disk JSON shape. Timestamps are absolute so
+// reloading after a restart yields the same wall-clock state without
+// re-running the AcquiredAt + duration arithmetic.
+type wireEntry struct {
+	ClientID    string    `json:"client_id"`
+	Purpose     string    `json:"purpose,omitempty"`
+	PoolName    string    `json:"pool_name,omitempty"`
+	VPCID       string    `json:"vpc_id,omitempty"`
+	IP          string    `json:"ip,omitempty"`
+	SubnetMask  string    `json:"subnet_mask,omitempty"`
+	Routers     []string  `json:"routers,omitempty"`
+	DNS         []string  `json:"dns,omitempty"`
+	ServerID    string    `json:"server_id,omitempty"`
+	HWAddr      string    `json:"hwaddr,omitempty"`
+	Bridge      string    `json:"bridge,omitempty"`
+	Hostname    string    `json:"hostname,omitempty"`
+	VendorClass string    `json:"vendor_class,omitempty"`
+	Acquired    time.Time `json:"acquired"`
+	T1          time.Time `json:"t1,omitzero"`
+	T2          time.Time `json:"t2,omitzero"`
+	Expiry      time.Time `json:"expiry,omitzero"`
+	RawOffer    []byte    `json:"raw_offer,omitempty"`
+	RawACK      []byte    `json:"raw_ack,omitempty"`
+}
+
+func toWireEntry(e Entry) wireEntry {
+	l := e.Lease
+	w := wireEntry{
+		ClientID:    l.ClientID,
+		Purpose:     e.Purpose,
+		PoolName:    e.PoolName,
+		VPCID:       e.VPCID,
+		IP:          ipToString(l.IP),
+		SubnetMask:  maskToString(l.SubnetMask),
+		Routers:     ipsToStrings(l.Routers),
+		DNS:         ipsToStrings(l.DNS),
+		ServerID:    ipToString(l.ServerID),
+		HWAddr:      hwToString(l.HWAddr),
+		Bridge:      l.Bridge,
+		Hostname:    l.Hostname,
+		VendorClass: l.VendorClass,
+		Acquired:    l.AcquiredAt,
+		T1:          l.AcquiredAt.Add(l.T1),
+		T2:          l.AcquiredAt.Add(l.T2),
+		Expiry:      l.AcquiredAt.Add(l.LeaseDuration),
+		RawOffer:    l.RawOffer,
+		RawACK:      l.RawACK,
+	}
+	return w
+}
+
+func fromWireEntry(w wireEntry) (Entry, error) {
+	lease := &Lease{
+		ClientID:    w.ClientID,
+		Bridge:      w.Bridge,
+		Hostname:    w.Hostname,
+		VendorClass: w.VendorClass,
+		AcquiredAt:  w.Acquired,
+		RawOffer:    w.RawOffer,
+		RawACK:      w.RawACK,
+	}
+	if w.IP != "" {
+		lease.IP = net.ParseIP(w.IP)
+	}
+	if w.SubnetMask != "" {
+		mask, err := parseMask(w.SubnetMask)
+		if err != nil {
+			return Entry{}, fmt.Errorf("parse subnet_mask %q: %w", w.SubnetMask, err)
+		}
+		lease.SubnetMask = mask
+	}
+	for _, s := range w.Routers {
+		if ip := net.ParseIP(s); ip != nil {
+			lease.Routers = append(lease.Routers, ip)
+		}
+	}
+	for _, s := range w.DNS {
+		if ip := net.ParseIP(s); ip != nil {
+			lease.DNS = append(lease.DNS, ip)
+		}
+	}
+	if w.ServerID != "" {
+		lease.ServerID = net.ParseIP(w.ServerID)
+	}
+	if w.HWAddr != "" {
+		hw, err := net.ParseMAC(w.HWAddr)
+		if err != nil {
+			return Entry{}, fmt.Errorf("parse hwaddr %q: %w", w.HWAddr, err)
+		}
+		lease.HWAddr = hw
+	}
+	if !w.Expiry.IsZero() {
+		lease.LeaseDuration = w.Expiry.Sub(w.Acquired)
+	}
+	if !w.T1.IsZero() {
+		lease.T1 = w.T1.Sub(w.Acquired)
+	}
+	if !w.T2.IsZero() {
+		lease.T2 = w.T2.Sub(w.Acquired)
+	}
+	return Entry{
+		Purpose:  w.Purpose,
+		PoolName: w.PoolName,
+		VPCID:    w.VPCID,
+		Lease:    lease,
+	}, nil
+}
+
+func ipToString(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func ipsToStrings(ips []net.IP) []string {
+	if len(ips) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		if ip != nil {
+			out = append(out, ip.String())
+		}
+	}
+	return out
+}
+
+func hwToString(hw net.HardwareAddr) string {
+	if len(hw) == 0 {
+		return ""
+	}
+	return hw.String()
+}
+
+func maskToString(m net.IPMask) string {
+	if len(m) == 0 {
+		return ""
+	}
+	ip := net.IP(m).To4()
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func parseMask(s string) (net.IPMask, error) {
+	ip := net.ParseIP(strings.TrimSpace(s)).To4()
+	if ip == nil {
+		return nil, errors.New("not a dotted-quad mask")
+	}
+	return net.IPv4Mask(ip[0], ip[1], ip[2], ip[3]), nil
+}

--- a/spinifex/network/external/dhcp/kv_test.go
+++ b/spinifex/network/external/dhcp/kv_test.go
@@ -1,0 +1,125 @@
+package dhcp_test
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T, az string) *dhcp.Store {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	s, err := dhcp.NewStore(js, az)
+	require.NoError(t, err)
+	return s
+}
+
+func sampleLease(clientID string) *dhcp.Lease {
+	mac, _ := net.ParseMAC("52:54:00:aa:bb:cc")
+	acq := time.Date(2026, 5, 28, 8, 30, 0, 0, time.UTC)
+	return &dhcp.Lease{
+		Bridge:        "br-wan",
+		ClientID:      clientID,
+		Hostname:      "node-a",
+		VendorClass:   "mulga-spinifex-gw",
+		HWAddr:        mac,
+		IP:            net.IPv4(192, 168, 0, 123),
+		SubnetMask:    net.CIDRMask(24, 32),
+		Routers:       []net.IP{net.IPv4(192, 168, 0, 1)},
+		DNS:           []net.IP{net.IPv4(192, 168, 0, 1)},
+		ServerID:      net.IPv4(192, 168, 0, 1),
+		AcquiredAt:    acq,
+		LeaseDuration: time.Hour,
+		T1:            30 * time.Minute,
+		T2:            52*time.Minute + 30*time.Second,
+		RawOffer:      []byte("offer-bytes"),
+		RawACK:        []byte("ack-bytes"),
+	}
+}
+
+func TestBucketNamePerAZ(t *testing.T) {
+	assert.Equal(t, "spinifex-dhcp-leases-ap-southeast-2a", dhcp.BucketName("ap-southeast-2a"))
+	assert.Equal(t, "spinifex-dhcp-leases", dhcp.BucketName(""))
+}
+
+func TestStorePutGetRoundtrip(t *testing.T) {
+	s := newTestStore(t, "az1")
+	e := dhcp.Entry{
+		Purpose:  "eip",
+		PoolName: "default",
+		Lease:    sampleLease("eipalloc-0a1b2c3d"),
+	}
+	require.NoError(t, s.Put(e))
+
+	got, err := s.Get("eipalloc-0a1b2c3d")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, e.Purpose, got.Purpose)
+	assert.Equal(t, e.PoolName, got.PoolName)
+	assert.Equal(t, e.Lease.ClientID, got.Lease.ClientID)
+	assert.True(t, e.Lease.IP.Equal(got.Lease.IP), "ip mismatch: %v vs %v", e.Lease.IP, got.Lease.IP)
+	assert.Equal(t, e.Lease.SubnetMask, got.Lease.SubnetMask)
+	assert.Equal(t, e.Lease.HWAddr.String(), got.Lease.HWAddr.String())
+	assert.Equal(t, e.Lease.LeaseDuration, got.Lease.LeaseDuration)
+	assert.Equal(t, e.Lease.T1, got.Lease.T1)
+	assert.Equal(t, e.Lease.T2, got.Lease.T2)
+	assert.True(t, e.Lease.AcquiredAt.Equal(got.Lease.AcquiredAt))
+	assert.Equal(t, e.Lease.RawOffer, got.Lease.RawOffer)
+	assert.Equal(t, e.Lease.RawACK, got.Lease.RawACK)
+}
+
+func TestStoreGetMissing(t *testing.T) {
+	s := newTestStore(t, "az1")
+	_, err := s.Get("absent")
+	assert.True(t, errors.Is(err, nats.ErrKeyNotFound), "got %v", err)
+}
+
+func TestStoreDeleteIdempotent(t *testing.T) {
+	s := newTestStore(t, "az1")
+	require.NoError(t, s.Delete("never-existed"))
+
+	require.NoError(t, s.Put(dhcp.Entry{Purpose: "eip", PoolName: "default", Lease: sampleLease("x")}))
+	require.NoError(t, s.Delete("x"))
+	_, err := s.Get("x")
+	assert.True(t, errors.Is(err, nats.ErrKeyNotFound))
+}
+
+func TestStoreListSkipsVersionKey(t *testing.T) {
+	s := newTestStore(t, "az1")
+
+	for _, id := range []string{"eipalloc-a", "eipalloc-b", "eipalloc-c"} {
+		require.NoError(t, s.Put(dhcp.Entry{Purpose: "eip", PoolName: "default", Lease: sampleLease(id)}))
+	}
+
+	entries, err := s.List()
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, e := range entries {
+		got[e.Lease.ClientID] = true
+	}
+	assert.True(t, got["eipalloc-a"])
+	assert.True(t, got["eipalloc-b"])
+	assert.True(t, got["eipalloc-c"])
+	assert.False(t, got["_version"], "version key must not appear in list")
+}
+
+func TestStorePutRejectsNilLease(t *testing.T) {
+	s := newTestStore(t, "az1")
+	err := s.Put(dhcp.Entry{Purpose: "eip", PoolName: "default", Lease: nil})
+	assert.Error(t, err)
+}
+
+func TestStorePutRejectsEmptyClientID(t *testing.T) {
+	s := newTestStore(t, "az1")
+	lease := sampleLease("")
+	err := s.Put(dhcp.Entry{Purpose: "eip", PoolName: "default", Lease: lease})
+	assert.Error(t, err)
+}

--- a/spinifex/network/external/dhcp/lrp_allocator.go
+++ b/spinifex/network/external/dhcp/lrp_allocator.go
@@ -45,18 +45,22 @@ func NewDHCPGatewayLRPAllocator(mgr *Manager) *DHCPGatewayLRPAllocator {
 
 // Allocate DORAs once per vpcID. Returns ok=false when pool is nil or
 // not DHCP-sourced so IGWManager can fall back to link-local.
-func (a *DHCPGatewayLRPAllocator) Allocate(ctx context.Context, vpcID string, pool *external.ExternalPoolConfig) (string, int, bool, error) {
+// Nexthop is the first router from the DHCP ACK; empty Routers is a hard
+// error — silent link-local fallback would yield 169.254.0.2 on the WAN
+// subnet, which is unreachable and was the root cause of the
+// extdhcp-restore-dhcp-source CI failures.
+func (a *DHCPGatewayLRPAllocator) Allocate(ctx context.Context, vpcID string, pool *external.ExternalPoolConfig) (string, int, string, bool, error) {
 	if a == nil || a.mgr == nil {
-		return "", 0, false, errors.New("dhcp gw-lrp allocator: nil manager")
+		return "", 0, "", false, errors.New("dhcp gw-lrp allocator: nil manager")
 	}
 	if vpcID == "" {
-		return "", 0, false, errors.New("dhcp gw-lrp allocator: vpcID required")
+		return "", 0, "", false, errors.New("dhcp gw-lrp allocator: vpcID required")
 	}
 	if !pool.IsDHCP() {
-		return "", 0, false, nil
+		return "", 0, "", false, nil
 	}
 	if pool.BindBridge == "" {
-		return "", 0, false, fmt.Errorf("dhcp gw-lrp allocator: pool %q missing bind_bridge", pool.Name)
+		return "", 0, "", false, fmt.Errorf("dhcp gw-lrp allocator: pool %q missing bind_bridge", pool.Name)
 	}
 
 	entry, err := a.mgr.handleAcquire(ctx, acquireWireRequest{
@@ -67,10 +71,14 @@ func (a *DHCPGatewayLRPAllocator) Allocate(ctx context.Context, vpcID string, po
 		VPCID:    vpcID,
 	})
 	if err != nil {
-		return "", 0, false, fmt.Errorf("dhcp gw-lrp acquire: %w", err)
+		return "", 0, "", false, fmt.Errorf("dhcp gw-lrp acquire: %w", err)
 	}
 	if entry == nil || entry.Lease == nil || entry.Lease.IP == nil {
-		return "", 0, false, errors.New("dhcp gw-lrp allocator: empty lease")
+		return "", 0, "", false, errors.New("dhcp gw-lrp allocator: empty lease")
+	}
+	nexthop, err := firstRouter(entry.Lease.Routers)
+	if err != nil {
+		return "", 0, "", false, fmt.Errorf("dhcp gw-lrp allocator: pool %q: %w", pool.Name, err)
 	}
 
 	prefix := maskToPrefix(entry.Lease.SubnetMask)
@@ -80,7 +88,20 @@ func (a *DHCPGatewayLRPAllocator) Allocate(ctx context.Context, vpcID string, po
 	if prefix <= 0 {
 		prefix = 24
 	}
-	return entry.Lease.IP.String(), prefix, true, nil
+	return entry.Lease.IP.String(), prefix, nexthop, true, nil
+}
+
+// firstRouter returns the first non-nil router in routers, or an error
+// when none is present. The OVN default route needs an on-link nexthop;
+// without one the VPC would have to fall back to link-local, which is
+// unreachable on the WAN subnet.
+func firstRouter(routers []net.IP) (string, error) {
+	for _, r := range routers {
+		if r != nil {
+			return r.String(), nil
+		}
+	}
+	return "", errors.New("DHCP ACK carried no Router option (DHCP code 3); cannot install default route")
 }
 
 // Release issues DHCPRELEASE for the per-VPC lease. Idempotent on

--- a/spinifex/network/external/dhcp/lrp_allocator.go
+++ b/spinifex/network/external/dhcp/lrp_allocator.go
@@ -1,0 +1,103 @@
+package dhcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+)
+
+// Purpose tags written to the per-AZ lease bucket so operators can
+// distinguish lease classes (mirrors the schema in
+// docs/development/improvements/external-pool-dhcp-source.md).
+const (
+	PurposeGatewayLRP    = "gw-lrp"
+	PurposeEIP           = "eip"
+	PurposeENIPublic     = "eni-public"
+	PurposeNATGWExternal = "natgw-external"
+)
+
+// GatewayLRPClientID returns the DHCP client-id used by
+// DHCPGatewayLRPAllocator. Operators see this string in dnsmasq.leases;
+// the "dhcp-" prefix keeps it disjoint from OVN object names (ADR-0006
+// S4 reserves "gw-" for L2-owned OVN identifiers).
+func GatewayLRPClientID(vpcID string) string { return "dhcp-gw-lrp-" + vpcID }
+
+// DHCPGatewayLRPAllocator obtains the per-VPC gateway LRP IP via DORA
+// against the upstream DHCP server. Idempotent on vpcID — the manager
+// short-circuits to the persisted lease on repeated calls.
+//
+// Used by vpcd's IGWManager when pool.Source == external.SourceDHCP
+// and NAT mode is centralized. Distributed NAT keeps using
+// external.LinkLocalAllocator (LRP IP never goes on wire).
+type DHCPGatewayLRPAllocator struct {
+	mgr *Manager
+}
+
+var _ external.GatewayIPAllocator = (*DHCPGatewayLRPAllocator)(nil)
+
+// NewDHCPGatewayLRPAllocator wraps an existing in-process Manager.
+func NewDHCPGatewayLRPAllocator(mgr *Manager) *DHCPGatewayLRPAllocator {
+	return &DHCPGatewayLRPAllocator{mgr: mgr}
+}
+
+// Allocate DORAs once per vpcID. Returns ok=false when pool is nil or
+// not DHCP-sourced so IGWManager can fall back to link-local.
+func (a *DHCPGatewayLRPAllocator) Allocate(ctx context.Context, vpcID string, pool *external.ExternalPoolConfig) (string, int, bool, error) {
+	if a == nil || a.mgr == nil {
+		return "", 0, false, errors.New("dhcp gw-lrp allocator: nil manager")
+	}
+	if vpcID == "" {
+		return "", 0, false, errors.New("dhcp gw-lrp allocator: vpcID required")
+	}
+	if !pool.IsDHCP() {
+		return "", 0, false, nil
+	}
+	if pool.BindBridge == "" {
+		return "", 0, false, fmt.Errorf("dhcp gw-lrp allocator: pool %q missing bind_bridge", pool.Name)
+	}
+
+	entry, err := a.mgr.handleAcquire(ctx, acquireWireRequest{
+		Bridge:   pool.BindBridge,
+		ClientID: GatewayLRPClientID(vpcID),
+		Purpose:  PurposeGatewayLRP,
+		PoolName: pool.Name,
+		VPCID:    vpcID,
+	})
+	if err != nil {
+		return "", 0, false, fmt.Errorf("dhcp gw-lrp acquire: %w", err)
+	}
+	if entry == nil || entry.Lease == nil || entry.Lease.IP == nil {
+		return "", 0, false, errors.New("dhcp gw-lrp allocator: empty lease")
+	}
+
+	prefix := maskToPrefix(entry.Lease.SubnetMask)
+	if prefix <= 0 {
+		prefix = pool.PrefixLen
+	}
+	if prefix <= 0 {
+		prefix = 24
+	}
+	return entry.Lease.IP.String(), prefix, true, nil
+}
+
+// Release issues DHCPRELEASE for the per-VPC lease. Idempotent on
+// unknown vpcIDs (manager treats missing client-ids as no-op).
+func (a *DHCPGatewayLRPAllocator) Release(ctx context.Context, vpcID string) error {
+	if a == nil || a.mgr == nil || vpcID == "" {
+		return nil
+	}
+	return a.mgr.handleRelease(ctx, GatewayLRPClientID(vpcID))
+}
+
+// maskToPrefix returns the prefix length encoded in an IPv4 subnet mask.
+// Empty mask → 0 (caller falls back to pool.PrefixLen).
+func maskToPrefix(m net.IPMask) int {
+	if len(m) == 0 {
+		return 0
+	}
+	ones, _ := m.Size()
+	return ones
+}

--- a/spinifex/network/external/dhcp/lrp_allocator_test.go
+++ b/spinifex/network/external/dhcp/lrp_allocator_test.go
@@ -28,11 +28,12 @@ func TestDHCPGatewayLRPAllocatorAllocate(t *testing.T) {
 		Source:     external.SourceDHCP,
 		BindBridge: "br-wan",
 	}
-	ip, prefix, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	ip, prefix, nexthop, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "192.0.2.100", ip)
 	assert.Equal(t, 24, prefix)
+	assert.Equal(t, "192.0.2.1", nexthop, "nexthop must come from lease.Routers[0]")
 
 	entry, err := store.Get(dhcp.GatewayLRPClientID("vpc-1"))
 	require.NoError(t, err)
@@ -49,9 +50,9 @@ func TestDHCPGatewayLRPAllocatorIdempotent(t *testing.T) {
 		Source:     external.SourceDHCP,
 		BindBridge: "br-wan",
 	}
-	first, _, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	first, _, _, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
 	require.NoError(t, err)
-	second, _, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	second, _, _, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
 	require.NoError(t, err)
 	assert.Equal(t, first, second)
 	assert.Equal(t, 1, fake.AcquireCount(), "second allocate must hit the persisted lease, not DORA again")
@@ -66,7 +67,7 @@ func TestDHCPGatewayLRPAllocatorRelease(t *testing.T) {
 		Source:     external.SourceDHCP,
 		BindBridge: "br-wan",
 	}
-	_, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	_, _, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
 	require.NoError(t, err)
 	require.True(t, ok)
 
@@ -81,7 +82,7 @@ func TestDHCPGatewayLRPAllocatorSkipsNonDHCPPool(t *testing.T) {
 	allocator, _, _ := newLRPAllocator(t, fake)
 
 	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceStatic}
-	ip, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	ip, _, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
 	require.NoError(t, err)
 	assert.False(t, ok)
 	assert.Empty(t, ip)
@@ -93,7 +94,7 @@ func TestDHCPGatewayLRPAllocatorRequiresBindBridge(t *testing.T) {
 	allocator, _, _ := newLRPAllocator(t, fake)
 
 	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP}
-	_, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	_, _, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
 	require.Error(t, err)
 	assert.False(t, ok)
 	assert.Contains(t, err.Error(), "bind_bridge")
@@ -104,13 +105,35 @@ func TestDHCPGatewayLRPAllocatorPrefixFromMask(t *testing.T) {
 	fake.SetDefaultLease(dhcp.LeaseTemplate{
 		IP:            net.IPv4(10, 0, 0, 50),
 		SubnetMask:    net.CIDRMask(16, 32),
+		Routers:       []net.IP{net.IPv4(10, 0, 0, 1)},
 		ServerID:      net.IPv4(10, 0, 0, 1),
 		LeaseDuration: time.Hour,
 	})
 	allocator, _, _ := newLRPAllocator(t, fake)
 
 	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan", PrefixLen: 24}
-	_, prefix, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	_, prefix, _, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
 	require.NoError(t, err)
 	assert.Equal(t, 16, prefix, "prefix should come from lease subnet mask, not pool config")
+}
+
+// Regression: a DHCP ACK without a Router option (DHCP code 3) used to
+// fall through to link-local 169.254.0.2 — unreachable on the WAN subnet.
+// Now the allocator must surface a hard error.
+func TestDHCPGatewayLRPAllocatorEmptyRoutersErrors(t *testing.T) {
+	fake := dhcp.NewFake()
+	fake.SetDefaultLease(dhcp.LeaseTemplate{
+		IP:            net.IPv4(10, 0, 0, 50),
+		SubnetMask:    net.CIDRMask(24, 32),
+		Routers:       nil,
+		ServerID:      net.IPv4(10, 0, 0, 1),
+		LeaseDuration: time.Hour,
+	})
+	allocator, _, _ := newLRPAllocator(t, fake)
+
+	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
+	_, _, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "no Router option")
 }

--- a/spinifex/network/external/dhcp/lrp_allocator_test.go
+++ b/spinifex/network/external/dhcp/lrp_allocator_test.go
@@ -1,0 +1,116 @@
+package dhcp_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newLRPAllocator(t *testing.T, fake *dhcp.Fake) (*dhcp.DHCPGatewayLRPAllocator, *dhcp.Manager, *dhcp.Store) {
+	t.Helper()
+	mgr, store, _ := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	return dhcp.NewDHCPGatewayLRPAllocator(mgr), mgr, store
+}
+
+func TestDHCPGatewayLRPAllocatorAllocate(t *testing.T) {
+	fake := dhcp.NewFake()
+	allocator, _, store := newLRPAllocator(t, fake)
+
+	pool := &external.ExternalPoolConfig{
+		Name:       "wan",
+		Source:     external.SourceDHCP,
+		BindBridge: "br-wan",
+	}
+	ip, prefix, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "192.0.2.100", ip)
+	assert.Equal(t, 24, prefix)
+
+	entry, err := store.Get(dhcp.GatewayLRPClientID("vpc-1"))
+	require.NoError(t, err)
+	assert.Equal(t, dhcp.PurposeGatewayLRP, entry.Purpose)
+	assert.Equal(t, "vpc-1", entry.VPCID)
+}
+
+func TestDHCPGatewayLRPAllocatorIdempotent(t *testing.T) {
+	fake := dhcp.NewFake()
+	allocator, _, _ := newLRPAllocator(t, fake)
+
+	pool := &external.ExternalPoolConfig{
+		Name:       "wan",
+		Source:     external.SourceDHCP,
+		BindBridge: "br-wan",
+	}
+	first, _, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.NoError(t, err)
+	second, _, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, fake.AcquireCount(), "second allocate must hit the persisted lease, not DORA again")
+}
+
+func TestDHCPGatewayLRPAllocatorRelease(t *testing.T) {
+	fake := dhcp.NewFake()
+	allocator, _, store := newLRPAllocator(t, fake)
+
+	pool := &external.ExternalPoolConfig{
+		Name:       "wan",
+		Source:     external.SourceDHCP,
+		BindBridge: "br-wan",
+	}
+	_, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, allocator.Release(context.Background(), "vpc-1"))
+	_, err = store.Get(dhcp.GatewayLRPClientID("vpc-1"))
+	assert.Error(t, err)
+	assert.Equal(t, 1, fake.ReleaseCount())
+}
+
+func TestDHCPGatewayLRPAllocatorSkipsNonDHCPPool(t *testing.T) {
+	fake := dhcp.NewFake()
+	allocator, _, _ := newLRPAllocator(t, fake)
+
+	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceStatic}
+	ip, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, ip)
+	assert.Equal(t, 0, fake.AcquireCount())
+}
+
+func TestDHCPGatewayLRPAllocatorRequiresBindBridge(t *testing.T) {
+	fake := dhcp.NewFake()
+	allocator, _, _ := newLRPAllocator(t, fake)
+
+	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP}
+	_, _, ok, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Contains(t, err.Error(), "bind_bridge")
+}
+
+func TestDHCPGatewayLRPAllocatorPrefixFromMask(t *testing.T) {
+	fake := dhcp.NewFake()
+	fake.SetDefaultLease(dhcp.LeaseTemplate{
+		IP:            net.IPv4(10, 0, 0, 50),
+		SubnetMask:    net.CIDRMask(16, 32),
+		ServerID:      net.IPv4(10, 0, 0, 1),
+		LeaseDuration: time.Hour,
+	})
+	allocator, _, _ := newLRPAllocator(t, fake)
+
+	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan", PrefixLen: 24}
+	_, prefix, _, err := allocator.Allocate(context.Background(), "vpc-1", pool)
+	require.NoError(t, err)
+	assert.Equal(t, 16, prefix, "prefix should come from lease subnet mask, not pool config")
+}

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -1,0 +1,496 @@
+package dhcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"golang.org/x/sync/singleflight"
+)
+
+// renewJitter is the ± window applied to every renewal/rebind/expiry
+// timer so cluster-wide synchronised wake-ups don't pile DORA traffic
+// onto the upstream DHCP server at the same instant.
+const renewJitter = time.Second
+
+// postExpiryBackoff is the cool-off applied after a re-DORA fails post
+// lease expiry. Bounded — the manager keeps re-DORAing in the
+// background until the server comes back (per plan §Failure modes).
+const postExpiryBackoff = 30 * time.Second
+
+// ManagerConfig: Client + Store required. Now is for tests.
+type ManagerConfig struct {
+	Client Client
+	Store  *Store
+	Now    func() time.Time
+}
+
+// Manager owns active DHCP leases in vpcd: one renewal goroutine per
+// BOUND lease, KV persistence, and request/reply NATS subscribers for
+// daemon-side acquire/release calls.
+type Manager struct {
+	client Client
+	store  *Store
+	now    func() time.Time
+
+	sf singleflight.Group
+
+	mu           sync.Mutex
+	loops        map[string]*leaseLoop
+	closed       bool
+	parentCtx    context.Context
+	parentCancel context.CancelFunc
+
+	wg sync.WaitGroup
+}
+
+// leaseLoop is the handle stored in Manager.loops. The pointer-identity
+// lets the run() defer disambiguate its own loop from a successor loop
+// that may have been registered after a cancel (e.g. expired lease
+// re-acquired with same client-id).
+type leaseLoop struct {
+	cancel context.CancelFunc
+}
+
+// NewManager constructs a Manager. Start must be called before
+// adopt-style work fires; Subscribe must be called before NATS RPCs are
+// answered.
+func NewManager(cfg ManagerConfig) (*Manager, error) {
+	switch {
+	case cfg.Client == nil:
+		return nil, errors.New("dhcp manager: Client required")
+	case cfg.Store == nil:
+		return nil, errors.New("dhcp manager: Store required")
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Manager{
+		client: cfg.Client,
+		store:  cfg.Store,
+		now:    now,
+		loops:  map[string]*leaseLoop{},
+	}, nil
+}
+
+// Start scans the KV bucket and, for every non-expired lease, kicks
+// off a renewal goroutine that first re-issues a RENEW to confirm the
+// upstream server still honours the binding (RFC 2131 §4.3.2
+// INIT-REBOOT equivalent — nclient4 unicasts to ServerID from raw_ack).
+// Expired entries are deleted. Repeated calls return an error.
+func (m *Manager) Start(ctx context.Context) error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return errors.New("dhcp manager: closed")
+	}
+	if m.parentCtx != nil {
+		m.mu.Unlock()
+		return errors.New("dhcp manager: already started")
+	}
+	base, cancel := context.WithCancel(ctx)
+	m.parentCtx = base
+	m.parentCancel = cancel
+	m.mu.Unlock()
+
+	entries, err := m.store.List()
+	if err != nil {
+		return fmt.Errorf("list dhcp leases: %w", err)
+	}
+	now := m.now()
+	for _, e := range entries {
+		if e.Lease == nil {
+			continue
+		}
+		if !e.Lease.ExpiresAt().After(now) {
+			if delErr := m.store.Delete(e.Lease.ClientID); delErr != nil {
+				slog.Warn("dhcp manager: drop expired lease failed", "client_id", e.Lease.ClientID, "err", delErr)
+			}
+			continue
+		}
+		m.spawnLoop(e, true)
+	}
+	return nil
+}
+
+// Stop cancels every renewal goroutine and waits for them to exit.
+// Lease state stays in KV so the next vpcd boot adopts it.
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
+	cancel := m.parentCancel
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	m.wg.Wait()
+}
+
+// Subscribe registers the two daemon-facing handlers. Request/reply,
+// no queue group: exactly one vpcd answers because exactly one vpcd
+// owns the WAN bridge per AZ.
+func (m *Manager) Subscribe(nc *nats.Conn) ([]*nats.Subscription, error) {
+	if nc == nil {
+		return nil, errors.New("dhcp manager: nats conn required")
+	}
+	type sub struct {
+		topic   string
+		handler nats.MsgHandler
+	}
+	subs := []sub{
+		{TopicAcquire, m.handleAcquireMsg},
+		{TopicRelease, m.handleReleaseMsg},
+	}
+	var out []*nats.Subscription
+	for _, s := range subs {
+		ns, err := nc.Subscribe(s.topic, s.handler)
+		if err != nil {
+			for _, r := range out {
+				_ = r.Unsubscribe()
+			}
+			return nil, fmt.Errorf("subscribe %s: %w", s.topic, err)
+		}
+		out = append(out, ns)
+		slog.Info("dhcp manager: subscribed", "topic", s.topic)
+	}
+	return out, nil
+}
+
+// spawnLoop registers and starts a renewal goroutine for entry.
+// Replaces any pre-existing loop for the same client-id. reaffirm=true
+// means do an immediate RENEW before sleeping for T1.
+func (m *Manager) spawnLoop(e Entry, reaffirm bool) {
+	m.mu.Lock()
+	if m.closed || m.parentCtx == nil {
+		m.mu.Unlock()
+		return
+	}
+	if existing, ok := m.loops[e.Lease.ClientID]; ok {
+		existing.cancel()
+		delete(m.loops, e.Lease.ClientID)
+	}
+	loopCtx, cancel := context.WithCancel(m.parentCtx)
+	loop := &leaseLoop{cancel: cancel}
+	m.loops[e.Lease.ClientID] = loop
+	m.wg.Add(1)
+	m.mu.Unlock()
+
+	go m.run(loopCtx, loop, e, reaffirm)
+}
+
+func (m *Manager) run(ctx context.Context, self *leaseLoop, e Entry, reaffirm bool) {
+	defer m.wg.Done()
+	defer func() {
+		m.mu.Lock()
+		if cur, ok := m.loops[e.Lease.ClientID]; ok && cur == self {
+			delete(m.loops, e.Lease.ClientID)
+		}
+		m.mu.Unlock()
+	}()
+
+	if reaffirm {
+		if err := m.doRenew(ctx, &e); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			slog.Warn("dhcp manager: startup reaffirm failed; will retry at T1", "client_id", e.Lease.ClientID, "err", err)
+		}
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		now := m.now()
+		expiry := e.Lease.ExpiresAt()
+		if !expiry.After(now) {
+			slog.Warn("dhcp manager: lease expired; attempting fresh DORA", "client_id", e.Lease.ClientID, "ip", e.Lease.IP)
+			if err := m.doAcquire(ctx, &e); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				slog.Warn("dhcp manager: re-DORA after expiry failed; backing off", "client_id", e.Lease.ClientID, "err", err)
+				if !sleepWithCtx(ctx, postExpiryBackoff) {
+					return
+				}
+			}
+			continue
+		}
+
+		renewAt := e.Lease.RenewAt()
+		rebindAt := e.Lease.RebindAt()
+		next := renewAt
+		switch {
+		case !now.Before(renewAt) && now.Before(rebindAt):
+			next = rebindAt
+		case !now.Before(rebindAt):
+			next = expiry
+		}
+		if !sleepUntil(ctx, m.now, next) {
+			return
+		}
+
+		now = m.now()
+		switch {
+		case !now.Before(expiry):
+			continue
+		case !now.Before(rebindAt):
+			if err := m.doRenew(ctx, &e); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				slog.Warn("dhcp manager: rebind failed; waiting for expiry", "client_id", e.Lease.ClientID, "err", err)
+			}
+		default:
+			if err := m.doRenew(ctx, &e); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				slog.Warn("dhcp manager: renew failed; will retry at T2", "client_id", e.Lease.ClientID, "err", err)
+			}
+		}
+	}
+}
+
+func (m *Manager) doAcquire(ctx context.Context, e *Entry) error {
+	lease, err := m.client.Acquire(ctx, AcquireRequest{
+		Bridge:      e.Lease.Bridge,
+		ClientID:    e.Lease.ClientID,
+		Hostname:    e.Lease.Hostname,
+		VendorClass: e.Lease.VendorClass,
+		HWAddr:      e.Lease.HWAddr,
+	})
+	if err != nil {
+		return err
+	}
+	e.Lease = lease
+	if err := m.store.Put(*e); err != nil {
+		return fmt.Errorf("persist re-acquired lease: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) doRenew(ctx context.Context, e *Entry) error {
+	renewed, err := m.client.Renew(ctx, e.Lease)
+	if err != nil {
+		return err
+	}
+	e.Lease = renewed
+	if err := m.store.Put(*e); err != nil {
+		return fmt.Errorf("persist renewed lease: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) handleAcquireMsg(msg *nats.Msg) {
+	if msg.Reply == "" {
+		slog.Warn("dhcp manager: acquire request missing reply subject; dropping")
+		return
+	}
+	var req acquireWireRequest
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		respondAcquireErr(msg, fmt.Sprintf("decode acquire: %v", err))
+		return
+	}
+	entry, err := m.handleAcquire(context.Background(), req)
+	if err != nil {
+		respondAcquireErr(msg, err.Error())
+		return
+	}
+	body, mErr := json.Marshal(acquireWireReply{Lease: toWireLease(entry.Lease)})
+	if mErr != nil {
+		respondAcquireErr(msg, fmt.Sprintf("encode reply: %v", mErr))
+		return
+	}
+	_ = msg.Respond(body)
+}
+
+func (m *Manager) handleReleaseMsg(msg *nats.Msg) {
+	if msg.Reply == "" {
+		slog.Warn("dhcp manager: release request missing reply subject; dropping")
+		return
+	}
+	var req releaseWireRequest
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		respondReleaseErr(msg, fmt.Sprintf("decode release: %v", err))
+		return
+	}
+	if err := m.handleRelease(context.Background(), req.ClientID); err != nil {
+		respondReleaseErr(msg, err.Error())
+		return
+	}
+	_ = msg.Respond(emptyReleaseReply)
+}
+
+// handleAcquire is the idempotent acquire path. Concurrent requests for
+// the same ClientID coalesce through singleflight so the upstream
+// server sees exactly one DISCOVER even when handlers race.
+func (m *Manager) handleAcquire(ctx context.Context, req acquireWireRequest) (*Entry, error) {
+	if req.ClientID == "" {
+		return nil, errors.New("client_id required")
+	}
+	result, err, _ := m.sf.Do(req.ClientID, func() (any, error) {
+		return m.acquireLocked(ctx, req)
+	})
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := result.(*Entry)
+	if !ok {
+		return nil, errors.New("acquire: unexpected singleflight result")
+	}
+	return entry, nil
+}
+
+func (m *Manager) acquireLocked(ctx context.Context, req acquireWireRequest) (*Entry, error) {
+	existing, err := m.store.Get(req.ClientID)
+	switch {
+	case err == nil:
+		if existing != nil && existing.Lease != nil && existing.Lease.ExpiresAt().After(m.now()) {
+			return existing, nil
+		}
+	case errors.Is(err, nats.ErrKeyNotFound):
+		// fall through to fresh acquire
+	default:
+		return nil, fmt.Errorf("look up lease: %w", err)
+	}
+
+	hw, err := decodeHWAddr(req.HWAddr)
+	if err != nil {
+		return nil, err
+	}
+	lease, err := m.client.Acquire(ctx, AcquireRequest{
+		Bridge:      req.Bridge,
+		ClientID:    req.ClientID,
+		Hostname:    req.Hostname,
+		VendorClass: req.VendorClass,
+		HWAddr:      hw,
+	})
+	if err != nil {
+		return nil, err
+	}
+	entry := Entry{Purpose: req.Purpose, PoolName: req.PoolName, VPCID: req.VPCID, Lease: lease}
+	if err := m.store.Put(entry); err != nil {
+		return nil, fmt.Errorf("persist new lease: %w", err)
+	}
+	m.spawnLoop(entry, false)
+	return &entry, nil
+}
+
+func (m *Manager) handleRelease(ctx context.Context, clientID string) error {
+	if clientID == "" {
+		return errors.New("client_id required")
+	}
+	entry, err := m.store.Get(clientID)
+	if err != nil {
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			slog.Warn("dhcp manager: release for unknown client", "client_id", clientID)
+			return nil
+		}
+		return fmt.Errorf("look up lease: %w", err)
+	}
+
+	m.mu.Lock()
+	if loop, ok := m.loops[clientID]; ok {
+		loop.cancel()
+		delete(m.loops, clientID)
+	}
+	m.mu.Unlock()
+
+	if err := m.client.Release(ctx, entry.Lease); err != nil {
+		slog.Warn("dhcp manager: client release failed; deleting KV entry anyway", "client_id", clientID, "err", err)
+	}
+	return m.store.Delete(clientID)
+}
+
+// LoopCount returns the number of active renewal goroutines. Test
+// hook; not part of the production surface.
+func (m *Manager) LoopCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.loops)
+}
+
+// emptyReleaseReply is the pre-encoded successful release response;
+// avoids repeatedly marshalling the same {} payload on the hot path.
+var emptyReleaseReply = []byte(`{}`)
+
+func respondAcquireErr(msg *nats.Msg, errMsg string) {
+	body, err := json.Marshal(acquireWireReply{Error: errMsg})
+	if err != nil {
+		slog.Warn("dhcp manager: encode acquire error reply failed", "err", err)
+		return
+	}
+	_ = msg.Respond(body)
+}
+
+func respondReleaseErr(msg *nats.Msg, errMsg string) {
+	body, err := json.Marshal(releaseWireReply{Error: errMsg})
+	if err != nil {
+		slog.Warn("dhcp manager: encode release error reply failed", "err", err)
+		return
+	}
+	_ = msg.Respond(body)
+}
+
+func decodeHWAddr(s string) (net.HardwareAddr, error) {
+	if s == "" {
+		return nil, nil
+	}
+	hw, err := net.ParseMAC(s)
+	if err != nil {
+		return nil, fmt.Errorf("parse hwaddr %q: %w", s, err)
+	}
+	return hw, nil
+}
+
+func sleepUntil(ctx context.Context, now func() time.Time, deadline time.Time) bool {
+	d := deadline.Sub(now())
+	if d > 0 {
+		d += jitter(renewJitter)
+		if d < 0 {
+			d = 0
+		}
+	} else {
+		d = 0
+	}
+	return sleepWithCtx(ctx, d)
+}
+
+func sleepWithCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			return true
+		}
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func jitter(span time.Duration) time.Duration {
+	if span <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(span*2))) - span //nolint:gosec // jitter, not cryptographic
+}

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -327,7 +327,22 @@ func (m *Manager) handleReleaseMsg(msg *nats.Msg) {
 		respondReleaseErr(msg, fmt.Sprintf("decode release: %v", err))
 		return
 	}
-	if err := m.handleRelease(context.Background(), req.ClientID); err != nil {
+	clientID := req.ClientID
+	if clientID == "" && req.IP != "" {
+		entry, err := m.store.LookupByIP(req.PoolName, req.IP)
+		switch {
+		case err == nil:
+			clientID = entry.Lease.ClientID
+		case errors.Is(err, nats.ErrKeyNotFound):
+			slog.Warn("dhcp manager: release for unknown IP", "pool", req.PoolName, "ip", req.IP)
+			_ = msg.Respond(emptyReleaseReply)
+			return
+		default:
+			respondReleaseErr(msg, fmt.Sprintf("lookup release ip: %v", err))
+			return
+		}
+	}
+	if err := m.handleRelease(context.Background(), clientID); err != nil {
 		respondReleaseErr(msg, err.Error())
 		return
 	}

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -25,20 +25,38 @@ const renewJitter = time.Second
 // background until the server comes back (per plan §Failure modes).
 const postExpiryBackoff = 30 * time.Second
 
+// defaultAcquireSchedule is the per-attempt timeout schedule for the
+// outer DORA backoff. Mirrors the deleted dhcp_manager.go retransmit
+// schedule — recovers under STP convergence on a freshly-up bridge.
+var defaultAcquireSchedule = []time.Duration{4 * time.Second, 8 * time.Second, 16 * time.Second, 32 * time.Second}
+
+// defaultAcquireBudget caps the wallclock for the full DORA loop.
+const defaultAcquireBudget = 90 * time.Second
+
+// acquireAttemptJitter is the ± window applied to each per-attempt
+// timeout so concurrent acquires across vpcds don't synchronise.
+const acquireAttemptJitter = time.Second
+
 // ManagerConfig: Client + Store required. Now is for tests.
+// AcquireSchedule/AcquireBudget control the outer DORA backoff;
+// zero values fall back to defaults.
 type ManagerConfig struct {
-	Client Client
-	Store  *Store
-	Now    func() time.Time
+	Client          Client
+	Store           *Store
+	Now             func() time.Time
+	AcquireSchedule []time.Duration
+	AcquireBudget   time.Duration
 }
 
 // Manager owns active DHCP leases in vpcd: one renewal goroutine per
 // BOUND lease, KV persistence, and request/reply NATS subscribers for
 // daemon-side acquire/release calls.
 type Manager struct {
-	client Client
-	store  *Store
-	now    func() time.Time
+	client          Client
+	store           *Store
+	now             func() time.Time
+	acquireSchedule []time.Duration
+	acquireBudget   time.Duration
 
 	sf singleflight.Group
 
@@ -73,11 +91,21 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if now == nil {
 		now = time.Now
 	}
+	schedule := cfg.AcquireSchedule
+	if len(schedule) == 0 {
+		schedule = defaultAcquireSchedule
+	}
+	budget := cfg.AcquireBudget
+	if budget <= 0 {
+		budget = defaultAcquireBudget
+	}
 	return &Manager{
-		client: cfg.Client,
-		store:  cfg.Store,
-		now:    now,
-		loops:  map[string]*leaseLoop{},
+		client:          cfg.Client,
+		store:           cfg.Store,
+		now:             now,
+		acquireSchedule: schedule,
+		acquireBudget:   budget,
+		loops:           map[string]*leaseLoop{},
 	}, nil
 }
 
@@ -138,12 +166,18 @@ func (m *Manager) Stop() {
 	m.wg.Wait()
 }
 
-// Subscribe registers the two daemon-facing handlers. Request/reply,
-// no queue group: exactly one vpcd answers because exactly one vpcd
-// owns the WAN bridge per AZ.
+// Subscribe registers the two daemon-facing handlers via a per-AZ
+// queue group so that exactly one vpcd answers each request even when
+// multiple vpcds in the AZ subscribe. Without the queue group every
+// vpcd would DORA in parallel with the same derived chaddr, causing
+// upstream-server NAKs / lease leaks (real-multi CI cells 8, 10).
 func (m *Manager) Subscribe(nc *nats.Conn) ([]*nats.Subscription, error) {
 	if nc == nil {
 		return nil, errors.New("dhcp manager: nats conn required")
+	}
+	queue := "vpcd-dhcp-workers"
+	if az := m.store.AZ(); az != "" {
+		queue = queue + "-" + az
 	}
 	type sub struct {
 		topic   string
@@ -155,7 +189,7 @@ func (m *Manager) Subscribe(nc *nats.Conn) ([]*nats.Subscription, error) {
 	}
 	var out []*nats.Subscription
 	for _, s := range subs {
-		ns, err := nc.Subscribe(s.topic, s.handler)
+		ns, err := nc.QueueSubscribe(s.topic, queue, s.handler)
 		if err != nil {
 			for _, r := range out {
 				_ = r.Unsubscribe()
@@ -163,7 +197,7 @@ func (m *Manager) Subscribe(nc *nats.Conn) ([]*nats.Subscription, error) {
 			return nil, fmt.Errorf("subscribe %s: %w", s.topic, err)
 		}
 		out = append(out, ns)
-		slog.Info("dhcp manager: subscribed", "topic", s.topic)
+		slog.Info("dhcp manager: subscribed", "topic", s.topic, "queue", queue)
 	}
 	return out, nil
 }
@@ -265,7 +299,7 @@ func (m *Manager) run(ctx context.Context, self *leaseLoop, e Entry, reaffirm bo
 }
 
 func (m *Manager) doAcquire(ctx context.Context, e *Entry) error {
-	lease, err := m.client.Acquire(ctx, AcquireRequest{
+	lease, err := m.acquireWithBackoff(ctx, AcquireRequest{
 		Bridge:      e.Lease.Bridge,
 		ClientID:    e.Lease.ClientID,
 		Hostname:    e.Lease.Hostname,
@@ -280,6 +314,54 @@ func (m *Manager) doAcquire(ctx context.Context, e *Entry) error {
 		return fmt.Errorf("persist re-acquired lease: %w", err)
 	}
 	return nil
+}
+
+// acquireWithBackoff drives client.Acquire under a per-attempt deadline
+// schedule, capped by AcquireBudget wallclock. Each attempt gets a fresh
+// child ctx with timeout schedule[i] ± acquireAttemptJitter so concurrent
+// acquires don't synchronise. Returns the last error if every attempt
+// fails or the budget is exhausted; ctx.Err() short-circuits immediately.
+func (m *Manager) acquireWithBackoff(ctx context.Context, req AcquireRequest) (*Lease, error) {
+	if len(m.acquireSchedule) == 0 {
+		return m.client.Acquire(ctx, req)
+	}
+	deadline := m.now().Add(m.acquireBudget)
+	var lastErr error
+	for i, base := range m.acquireSchedule {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		now := m.now()
+		remaining := deadline.Sub(now)
+		if remaining <= 0 {
+			break
+		}
+		attempt := base + jitter(acquireAttemptJitter)
+		if attempt <= 0 {
+			attempt = base
+		}
+		if attempt > remaining {
+			attempt = remaining
+		}
+
+		attemptCtx, cancel := context.WithTimeout(ctx, attempt)
+		lease, err := m.client.Acquire(attemptCtx, req)
+		cancel()
+		if err == nil {
+			return lease, nil
+		}
+		if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		lastErr = err
+		slog.Warn("dhcp manager: acquire attempt failed",
+			"client_id", req.ClientID, "attempt", i+1, "of", len(m.acquireSchedule),
+			"timeout", attempt, "err", err)
+	}
+	if lastErr == nil {
+		lastErr = errors.New("acquire budget exhausted before first attempt")
+	}
+	return nil, fmt.Errorf("acquire after %d attempts: %w", len(m.acquireSchedule), lastErr)
 }
 
 func (m *Manager) doRenew(ctx context.Context, e *Entry) error {
@@ -386,7 +468,7 @@ func (m *Manager) acquireLocked(ctx context.Context, req acquireWireRequest) (*E
 	if err != nil {
 		return nil, err
 	}
-	lease, err := m.client.Acquire(ctx, AcquireRequest{
+	lease, err := m.acquireWithBackoff(ctx, AcquireRequest{
 		Bridge:      req.Bridge,
 		ClientID:    req.ClientID,
 		Hostname:    req.Hostname,

--- a/spinifex/network/external/dhcp/manager_test.go
+++ b/spinifex/network/external/dhcp/manager_test.go
@@ -2,6 +2,8 @@ package dhcp_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -243,6 +245,110 @@ func TestManagerReleaseUnknownClientIsNoop(t *testing.T) {
 	client := dhcp.NewNATSClient(nc, time.Second)
 	assert.NoError(t, client.RequestRelease(context.Background(), "never-existed"))
 	assert.Equal(t, 0, fake.ReleaseCount())
+}
+
+// TestManagerAcquireRetriesUnderBackoff exercises the outer DORA loop:
+// two attempts return i/o timeout, the third succeeds. Asserts the
+// caller sees one lease and the wire saw three DORAs (Bug 2 regression).
+func TestManagerAcquireRetriesUnderBackoff(t *testing.T) {
+	fake := dhcp.NewFake()
+	var attempts atomic.Int32
+	fake.AcquireHook = func(req dhcp.AcquireRequest) (*dhcp.Lease, error) {
+		n := attempts.Add(1)
+		if n < 3 {
+			return nil, errors.New("i/o timeout")
+		}
+		mac, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+		return &dhcp.Lease{
+			Bridge:        req.Bridge,
+			ClientID:      req.ClientID,
+			HWAddr:        mac,
+			IP:            net.IPv4(192, 0, 2, 100),
+			SubnetMask:    net.CIDRMask(24, 32),
+			Routers:       []net.IP{net.IPv4(192, 0, 2, 1)},
+			ServerID:      net.IPv4(192, 0, 2, 1),
+			AcquiredAt:    time.Now(),
+			LeaseDuration: time.Hour,
+			T1:            30 * time.Minute,
+			T2:            52*time.Minute + 30*time.Second,
+			RawOffer:      []byte("fake-offer"),
+			RawACK:        []byte("fake-ack"),
+		}, nil
+	}
+
+	// Compress the schedule to keep the test sub-second.
+	_, nc, js := testutil.StartTestJetStream(t)
+	store, err := dhcp.NewStore(js, "az1")
+	require.NoError(t, err)
+	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{
+		Client:          fake,
+		Store:           store,
+		Now:             time.Now,
+		AcquireSchedule: []time.Duration{20 * time.Millisecond, 40 * time.Millisecond, 80 * time.Millisecond, 160 * time.Millisecond},
+		AcquireBudget:   2 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(mgr.Stop)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+
+	client := dhcp.NewNATSClient(nc, 3*time.Second)
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := client.RequestAcquire(context.Background(), dhcp.AcquireParams{
+		Bridge: "br-wan", ClientID: "eipalloc-retry", HWAddr: hw, Purpose: "eip",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, int32(3), attempts.Load(), "expected three wire DORAs (two failures + success)")
+}
+
+// TestManagerSubscribeIsQueueGroup_ExactlyOneHandlerFires brings up two
+// Managers against a shared NATS conn. Each acquire must fire exactly one
+// handler (queue-group semantics) — Bug 3 regression.
+func TestManagerSubscribeIsQueueGroup_ExactlyOneHandlerFires(t *testing.T) {
+	_, nc, js := testutil.StartTestJetStream(t)
+	store, err := dhcp.NewStore(js, "az1")
+	require.NoError(t, err)
+
+	fakeA := dhcp.NewFake()
+	fakeB := dhcp.NewFake()
+	mgrA, err := dhcp.NewManager(dhcp.ManagerConfig{Client: fakeA, Store: store, Now: time.Now})
+	require.NoError(t, err)
+	mgrB, err := dhcp.NewManager(dhcp.ManagerConfig{Client: fakeB, Store: store, Now: time.Now})
+	require.NoError(t, err)
+	t.Cleanup(mgrA.Stop)
+	t.Cleanup(mgrB.Stop)
+	require.NoError(t, mgrA.Start(context.Background()))
+	require.NoError(t, mgrB.Start(context.Background()))
+
+	subsA, err := mgrA.Subscribe(nc)
+	require.NoError(t, err)
+	subsB, err := mgrB.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range append(subsA, subsB...) {
+			_ = s.Unsubscribe()
+		}
+	})
+
+	client := dhcp.NewNATSClient(nc, 3*time.Second)
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	const requests = 5
+	for i := range requests {
+		clientID := fmt.Sprintf("eipalloc-qg-%d", i)
+		_, err := client.RequestAcquire(context.Background(), dhcp.AcquireParams{
+			Bridge: "br-wan", ClientID: clientID, HWAddr: hw, Purpose: "eip",
+		})
+		require.NoError(t, err)
+	}
+	total := fakeA.AcquireCount() + fakeB.AcquireCount()
+	assert.Equal(t, requests, total, "queue group must deliver each request to exactly one handler (A=%d, B=%d)", fakeA.AcquireCount(), fakeB.AcquireCount())
 }
 
 func TestManagerStopCancelsLoops(t *testing.T) {

--- a/spinifex/network/external/dhcp/manager_test.go
+++ b/spinifex/network/external/dhcp/manager_test.go
@@ -1,0 +1,272 @@
+package dhcp_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestManager(t *testing.T, az string, fake *dhcp.Fake, now func() time.Time) (*dhcp.Manager, *dhcp.Store, *nats.Conn) {
+	t.Helper()
+	_, nc, js := testutil.StartTestJetStream(t)
+	store, err := dhcp.NewStore(js, az)
+	require.NoError(t, err)
+	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{Client: fake, Store: store, Now: now})
+	require.NoError(t, err)
+	t.Cleanup(mgr.Stop)
+	return mgr, store, nc
+}
+
+func TestManagerNewRequiresClientAndStore(t *testing.T) {
+	_, err := dhcp.NewManager(dhcp.ManagerConfig{})
+	assert.Error(t, err)
+	_, err = dhcp.NewManager(dhcp.ManagerConfig{Client: dhcp.NewFake()})
+	assert.Error(t, err)
+}
+
+func TestManagerStartScansAndReaffirms(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "az1", fake, time.Now)
+
+	// Pre-populate KV with two BOUND leases. Manager.Start should adopt
+	// both and call Renew on each (RFC 2131 §4.3.2 INIT-REBOOT
+	// equivalent — fake.Renew counts every reaffirm).
+	for _, id := range []string{"eipalloc-a", "eipalloc-b"} {
+		hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+		_, err := fake.Acquire(context.Background(), dhcp.AcquireRequest{
+			Bridge: "br-wan", ClientID: id, HWAddr: hw,
+		})
+		require.NoError(t, err)
+		held, _ := fake.HeldLease(id)
+		require.NoError(t, store.Put(dhcp.Entry{Purpose: "eip", PoolName: "default", Lease: held}))
+	}
+	require.Equal(t, 0, fake.RenewCount())
+
+	require.NoError(t, mgr.Start(context.Background()))
+	require.Eventually(t, func() bool { return fake.RenewCount() == 2 }, time.Second, 10*time.Millisecond)
+	assert.Equal(t, 2, mgr.LoopCount())
+}
+
+func TestManagerStartDropsExpiredLeases(t *testing.T) {
+	fake := dhcp.NewFake()
+	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
+
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	expired := &dhcp.Lease{
+		Bridge:        "br-wan",
+		ClientID:      "eipalloc-old",
+		HWAddr:        hw,
+		IP:            net.IPv4(192, 0, 2, 50),
+		AcquiredAt:    fixed.Add(-2 * time.Hour),
+		LeaseDuration: time.Hour,
+	}
+	require.NoError(t, store.Put(dhcp.Entry{Purpose: "eip", PoolName: "default", Lease: expired}))
+
+	require.NoError(t, mgr.Start(context.Background()))
+	_, err := store.Get("eipalloc-old")
+	assert.ErrorIs(t, err, nats.ErrKeyNotFound)
+	assert.Equal(t, 0, fake.RenewCount())
+	assert.Equal(t, 0, mgr.LoopCount())
+}
+
+func TestManagerStartTwiceErrors(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, _, _ := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	err := mgr.Start(context.Background())
+	assert.Error(t, err)
+}
+
+func TestNATSClientAcquireReleaseRoundtrip(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, nc := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+
+	client := dhcp.NewNATSClient(nc, 2*time.Second)
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := client.RequestAcquire(context.Background(), dhcp.AcquireParams{
+		Bridge: "br-wan", ClientID: "eipalloc-A", HWAddr: hw,
+		Purpose: "eip", PoolName: "default",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, "eipalloc-A", lease.ClientID)
+	assert.NotNil(t, lease.IP)
+
+	got, err := store.Get("eipalloc-A")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "eip", got.Purpose)
+	assert.Equal(t, "default", got.PoolName)
+
+	require.NoError(t, client.RequestRelease(context.Background(), "eipalloc-A"))
+	_, err = store.Get("eipalloc-A")
+	assert.ErrorIs(t, err, nats.ErrKeyNotFound)
+	assert.Equal(t, 1, fake.ReleaseCount())
+}
+
+func TestNATSClientAcquireIdempotent(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, _, nc := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+
+	client := dhcp.NewNATSClient(nc, 2*time.Second)
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	params := dhcp.AcquireParams{
+		Bridge: "br-wan", ClientID: "eipalloc-idem", HWAddr: hw,
+		Purpose: "eip", PoolName: "default",
+	}
+	first, err := client.RequestAcquire(context.Background(), params)
+	require.NoError(t, err)
+	second, err := client.RequestAcquire(context.Background(), params)
+	require.NoError(t, err)
+	assert.True(t, first.IP.Equal(second.IP), "second acquire returned a different IP: %v vs %v", first.IP, second.IP)
+	assert.Equal(t, 1, fake.AcquireCount(), "idempotency should yield exactly one wire DORA")
+}
+
+func TestNATSClientAcquireConcurrent(t *testing.T) {
+	fake := dhcp.NewFake()
+	// Block the first Acquire until both callers have raced past the
+	// KV-existence check; the second caller must coalesce through
+	// singleflight rather than launching its own DORA.
+	gate := make(chan struct{})
+	var firstHit atomic.Int32
+	fake.AcquireHook = func(req dhcp.AcquireRequest) (*dhcp.Lease, error) {
+		if firstHit.Add(1) == 1 {
+			<-gate
+		}
+		mac, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+		return &dhcp.Lease{
+			Bridge:        req.Bridge,
+			ClientID:      req.ClientID,
+			HWAddr:        mac,
+			IP:            net.IPv4(192, 0, 2, 100),
+			SubnetMask:    net.CIDRMask(24, 32),
+			ServerID:      net.IPv4(192, 0, 2, 1),
+			AcquiredAt:    time.Now(),
+			LeaseDuration: time.Hour,
+			T1:            30 * time.Minute,
+			T2:            52*time.Minute + 30*time.Second,
+			RawOffer:      []byte("fake-offer"),
+			RawACK:        []byte("fake-ack"),
+		}, nil
+	}
+
+	mgr, _, nc := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+
+	client := dhcp.NewNATSClient(nc, 3*time.Second)
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	params := dhcp.AcquireParams{Bridge: "br-wan", ClientID: "eipalloc-race", HWAddr: hw, Purpose: "eip"}
+
+	var wg sync.WaitGroup
+	results := make([]*dhcp.Lease, 2)
+	errs := make([]error, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = client.RequestAcquire(context.Background(), params)
+		}(i)
+	}
+	// Let the first DORA "start"; gate is closed below so the in-flight
+	// Acquire completes. Singleflight collapses the second caller into
+	// the first.
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+	require.True(t, results[0].IP.Equal(results[1].IP))
+	assert.Equal(t, int32(1), firstHit.Load(), "exactly one wire DORA expected")
+}
+
+func TestManagerHandleAcquireRequiresClientID(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, _, nc := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+	client := dhcp.NewNATSClient(nc, time.Second)
+	_, err = client.RequestAcquire(context.Background(), dhcp.AcquireParams{Bridge: "br-wan"})
+	assert.Error(t, err)
+}
+
+func TestManagerReleaseUnknownClientIsNoop(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, _, nc := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+	client := dhcp.NewNATSClient(nc, time.Second)
+	assert.NoError(t, client.RequestRelease(context.Background(), "never-existed"))
+	assert.Equal(t, 0, fake.ReleaseCount())
+}
+
+func TestManagerStopCancelsLoops(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, _, nc := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+
+	client := dhcp.NewNATSClient(nc, time.Second)
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	for _, id := range []string{"a", "b", "c"} {
+		_, err := client.RequestAcquire(context.Background(), dhcp.AcquireParams{
+			Bridge: "br-wan", ClientID: id, HWAddr: hw, Purpose: "eip",
+		})
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 3, mgr.LoopCount())
+
+	mgr.Stop()
+	assert.Equal(t, 0, mgr.LoopCount())
+}

--- a/spinifex/network/external/dhcp/nats_client.go
+++ b/spinifex/network/external/dhcp/nats_client.go
@@ -1,0 +1,125 @@
+package dhcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// NATSClient is the daemon-side wrapper around vpcd's Manager. It
+// marshals acquire/release requests over NATS request/reply and
+// unmarshals the Lease returned by the bridge-owning vpcd. Used by
+// ExternalIPAM (Q4) for DHCP-sourced pools.
+type NATSClient struct {
+	nc      *nats.Conn
+	timeout time.Duration
+}
+
+// NewNATSClient wraps nc with the given RPC timeout. timeout <= 0
+// defaults to 60s — DORA + raw_offer/ack persistence can take seconds
+// on a busy upstream server.
+func NewNATSClient(nc *nats.Conn, timeout time.Duration) *NATSClient {
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	return &NATSClient{nc: nc, timeout: timeout}
+}
+
+// AcquireParams is the wire-level acquire payload. Bridge/HWAddr are
+// passed through to the vpcd-side Client.Acquire; Purpose/PoolName/
+// VPCID let the manager persist the lease against the right pool
+// record.
+type AcquireParams struct {
+	Bridge      string
+	ClientID    string
+	Hostname    string
+	VendorClass string
+	HWAddr      net.HardwareAddr
+	Purpose     string
+	PoolName    string
+	VPCID       string
+}
+
+// RequestAcquire issues an idempotent acquire RPC. Retries with the
+// same ClientID return the same lease (vpcd's Manager short-circuits
+// to the persisted KV record).
+func (c *NATSClient) RequestAcquire(ctx context.Context, p AcquireParams) (*Lease, error) {
+	if c == nil || c.nc == nil {
+		return nil, errors.New("dhcp NATSClient: nil conn")
+	}
+	if p.ClientID == "" {
+		return nil, errors.New("dhcp NATSClient: ClientID required")
+	}
+	body, err := json.Marshal(acquireWireRequest{
+		Bridge:      p.Bridge,
+		ClientID:    p.ClientID,
+		Hostname:    p.Hostname,
+		VendorClass: p.VendorClass,
+		HWAddr:      hwToString(p.HWAddr),
+		Purpose:     p.Purpose,
+		PoolName:    p.PoolName,
+		VPCID:       p.VPCID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode acquire request: %w", err)
+	}
+
+	rpcCtx, cancel := c.withTimeout(ctx)
+	defer cancel()
+
+	msg, err := c.nc.RequestWithContext(rpcCtx, TopicAcquire, body)
+	if err != nil {
+		return nil, fmt.Errorf("dhcp acquire RPC: %w", err)
+	}
+	var reply acquireWireReply
+	if err := json.Unmarshal(msg.Data, &reply); err != nil {
+		return nil, fmt.Errorf("decode acquire reply: %w", err)
+	}
+	if reply.Error != "" {
+		return nil, errors.New(reply.Error)
+	}
+	return fromWireLease(reply.Lease)
+}
+
+// RequestRelease issues an idempotent release RPC. Unknown client-ids
+// return nil (vpcd treats them as already-released).
+func (c *NATSClient) RequestRelease(ctx context.Context, clientID string) error {
+	if c == nil || c.nc == nil {
+		return errors.New("dhcp NATSClient: nil conn")
+	}
+	if clientID == "" {
+		return errors.New("dhcp NATSClient: clientID required")
+	}
+	body, err := json.Marshal(releaseWireRequest{ClientID: clientID})
+	if err != nil {
+		return fmt.Errorf("encode release request: %w", err)
+	}
+
+	rpcCtx, cancel := c.withTimeout(ctx)
+	defer cancel()
+
+	msg, err := c.nc.RequestWithContext(rpcCtx, TopicRelease, body)
+	if err != nil {
+		return fmt.Errorf("dhcp release RPC: %w", err)
+	}
+	var reply releaseWireReply
+	if err := json.Unmarshal(msg.Data, &reply); err != nil {
+		return fmt.Errorf("decode release reply: %w", err)
+	}
+	if reply.Error != "" {
+		return errors.New(reply.Error)
+	}
+	return nil
+}
+
+func (c *NATSClient) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, c.timeout)
+}

--- a/spinifex/network/external/dhcp/nats_client.go
+++ b/spinifex/network/external/dhcp/nats_client.go
@@ -89,13 +89,27 @@ func (c *NATSClient) RequestAcquire(ctx context.Context, p AcquireParams) (*Leas
 // RequestRelease issues an idempotent release RPC. Unknown client-ids
 // return nil (vpcd treats them as already-released).
 func (c *NATSClient) RequestRelease(ctx context.Context, clientID string) error {
-	if c == nil || c.nc == nil {
-		return errors.New("dhcp NATSClient: nil conn")
-	}
 	if clientID == "" {
 		return errors.New("dhcp NATSClient: clientID required")
 	}
-	body, err := json.Marshal(releaseWireRequest{ClientID: clientID})
+	return c.requestRelease(ctx, releaseWireRequest{ClientID: clientID})
+}
+
+// RequestReleaseByIP releases the lease that holds (poolName, ip).
+// Used by DHCPPoolAllocator.Release, whose external.Allocator signature
+// only carries the IP — vpcd looks up the client-id from the lease store.
+func (c *NATSClient) RequestReleaseByIP(ctx context.Context, poolName, ip string) error {
+	if ip == "" {
+		return errors.New("dhcp NATSClient: ip required")
+	}
+	return c.requestRelease(ctx, releaseWireRequest{PoolName: poolName, IP: ip})
+}
+
+func (c *NATSClient) requestRelease(ctx context.Context, req releaseWireRequest) error {
+	if c == nil || c.nc == nil {
+		return errors.New("dhcp NATSClient: nil conn")
+	}
+	body, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("encode release request: %w", err)
 	}

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -3,10 +3,12 @@ package dhcp
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
 // NClient4Client is the production DHCP client backed by
@@ -38,7 +40,14 @@ func (c *NClient4Client) Acquire(ctx context.Context, req AcquireRequest) (*Leas
 		return nil, fmt.Errorf("dhcp acquire: bridge is required")
 	}
 	if len(req.HWAddr) == 0 {
-		return nil, fmt.Errorf("dhcp acquire: hw_addr is required")
+		if req.ClientID == "" {
+			return nil, fmt.Errorf("dhcp acquire: client_id or hw_addr is required")
+		}
+		hw, err := DeriveMAC(req.ClientID)
+		if err != nil {
+			return nil, fmt.Errorf("dhcp acquire: derive hw_addr: %w", err)
+		}
+		req.HWAddr = hw
 	}
 
 	client, err := nclient4.New(req.Bridge,
@@ -120,6 +129,19 @@ func (c *NClient4Client) Release(_ context.Context, lease *Lease) error {
 		return fmt.Errorf("dhcp release on %s (client=%s): %w", lease.Bridge, lease.ClientID, err)
 	}
 	return nil
+}
+
+// DeriveMAC returns the deterministic locally-administered unicast MAC
+// (02:xx:xx:xx:xx:xx) used as chaddr when an allocator has no NIC of
+// its own — DHCPGatewayLRPAllocator and DHCPPoolAllocator on first
+// acquire. Wraps utils.HashMAC so the same 0x02-prefixed scheme used
+// for OVN router/port MACs is also visible in upstream dnsmasq leases.
+func DeriveMAC(clientID string) (net.HardwareAddr, error) {
+	hw, err := net.ParseMAC(utils.HashMAC(clientID))
+	if err != nil {
+		return nil, fmt.Errorf("derive mac for client-id %q: %w", clientID, err)
+	}
+	return hw, nil
 }
 
 // identityModifiers builds the three identifying DHCP options set on every

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -17,15 +17,15 @@ import (
 // opens an AF_PACKET socket on the target bridge for the duration of the
 // handshake and closes it when done — no long-lived per-lease process.
 //
-// Retransmission follows RFC 2131 §4.1: 3 DISCOVER attempts with
-// exponential per-attempt deadline (timeout, 2×timeout, 4×timeout).
-// nclient4 issues a fresh DISCOVER on each retry — covers transient drops
-// during STP convergence on a freshly-up bridge and lossy upstream paths.
+// Single-shot per call: Manager.acquireWithBackoff drives the outer DORA
+// schedule and per-attempt deadlines, so the leaf does not retry. This
+// keeps the budget arithmetic in one place instead of being multiplied
+// by nclient4's internal retry count.
 type NClient4Client struct {
 	timeout time.Duration
 }
 
-const nclient4Retries = 3
+const nclient4Retries = 1
 
 var _ Client = (*NClient4Client)(nil)
 

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -17,12 +17,15 @@ import (
 // opens an AF_PACKET socket on the target bridge for the duration of the
 // handshake and closes it when done — no long-lived per-lease process.
 //
-// Retransmission lives one layer up in DHCPManager.acquireWithBackoff
-// (RFC 2131 §4.1). This client always does exactly one DISCOVER attempt;
-// the per-attempt window is whatever the caller's context allows.
+// Retransmission follows RFC 2131 §4.1: 3 DISCOVER attempts with
+// exponential per-attempt deadline (timeout, 2×timeout, 4×timeout).
+// nclient4 issues a fresh DISCOVER on each retry — covers transient drops
+// during STP convergence on a freshly-up bridge and lossy upstream paths.
 type NClient4Client struct {
 	timeout time.Duration
 }
+
+const nclient4Retries = 3
 
 var _ Client = (*NClient4Client)(nil)
 
@@ -31,7 +34,7 @@ var _ Client = (*NClient4Client)(nil)
 // context deadline.
 func NewNClient4(timeout time.Duration) *NClient4Client {
 	if timeout <= 0 {
-		timeout = 60 * time.Second
+		timeout = 5 * time.Second
 	}
 	return &NClient4Client{timeout: timeout}
 }
@@ -65,7 +68,7 @@ func (c *NClient4Client) Acquire(ctx context.Context, req AcquireRequest) (*Leas
 	client, err := nclient4.New(req.Bridge,
 		nclient4.WithHWAddr(req.HWAddr),
 		nclient4.WithTimeout(c.timeout),
-		nclient4.WithRetry(1),
+		nclient4.WithRetry(nclient4Retries),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open nclient4 on %s: %w", req.Bridge, err)
@@ -107,7 +110,7 @@ func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error
 	client, err := nclient4.New(lease.Bridge,
 		nclient4.WithHWAddr(lease.HWAddr),
 		nclient4.WithTimeout(c.timeout),
-		nclient4.WithRetry(1),
+		nclient4.WithRetry(nclient4Retries),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open nclient4 on %s for renew: %w", lease.Bridge, err)

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -3,6 +3,7 @@ package dhcp
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"time"
 
@@ -50,6 +51,17 @@ func (c *NClient4Client) Acquire(ctx context.Context, req AcquireRequest) (*Leas
 		req.HWAddr = hw
 	}
 
+	releasePromisc, err := enableBridgePromisc(req.Bridge)
+	if err != nil {
+		slog.Warn("dhcp acquire: continuing without IFF_PROMISC", "bridge", req.Bridge, "err", err)
+	} else {
+		defer func() {
+			if rerr := releasePromisc(); rerr != nil {
+				slog.Warn("dhcp acquire: release promisc", "bridge", req.Bridge, "err", rerr)
+			}
+		}()
+	}
+
 	client, err := nclient4.New(req.Bridge,
 		nclient4.WithHWAddr(req.HWAddr),
 		nclient4.WithTimeout(c.timeout),
@@ -79,6 +91,17 @@ func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error
 	nclient4Lease, err := reconstructNClient4Lease(lease)
 	if err != nil {
 		return nil, fmt.Errorf("dhcp renew: %w", err)
+	}
+
+	releasePromisc, err := enableBridgePromisc(lease.Bridge)
+	if err != nil {
+		slog.Warn("dhcp renew: continuing without IFF_PROMISC", "bridge", lease.Bridge, "err", err)
+	} else {
+		defer func() {
+			if rerr := releasePromisc(); rerr != nil {
+				slog.Warn("dhcp renew: release promisc", "bridge", lease.Bridge, "err", rerr)
+			}
+		}()
 	}
 
 	client, err := nclient4.New(lease.Bridge,
@@ -113,6 +136,17 @@ func (c *NClient4Client) Release(_ context.Context, lease *Lease) error {
 	nclient4Lease, err := reconstructNClient4Lease(lease)
 	if err != nil {
 		return fmt.Errorf("dhcp release: %w", err)
+	}
+
+	releasePromisc, err := enableBridgePromisc(lease.Bridge)
+	if err != nil {
+		slog.Warn("dhcp release: continuing without IFF_PROMISC", "bridge", lease.Bridge, "err", err)
+	} else {
+		defer func() {
+			if rerr := releasePromisc(); rerr != nil {
+				slog.Warn("dhcp release: release promisc", "bridge", lease.Bridge, "err", rerr)
+			}
+		}()
 	}
 
 	client, err := nclient4.New(lease.Bridge,

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -1,0 +1,182 @@
+package dhcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
+)
+
+// NClient4Client is the production DHCP client backed by
+// github.com/insomniacslk/dhcp/dhcpv4/nclient4. Each Acquire/Renew/Release
+// opens an AF_PACKET socket on the target bridge for the duration of the
+// handshake and closes it when done — no long-lived per-lease process.
+//
+// Retransmission lives one layer up in DHCPManager.acquireWithBackoff
+// (RFC 2131 §4.1). This client always does exactly one DISCOVER attempt;
+// the per-attempt window is whatever the caller's context allows.
+type NClient4Client struct {
+	timeout time.Duration
+}
+
+var _ Client = (*NClient4Client)(nil)
+
+// NewNClient4 creates an NClient4Client. timeout is the nclient4-internal
+// socket read deadline used as a safety net when the caller supplies no
+// context deadline.
+func NewNClient4(timeout time.Duration) *NClient4Client {
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	return &NClient4Client{timeout: timeout}
+}
+
+func (c *NClient4Client) Acquire(ctx context.Context, req AcquireRequest) (*Lease, error) {
+	if req.Bridge == "" {
+		return nil, fmt.Errorf("dhcp acquire: bridge is required")
+	}
+	if len(req.HWAddr) == 0 {
+		return nil, fmt.Errorf("dhcp acquire: hw_addr is required")
+	}
+
+	client, err := nclient4.New(req.Bridge,
+		nclient4.WithHWAddr(req.HWAddr),
+		nclient4.WithTimeout(c.timeout),
+		nclient4.WithRetry(1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open nclient4 on %s: %w", req.Bridge, err)
+	}
+	defer func() { _ = client.Close() }()
+
+	// Without the broadcast flag, the server sends a unicast OFFER to the
+	// generated chaddr MAC. The physical NIC drops it in hardware (not its
+	// MAC), so the AF_PACKET socket on the bridge never sees the frame.
+	// Setting the broadcast flag forces ff:ff:ff:ff:ff:ff.
+	mods := append(identityModifiers(req.ClientID, req.Hostname, req.VendorClass), dhcpv4.WithBroadcast(true))
+	lease, err := client.Request(ctx, mods...)
+	if err != nil {
+		return nil, fmt.Errorf("dhcp DORA on %s (client=%s): %w", req.Bridge, req.ClientID, err)
+	}
+	return leaseFromNClient4(req, lease), nil
+}
+
+func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error) {
+	if lease == nil {
+		return nil, fmt.Errorf("dhcp renew: lease is nil")
+	}
+	nclient4Lease, err := reconstructNClient4Lease(lease)
+	if err != nil {
+		return nil, fmt.Errorf("dhcp renew: %w", err)
+	}
+
+	client, err := nclient4.New(lease.Bridge,
+		nclient4.WithHWAddr(lease.HWAddr),
+		nclient4.WithTimeout(c.timeout),
+		nclient4.WithRetry(1),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open nclient4 on %s for renew: %w", lease.Bridge, err)
+	}
+	defer func() { _ = client.Close() }()
+
+	renewed, err := client.Renew(ctx, nclient4Lease,
+		identityModifiers(lease.ClientID, lease.Hostname, lease.VendorClass)...)
+	if err != nil {
+		return nil, fmt.Errorf("dhcp renew on %s (client=%s): %w", lease.Bridge, lease.ClientID, err)
+	}
+
+	return leaseFromNClient4(AcquireRequest{
+		Bridge:      lease.Bridge,
+		ClientID:    lease.ClientID,
+		Hostname:    lease.Hostname,
+		VendorClass: lease.VendorClass,
+		HWAddr:      lease.HWAddr,
+	}, renewed), nil
+}
+
+func (c *NClient4Client) Release(_ context.Context, lease *Lease) error {
+	if lease == nil {
+		return nil
+	}
+	nclient4Lease, err := reconstructNClient4Lease(lease)
+	if err != nil {
+		return fmt.Errorf("dhcp release: %w", err)
+	}
+
+	client, err := nclient4.New(lease.Bridge,
+		nclient4.WithHWAddr(lease.HWAddr),
+		nclient4.WithTimeout(c.timeout),
+	)
+	if err != nil {
+		return fmt.Errorf("open nclient4 on %s for release: %w", lease.Bridge, err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if err := client.Release(nclient4Lease,
+		dhcpv4.WithOption(dhcpv4.OptClientIdentifier([]byte(lease.ClientID)))); err != nil {
+		return fmt.Errorf("dhcp release on %s (client=%s): %w", lease.Bridge, lease.ClientID, err)
+	}
+	return nil
+}
+
+// identityModifiers builds the three identifying DHCP options set on every
+// outbound message: option 61 (client-id), option 12 (hostname), option 60
+// (vendor class).
+func identityModifiers(clientID, hostname, vendorClass string) []dhcpv4.Modifier {
+	var mods []dhcpv4.Modifier
+	if clientID != "" {
+		mods = append(mods, dhcpv4.WithOption(dhcpv4.OptClientIdentifier([]byte(clientID))))
+	}
+	if hostname != "" {
+		mods = append(mods, dhcpv4.WithOption(dhcpv4.OptHostName(hostname)))
+	}
+	if vendorClass != "" {
+		mods = append(mods, dhcpv4.WithOption(dhcpv4.OptClassIdentifier(vendorClass)))
+	}
+	return mods
+}
+
+func leaseFromNClient4(req AcquireRequest, in *nclient4.Lease) *Lease {
+	ack := in.ACK
+	leaseTime := ack.IPAddressLeaseTime(24 * time.Hour)
+	return &Lease{
+		Bridge:        req.Bridge,
+		ClientID:      req.ClientID,
+		Hostname:      req.Hostname,
+		VendorClass:   req.VendorClass,
+		HWAddr:        req.HWAddr,
+		IP:            ack.YourIPAddr,
+		SubnetMask:    ack.SubnetMask(),
+		Routers:       ack.Router(),
+		DNS:           ack.DNS(),
+		ServerID:      ack.ServerIdentifier(),
+		AcquiredAt:    in.CreationTime,
+		LeaseDuration: leaseTime,
+		T1:            ack.IPAddressRenewalTime(leaseTime / 2),
+		T2:            ack.IPAddressRebindingTime(leaseTime * 7 / 8),
+		RawOffer:      in.Offer.ToBytes(),
+		RawACK:        ack.ToBytes(),
+	}
+}
+
+func reconstructNClient4Lease(l *Lease) (*nclient4.Lease, error) {
+	if len(l.RawOffer) == 0 || len(l.RawACK) == 0 {
+		return nil, fmt.Errorf("lease is missing raw offer/ack bytes; renewal/release not possible")
+	}
+	offer, err := dhcpv4.FromBytes(l.RawOffer)
+	if err != nil {
+		return nil, fmt.Errorf("parse stored offer: %w", err)
+	}
+	ack, err := dhcpv4.FromBytes(l.RawACK)
+	if err != nil {
+		return nil, fmt.Errorf("parse stored ack: %w", err)
+	}
+	return &nclient4.Lease{
+		Offer:        offer,
+		ACK:          ack,
+		CreationTime: l.AcquiredAt,
+	}, nil
+}

--- a/spinifex/network/external/dhcp/pool_allocator.go
+++ b/spinifex/network/external/dhcp/pool_allocator.go
@@ -1,0 +1,149 @@
+package dhcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+)
+
+// DHCPPoolAllocator implements external.Allocator for a single
+// DHCP-sourced pool. Runs daemon-side and routes acquire/release through
+// vpcd over NATS (the bridge-owning vpcd answers).
+//
+// Each call DORAs once per AWS identity; the client-id is derived from
+// req.AllocationID / ENIID / InstanceID, in that order. Vpcd's Manager is
+// idempotent on client-id, so retries return the same IP.
+type DHCPPoolAllocator struct {
+	client *NATSClient
+	pool   external.ExternalPoolConfig
+
+	mu      sync.Mutex
+	hwAddrs map[string]net.HardwareAddr // cached per client-id; vpcd's nclient4 fills its own when zero
+}
+
+var _ external.Allocator = (*DHCPPoolAllocator)(nil)
+
+// NewDHCPPoolAllocator constructs an allocator bound to a single pool.
+// Pool must have Source == external.SourceDHCP and a non-empty
+// BindBridge; otherwise Allocate returns an error.
+func NewDHCPPoolAllocator(client *NATSClient, pool external.ExternalPoolConfig) *DHCPPoolAllocator {
+	return &DHCPPoolAllocator{
+		client:  client,
+		pool:    pool,
+		hwAddrs: map[string]net.HardwareAddr{},
+	}
+}
+
+// Pool returns the pool this allocator manages.
+func (a *DHCPPoolAllocator) Pool() external.ExternalPoolConfig { return a.pool }
+
+// Allocate issues vpc.dhcp.acquire over NATS and returns the leased IP.
+func (a *DHCPPoolAllocator) Allocate(ctx context.Context, req external.AllocateRequest) (netip.Addr, error) {
+	if a == nil || a.client == nil {
+		return netip.Addr{}, errors.New("dhcp pool allocator: nil client")
+	}
+	if !a.pool.IsDHCP() {
+		return netip.Addr{}, fmt.Errorf("dhcp pool allocator: pool %q is not dhcp-sourced", a.pool.Name)
+	}
+	if a.pool.BindBridge == "" {
+		return netip.Addr{}, fmt.Errorf("dhcp pool allocator: pool %q missing bind_bridge", a.pool.Name)
+	}
+	if req.PoolName != "" && req.PoolName != a.pool.Name {
+		return netip.Addr{}, fmt.Errorf("dhcp pool allocator: pool mismatch (got %q, bound to %q)", req.PoolName, a.pool.Name)
+	}
+
+	clientID := poolClientID(req)
+	if clientID == "" {
+		return netip.Addr{}, errors.New("dhcp pool allocator: AllocationID, ENIID or InstanceID required for client-id")
+	}
+
+	lease, err := a.client.RequestAcquire(ctx, AcquireParams{
+		Bridge:   a.pool.BindBridge,
+		ClientID: clientID,
+		HWAddr:   a.hwAddrFor(clientID),
+		Purpose:  poolPurpose(req),
+		PoolName: a.pool.Name,
+	})
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("dhcp pool allocate: %w", err)
+	}
+	if lease == nil || lease.IP == nil {
+		return netip.Addr{}, errors.New("dhcp pool allocator: empty lease")
+	}
+	if len(lease.HWAddr) > 0 {
+		a.rememberHWAddr(clientID, lease.HWAddr)
+	}
+	addr, ok := netip.AddrFromSlice(lease.IP.To4())
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("dhcp pool allocator: parse leased ip %q", lease.IP)
+	}
+	return addr.Unmap(), nil
+}
+
+// Release looks up the lease holding ip and issues vpc.dhcp.release.
+// Static-pool semantics — error when poolName doesn't match this
+// allocator's pool — so ExternalIPAM's dispatch table doesn't accidentally
+// release a different pool's lease.
+func (a *DHCPPoolAllocator) Release(ctx context.Context, poolName string, ip netip.Addr) error {
+	if a == nil || a.client == nil {
+		return errors.New("dhcp pool allocator: nil client")
+	}
+	if poolName != "" && poolName != a.pool.Name {
+		return fmt.Errorf("dhcp pool allocator: pool mismatch (got %q, bound to %q)", poolName, a.pool.Name)
+	}
+	if !ip.IsValid() {
+		return errors.New("dhcp pool allocator: invalid ip")
+	}
+	return a.client.RequestReleaseByIP(ctx, a.pool.Name, ip.String())
+}
+
+func (a *DHCPPoolAllocator) hwAddrFor(clientID string) net.HardwareAddr {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if hw, ok := a.hwAddrs[clientID]; ok && len(hw) > 0 {
+		return hw
+	}
+	return nil
+}
+
+func (a *DHCPPoolAllocator) rememberHWAddr(clientID string, hw net.HardwareAddr) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.hwAddrs[clientID] = append(net.HardwareAddr(nil), hw...)
+}
+
+// poolClientID picks the first non-empty AWS identifier. Mirrors the
+// precedence documented in the plan: AllocationID > ENIID > InstanceID.
+func poolClientID(req external.AllocateRequest) string {
+	switch {
+	case req.AllocationID != "":
+		return req.AllocationID
+	case req.ENIID != "":
+		return req.ENIID
+	case req.InstanceID != "":
+		return req.InstanceID
+	default:
+		return ""
+	}
+}
+
+func poolPurpose(req external.AllocateRequest) string {
+	if req.Purpose != "" {
+		return req.Purpose
+	}
+	switch {
+	case req.AllocationID != "":
+		return PurposeEIP
+	case req.ENIID != "":
+		return PurposeENIPublic
+	case req.InstanceID != "":
+		return PurposeENIPublic
+	default:
+		return ""
+	}
+}

--- a/spinifex/network/external/dhcp/pool_allocator_test.go
+++ b/spinifex/network/external/dhcp/pool_allocator_test.go
@@ -1,0 +1,118 @@
+package dhcp_test
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPoolAllocator(t *testing.T, fake *dhcp.Fake, pool external.ExternalPoolConfig) (*dhcp.DHCPPoolAllocator, *dhcp.Store) {
+	t.Helper()
+	mgr, store, nc := newTestManager(t, "az1", fake, time.Now)
+	require.NoError(t, mgr.Start(context.Background()))
+	subs, err := mgr.Subscribe(nc)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+	client := dhcp.NewNATSClient(nc, 3*time.Second)
+	return dhcp.NewDHCPPoolAllocator(client, pool), store
+}
+
+func TestDHCPPoolAllocatorAllocateAndRelease(t *testing.T) {
+	fake := dhcp.NewFake()
+	pool := external.ExternalPoolConfig{
+		Name:       "wan",
+		Source:     external.SourceDHCP,
+		BindBridge: "br-wan",
+	}
+	allocator, store := newPoolAllocator(t, fake, pool)
+
+	addr, err := allocator.Allocate(context.Background(), external.AllocateRequest{
+		PoolName:     "wan",
+		AllocationID: "eipalloc-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "192.0.2.100", addr.String())
+
+	entry, err := store.Get("eipalloc-1")
+	require.NoError(t, err)
+	assert.Equal(t, dhcp.PurposeEIP, entry.Purpose)
+	assert.Equal(t, "wan", entry.PoolName)
+
+	require.NoError(t, allocator.Release(context.Background(), "wan", addr))
+	_, err = store.Get("eipalloc-1")
+	assert.Error(t, err)
+	assert.Equal(t, 1, fake.ReleaseCount())
+}
+
+func TestDHCPPoolAllocatorClientIDPrecedence(t *testing.T) {
+	fake := dhcp.NewFake()
+	pool := external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
+	allocator, store := newPoolAllocator(t, fake, pool)
+
+	cases := []struct {
+		req      external.AllocateRequest
+		clientID string
+		purpose  string
+	}{
+		{external.AllocateRequest{AllocationID: "eipalloc-x", ENIID: "eni-y", InstanceID: "i-z"}, "eipalloc-x", dhcp.PurposeEIP},
+		{external.AllocateRequest{ENIID: "eni-y", InstanceID: "i-z"}, "eni-y", dhcp.PurposeENIPublic},
+		{external.AllocateRequest{InstanceID: "i-z"}, "i-z", dhcp.PurposeENIPublic},
+	}
+	for _, tc := range cases {
+		_, err := allocator.Allocate(context.Background(), tc.req)
+		require.NoError(t, err, "case %+v", tc.req)
+		entry, err := store.Get(tc.clientID)
+		require.NoError(t, err, "client id %q not persisted", tc.clientID)
+		assert.Equal(t, tc.purpose, entry.Purpose)
+	}
+}
+
+func TestDHCPPoolAllocatorRejectsMissingIdentity(t *testing.T) {
+	fake := dhcp.NewFake()
+	pool := external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
+	allocator, _ := newPoolAllocator(t, fake, pool)
+
+	_, err := allocator.Allocate(context.Background(), external.AllocateRequest{PoolName: "wan"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AllocationID")
+}
+
+func TestDHCPPoolAllocatorRejectsStaticPool(t *testing.T) {
+	fake := dhcp.NewFake()
+	pool := external.ExternalPoolConfig{Name: "wan", Source: external.SourceStatic}
+	allocator, _ := newPoolAllocator(t, fake, pool)
+
+	_, err := allocator.Allocate(context.Background(), external.AllocateRequest{PoolName: "wan", AllocationID: "eipalloc-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not dhcp-sourced")
+}
+
+func TestDHCPPoolAllocatorRejectsPoolMismatch(t *testing.T) {
+	fake := dhcp.NewFake()
+	pool := external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
+	allocator, _ := newPoolAllocator(t, fake, pool)
+
+	_, err := allocator.Allocate(context.Background(), external.AllocateRequest{PoolName: "other", AllocationID: "eipalloc-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pool mismatch")
+}
+
+func TestDHCPPoolAllocatorReleaseUnknownIPIsNoop(t *testing.T) {
+	fake := dhcp.NewFake()
+	pool := external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
+	allocator, _ := newPoolAllocator(t, fake, pool)
+
+	addr := netip.MustParseAddr("198.51.100.99")
+	assert.NoError(t, allocator.Release(context.Background(), "wan", addr))
+	assert.Equal(t, 0, fake.ReleaseCount())
+}

--- a/spinifex/network/external/dhcp/promisc.go
+++ b/spinifex/network/external/dhcp/promisc.go
@@ -1,0 +1,128 @@
+package dhcp
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// enableBridgePromisc puts iface into IFF_PROMISC and returns a release
+// callback the caller defers. Reference-counted across concurrent DORAs
+// on the same bridge so the first caller flips PROMISC on and the last
+// caller flips it off — concurrent leases don't fight over flag state.
+//
+// Rationale: nclient4 sends DHCPDISCOVER with the derived 02:xx:xx:xx:xx:xx
+// chaddr (see DeriveMAC) which doesn't match the bridge's own MAC. Many
+// upstream DHCP servers reply unicast to chaddr regardless of the
+// broadcast flag, so the OFFER egresses the Linux bridge with a destination
+// MAC the bridge has never learned. Without IFF_PROMISC the kernel
+// AF_PACKET socket bound to the bridge drops those frames in software and
+// the DORA times out with "no matching response packet received". With
+// PROMISC the bridge surfaces every received frame to the socket and
+// nclient4 sees the OFFER.
+//
+// On failure (typically EPERM when vpcd lost CAP_NET_ADMIN) the function
+// returns the error so the caller can decide whether to proceed — the
+// bridge may already be in PROMISC via operator config.
+var enableBridgePromisc = func(iface string) (func() error, error) {
+	if iface == "" {
+		return nil, errors.New("promisc: iface required")
+	}
+	promiscMu.Lock()
+	defer promiscMu.Unlock()
+
+	if promiscRefs[iface] > 0 {
+		promiscRefs[iface]++
+		return makePromiscRelease(iface), nil
+	}
+	if err := setPromiscFn(iface, true); err != nil {
+		return nil, fmt.Errorf("promisc: enable on %s: %w", iface, err)
+	}
+	promiscRefs[iface] = 1
+	return makePromiscRelease(iface), nil
+}
+
+func makePromiscRelease(iface string) func() error {
+	return func() error {
+		promiscMu.Lock()
+		defer promiscMu.Unlock()
+		n := promiscRefs[iface]
+		if n <= 0 {
+			delete(promiscRefs, iface)
+			return nil
+		}
+		n--
+		if n > 0 {
+			promiscRefs[iface] = n
+			return nil
+		}
+		delete(promiscRefs, iface)
+		if err := setPromiscFn(iface, false); err != nil {
+			return fmt.Errorf("promisc: disable on %s: %w", iface, err)
+		}
+		return nil
+	}
+}
+
+// setPromiscFn is the syscall sink, swappable in tests to assert
+// ref-count behaviour without root or a real interface.
+var setPromiscFn = setPromisc
+
+var (
+	promiscMu   sync.Mutex
+	promiscRefs = map[string]int{}
+)
+
+// ifReq mirrors `struct ifreq` from <net/if.h> — 16-byte name padded out
+// to the same total size as the kernel expects. Only the flags overlay
+// is read/written here.
+type ifReq struct {
+	name  [unix.IFNAMSIZ]byte
+	flags uint16
+	_pad  [22]byte
+}
+
+// setPromisc toggles IFF_PROMISC on iface via SIOCGIFFLAGS / SIOCSIFFLAGS.
+// Requires CAP_NET_ADMIN (granted to spinifex-vpcd via AmbientCapabilities
+// in the systemd unit).
+func setPromisc(iface string, on bool) error {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return fmt.Errorf("open socket: %w", err)
+	}
+	defer unix.Close(fd)
+
+	var req ifReq
+	if len(iface) >= unix.IFNAMSIZ {
+		return fmt.Errorf("iface name too long: %q", iface)
+	}
+	copy(req.name[:], iface)
+
+	if errno := ioctl(fd, unix.SIOCGIFFLAGS, unsafe.Pointer(&req)); errno != 0 {
+		return fmt.Errorf("SIOCGIFFLAGS: %w", errno)
+	}
+	if on {
+		if req.flags&unix.IFF_PROMISC != 0 {
+			return nil
+		}
+		req.flags |= unix.IFF_PROMISC
+	} else {
+		if req.flags&unix.IFF_PROMISC == 0 {
+			return nil
+		}
+		req.flags &^= unix.IFF_PROMISC
+	}
+	if errno := ioctl(fd, unix.SIOCSIFFLAGS, unsafe.Pointer(&req)); errno != 0 {
+		return fmt.Errorf("SIOCSIFFLAGS: %w", errno)
+	}
+	return nil
+}
+
+func ioctl(fd int, req uint, arg unsafe.Pointer) syscall.Errno {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+	return errno
+}

--- a/spinifex/network/external/dhcp/promisc_test.go
+++ b/spinifex/network/external/dhcp/promisc_test.go
@@ -1,0 +1,98 @@
+package dhcp
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPromiscRefCount verifies the bridge stays in IFF_PROMISC across
+// overlapping DORAs: first caller flips on, intermediate callers piggy-back
+// without touching the flag, last caller flips off. Catches the regression
+// where nightly cell 1 timed out on "no matching response packet received"
+// because chaddr-derived 02:xx unicast OFFERs never reach AF_PACKET on a
+// non-promisc Linux bridge.
+func TestPromiscRefCount(t *testing.T) {
+	defer resetPromiscState()
+	var (
+		mu     sync.Mutex
+		states []bool
+	)
+	setPromiscBackup := setPromiscFn
+	t.Cleanup(func() { setPromiscFn = setPromiscBackup })
+	setPromiscFn = func(iface string, on bool) error {
+		mu.Lock()
+		defer mu.Unlock()
+		states = append(states, on)
+		return nil
+	}
+
+	rel1, err := enableBridgePromisc("br-wan")
+	require.NoError(t, err)
+	rel2, err := enableBridgePromisc("br-wan")
+	require.NoError(t, err)
+	rel3, err := enableBridgePromisc("br-wan")
+	require.NoError(t, err)
+
+	mu.Lock()
+	assert.Equal(t, []bool{true}, states, "only first acquire should flip PROMISC on")
+	mu.Unlock()
+
+	require.NoError(t, rel1())
+	require.NoError(t, rel2())
+	mu.Lock()
+	assert.Equal(t, []bool{true}, states, "PROMISC must stay on while at least one lease in flight")
+	mu.Unlock()
+
+	require.NoError(t, rel3())
+	mu.Lock()
+	assert.Equal(t, []bool{true, false}, states, "last release flips PROMISC off")
+	mu.Unlock()
+}
+
+func TestPromiscDifferentBridgesIndependent(t *testing.T) {
+	defer resetPromiscState()
+	type call struct {
+		iface string
+		on    bool
+	}
+	var (
+		mu    sync.Mutex
+		calls []call
+	)
+	setPromiscBackup := setPromiscFn
+	t.Cleanup(func() { setPromiscFn = setPromiscBackup })
+	setPromiscFn = func(iface string, on bool) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, call{iface, on})
+		return nil
+	}
+
+	relA, err := enableBridgePromisc("br-wan")
+	require.NoError(t, err)
+	relB, err := enableBridgePromisc("br-mgmt")
+	require.NoError(t, err)
+
+	require.NoError(t, relA())
+	require.NoError(t, relB())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []call{
+		{"br-wan", true},
+		{"br-mgmt", true},
+		{"br-wan", false},
+		{"br-mgmt", false},
+	}, calls)
+}
+
+func resetPromiscState() {
+	promiscMu.Lock()
+	defer promiscMu.Unlock()
+	for k := range promiscRefs {
+		delete(promiscRefs, k)
+	}
+}

--- a/spinifex/network/external/dhcp/wire.go
+++ b/spinifex/network/external/dhcp/wire.go
@@ -1,0 +1,140 @@
+package dhcp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"time"
+)
+
+// NATS subjects for daemon ↔ vpcd DHCP RPCs. Plain (non-AZ-prefixed)
+// because the vpcd that owns br-wan is exactly one process per AZ; an
+// AZ-prefixed subject would just push the same constraint into the
+// subject string.
+const (
+	TopicAcquire = "vpc.dhcp.acquire"
+	TopicRelease = "vpc.dhcp.release"
+)
+
+// acquireWireRequest is the JSON payload sent by daemon-side
+// NATSClient.RequestAcquire and consumed by Manager.handleAcquireMsg.
+type acquireWireRequest struct {
+	Bridge      string `json:"bridge,omitempty"`
+	ClientID    string `json:"client_id"`
+	Hostname    string `json:"hostname,omitempty"`
+	VendorClass string `json:"vendor_class,omitempty"`
+	HWAddr      string `json:"hwaddr,omitempty"`
+	Purpose     string `json:"purpose,omitempty"`
+	PoolName    string `json:"pool_name,omitempty"`
+	VPCID       string `json:"vpc_id,omitempty"`
+}
+
+// acquireWireReply carries either an error string or the resulting
+// Lease. Empty Error means success; Lease may still be nil if the
+// caller is the vpcd's own internal short-circuit (it isn't, currently).
+type acquireWireReply struct {
+	Error string     `json:"error,omitempty"`
+	Lease *wireLease `json:"lease,omitempty"`
+}
+
+type releaseWireRequest struct {
+	ClientID string `json:"client_id"`
+}
+
+type releaseWireReply struct {
+	Error string `json:"error,omitempty"`
+}
+
+// wireLease is Lease in JSON-friendly form: dotted-quad IPs, MAC string,
+// durations as nanoseconds.
+type wireLease struct {
+	Bridge        string        `json:"bridge,omitempty"`
+	ClientID      string        `json:"client_id"`
+	Hostname      string        `json:"hostname,omitempty"`
+	VendorClass   string        `json:"vendor_class,omitempty"`
+	HWAddr        string        `json:"hwaddr,omitempty"`
+	IP            string        `json:"ip,omitempty"`
+	SubnetMask    string        `json:"subnet_mask,omitempty"`
+	Routers       []string      `json:"routers,omitempty"`
+	DNS           []string      `json:"dns,omitempty"`
+	ServerID      string        `json:"server_id,omitempty"`
+	AcquiredAt    time.Time     `json:"acquired"`
+	LeaseDuration time.Duration `json:"lease_duration"`
+	T1            time.Duration `json:"t1"`
+	T2            time.Duration `json:"t2"`
+	RawOffer      []byte        `json:"raw_offer,omitempty"`
+	RawACK        []byte        `json:"raw_ack,omitempty"`
+}
+
+func toWireLease(l *Lease) *wireLease {
+	if l == nil {
+		return nil
+	}
+	return &wireLease{
+		Bridge:        l.Bridge,
+		ClientID:      l.ClientID,
+		Hostname:      l.Hostname,
+		VendorClass:   l.VendorClass,
+		HWAddr:        hwToString(l.HWAddr),
+		IP:            ipToString(l.IP),
+		SubnetMask:    maskToString(l.SubnetMask),
+		Routers:       ipsToStrings(l.Routers),
+		DNS:           ipsToStrings(l.DNS),
+		ServerID:      ipToString(l.ServerID),
+		AcquiredAt:    l.AcquiredAt,
+		LeaseDuration: l.LeaseDuration,
+		T1:            l.T1,
+		T2:            l.T2,
+		RawOffer:      l.RawOffer,
+		RawACK:        l.RawACK,
+	}
+}
+
+func fromWireLease(w *wireLease) (*Lease, error) {
+	if w == nil {
+		return nil, errors.New("nil wire lease")
+	}
+	l := &Lease{
+		Bridge:        w.Bridge,
+		ClientID:      w.ClientID,
+		Hostname:      w.Hostname,
+		VendorClass:   w.VendorClass,
+		AcquiredAt:    w.AcquiredAt,
+		LeaseDuration: w.LeaseDuration,
+		T1:            w.T1,
+		T2:            w.T2,
+		RawOffer:      w.RawOffer,
+		RawACK:        w.RawACK,
+	}
+	if w.IP != "" {
+		l.IP = net.ParseIP(w.IP)
+	}
+	if w.SubnetMask != "" {
+		m, err := parseMask(w.SubnetMask)
+		if err != nil {
+			return nil, fmt.Errorf("subnet_mask: %w", err)
+		}
+		l.SubnetMask = m
+	}
+	for _, s := range w.Routers {
+		if ip := net.ParseIP(s); ip != nil {
+			l.Routers = append(l.Routers, ip)
+		}
+	}
+	for _, s := range w.DNS {
+		if ip := net.ParseIP(s); ip != nil {
+			l.DNS = append(l.DNS, ip)
+		}
+	}
+	if w.ServerID != "" {
+		l.ServerID = net.ParseIP(w.ServerID)
+	}
+	if w.HWAddr != "" {
+		hw, err := net.ParseMAC(w.HWAddr)
+		if err != nil {
+			return nil, fmt.Errorf("hwaddr: %w", err)
+		}
+		l.HWAddr = hw
+	}
+	return l, nil
+}

--- a/spinifex/network/external/dhcp/wire.go
+++ b/spinifex/network/external/dhcp/wire.go
@@ -37,8 +37,14 @@ type acquireWireReply struct {
 	Lease *wireLease `json:"lease,omitempty"`
 }
 
+// releaseWireRequest carries either a direct ClientID, or a (PoolName, IP)
+// pair the manager uses to reverse-lookup the ClientID from the per-AZ
+// lease store. ExternalIPAM's Allocator.Release signature only has the
+// IP, so the daemon side uses the IP path; in-process callers use ClientID.
 type releaseWireRequest struct {
-	ClientID string `json:"client_id"`
+	ClientID string `json:"client_id,omitempty"`
+	PoolName string `json:"pool_name,omitempty"`
+	IP       string `json:"ip,omitempty"`
 }
 
 type releaseWireReply struct {

--- a/spinifex/network/external/igw.go
+++ b/spinifex/network/external/igw.go
@@ -263,12 +263,15 @@ func (m *igwManager) resolveGatewayNetwork(ctx context.Context, vpcID string) (n
 		return network, nexthop, "", nil
 	}
 
-	ip, prefix, ok, allocErr := m.allocator.Allocate(ctx, vpcID, m.pool)
+	ip, prefix, allocNexthop, ok, allocErr := m.allocator.Allocate(ctx, vpcID, m.pool)
 	if allocErr != nil {
 		return "", "", "", fmt.Errorf("allocate gateway LRP IP: %w", allocErr)
 	}
 	if !ok {
 		return network, nexthop, "", nil
+	}
+	if allocNexthop != "" {
+		nexthop = allocNexthop
 	}
 	return fmt.Sprintf("%s/%d", ip, prefix), nexthop, ip, nil
 }

--- a/spinifex/network/external/igw_test.go
+++ b/spinifex/network/external/igw_test.go
@@ -191,11 +191,47 @@ type failingAllocator struct{}
 
 var _ GatewayIPAllocator = failingAllocator{}
 
-func (failingAllocator) Allocate(_ context.Context, _ string, _ *ExternalPoolConfig) (string, int, bool, error) {
-	return "", 0, false, errors.New("boom")
+func (failingAllocator) Allocate(_ context.Context, _ string, _ *ExternalPoolConfig) (string, int, string, bool, error) {
+	return "", 0, "", false, errors.New("boom")
 }
 
 func (failingAllocator) Release(_ context.Context, _ string) error { return nil }
+
+// fixedNexthopAllocator returns a non-empty nexthop so the IGW manager's
+// allocator-nexthop override is exercised.
+type fixedNexthopAllocator struct {
+	ip      string
+	prefix  int
+	nexthop string
+}
+
+var _ GatewayIPAllocator = fixedNexthopAllocator{}
+
+func (a fixedNexthopAllocator) Allocate(_ context.Context, _ string, _ *ExternalPoolConfig) (string, int, string, bool, error) {
+	return a.ip, a.prefix, a.nexthop, true, nil
+}
+
+func (fixedNexthopAllocator) Release(_ context.Context, _ string) error { return nil }
+
+// TestAttachIGW_Centralized_AllocatorNexthopOverridesPool covers the bug
+// where DHCP-source pools have empty pool.Gateway and fell back to
+// 169.254.0.2. Allocator-returned nexthop must win.
+func TestAttachIGW_Centralized_AllocatorNexthopOverridesPool(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
+	// pool.Gateway empty (mirrors DHCP-source config).
+	pool := &ExternalPoolConfig{Name: "p", PrefixLen: 24}
+	alloc := fixedNexthopAllocator{ip: "192.168.1.50", prefix: 24, nexthop: "192.168.1.254"}
+	mgr, _ := newTestIGWManager(t, m, policy.NATModeCentralized, pool, alloc, []string{"chassis-a"})
+
+	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
+
+	route, err := m.FindStaticRoute(ctx, topology.VPCRouter("vpc-1"), "0.0.0.0/0")
+	require.NoError(t, err)
+	require.NotNil(t, route)
+	assert.Equal(t, "192.168.1.254", route.Nexthop, "allocator-supplied nexthop must override pool/link-local fallback")
+}
 
 func TestAttachIGW_AllocatorFailureUnwindsExtSwitch(t *testing.T) {
 	ctx := context.Background()

--- a/spinifex/network/external/pool.go
+++ b/spinifex/network/external/pool.go
@@ -46,8 +46,10 @@ func FindPool(pools []ExternalPoolConfig, region, az string) *ExternalPoolConfig
 
 // GatewayIPAllocator resolves the gateway LRP IP for a VPC.
 // ok=false means caller falls back to link-local; error means abort.
+// nexthop is the upstream gateway the VPC's default route should point at;
+// empty means caller falls back to pool.Gateway / link-local.
 type GatewayIPAllocator interface {
-	Allocate(ctx context.Context, vpcID string, pool *ExternalPoolConfig) (ip string, prefixLen int, ok bool, err error)
+	Allocate(ctx context.Context, vpcID string, pool *ExternalPoolConfig) (ip string, prefixLen int, nexthop string, ok bool, err error)
 	Release(ctx context.Context, vpcID string) error
 }
 
@@ -56,8 +58,8 @@ type LinkLocalAllocator struct{}
 
 var _ GatewayIPAllocator = LinkLocalAllocator{}
 
-func (LinkLocalAllocator) Allocate(_ context.Context, _ string, _ *ExternalPoolConfig) (string, int, bool, error) {
-	return "", 0, false, nil
+func (LinkLocalAllocator) Allocate(_ context.Context, _ string, _ *ExternalPoolConfig) (string, int, string, bool, error) {
+	return "", 0, "", false, nil
 }
 
 func (LinkLocalAllocator) Release(_ context.Context, _ string) error { return nil }
@@ -76,16 +78,17 @@ func NewStaticRangeAllocator(client ovn.Client) *StaticRangeAllocator {
 
 // Allocate returns the next free gateway LRP IP for vpcID. Idempotent: if the
 // LRP already exists with a recorded allocation, returns the existing IP.
-func (a *StaticRangeAllocator) Allocate(ctx context.Context, vpcID string, pool *ExternalPoolConfig) (string, int, bool, error) {
+// Nexthop comes from pool.Gateway (operator-supplied for static pools).
+func (a *StaticRangeAllocator) Allocate(ctx context.Context, vpcID string, pool *ExternalPoolConfig) (string, int, string, bool, error) {
 	start, end, prefix, ok := gwLrpRange(pool)
 	if !ok {
-		return "", 0, false, nil
+		return "", 0, "", false, nil
 	}
 
 	gwPortName := topology.GatewayRouterPort(vpcID)
 	lrps, err := a.OVN.ListLogicalRouterPorts(ctx)
 	if err != nil {
-		return "", 0, false, fmt.Errorf("list LRPs for gw IP allocation: %w", err)
+		return "", 0, "", false, fmt.Errorf("list LRPs for gw IP allocation: %w", err)
 	}
 	used := make(map[uint32]struct{}, len(lrps))
 	for _, lrp := range lrps {
@@ -94,7 +97,7 @@ func (a *StaticRangeAllocator) Allocate(ctx context.Context, vpcID string, pool 
 			continue
 		}
 		if lrp.Name == gwPortName {
-			return existing, prefix, true, nil
+			return existing, prefix, pool.Gateway, true, nil
 		}
 		if v := net.ParseIP(existing).To4(); v != nil {
 			used[ipv4ToUint32(v)] = struct{}{}
@@ -107,9 +110,9 @@ func (a *StaticRangeAllocator) Allocate(ctx context.Context, vpcID string, pool 
 		if _, taken := used[n]; taken {
 			continue
 		}
-		return uint32ToIPv4(n).String(), prefix, true, nil
+		return uint32ToIPv4(n).String(), prefix, pool.Gateway, true, nil
 	}
-	return "", 0, false, fmt.Errorf("gw_lrp_range exhausted for pool %q (%s-%s)", pool.Name, pool.GwLrpRangeStart, pool.GwLrpRangeEnd)
+	return "", 0, "", false, fmt.Errorf("gw_lrp_range exhausted for pool %q (%s-%s)", pool.Name, pool.GwLrpRangeStart, pool.GwLrpRangeEnd)
 }
 
 // Release is a no-op — LRP external_id is source of truth, cleared on detach.

--- a/spinifex/network/external/pool_test.go
+++ b/spinifex/network/external/pool_test.go
@@ -32,10 +32,11 @@ func TestFindPool_NoMatchReturnsNil(t *testing.T) {
 
 func TestLinkLocalAllocator_AlwaysReturnsNotOK(t *testing.T) {
 	a := LinkLocalAllocator{}
-	ip, prefix, ok, err := a.Allocate(context.Background(), "vpc-1", &ExternalPoolConfig{Gateway: "192.168.1.1", PrefixLen: 24})
+	ip, prefix, nexthop, ok, err := a.Allocate(context.Background(), "vpc-1", &ExternalPoolConfig{Gateway: "192.168.1.1", PrefixLen: 24})
 	require.NoError(t, err)
 	assert.False(t, ok)
 	assert.Empty(t, ip)
+	assert.Empty(t, nexthop)
 	assert.Zero(t, prefix)
 	require.NoError(t, a.Release(context.Background(), "vpc-1"))
 }
@@ -53,17 +54,17 @@ func TestStaticRangeAllocator_ExplicitRange_AllocatesFirstFree(t *testing.T) {
 		GwLrpRangeEnd:   "192.168.1.243",
 	}
 
-	ip, prefix, ok, err := a.Allocate(ctx, "vpc-1", pool)
+	ip, prefix, nexthop, ok, err := a.Allocate(ctx, "vpc-1", pool)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "192.168.1.240", ip)
 	assert.Equal(t, 24, prefix)
+	assert.Equal(t, "192.168.1.1", nexthop, "static allocator nexthop must come from pool.Gateway")
 }
 
 func TestStaticRangeAllocator_SkipsUsedIPs(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()
-	// Seed an existing LRP on a sibling VPC already holding .240.
 	require.NoError(t, m.CreateLogicalRouter(ctx, &nbdb.LogicalRouter{Name: topology.VPCRouter("vpc-other")}))
 	require.NoError(t, m.CreateLogicalRouterPort(ctx, topology.VPCRouter("vpc-other"), &nbdb.LogicalRouterPort{
 		Name:        topology.GatewayRouterPort("vpc-other"),
@@ -76,7 +77,7 @@ func TestStaticRangeAllocator_SkipsUsedIPs(t *testing.T) {
 		GwLrpRangeStart: "192.168.1.240", GwLrpRangeEnd: "192.168.1.243",
 	}
 
-	ip, _, ok, err := a.Allocate(ctx, "vpc-new", pool)
+	ip, _, _, ok, err := a.Allocate(ctx, "vpc-new", pool)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "192.168.1.241", ip)
@@ -97,10 +98,11 @@ func TestStaticRangeAllocator_ReturnsExistingForSameVPC(t *testing.T) {
 		GwLrpRangeStart: "192.168.1.240", GwLrpRangeEnd: "192.168.1.243",
 	}
 
-	ip, _, ok, err := a.Allocate(ctx, "vpc-1", pool)
+	ip, _, nexthop, ok, err := a.Allocate(ctx, "vpc-1", pool)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "192.168.1.242", ip)
+	assert.Equal(t, "192.168.1.1", nexthop)
 }
 
 func TestStaticRangeAllocator_RangeExhaustedReturnsError(t *testing.T) {
@@ -117,14 +119,14 @@ func TestStaticRangeAllocator_RangeExhaustedReturnsError(t *testing.T) {
 		GwLrpRangeStart: "192.168.1.240", GwLrpRangeEnd: "192.168.1.240",
 	}
 
-	_, _, ok, err := a.Allocate(ctx, "vpc-new", pool)
+	_, _, _, ok, err := a.Allocate(ctx, "vpc-new", pool)
 	require.Error(t, err)
 	assert.False(t, ok)
 }
 
 func TestStaticRangeAllocator_NoRangeReturnsNotOK(t *testing.T) {
 	a := NewStaticRangeAllocator(mock.New())
-	_, _, ok, err := a.Allocate(context.Background(), "vpc-1", &ExternalPoolConfig{})
+	_, _, _, ok, err := a.Allocate(context.Background(), "vpc-1", &ExternalPoolConfig{})
 	require.NoError(t, err)
 	assert.False(t, ok)
 }

--- a/spinifex/network/external/static_pool.go
+++ b/spinifex/network/external/static_pool.go
@@ -1,0 +1,314 @@
+package external
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+
+	"github.com/mulgadc/spinifex/spinifex/migrate"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	// KVBucketStaticPool persists static-pool allocations. The bucket name
+	// is unchanged from the pre-Q1 ExternalIPAM so existing cluster data
+	// carries over with no manual migration.
+	KVBucketStaticPool        = "spinifex-external-ipam"
+	KVBucketStaticPoolVersion = 2
+
+	staticPoolCASRetries = 5
+
+	// purposeIGWLRP duplicates handlers/ec2/vpc.PurposeIGWLRP so the
+	// allocator can reserve the gateway slot without importing handlers.
+	// The string value is frozen by migration 002 — do not change it.
+	purposeIGWLRP = "igw-lrp"
+)
+
+// ExternalIPAllocation describes how an external IP is being used.
+type ExternalIPAllocation struct {
+	Purpose      string `json:"purpose"`
+	AllocationID string `json:"allocation_id,omitempty"`
+	Association  string `json:"association,omitempty"`
+	ENIId        string `json:"eni_id,omitempty"`
+	InstanceId   string `json:"instance_id,omitempty"`
+	Note         string `json:"note,omitempty"`
+}
+
+// PoolRecord tracks allocated external IPs for a single pool.
+type PoolRecord struct {
+	PoolName        string                          `json:"pool_name"`
+	RangeStart      string                          `json:"range_start"`
+	RangeEnd        string                          `json:"range_end"`
+	Gateway         string                          `json:"gateway"`
+	GatewayIP       string                          `json:"gateway_ip"`
+	PrefixLen       int                             `json:"prefix_len"`
+	Region          string                          `json:"region,omitempty"`
+	AZ              string                          `json:"az,omitempty"`
+	GwLrpRangeStart string                          `json:"gw_lrp_range_start,omitempty"`
+	GwLrpRangeEnd   string                          `json:"gw_lrp_range_end,omitempty"`
+	Allocated       map[string]ExternalIPAllocation `json:"allocated"`
+}
+
+// StaticPoolAllocator implements Allocator backed by a NATS JetStream KV
+// bucket. Bucket schema and CAS semantics are unchanged from the pre-Q1
+// ExternalIPAM.
+type StaticPoolAllocator struct {
+	kv    nats.KeyValue
+	pools []ExternalPoolConfig
+}
+
+var _ Allocator = (*StaticPoolAllocator)(nil)
+
+// NewStaticPoolAllocator creates the KV bucket (if missing), runs pending
+// migrations, and seeds each pool's record.
+func NewStaticPoolAllocator(js nats.JetStreamContext, pools []ExternalPoolConfig) (*StaticPoolAllocator, error) {
+	kv, err := utils.GetOrCreateKVBucket(js, KVBucketStaticPool, 5)
+	if err != nil {
+		return nil, fmt.Errorf("create external IPAM KV bucket: %w", err)
+	}
+	if err := migrate.DefaultRegistry.RunKV(KVBucketStaticPool, kv, KVBucketStaticPoolVersion); err != nil {
+		return nil, fmt.Errorf("migrate %s: %w", KVBucketStaticPool, err)
+	}
+	a := &StaticPoolAllocator{kv: kv, pools: pools}
+	if err := a.initPools(); err != nil {
+		return nil, fmt.Errorf("init external IPAM pools: %w", err)
+	}
+	return a, nil
+}
+
+// NewStaticPoolAllocatorWithKV is the test constructor — skips bucket
+// creation and migrations.
+func NewStaticPoolAllocatorWithKV(kv nats.KeyValue, pools []ExternalPoolConfig) *StaticPoolAllocator {
+	return &StaticPoolAllocator{kv: kv, pools: pools}
+}
+
+// KV exposes the underlying bucket so callers that share the bucket
+// (notably ExternalIPAM facade tests) can construct sibling allocators.
+func (a *StaticPoolAllocator) KV() nats.KeyValue { return a.kv }
+
+// Pools returns the allocator's pool list. Used by the ExternalIPAM
+// facade to satisfy pool-by-region lookups.
+func (a *StaticPoolAllocator) Pools() []ExternalPoolConfig { return a.pools }
+
+// Allocate implements Allocator.
+func (a *StaticPoolAllocator) Allocate(_ context.Context, req AllocateRequest) (netip.Addr, error) {
+	for attempt := range staticPoolCASRetries {
+		record, revision, err := a.getRecord(req.PoolName)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("get external IPAM record: %w", err)
+		}
+
+		ip, err := nextAvailableIP(record)
+		if err != nil {
+			return netip.Addr{}, err
+		}
+
+		record.Allocated[ip] = ExternalIPAllocation{
+			Purpose:      req.Purpose,
+			AllocationID: req.AllocationID,
+			ENIId:        req.ENIID,
+			InstanceId:   req.InstanceID,
+		}
+
+		data, err := json.Marshal(record)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("marshal external IPAM record: %w", err)
+		}
+
+		if _, err := a.kv.Update(req.PoolName, data, revision); err != nil {
+			slog.Debug("external IPAM CAS conflict, retrying", "pool", req.PoolName, "attempt", attempt)
+			continue
+		}
+
+		addr, ok := netip.AddrFromSlice(net.ParseIP(ip).To4())
+		if !ok {
+			return netip.Addr{}, fmt.Errorf("parse allocated ip %q", ip)
+		}
+		slog.Info("external IPAM allocated IP", "pool", req.PoolName, "ip", ip, "purpose", req.Purpose)
+		return addr.Unmap(), nil
+	}
+	return netip.Addr{}, fmt.Errorf("external IPAM allocation failed after CAS retries for pool %s", req.PoolName)
+}
+
+// Release implements Allocator.
+func (a *StaticPoolAllocator) Release(_ context.Context, poolName string, ip netip.Addr) error {
+	target := ip.String()
+	for attempt := range staticPoolCASRetries {
+		record, revision, err := a.getRecord(poolName)
+		if err != nil {
+			return fmt.Errorf("get external IPAM record for release: %w", err)
+		}
+
+		alloc, ok := record.Allocated[target]
+		if !ok {
+			return fmt.Errorf("IP %s not allocated in pool %s", target, poolName)
+		}
+		if alloc.Purpose == purposeIGWLRP {
+			return fmt.Errorf("cannot release gateway IP %s in pool %s", target, poolName)
+		}
+
+		delete(record.Allocated, target)
+
+		data, err := json.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("marshal external IPAM record: %w", err)
+		}
+
+		if _, err := a.kv.Update(poolName, data, revision); err != nil {
+			slog.Debug("external IPAM release CAS conflict, retrying", "pool", poolName, "attempt", attempt)
+			continue
+		}
+
+		slog.Info("external IPAM released IP", "pool", poolName, "ip", target)
+		return nil
+	}
+	return fmt.Errorf("external IPAM release failed after CAS retries for pool %s", poolName)
+}
+
+// GetPoolRecord returns the current pool record.
+func (a *StaticPoolAllocator) GetPoolRecord(poolName string) (*PoolRecord, error) {
+	rec, _, err := a.getRecord(poolName)
+	return rec, err
+}
+
+func (a *StaticPoolAllocator) initPools() error {
+	for _, pool := range a.pools {
+		if err := a.initPool(pool); err != nil {
+			return fmt.Errorf("init pool %q: %w", pool.Name, err)
+		}
+	}
+	return nil
+}
+
+func (a *StaticPoolAllocator) initPool(pool ExternalPoolConfig) error {
+	chk, revision, err := a.getRecord(pool.Name)
+
+	if err != nil && !errors.Is(err, nats.ErrKeyNotFound) {
+		return err
+	}
+
+	if err == nil {
+		if chk.RangeStart != pool.RangeStart || chk.RangeEnd != pool.RangeEnd ||
+			chk.GwLrpRangeStart != pool.GwLrpRangeStart || chk.GwLrpRangeEnd != pool.GwLrpRangeEnd {
+			slog.Info("external IPAM pool config drift, reconciling KV",
+				"pool", pool.Name,
+				"old_range", chk.RangeStart+"-"+chk.RangeEnd, "new_range", pool.RangeStart+"-"+pool.RangeEnd,
+				"old_gw_lrp_range", chk.GwLrpRangeStart+"-"+chk.GwLrpRangeEnd,
+				"new_gw_lrp_range", pool.GwLrpRangeStart+"-"+pool.GwLrpRangeEnd)
+
+			chk.RangeStart = pool.RangeStart
+			chk.RangeEnd = pool.RangeEnd
+			chk.GwLrpRangeStart = pool.GwLrpRangeStart
+			chk.GwLrpRangeEnd = pool.GwLrpRangeEnd
+
+			data, err := json.Marshal(chk)
+			if err != nil {
+				return fmt.Errorf("marshal external IPAM record: %w", err)
+			}
+
+			if _, err := a.kv.Update(pool.Name, data, revision); err != nil {
+				slog.Warn("external IPAM update failed", "pool", pool.Name, "err", err)
+				return err
+			}
+			return nil
+		}
+		slog.Debug("external IPAM pool already initialized", "pool", pool.Name)
+		return nil
+	}
+
+	slog.Info("external IPAM pool not found, creating", "pool", pool.Name)
+
+	gwIP := pool.GatewayIP
+	if gwIP == "" {
+		gwIP = pool.RangeStart
+	}
+
+	record := &PoolRecord{
+		PoolName:        pool.Name,
+		RangeStart:      pool.RangeStart,
+		RangeEnd:        pool.RangeEnd,
+		Gateway:         pool.Gateway,
+		GatewayIP:       gwIP,
+		PrefixLen:       pool.PrefixLen,
+		Region:          pool.Region,
+		AZ:              pool.AZ,
+		GwLrpRangeStart: pool.GwLrpRangeStart,
+		GwLrpRangeEnd:   pool.GwLrpRangeEnd,
+		Allocated: map[string]ExternalIPAllocation{
+			gwIP: {Purpose: purposeIGWLRP, Note: "OVN router SNAT address"},
+		},
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal pool record: %w", err)
+	}
+
+	if _, err := a.kv.Create(pool.Name, data); err != nil {
+		if errors.Is(err, nats.ErrKeyExists) {
+			return nil
+		}
+		return fmt.Errorf("create pool KV entry: %w", err)
+	}
+
+	slog.Info("external IPAM pool initialized", "pool", pool.Name, "gateway_ip", gwIP)
+	return nil
+}
+
+func (a *StaticPoolAllocator) getRecord(poolName string) (*PoolRecord, uint64, error) {
+	entry, err := a.kv.Get(poolName)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var record PoolRecord
+	if err := json.Unmarshal(entry.Value(), &record); err != nil {
+		return nil, 0, fmt.Errorf("unmarshal external IPAM record: %w", err)
+	}
+	return &record, entry.Revision(), nil
+}
+
+// nextAvailableIP picks the next unallocated address in the pool's range,
+// skipping addresses inside [GwLrpRangeStart, GwLrpRangeEnd]. Carved from
+// the pre-Q1 handlers/ec2/vpc.nextAvailableExternalIP.
+func nextAvailableIP(record *PoolRecord) (string, error) {
+	startIP := net.ParseIP(record.RangeStart).To4()
+	endIP := net.ParseIP(record.RangeEnd).To4()
+	if startIP == nil || endIP == nil {
+		return "", fmt.Errorf("invalid IP range: %s - %s", record.RangeStart, record.RangeEnd)
+	}
+
+	var gwLrpStart, gwLrpEnd uint32
+	hasGwLrp := false
+	if record.GwLrpRangeStart != "" && record.GwLrpRangeEnd != "" {
+		s := net.ParseIP(record.GwLrpRangeStart).To4()
+		e := net.ParseIP(record.GwLrpRangeEnd).To4()
+		if s != nil && e != nil {
+			gwLrpStart = ipv4ToUint32(s)
+			gwLrpEnd = ipv4ToUint32(e)
+			hasGwLrp = true
+		}
+	}
+
+	startInt := ipv4ToUint32(startIP)
+	endInt := ipv4ToUint32(endIP)
+
+	for i := startInt; ; i++ {
+		if !hasGwLrp || i < gwLrpStart || i > gwLrpEnd {
+			candidate := uint32ToIPv4(i).String()
+			if _, taken := record.Allocated[candidate]; !taken {
+				return candidate, nil
+			}
+		}
+		if i == endInt {
+			break
+		}
+	}
+
+	return "", fmt.Errorf("InsufficientAddressCapacity: pool %s exhausted", record.PoolName)
+}

--- a/spinifex/network/external/static_pool_test.go
+++ b/spinifex/network/external/static_pool_test.go
@@ -1,0 +1,154 @@
+package external
+
+import (
+	"context"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newStaticAllocator(t *testing.T, pools []ExternalPoolConfig) *StaticPoolAllocator {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	a, err := NewStaticPoolAllocator(js, pools)
+	require.NoError(t, err)
+	return a
+}
+
+func wanPool() ExternalPoolConfig {
+	return ExternalPoolConfig{
+		Name:       "wan",
+		RangeStart: "192.168.1.150",
+		RangeEnd:   "192.168.1.160",
+		Gateway:    "192.168.1.1",
+		PrefixLen:  24,
+	}
+}
+
+func mustAddr(t *testing.T, s string) netip.Addr {
+	t.Helper()
+	a, err := netip.ParseAddr(s)
+	require.NoError(t, err)
+	return a
+}
+
+func TestStaticPool_AllocateSequential(t *testing.T) {
+	a := newStaticAllocator(t, []ExternalPoolConfig{wanPool()})
+	ctx := context.Background()
+
+	ip1, err := a.Allocate(ctx, AllocateRequest{PoolName: "wan", Purpose: "eni-public", ENIID: "eni-1", InstanceID: "i-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.151", ip1.String())
+
+	ip2, err := a.Allocate(ctx, AllocateRequest{PoolName: "wan", Purpose: "eni-public", ENIID: "eni-2", InstanceID: "i-2"})
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.152", ip2.String())
+}
+
+func TestStaticPool_GatewayReserved(t *testing.T) {
+	a := newStaticAllocator(t, []ExternalPoolConfig{wanPool()})
+
+	rec, err := a.GetPoolRecord("wan")
+	require.NoError(t, err)
+	alloc, ok := rec.Allocated["192.168.1.150"]
+	require.True(t, ok)
+	assert.Equal(t, purposeIGWLRP, alloc.Purpose)
+
+	err = a.Release(context.Background(), "wan", mustAddr(t, "192.168.1.150"))
+	assert.ErrorContains(t, err, "cannot release gateway IP")
+}
+
+func TestStaticPool_Release(t *testing.T) {
+	a := newStaticAllocator(t, []ExternalPoolConfig{wanPool()})
+	ctx := context.Background()
+
+	ip1, err := a.Allocate(ctx, AllocateRequest{PoolName: "wan", Purpose: "eni-public", ENIID: "eni-1"})
+	require.NoError(t, err)
+	_, err = a.Allocate(ctx, AllocateRequest{PoolName: "wan", Purpose: "eni-public", ENIID: "eni-2"})
+	require.NoError(t, err)
+
+	require.NoError(t, a.Release(ctx, "wan", ip1))
+
+	ip3, err := a.Allocate(ctx, AllocateRequest{PoolName: "wan", Purpose: "eni-public", ENIID: "eni-3"})
+	require.NoError(t, err)
+	assert.Equal(t, ip1, ip3)
+}
+
+func TestStaticPool_Exhaustion(t *testing.T) {
+	pool := ExternalPoolConfig{
+		Name:       "tiny",
+		RangeStart: "10.0.0.1",
+		RangeEnd:   "10.0.0.3",
+		Gateway:    "10.0.0.254",
+		PrefixLen:  24,
+	}
+	a := newStaticAllocator(t, []ExternalPoolConfig{pool})
+	ctx := context.Background()
+
+	_, err := a.Allocate(ctx, AllocateRequest{PoolName: "tiny"})
+	require.NoError(t, err)
+	_, err = a.Allocate(ctx, AllocateRequest{PoolName: "tiny"})
+	require.NoError(t, err)
+	_, err = a.Allocate(ctx, AllocateRequest{PoolName: "tiny"})
+	assert.ErrorContains(t, err, "InsufficientAddressCapacity")
+}
+
+func TestStaticPool_CASConflict(t *testing.T) {
+	a := newStaticAllocator(t, []ExternalPoolConfig{wanPool()})
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	results := make([]netip.Addr, 5)
+	errs := make([]error, 5)
+	for i := range 5 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = a.Allocate(ctx, AllocateRequest{PoolName: "wan"})
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool)
+	for i, err := range errs {
+		require.NoError(t, err, "concurrent allocation %d should succeed", i)
+		ip := results[i].String()
+		assert.False(t, seen[ip], "duplicate IP %s", ip)
+		seen[ip] = true
+	}
+}
+
+func TestStaticPool_ReleaseUnknown(t *testing.T) {
+	a := newStaticAllocator(t, []ExternalPoolConfig{wanPool()})
+	err := a.Release(context.Background(), "wan", mustAddr(t, "192.168.1.200"))
+	assert.ErrorContains(t, err, "not allocated")
+}
+
+// TestNextAvailableIP_SkipsGwLrpRange verifies the static allocator honors
+// gw_lrp_range — addresses inside the reservation are skipped (siv-36).
+func TestNextAvailableIP_SkipsGwLrpRange(t *testing.T) {
+	rec := &PoolRecord{
+		PoolName:        "wan",
+		RangeStart:      "192.168.1.10",
+		RangeEnd:        "192.168.1.14",
+		GwLrpRangeStart: "192.168.1.11",
+		GwLrpRangeEnd:   "192.168.1.13",
+		Allocated:       map[string]ExternalIPAllocation{},
+	}
+	ip, err := nextAvailableIP(rec)
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.10", ip)
+	rec.Allocated[ip] = ExternalIPAllocation{}
+
+	ip, err = nextAvailableIP(rec)
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.14", ip)
+	rec.Allocated[ip] = ExternalIPAllocation{}
+
+	_, err = nextAvailableIP(rec)
+	require.Error(t, err)
+}

--- a/spinifex/network/external/types.go
+++ b/spinifex/network/external/types.go
@@ -3,7 +3,13 @@ package external
 // ExternalPoolConfig describes one external IP pool wired to a VPC.
 // Mirrors [external_pools] in spinifex.toml.
 type ExternalPoolConfig struct {
-	Name            string
+	Name string
+	// Source selects the IP source: "static" (default) for inline range
+	// math or "dhcp" for RFC 2131 DORA via vpcd's DHCPManager.
+	Source string
+	// BindBridge is the Linux bridge the DHCP client runs against
+	// (required when Source="dhcp"). Empty for static pools.
+	BindBridge      string
 	RangeStart      string
 	RangeEnd        string
 	Gateway         string
@@ -15,6 +21,18 @@ type ExternalPoolConfig struct {
 	GwLrpRangeStart string
 	GwLrpRangeEnd   string
 }
+
+// IsDHCP reports whether the pool sources IPs from an upstream DHCP server.
+func (p *ExternalPoolConfig) IsDHCP() bool {
+	return p != nil && p.Source == SourceDHCP
+}
+
+const (
+	// SourceStatic is the default pool source (inline range math, KV-backed).
+	SourceStatic = "static"
+	// SourceDHCP delegates allocation to vpcd's DHCPManager.
+	SourceDHCP = "dhcp"
+)
 
 // IGWSpec is the L5 input for IGWManager.AttachIGW / DetachIGW.
 // InternetGatewayID is propagated into OVN external_ids for reconcile correlation.

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
 	"github.com/mulgadc/spinifex/spinifex/network/host"
 	"github.com/mulgadc/spinifex/spinifex/network/ovn"
 	"github.com/mulgadc/spinifex/spinifex/network/policy"
@@ -23,6 +24,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/network/subscribers"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
 )
 
 // Bridge mode constants for external connectivity. Bridge mode selects how
@@ -133,6 +135,8 @@ type Config struct {
 // ExternalPoolConfig mirrors config.ExternalPool for vpcd's internal use.
 type ExternalPoolConfig struct {
 	Name            string
+	Source          string // "static" (default) or "dhcp"
+	BindBridge      string // Linux bridge for DHCP DORA (source=dhcp only)
 	RangeStart      string
 	RangeEnd        string
 	Gateway         string
@@ -510,12 +514,32 @@ func launchService(cfg *Config) error {
 		p := externalPoolConfigToShared(cfg.ExternalPools[0])
 		igwPool = &p
 	}
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return fmt.Errorf("get JetStream context: %w", err)
+	}
+
+	dhcpMgr, dhcpSubs, err := startDHCPManagerIfNeeded(ctx, nc, js, cfg)
+	if err != nil {
+		return fmt.Errorf("start dhcp manager: %w", err)
+	}
+	defer func() {
+		for _, s := range dhcpSubs {
+			_ = s.Unsubscribe()
+		}
+		if dhcpMgr != nil {
+			dhcpMgr.Stop()
+		}
+	}()
+
+	gwAllocator := pickGatewayAllocator(igwPool, liveClient, dhcpMgr)
 	igwMgr, err := external.NewIGWManager(external.IGWManagerConfig{
 		OVN:          liveClient,
 		Routes:       routeMgr,
 		NAT:          natMgr,
 		Pool:         igwPool,
-		Allocator:    external.NewStaticRangeAllocator(liveClient),
+		Allocator:    gwAllocator,
 		Chassis:      chassisNames,
 		NATMode:      natMode,
 		FlowsBarrier: waitForFlowsHV,
@@ -561,12 +585,6 @@ func launchService(cfg *Config) error {
 			_ = s.Unsubscribe()
 		}
 	}()
-
-	js, err := nc.JetStream()
-	if err != nil {
-		slog.Error("Failed to get JetStream context", "err", err)
-		return err
-	}
 
 	rec, err := reconcile.New(reconcile.Config{
 		OVN:          liveClient,
@@ -645,6 +663,59 @@ func pickDNSServer(pools []ExternalPoolConfig) string {
 	return ""
 }
 
+// startDHCPManagerIfNeeded constructs and starts the per-AZ DHCP Manager
+// when any configured pool has Source="dhcp", and subscribes its NATS
+// handlers. Returns (nil, nil, nil) when no pool needs DHCP.
+func startDHCPManagerIfNeeded(ctx context.Context, nc *nats.Conn, js nats.JetStreamContext, cfg *Config) (*dhcp.Manager, []*nats.Subscription, error) {
+	if cfg == nil || cfg.ExternalMode == "" {
+		return nil, nil, nil
+	}
+	wantDHCP := false
+	for _, p := range cfg.ExternalPools {
+		if p.Source == external.SourceDHCP {
+			wantDHCP = true
+			break
+		}
+	}
+	if !wantDHCP {
+		return nil, nil, nil
+	}
+
+	store, err := dhcp.NewStore(js, cfg.AZ)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create dhcp lease store: %w", err)
+	}
+	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{
+		Client: dhcp.NewNClient4(0),
+		Store:  store,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("create dhcp manager: %w", err)
+	}
+	if err := mgr.Start(ctx); err != nil {
+		return nil, nil, fmt.Errorf("start dhcp manager: %w", err)
+	}
+	subs, err := mgr.Subscribe(nc)
+	if err != nil {
+		mgr.Stop()
+		return nil, nil, fmt.Errorf("subscribe dhcp manager: %w", err)
+	}
+	slog.Info("vpcd: dhcp manager started", "az", cfg.AZ, "subscriptions", len(subs))
+	return mgr, subs, nil
+}
+
+// pickGatewayAllocator chooses the GatewayIPAllocator wired into
+// IGWManager. DHCP-sourced pools with a started Manager get the
+// DHCPGatewayLRPAllocator; everything else keeps StaticRangeAllocator
+// (centralized + static) or LinkLocalAllocator selection inside the
+// resolveGatewayNetwork code path.
+func pickGatewayAllocator(pool *external.ExternalPoolConfig, ovnClient ovn.Client, mgr *dhcp.Manager) external.GatewayIPAllocator {
+	if pool.IsDHCP() && mgr != nil {
+		return dhcp.NewDHCPGatewayLRPAllocator(mgr)
+	}
+	return external.NewStaticRangeAllocator(ovnClient)
+}
+
 // externalPoolConfigToShared translates the vpcd-local ExternalPoolConfig
 // into the network/external package's shared shape. The two will merge
 // once topology.go is split (see external.go's type doc); until then
@@ -652,6 +723,8 @@ func pickDNSServer(pools []ExternalPoolConfig) string {
 func externalPoolConfigToShared(p ExternalPoolConfig) external.ExternalPoolConfig {
 	return external.ExternalPoolConfig{
 		Name:            p.Name,
+		Source:          p.Source,
+		BindBridge:      p.BindBridge,
 		RangeStart:      p.RangeStart,
 		RangeEnd:        p.RangeEnd,
 		Gateway:         p.Gateway,


### PR DESCRIPTION
## Summary

Reintroduce DHCP as an `--external-pool` source. Two allocators live in vpcd:

- **`DHCPGatewayLRPAllocator`** — DORAs once per VPC for the gateway LRP IP in centralized NAT.
- **`DHCPPoolAllocator`** — DORAs once per EIP / ENI public IP / NAT-GW external IP, keyed by AWS allocation ID.

Both wrap a single `dhcp.Client` (RFC 2131 DORA over AF_PACKET on `br-wan`). Leases persisted in per-AZ KV bucket `spinifex-dhcp-leases-<az>`. `ExternalIPAM` talks to vpcd over NATS via restored `vpc.dhcp.acquire` / `vpc.dhcp.release` topics.

Plan: `mulga:docs/development/improvements/external-pool-dhcp-source.md`.

## Commits (oldest first)

- `b6a70ab` refactor: `Allocator` interface + `StaticPoolAllocator`
- `d3b1731` feat(dhcp): package skeleton — Client + Fake + KV store
- `970e85e` feat(dhcp): DHCPManager + daemon-side NATSClient
- `5441d04` feat: wire DHCP allocators; re-allow `source=dhcp` in config
- `17ff430` feat(spx admin init): `--external-source=dhcp` + `--external-bind-bridge`
- `d997406` fix(dhcp): derive chaddr from client-id when HWAddr unset
- `66e532f` fix(dhcp): enable `IFF_PROMISC` on bind_bridge across DORA
- `a82d1a4` fix(dhcp): RFC 2131 retransmission — retry DISCOVER 3×
- `c648440` fix: three CI-blocking bugs (gateway nexthop, DORA backoff, queue group)

## CI

`e2e-nightly` cell 1 green on this branch (just verified). Cells 3, 8, 10 should follow.

## Test plan

- [x] `make preflight` — green
- [x] `e2e-nightly` cell 1 — green
- [x] `e2e-nightly` cells 3, 8, 10
- [ ] Manual single-node smoke: `spx admin init --external-mode=pool --external-source=dhcp --external-bind-bridge=br-wan`, `aws ec2 run-instances ...`, SSH via public IP