### PR TITLE
fix(gateway/ec2): fan out DescribeInstanceAttribute across daemons

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -745,16 +745,18 @@ func (d *Daemon) subscribeAll() error {
 		{"ec2.RevokeSecurityGroupIngress", d.handleEC2RevokeSecurityGroupIngress, "spinifex-workers"},
 		{"ec2.RevokeSecurityGroupEgress", d.handleEC2RevokeSecurityGroupEgress, "spinifex-workers"},
 		{"ec2.ModifyInstanceAttribute", d.handleEC2ModifyInstanceAttribute, "spinifex-workers"},
-		{"ec2.DescribeInstanceAttribute", d.handleEC2DescribeInstanceAttribute, "spinifex-workers"},
 		{"ec2.start", d.handleEC2StartStoppedInstance, "spinifex-workers"},
 		{fmt.Sprintf("ec2.start.%s", d.node), d.handleEC2StartStoppedInstanceDirect, ""},
 		{"ec2.terminate", d.handleEC2TerminateStoppedInstance, "spinifex-workers"},
 		{"ec2.DescribeStoppedInstances", d.handleEC2DescribeStoppedInstances, "spinifex-workers"},
 		{"ec2.DescribeTerminatedInstances", d.handleEC2DescribeTerminatedInstances, "spinifex-workers"},
-		// these 3 fan out to all nodes and gateway aggregates the results
+		// these fan out to all nodes and gateway aggregates the results. The
+		// handler only sees per-daemon local state (vmMgr/stoppedStore), so
+		// any queue-grouped routing produces 1/N false NotFound responses.
 		{"ec2.DescribeInstances", d.handleEC2DescribeInstances, ""},
 		{"ec2.DescribeInstanceStatus", d.handleEC2DescribeInstanceStatus, ""},
 		{"ec2.DescribeInstanceTypes", d.handleEC2DescribeInstanceTypes, ""},
+		{"ec2.DescribeInstanceAttribute", d.handleEC2DescribeInstanceAttribute, ""},
 		// IAM instance profile associations: Disassociate/Replace mutate the
 		// owning daemon's vm.VM (non-owners NoOp with Found=false); Describe
 		// returns per-daemon matches that the gateway concatenates.

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -548,6 +548,31 @@ func (rm *ResourceManager) GetAvailableInstanceTypeInfos(showCapacity bool) []*e
 	return infos
 }
 
+// GetSupportedInstanceTypeInfos returns every instance type this node is
+// configured to run, irrespective of current free capacity. It mirrors
+// AWS's DescribeInstanceTypes semantics: callers asking "what types do you
+// support?" must see a stable answer even when every slot is occupied.
+// System types and entries with incomplete CPU/memory metadata are still
+// skipped.
+func (rm *ResourceManager) GetSupportedInstanceTypeInfos() []*ec2.InstanceTypeInfo {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	var infos []*ec2.InstanceTypeInfo
+	for name, it := range rm.instanceTypes {
+		if instancetypes.IsSystemType(name) {
+			continue
+		}
+		if instanceTypeVCPUs(it) == 0 || instanceTypeMemoryMiB(it) == 0 {
+			continue
+		}
+		infos = append(infos, it)
+	}
+
+	slog.Info("GetSupportedInstanceTypeInfos", "total_types", len(rm.instanceTypes), "supported", len(infos))
+	return infos
+}
+
 // GetResourceStats returns current resource allocation stats for the node status response.
 // totalVCPU / totalMemGB are the raw host figures; reservedVCPU / reservedMemGB are
 // held back from guest scheduling. Per-type caps reflect host - reserved - allocated,

--- a/spinifex/daemon/daemon_handlers_test.go
+++ b/spinifex/daemon/daemon_handlers_test.go
@@ -1566,7 +1566,7 @@ func TestHandleEC2DescribeInstanceAttribute_RunningInstance_InstanceType(t *test
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1608,7 +1608,7 @@ func TestHandleEC2DescribeInstanceAttribute_StoppedInstance_InstanceType(t *test
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1648,7 +1648,7 @@ func TestHandleEC2DescribeInstanceAttribute_UserData(t *testing.T) {
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1687,7 +1687,7 @@ func TestHandleEC2DescribeInstanceAttribute_DefaultAttribute_DisableApiTerminati
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1731,7 +1731,7 @@ func TestHandleEC2DescribeInstanceAttribute_DefaultAttribute_ShutdownBehavior(t 
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1769,7 +1769,7 @@ func TestHandleEC2DescribeInstanceAttribute_GroupSet_WithSecurityGroups(t *testi
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1815,7 +1815,7 @@ func TestHandleEC2DescribeInstanceAttribute_GroupSet_NilInstance(t *testing.T) {
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1852,7 +1852,7 @@ func TestHandleEC2DescribeInstanceAttribute_InstanceNotFound(t *testing.T) {
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1875,7 +1875,7 @@ func TestHandleEC2DescribeInstanceAttribute_UnsupportedAttribute(t *testing.T) {
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
@@ -1911,7 +1911,7 @@ func TestHandleEC2DescribeInstanceAttribute_InvalidJSON(t *testing.T) {
 
 	daemon := createFullTestDaemonWithJetStream(t, natsURL)
 
-	sub, err := daemon.natsConn.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", daemon.handleEC2DescribeInstanceAttribute)
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstanceAttribute", daemon.handleEC2DescribeInstanceAttribute)
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 

--- a/spinifex/daemon/daemon_handlers_volume.go
+++ b/spinifex/daemon/daemon_handlers_volume.go
@@ -80,7 +80,14 @@ func (d *Daemon) handleAttachVolume(msg *nats.Msg, command types.EC2InstanceComm
 		return
 	}
 
-	d.respondWithVolumeAttachment(msg, volumeID, command.ID, res.GuestDevice, "attached")
+	// AttachVolume returns the API-form device name (/dev/sd[f-p]), not
+	// the in-guest path. Callers (including the Terraform AWS provider)
+	// round-trip this through DescribeVolumes' attachment.device filter,
+	// which only matches the API-form name persisted in volume metadata.
+	// A guest-form name here breaks the immediate post-attach wait loop.
+	// This diverges intentionally from BlockDeviceMappings, which retain
+	// the guest path under mulga-599.
+	d.respondWithVolumeAttachment(msg, volumeID, command.ID, res.DeviceName, "attached")
 }
 
 // handleDetachVolume dispatches the QMP/state-machine pipeline to

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -434,8 +434,10 @@ func TestHandleEC2DescribeInstanceTypes(t *testing.T) {
 		err = json.Unmarshal(reply.Data, &output)
 		require.NoError(t, err)
 
-		// Get expected instance types from ResourceManager
-		expectedTypes := daemon.resourceMgr.GetAvailableInstanceTypeInfos(false)
+		// Get expected instance types from ResourceManager. The no-filter
+		// handler path returns the supported set (AWS-compatible), not the
+		// capacity-gated set, so compare against the same source.
+		expectedTypes := daemon.resourceMgr.GetSupportedInstanceTypeInfos()
 		require.NotEmpty(t, expectedTypes, "Should have expected instance types")
 
 		// Build map of expected instance type names
@@ -464,9 +466,11 @@ func TestHandleEC2DescribeInstanceTypes(t *testing.T) {
 		t.Logf("Verified %d instance types match expected list", len(output.InstanceTypes))
 	})
 
-	// Test 3: Filter unavailable types after allocating 2 CPUs
-	t.Run("FilterUnavailableTypesAfterAllocation", func(t *testing.T) {
-		// Get initial available types
+	// Test 3a: No-filter responses list every supported type even when an
+	// allocation has consumed slots. This is the AWS-compatible semantics
+	// that lets the Terraform provider look up an instance type's metadata
+	// after RunInstances has taken the last free slot.
+	t.Run("NoFilterReturnsSupportedRegardlessOfAllocation", func(t *testing.T) {
 		input := &ec2.DescribeInstanceTypesInput{}
 		msgData, err := json.Marshal(input)
 		require.NoError(t, err)
@@ -480,110 +484,102 @@ func TestHandleEC2DescribeInstanceTypes(t *testing.T) {
 		require.NoError(t, err)
 
 		initialCount := len(initialOutput.InstanceTypes)
-		t.Logf("Initial available instance types: %d", initialCount)
+		t.Logf("Initial supported instance types: %d", initialCount)
 
-		// Find an instance type that uses 2 vCPUs from the available types
-		// (not the raw map, which may contain types that exceed host memory)
 		var instanceType2CPU *ec2.InstanceTypeInfo
-		var instanceTypeName string
 		for _, it := range initialOutput.InstanceTypes {
 			if it.VCpuInfo != nil && it.VCpuInfo.DefaultVCpus != nil && *it.VCpuInfo.DefaultVCpus == 2 {
 				instanceType2CPU = it
-				if it.InstanceType != nil {
-					instanceTypeName = *it.InstanceType
-				}
 				break
 			}
 		}
-
 		require.NotNil(t, instanceType2CPU, "Should find an instance type with 2 vCPUs")
-		t.Logf("Allocating instance type: %s (2 vCPUs)", instanceTypeName)
 
-		// Allocate the 2 vCPU instance type
 		err = daemon.resourceMgr.allocate(instanceType2CPU)
 		require.NoError(t, err, "Should be able to allocate 2 vCPU instance")
+		assert.Equal(t, 2, daemon.resourceMgr.allocatedVCPU)
 
-		// Verify allocation
-		assert.Equal(t, 2, daemon.resourceMgr.allocatedVCPU, "Should have allocated 2 vCPUs")
-		t.Logf("Allocated resources: %d vCPUs, %.2f GB RAM",
-			daemon.resourceMgr.allocatedVCPU, daemon.resourceMgr.allocatedMem)
-
-		// Get available types after allocation
 		reply, err = daemon.natsConn.Request("ec2.DescribeInstanceTypes", msgData, 5*time.Second)
 		require.NoError(t, err)
-		require.NotNil(t, reply)
 
 		var afterAllocationOutput ec2.DescribeInstanceTypesOutput
 		err = json.Unmarshal(reply.Data, &afterAllocationOutput)
 		require.NoError(t, err)
 
-		afterAllocationCount := len(afterAllocationOutput.InstanceTypes)
-		t.Logf("Available instance types after allocation: %d", afterAllocationCount)
+		assert.Equal(t, initialCount, len(afterAllocationOutput.InstanceTypes),
+			"no-filter response must list the same supported types before and after allocation")
 
-		// Verify fewer types are available
-		assert.LessOrEqual(t, afterAllocationCount, initialCount,
-			"Should have fewer or equal instance types after allocation")
+		afterTypes := make(map[string]bool)
+		for _, info := range afterAllocationOutput.InstanceTypes {
+			require.NotNil(t, info.InstanceType)
+			afterTypes[*info.InstanceType] = true
+		}
+		require.NotNil(t, instanceType2CPU.InstanceType)
+		assert.True(t, afterTypes[*instanceType2CPU.InstanceType],
+			"the allocated type %s must still appear in no-filter responses", *instanceType2CPU.InstanceType)
 
-		// Calculate remaining schedulable resources (host - reserved - allocated).
+		daemon.resourceMgr.deallocate(instanceType2CPU)
+		assert.Equal(t, 0, daemon.resourceMgr.allocatedVCPU)
+	})
+
+	// Test 3b: capacity=true must still gate on remaining schedulable
+	// resources so cluster-wide aggregation reflects current load.
+	t.Run("CapacityFilterRespectsAllocation", func(t *testing.T) {
+		capInput := &ec2.DescribeInstanceTypesInput{
+			Filters: []*ec2.Filter{
+				{Name: aws.String("capacity"), Values: []*string{aws.String("true")}},
+			},
+		}
+		capMsgData, err := json.Marshal(capInput)
+		require.NoError(t, err)
+
+		// Pick a 2-vCPU type from the capacity-aware set so we know the
+		// host has room for it — the raw instanceTypes map contains
+		// entries (e.g. r5.large at 16 GiB) that exceed schedulable
+		// memory on small test hosts.
+		var instanceType2CPU *ec2.InstanceTypeInfo
+		for _, it := range daemon.resourceMgr.GetAvailableInstanceTypeInfos(false) {
+			if it.VCpuInfo != nil && it.VCpuInfo.DefaultVCpus != nil && *it.VCpuInfo.DefaultVCpus == 2 &&
+				it.MemoryInfo != nil && it.MemoryInfo.SizeInMiB != nil {
+				instanceType2CPU = it
+				break
+			}
+		}
+		require.NotNil(t, instanceType2CPU, "Should find a 2-vCPU type that fits the host")
+
+		err = daemon.resourceMgr.allocate(instanceType2CPU)
+		require.NoError(t, err)
+		defer daemon.resourceMgr.deallocate(instanceType2CPU)
+
+		reply, err := daemon.natsConn.Request("ec2.DescribeInstanceTypes", capMsgData, 5*time.Second)
+		require.NoError(t, err)
+
+		var capOutput ec2.DescribeInstanceTypesOutput
+		err = json.Unmarshal(reply.Data, &capOutput)
+		require.NoError(t, err)
+
 		remainingVCPU := daemon.resourceMgr.hostVCPU - daemon.resourceMgr.reservedVCPU - daemon.resourceMgr.allocatedVCPU
 		remainingMem := daemon.resourceMgr.hostMemGB - daemon.resourceMgr.reservedMem - daemon.resourceMgr.allocatedMem
-
 		t.Logf("Remaining resources: %d vCPUs, %.2f GB RAM", remainingVCPU, remainingMem)
 
-		// Verify all returned types fit within remaining resources
-		for _, info := range afterAllocationOutput.InstanceTypes {
-			require.NotNil(t, info.InstanceType, "InstanceType should not be nil")
-			require.NotNil(t, info.VCpuInfo, "VCpuInfo should not be nil")
-			require.NotNil(t, info.VCpuInfo.DefaultVCpus, "DefaultVCpus should not be nil")
-			require.NotNil(t, info.MemoryInfo, "MemoryInfo should not be nil")
-			require.NotNil(t, info.MemoryInfo.SizeInMiB, "SizeInMiB should not be nil")
+		for _, info := range capOutput.InstanceTypes {
+			require.NotNil(t, info.InstanceType)
+			require.NotNil(t, info.VCpuInfo)
+			require.NotNil(t, info.VCpuInfo.DefaultVCpus)
+			require.NotNil(t, info.MemoryInfo)
+			require.NotNil(t, info.MemoryInfo.SizeInMiB)
 
 			typeName := *info.InstanceType
 			vcpus := int(*info.VCpuInfo.DefaultVCpus)
 			memGB := float64(*info.MemoryInfo.SizeInMiB) / 1024.0
 
 			assert.LessOrEqual(t, vcpus, remainingVCPU,
-				"Instance type %s (%d vCPUs) should not exceed remaining vCPUs (%d)",
+				"capacity=true: %s (%d vCPUs) should not exceed remaining vCPUs (%d)",
 				typeName, vcpus, remainingVCPU)
 			assert.LessOrEqual(t, memGB, remainingMem,
-				"Instance type %s (%.2f GB) should not exceed remaining memory (%.2f GB)",
+				"capacity=true: %s (%.2f GB) should not exceed remaining memory (%.2f GB)",
 				typeName, memGB, remainingMem)
-
-			t.Logf("Available: %s (vCPUs: %d, Memory: %.2f GB)", typeName, vcpus, memGB)
 		}
-
-		// Verify that instance types requiring more than remaining resources are NOT returned
-		// Find instance types that should be filtered out
-		for _, it := range daemon.resourceMgr.instanceTypes {
-			if it.InstanceType == nil || it.VCpuInfo == nil || it.VCpuInfo.DefaultVCpus == nil {
-				continue
-			}
-
-			typeName := *it.InstanceType
-			vcpus := int(*it.VCpuInfo.DefaultVCpus)
-			memGB := float64(0)
-			if it.MemoryInfo != nil && it.MemoryInfo.SizeInMiB != nil {
-				memGB = float64(*it.MemoryInfo.SizeInMiB) / 1024.0
-			}
-
-			// If this type exceeds remaining resources, it should NOT be in the response
-			if vcpus > remainingVCPU || memGB > remainingMem {
-				found := false
-				for _, returnedInfo := range afterAllocationOutput.InstanceTypes {
-					if returnedInfo.InstanceType != nil && *returnedInfo.InstanceType == typeName {
-						found = true
-						break
-					}
-				}
-				assert.False(t, found,
-					"Instance type %s (%d vCPUs, %.2f GB) should NOT be returned as it exceeds remaining resources",
-					typeName, vcpus, memGB)
-			}
-		}
-
-		// Cleanup: deallocate
-		daemon.resourceMgr.deallocate(instanceType2CPU)
-		assert.Equal(t, 0, daemon.resourceMgr.allocatedVCPU, "Should have deallocated all vCPUs")
 	})
 
 	// Test 4: Verify "capacity" filter returns duplicates
@@ -3032,6 +3028,99 @@ func TestCanAllocate_GPUType_BypassesCPUMemory(t *testing.T) {
 	gpuType := makeGPUInstanceType("g7e.4xlarge", 16, 128*1024)
 	assert.Equal(t, 1, rm.canAllocate(gpuType, 1),
 		"GPU type must be allocatable even when CPU/memory would normally block it")
+}
+
+// --- GetSupportedInstanceTypeInfos ---
+
+// Supported set is independent of remaining capacity: even when every host
+// slot for a type is occupied the type must still appear, because callers
+// (e.g. Terraform AWS provider) treat DescribeInstanceTypes as a global
+// metadata lookup, not a "what can fit right now" query.
+func TestGetSupportedInstanceTypeInfos_IgnoresFreeSlots(t *testing.T) {
+	rm := &ResourceManager{
+		hostVCPU:      4,
+		hostMemGB:     8.0,
+		allocatedVCPU: 4, // fully consumed
+		allocatedMem:  8.0,
+		instanceTypes: map[string]*ec2.InstanceTypeInfo{
+			"t3.micro": {
+				InstanceType: aws.String("t3.micro"),
+				VCpuInfo:     &ec2.VCpuInfo{DefaultVCpus: aws.Int64(2)},
+				MemoryInfo:   &ec2.MemoryInfo{SizeInMiB: aws.Int64(1024)},
+			},
+			"m5.large": {
+				InstanceType: aws.String("m5.large"),
+				VCpuInfo:     &ec2.VCpuInfo{DefaultVCpus: aws.Int64(2)},
+				MemoryInfo:   &ec2.MemoryInfo{SizeInMiB: aws.Int64(8 * 1024)},
+			},
+		},
+	}
+
+	// Capacity-gated view: nothing fits because resources are exhausted.
+	assert.Empty(t, rm.GetAvailableInstanceTypeInfos(false),
+		"capacity-gated set must be empty when resources are exhausted")
+
+	// Supported view: every loaded type is still announced.
+	supported := rm.GetSupportedInstanceTypeInfos()
+	got := make(map[string]bool)
+	for _, it := range supported {
+		require.NotNil(t, it.InstanceType)
+		got[*it.InstanceType] = true
+	}
+	assert.True(t, got["t3.micro"], "t3.micro must appear in supported set")
+	assert.True(t, got["m5.large"], "m5.large must appear in supported set even with no free slots")
+}
+
+// System types and entries missing CPU/memory metadata stay filtered — they
+// would break callers if returned regardless of capacity.
+func TestGetSupportedInstanceTypeInfos_SkipsSystemAndIncomplete(t *testing.T) {
+	systemTypeName := "sys.micro"
+	require.True(t, instancetypes.IsSystemType(systemTypeName),
+		"sentinel %s must satisfy IsSystemType — update the test if the prefix changes", systemTypeName)
+
+	rm := &ResourceManager{
+		hostVCPU:  16,
+		hostMemGB: 64.0,
+		instanceTypes: map[string]*ec2.InstanceTypeInfo{
+			systemTypeName: {
+				InstanceType: aws.String(systemTypeName),
+				VCpuInfo:     &ec2.VCpuInfo{DefaultVCpus: aws.Int64(1)},
+				MemoryInfo:   &ec2.MemoryInfo{SizeInMiB: aws.Int64(512)},
+			},
+			"t3.micro": {
+				InstanceType: aws.String("t3.micro"),
+				VCpuInfo:     &ec2.VCpuInfo{DefaultVCpus: aws.Int64(2)},
+				MemoryInfo:   &ec2.MemoryInfo{SizeInMiB: aws.Int64(1024)},
+			},
+			"broken.type": {
+				InstanceType: aws.String("broken.type"),
+				// missing VCpuInfo / MemoryInfo → metadata gate excludes it
+			},
+		},
+	}
+
+	supported := rm.GetSupportedInstanceTypeInfos()
+	require.Len(t, supported, 1, "only the well-formed non-system type must appear")
+	require.NotNil(t, supported[0].InstanceType)
+	assert.Equal(t, "t3.micro", *supported[0].InstanceType)
+}
+
+// GPU types must appear in the supported set regardless of GPU pool state —
+// the goal is to advertise what this node *can* run, not what it can run
+// right now. Capacity gating is the capacity=true path's job.
+func TestGetSupportedInstanceTypeInfos_GPUType_AppearsWithoutPool(t *testing.T) {
+	rm := &ResourceManager{
+		hostVCPU:  128,
+		hostMemGB: 1024.0,
+		instanceTypes: map[string]*ec2.InstanceTypeInfo{
+			"g7e.4xlarge": makeGPUInstanceType("g7e.4xlarge", 16, 128*1024),
+		},
+		// no gpuManager
+	}
+	supported := rm.GetSupportedInstanceTypeInfos()
+	require.Len(t, supported, 1, "GPU type must appear in supported set even without a GPU manager")
+	require.NotNil(t, supported[0].InstanceType)
+	assert.Equal(t, "g7e.4xlarge", *supported[0].InstanceType)
 }
 
 // --- NewDaemon ---

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -144,7 +144,7 @@ var ec2Actions = map[string]EC2Handler{
 		return gateway_ec2_instance.ModifyInstanceAttribute(input, gw.NATSConn, accountID)
 	}),
 	"DescribeInstanceAttribute": ec2Handler(func(input *ec2.DescribeInstanceAttributeInput, gw *GatewayConfig, accountID string) (any, error) {
-		return gateway_ec2_instance.DescribeInstanceAttribute(input, gw.NATSConn, accountID)
+		return gateway_ec2_instance.DescribeInstanceAttribute(input, gw.NATSConn, gw.DiscoverActiveNodes(), accountID)
 	}),
 	"DescribeInstanceCreditSpecifications": ec2Handler(func(input *ec2.DescribeInstanceCreditSpecificationsInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_instance.DescribeInstanceCreditSpecifications(input)

--- a/spinifex/gateway/ec2/instance/DescribeInstanceAttribute.go
+++ b/spinifex/gateway/ec2/instance/DescribeInstanceAttribute.go
@@ -1,7 +1,9 @@
 package gateway_ec2_instance
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -29,19 +31,120 @@ func ValidateDescribeInstanceAttributeInput(input *ec2.DescribeInstanceAttribute
 	return nil
 }
 
-// DescribeInstanceAttribute sends a describe-attribute request to the daemon via NATS.
-func DescribeInstanceAttribute(input *ec2.DescribeInstanceAttributeInput, natsConn *nats.Conn, accountID string) (*ec2.DescribeInstanceAttributeOutput, error) {
+// DescribeInstanceAttribute fans the request out to every daemon and returns
+// the first successful payload. Only the daemon that owns the instance can
+// answer; all others reply ErrorInvalidInstanceIDNotFound because they only
+// inspect per-daemon local state (vmMgr / stoppedStore). The aggregator drops
+// those NotFound replies and surfaces a real success, falling back to
+// ErrorInvalidInstanceIDNotFound only when every node confirmed the instance
+// is absent.
+func DescribeInstanceAttribute(input *ec2.DescribeInstanceAttributeInput, natsConn *nats.Conn, expectedNodes int, accountID string) (*ec2.DescribeInstanceAttributeOutput, error) {
 	if err := ValidateDescribeInstanceAttributeInput(input); err != nil {
 		return nil, err
 	}
 
-	slog.Info("DescribeInstanceAttribute: Processing request", "instance_id", *input.InstanceId, "attribute", *input.Attribute)
+	slog.Info("DescribeInstanceAttribute: Processing request",
+		"instance_id", *input.InstanceId, "attribute", *input.Attribute)
 
-	output, err := utils.NATSRequest[ec2.DescribeInstanceAttributeOutput](natsConn, "ec2.DescribeInstanceAttribute", input, 30*time.Second, accountID)
+	jsonData, err := json.Marshal(input)
 	if err != nil {
-		return nil, err
+		slog.Error("DescribeInstanceAttribute: Failed to marshal input", "err", err)
+		return nil, fmt.Errorf("failed to marshal input: %w", err)
 	}
 
-	slog.Info("DescribeInstanceAttribute: Completed successfully", "instance_id", *input.InstanceId)
-	return output, nil
+	inbox := nats.NewInbox()
+	sub, err := natsConn.SubscribeSync(inbox)
+	if err != nil {
+		slog.Error("DescribeInstanceAttribute: Failed to create inbox subscription", "err", err)
+		return nil, fmt.Errorf("failed to create inbox: %w", err)
+	}
+	defer sub.Unsubscribe()
+
+	pubMsg := nats.NewMsg("ec2.DescribeInstanceAttribute")
+	pubMsg.Reply = inbox
+	pubMsg.Data = jsonData
+	pubMsg.Header.Set(utils.AccountIDHeader, accountID)
+	if err := natsConn.PublishMsg(pubMsg); err != nil {
+		slog.Error("DescribeInstanceAttribute: Failed to publish request", "err", err)
+		return nil, fmt.Errorf("failed to publish request: %w", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+
+	if expectedNodes <= 0 {
+		expectedNodes = -1
+		slog.Warn("DescribeInstanceAttribute: ExpectedNodes not configured, using timeout-only collection")
+	}
+
+	var (
+		success       *ec2.DescribeInstanceAttributeOutput
+		clientErr     string // first non-NotFound AWS error seen
+		notFoundCount int
+		responses     int
+	)
+
+	for time.Now().Before(deadline) {
+		if expectedNodes > 0 && responses >= expectedNodes {
+			break
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		msg, err := sub.NextMsg(remaining)
+		if err != nil {
+			if err == nats.ErrTimeout {
+				break
+			}
+			slog.Error("DescribeInstanceAttribute: Error receiving message", "err", err)
+			break
+		}
+		responses++
+
+		// ValidateErrorPayload returns a non-nil error when the payload is an
+		// ec2.ResponseError envelope (the daemon's GenerateErrorPayload output);
+		// nil means a normal success payload.
+		if respErr, perr := utils.ValidateErrorPayload(msg.Data); perr != nil {
+			code := ""
+			if respErr.Code != nil {
+				code = *respErr.Code
+			}
+			if code == awserrors.ErrorInvalidInstanceIDNotFound {
+				notFoundCount++
+				continue
+			}
+			if clientErr == "" && code != "" {
+				clientErr = code
+			}
+			continue
+		}
+
+		// Skip success parsing once we already have one — the daemon that
+		// owns the instance is unique, so the first parsed payload wins.
+		if success != nil {
+			continue
+		}
+		var out ec2.DescribeInstanceAttributeOutput
+		if err := json.Unmarshal(msg.Data, &out); err != nil {
+			slog.Error("DescribeInstanceAttribute: Failed to unmarshal node response", "err", err)
+			continue
+		}
+		success = &out
+	}
+
+	if success != nil {
+		slog.Info("DescribeInstanceAttribute: Completed successfully",
+			"instance_id", *input.InstanceId, "responses", responses, "notfound", notFoundCount)
+		return success, nil
+	}
+	if clientErr != "" {
+		return nil, errors.New(clientErr)
+	}
+	if notFoundCount > 0 {
+		return nil, errors.New(awserrors.ErrorInvalidInstanceIDNotFound)
+	}
+	// No responses at all — surface NotFound so terraform retries cleanly.
+	slog.Warn("DescribeInstanceAttribute: No responses from any daemon",
+		"instance_id", *input.InstanceId, "expected", expectedNodes)
+	return nil, errors.New(awserrors.ErrorInvalidInstanceIDNotFound)
 }

--- a/spinifex/gateway/ec2/instance/DescribeInstanceAttribute_test.go
+++ b/spinifex/gateway/ec2/instance/DescribeInstanceAttribute_test.go
@@ -3,10 +3,12 @@ package gateway_ec2_instance
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,57 +75,152 @@ func TestValidateDescribeInstanceAttributeInput_Valid(t *testing.T) {
 
 // --- Gateway function tests ---
 
-func TestDescribeInstanceAttribute_Success(t *testing.T) {
+// respondWithInstance returns a subscriber callback that emits a successful
+// DescribeInstanceAttribute payload.
+func respondWithInstance(t *testing.T, instanceID, instanceType string) nats.MsgHandler {
+	return func(msg *nats.Msg) {
+		var input ec2.DescribeInstanceAttributeInput
+		require.NoError(t, json.Unmarshal(msg.Data, &input))
+		out := &ec2.DescribeInstanceAttributeOutput{
+			InstanceId:   aws.String(instanceID),
+			InstanceType: &ec2.AttributeValue{Value: aws.String(instanceType)},
+		}
+		resp, _ := json.Marshal(out)
+		msg.Respond(resp)
+	}
+}
+
+// respondWithError returns a subscriber callback that emits a daemon-style
+// ResponseError envelope (matches utils.GenerateErrorPayload).
+func respondWithError(code string) nats.MsgHandler {
+	return func(msg *nats.Msg) {
+		msg.Respond(utils.GenerateErrorPayload(code))
+	}
+}
+
+func TestDescribeInstanceAttribute_SingleNode(t *testing.T) {
 	_, nc := startTestNATSServer(t)
 
-	nc.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", func(msg *nats.Msg) {
-		var input ec2.DescribeInstanceAttributeInput
-		err := json.Unmarshal(msg.Data, &input)
-		require.NoError(t, err)
-		assert.Equal(t, "i-test123", *input.InstanceId)
-		assert.Equal(t, "instanceType", *input.Attribute)
-
-		output := &ec2.DescribeInstanceAttributeOutput{
-			InstanceId:   aws.String("i-test123"),
-			InstanceType: &ec2.AttributeValue{Value: aws.String("t3.micro")},
-		}
-		resp, _ := json.Marshal(output)
-		msg.Respond(resp)
-	})
+	_, err := nc.Subscribe("ec2.DescribeInstanceAttribute", respondWithInstance(t, "i-test123", "t3.micro"))
+	require.NoError(t, err)
+	nc.Flush()
 
 	input := &ec2.DescribeInstanceAttributeInput{
 		InstanceId: aws.String("i-test123"),
 		Attribute:  aws.String(ec2.InstanceAttributeNameInstanceType),
 	}
 
-	output, err := DescribeInstanceAttribute(input, nc, "123456789012")
+	output, err := DescribeInstanceAttribute(input, nc, 1, "123456789012")
 	require.NoError(t, err)
 	require.NotNil(t, output)
 	assert.Equal(t, "i-test123", *output.InstanceId)
 	assert.Equal(t, "t3.micro", *output.InstanceType.Value)
 }
 
-func TestDescribeInstanceAttribute_DaemonError(t *testing.T) {
+// TestDescribeInstanceAttribute_MultipleNodes_OwnerWins reproduces the
+// regression that motivated the fan-out fix: in a 2-node cluster, only the
+// owner has the instance in its local vmMgr/stoppedStore; the other returns
+// InvalidInstanceID.NotFound. Pre-fix, queue-group routing made this fail
+// ~50% of the time. Post-fix, the aggregator drops the NotFound and surfaces
+// the success.
+func TestDescribeInstanceAttribute_MultipleNodes_OwnerWins(t *testing.T) {
 	_, nc := startTestNATSServer(t)
 
-	nc.QueueSubscribe("ec2.DescribeInstanceAttribute", "spinifex-workers", func(msg *nats.Msg) {
-		msg.Respond([]byte(`{"Code":"InvalidInstanceID.NotFound"}`))
-	})
+	_, err := nc.Subscribe("ec2.DescribeInstanceAttribute", respondWithError(awserrors.ErrorInvalidInstanceIDNotFound))
+	require.NoError(t, err)
+
+	nc2, err := nats.Connect(nc.ConnectedUrl())
+	require.NoError(t, err)
+	defer nc2.Close()
+	_, err = nc2.Subscribe("ec2.DescribeInstanceAttribute", respondWithInstance(t, "i-owned", "t3.medium"))
+	require.NoError(t, err)
+
+	nc.Flush()
+	nc2.Flush()
 
 	input := &ec2.DescribeInstanceAttributeInput{
-		InstanceId: aws.String("i-notfound"),
+		InstanceId: aws.String("i-owned"),
 		Attribute:  aws.String(ec2.InstanceAttributeNameInstanceType),
 	}
 
-	_, err := DescribeInstanceAttribute(input, nc, "123456789012")
+	output, err := DescribeInstanceAttribute(input, nc, 2, "123456789012")
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "i-owned", *output.InstanceId)
+	assert.Equal(t, "t3.medium", *output.InstanceType.Value)
+}
+
+// TestDescribeInstanceAttribute_AllNodesNotFound covers the genuine missing
+// instance case: every daemon confirms the instance is absent.
+func TestDescribeInstanceAttribute_AllNodesNotFound(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+
+	_, err := nc.Subscribe("ec2.DescribeInstanceAttribute", respondWithError(awserrors.ErrorInvalidInstanceIDNotFound))
+	require.NoError(t, err)
+
+	nc2, err := nats.Connect(nc.ConnectedUrl())
+	require.NoError(t, err)
+	defer nc2.Close()
+	_, err = nc2.Subscribe("ec2.DescribeInstanceAttribute", respondWithError(awserrors.ErrorInvalidInstanceIDNotFound))
+	require.NoError(t, err)
+
+	nc.Flush()
+	nc2.Flush()
+
+	input := &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String("i-missing"),
+		Attribute:  aws.String(ec2.InstanceAttributeNameInstanceType),
+	}
+
+	_, err = DescribeInstanceAttribute(input, nc, 2, "123456789012")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorInvalidInstanceIDNotFound, err.Error())
+}
+
+// TestDescribeInstanceAttribute_ClientErrorPropagates ensures that a
+// validation-class error (deterministic across daemons) is surfaced to the
+// caller rather than getting masked by NotFound.
+func TestDescribeInstanceAttribute_ClientErrorPropagates(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+
+	_, err := nc.Subscribe("ec2.DescribeInstanceAttribute", respondWithError(awserrors.ErrorInvalidParameterValue))
+	require.NoError(t, err)
+	nc.Flush()
+
+	input := &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String("i-abc123"),
+		Attribute:  aws.String(ec2.InstanceAttributeNameInstanceType),
+	}
+
+	_, err = DescribeInstanceAttribute(input, nc, 1, "123456789012")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, err.Error())
+}
+
+// TestDescribeInstanceAttribute_NoResponders returns NotFound (not a NATS
+// timeout) so terraform retries cleanly rather than hanging.
+func TestDescribeInstanceAttribute_NoResponders(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+
+	input := &ec2.DescribeInstanceAttributeInput{
+		InstanceId: aws.String("i-nowhere"),
+		Attribute:  aws.String(ec2.InstanceAttributeNameInstanceType),
+	}
+
+	start := time.Now()
+	_, err := DescribeInstanceAttribute(input, nc, 0, "123456789012")
+	duration := time.Since(start)
+
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidInstanceIDNotFound, err.Error())
+	// Must not block the caller past the 3 s deadline.
+	assert.Less(t, duration, 4*time.Second)
 }
 
 func TestDescribeInstanceAttribute_ValidationFailure(t *testing.T) {
 	_, nc := startTestNATSServer(t)
 
-	_, err := DescribeInstanceAttribute(nil, nc, "123456789012")
+	_, err := DescribeInstanceAttribute(nil, nc, 1, "123456789012")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorInvalidParameterValue, err.Error())
 }

--- a/spinifex/handlers/ec2/instance/service.go
+++ b/spinifex/handlers/ec2/instance/service.go
@@ -45,8 +45,20 @@ type TerminateStoppedInstanceOutput struct {
 
 // ResourceCapacityProvider exposes per-node instance-type availability used by
 // DescribeInstanceTypes. Implemented by daemon.ResourceManager.
+//
+// GetAvailableInstanceTypeInfos reports types gated by free schedulable
+// capacity (one entry per free slot when showCapacity is true). It is used
+// when callers ask "what could you launch right now?" — typically with the
+// capacity=true filter for aggregated cluster-wide accounting.
+//
+// GetSupportedInstanceTypeInfos reports every type this node is configured
+// to run, regardless of current allocation. This is the AWS-compatible
+// answer for plain DescribeInstanceTypes and is what tooling like the
+// Terraform AWS provider expects when it performs a metadata lookup after
+// RunInstances.
 type ResourceCapacityProvider interface {
 	GetAvailableInstanceTypeInfos(showCapacity bool) []*ec2.InstanceTypeInfo
+	GetSupportedInstanceTypeInfos() []*ec2.InstanceTypeInfo
 }
 
 // InstanceTypeAllocator extends ResourceCapacityProvider with the mutating

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -2102,9 +2102,12 @@ func (s *InstanceServiceImpl) DescribeInstances(input *ec2.DescribeInstancesInpu
 	return &ec2.DescribeInstancesOutput{Reservations: reservations}, nil
 }
 
-// DescribeInstanceTypes returns instance types provisionable on this node.
-// The "capacity" filter (when "true") expands each type to one entry per
-// available slot so callers can report cluster-wide capacity by aggregating.
+// DescribeInstanceTypes returns instance types this node supports. Without
+// the "capacity" filter the response lists every supported type once,
+// matching AWS semantics — callers (e.g. the Terraform AWS provider) expect
+// a stable answer that does not depend on current allocation. With
+// `capacity=true` each type expands to one entry per free schedulable slot
+// so callers can aggregate cluster-wide remaining capacity.
 func (s *InstanceServiceImpl) DescribeInstanceTypes(input *ec2.DescribeInstanceTypesInput, _ string) (*ec2.DescribeInstanceTypesOutput, error) {
 	slog.Info("Processing DescribeInstanceTypes request from this node")
 
@@ -2124,8 +2127,13 @@ func (s *InstanceServiceImpl) DescribeInstanceTypes(input *ec2.DescribeInstanceT
 		}
 	}
 
-	filteredTypes := s.resourceMgr.GetAvailableInstanceTypeInfos(showCapacity)
-	slog.Info("DescribeInstanceTypes completed", "count", len(filteredTypes))
+	var filteredTypes []*ec2.InstanceTypeInfo
+	if showCapacity {
+		filteredTypes = s.resourceMgr.GetAvailableInstanceTypeInfos(true)
+	} else {
+		filteredTypes = s.resourceMgr.GetSupportedInstanceTypeInfos()
+	}
+	slog.Info("DescribeInstanceTypes completed", "count", len(filteredTypes), "showCapacity", showCapacity)
 	return &ec2.DescribeInstanceTypesOutput{InstanceTypes: filteredTypes}, nil
 }
 

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -845,19 +845,29 @@ func TestCloudInitVolumeNamePerInstance(t *testing.T) {
 // --- 1b-pre Describe* coverage (siv-22 parts) ------------------------------
 
 type fakeResourceCapacityProvider struct {
-	types         []*ec2.InstanceTypeInfo
-	gotShowCap    bool
-	calls         int
-	instanceTypes map[string]*ec2.InstanceTypeInfo
-	allocateErr   error
-	allocated     []*ec2.InstanceTypeInfo
-	deallocated   []*ec2.InstanceTypeInfo
-	canAllocFn    func(*ec2.InstanceTypeInfo, int) int
+	types          []*ec2.InstanceTypeInfo
+	supportedTypes []*ec2.InstanceTypeInfo
+	gotShowCap     bool
+	calls          int
+	supportedCalls int
+	instanceTypes  map[string]*ec2.InstanceTypeInfo
+	allocateErr    error
+	allocated      []*ec2.InstanceTypeInfo
+	deallocated    []*ec2.InstanceTypeInfo
+	canAllocFn     func(*ec2.InstanceTypeInfo, int) int
 }
 
 func (f *fakeResourceCapacityProvider) GetAvailableInstanceTypeInfos(showCapacity bool) []*ec2.InstanceTypeInfo {
 	f.calls++
 	f.gotShowCap = showCapacity
+	return f.types
+}
+
+func (f *fakeResourceCapacityProvider) GetSupportedInstanceTypeInfos() []*ec2.InstanceTypeInfo {
+	f.supportedCalls++
+	if f.supportedTypes != nil {
+		return f.supportedTypes
+	}
 	return f.types
 }
 
@@ -961,23 +971,38 @@ func TestDescribeInstanceTypes_NilResourceMgr(t *testing.T) {
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 }
 
-func TestDescribeInstanceTypes_ReturnsProviderTypes(t *testing.T) {
+func TestDescribeInstanceTypes_ReturnsSupportedByDefault(t *testing.T) {
 	prov := &fakeResourceCapacityProvider{
-		types: []*ec2.InstanceTypeInfo{
+		supportedTypes: []*ec2.InstanceTypeInfo{
 			{InstanceType: aws.String("t3.micro")},
 			{InstanceType: aws.String("t3.small")},
+			{InstanceType: aws.String("m5.large")},
+		},
+		types: []*ec2.InstanceTypeInfo{
+			{InstanceType: aws.String("t3.micro")},
 		},
 	}
 	svc := &InstanceServiceImpl{resourceMgr: prov}
 
 	out, err := svc.DescribeInstanceTypes(&ec2.DescribeInstanceTypesInput{}, "")
 	require.NoError(t, err)
-	require.Len(t, out.InstanceTypes, 2)
-	assert.False(t, prov.gotShowCap)
+	require.Len(t, out.InstanceTypes, 3,
+		"no-filter DescribeInstanceTypes must return the supported set, not the capacity-gated set")
+	assert.Equal(t, 1, prov.supportedCalls, "supported-types path must be hit when capacity filter absent")
+	assert.Equal(t, 0, prov.calls, "capacity-gated path must not be hit when capacity filter absent")
 }
 
-func TestDescribeInstanceTypes_CapacityFilterPropagates(t *testing.T) {
-	prov := &fakeResourceCapacityProvider{}
+func TestDescribeInstanceTypes_CapacityFilterHitsAvailable(t *testing.T) {
+	prov := &fakeResourceCapacityProvider{
+		types: []*ec2.InstanceTypeInfo{
+			{InstanceType: aws.String("t3.micro")},
+			{InstanceType: aws.String("t3.micro")},
+		},
+		supportedTypes: []*ec2.InstanceTypeInfo{
+			{InstanceType: aws.String("t3.micro")},
+			{InstanceType: aws.String("m5.large")},
+		},
+	}
 	svc := &InstanceServiceImpl{resourceMgr: prov}
 
 	input := &ec2.DescribeInstanceTypesInput{
@@ -985,9 +1010,12 @@ func TestDescribeInstanceTypes_CapacityFilterPropagates(t *testing.T) {
 			{Name: aws.String("capacity"), Values: []*string{aws.String("true")}},
 		},
 	}
-	_, err := svc.DescribeInstanceTypes(input, "")
+	out, err := svc.DescribeInstanceTypes(input, "")
 	require.NoError(t, err)
+	require.Len(t, out.InstanceTypes, 2, "capacity=true must use the per-slot list")
+	assert.Equal(t, 1, prov.calls, "capacity-gated path must be hit when capacity=true")
 	assert.True(t, prov.gotShowCap, "capacity=true filter must reach the provider")
+	assert.Equal(t, 0, prov.supportedCalls, "supported-types path must not be hit when capacity=true")
 }
 
 func TestDescribeInstances_Empty(t *testing.T) {

--- a/spinifex/vm/manager_deps_test.go
+++ b/spinifex/vm/manager_deps_test.go
@@ -157,3 +157,45 @@ func (f *fakeVolumeMounter) UnmountOne(req types.EBSRequest) {
 }
 
 var _ VolumeMounter = (*fakeVolumeMounter)(nil)
+
+// fakeVolumeStateUpdater records every UpdateVolumeState call so tests can
+// assert that AttachVolume / DetachVolume / boot-volume promotion pass the
+// correct attachment-device name. The arguments captured here back the
+// AWS-spec round-trip through DescribeVolumes' attachment.device filter,
+// so a regression that passes the in-guest path (e.g. /dev/vdc) instead
+// of the API-form name (e.g. /dev/sdf) shows up as the wrong stored
+// device on the recorded call.
+type fakeVolumeStateUpdater struct {
+	mu    sync.Mutex
+	calls []volumeStateUpdate
+	err   error
+}
+
+type volumeStateUpdate struct {
+	VolumeID         string
+	State            string
+	InstanceID       string
+	AttachmentDevice string
+}
+
+func (f *fakeVolumeStateUpdater) UpdateVolumeState(volumeID, state, instanceID, attachmentDevice string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, volumeStateUpdate{
+		VolumeID:         volumeID,
+		State:            state,
+		InstanceID:       instanceID,
+		AttachmentDevice: attachmentDevice,
+	})
+	return f.err
+}
+
+func (f *fakeVolumeStateUpdater) snapshot() []volumeStateUpdate {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]volumeStateUpdate, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+var _ VolumeStateUpdater = (*fakeVolumeStateUpdater)(nil)

--- a/spinifex/vm/volumes.go
+++ b/spinifex/vm/volumes.go
@@ -20,10 +20,14 @@ import (
 const blockdevDelMaxAttempts = 20
 
 // AttachVolumeResult carries the device names produced by AttachVolume:
-// the AWS-API name (/dev/sdf, possibly auto-allocated) and the discovered
-// guest device path (/dev/vdb…). Daemon handlers use GuestDevice in the
-// AWS API response; the discovered name eventually appears in
-// DescribeInstances.
+// the AWS-API name (/dev/sd[f-p], possibly auto-allocated when the
+// caller passed an empty device) and the in-guest path discovered from
+// QMP query-block (/dev/vd*). Daemon handlers echo DeviceName in the
+// AttachVolume response and into volume metadata so AWS-spec round-trips
+// (Volume.Attachments[].Device, the attachment.device filter on
+// DescribeVolumes) match. GuestDevice is retained for diagnostics and
+// for any internal callers that need to map back to the guest's virtio
+// enumeration.
 type AttachVolumeResult struct {
 	DeviceName  string
 	GuestDevice string
@@ -191,6 +195,12 @@ func (m *Manager) AttachVolume(id, volumeID, device string) (AttachVolumeResult,
 	}
 	instance.EBSRequests.Mu.Unlock()
 
+	// BlockDeviceMappings[].DeviceName carries the in-guest path so
+	// callers who SSH into the VM and `lsblk` see names that match
+	// DescribeInstances (mulga-599 / PR #55). UpdateGuestDeviceNames
+	// re-applies this convention on every Launch/Start, so any "fix"
+	// to use the API name here would be silently overwritten on the
+	// next start.
 	m.UpdateState(id, func(v *VM) {
 		if v.Instance == nil {
 			return
@@ -206,8 +216,16 @@ func (m *Manager) AttachVolume(id, volumeID, device string) (AttachVolumeResult,
 		v.Instance.BlockDeviceMappings = append(v.Instance.BlockDeviceMappings, mapping)
 	})
 
+	// Volume metadata, by contrast, drives Volume.Attachments[].Device
+	// and the attachment.device filter on DescribeVolumes. The Terraform
+	// AWS provider polls that filter with the API-form name (/dev/sd[f-p])
+	// supplied in the .tf config, so storing the guest path here makes
+	// the filter reject every attached volume and the post-attach wait
+	// loop fails with "couldn't find resource". Always persist the API
+	// name even though it diverges from the BDM convention above —
+	// nothing in mulga-599 rewrites this field after attach.
 	if m.deps.VolumeStateUpdater != nil {
-		if err := m.deps.VolumeStateUpdater.UpdateVolumeState(volumeID, "in-use", instance.ID, guestDevice); err != nil {
+		if err := m.deps.VolumeStateUpdater.UpdateVolumeState(volumeID, "in-use", instance.ID, device); err != nil {
 			slog.Error("AttachVolume: failed to update volume metadata",
 				"volumeId", volumeID, "err", err)
 		}

--- a/spinifex/vm/volumes_test.go
+++ b/spinifex/vm/volumes_test.go
@@ -647,6 +647,90 @@ func captureSlog(t *testing.T) *bytes.Buffer {
 	return &buf
 }
 
+// TestAttachVolume_PersistsAPIDeviceNameInVolumeMetadata locks down the
+// AWS-spec contract that Volume.Attachments[].Device carries the API-form
+// name (/dev/sd[f-p]), not the in-guest virtio path (/dev/vd*). The
+// Terraform AWS provider's aws_volume_attachment polls DescribeVolumes
+// with attachment.device=/dev/sdf — storing the guest path makes that
+// filter reject every attached volume and the wait loop times out with
+// "couldn't find resource". This regression is mulga-siv-154.
+//
+// The QMP responder returns a query-block payload where vdisk-vol-1
+// maps to /dev/vdc (the third virtio slot after os + cloudinit), so the
+// test can distinguish the API name from the guest name in every assertion.
+// BlockDeviceMappings still carries the guest device name per mulga-599;
+// only the volume-metadata path uses the API name.
+func TestAttachVolume_PersistsAPIDeviceNameInVolumeMetadata(t *testing.T) {
+	qmpClient, cancel := newMockQMPClient(t, func(cmd qmp.QMPCommand) map[string]any {
+		if cmd.Execute == "query-block" {
+			return map[string]any{
+				"return": []qmp.BlockDevice{
+					{
+						Device:   "os",
+						Inserted: &qmp.BlockInserted{},
+						QDev:     "/machine/peripheral-anon/device[0]/virtio-backend",
+					},
+					{
+						Device:   "cloudinit",
+						Inserted: &qmp.BlockInserted{},
+						QDev:     "/machine/peripheral-anon/device[1]/virtio-backend",
+					},
+					{
+						Device:   "",
+						Inserted: &qmp.BlockInserted{},
+						QDev:     "/machine/peripheral/vdisk-vol-1/hotplug-ebs1/virtio-backend",
+					},
+				},
+			}
+		}
+		return nil
+	})
+	defer cancel()
+
+	mounter := &fakeVolumeMounter{mountOneURI: "nbd:unix:/tmp/test.sock"}
+	stateUpdater := &fakeVolumeStateUpdater{}
+
+	m := NewManagerWithDeps(Deps{
+		VolumeMounter:      mounter,
+		VolumeStateUpdater: stateUpdater,
+	})
+	m.Insert(&VM{
+		ID:        "i-1",
+		Status:    StateRunning,
+		Instance:  &ec2.Instance{},
+		QMPClient: qmpClient,
+	})
+
+	res, err := m.AttachVolume("i-1", "vol-1", "/dev/sdf")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/dev/sdf", res.DeviceName,
+		"AttachVolumeResult.DeviceName must echo the API-form name so the daemon's AttachVolume response and aws_volume_attachment's post-attach wait both round-trip the AWS-spec contract")
+	assert.Equal(t, "/dev/vdc", res.GuestDevice,
+		"AttachVolumeResult.GuestDevice must carry the in-guest virtio path discovered from query-block")
+
+	calls := stateUpdater.snapshot()
+	require.Len(t, calls, 1,
+		"AttachVolume must persist exactly one volume-metadata update")
+	assert.Equal(t, "vol-1", calls[0].VolumeID)
+	assert.Equal(t, "in-use", calls[0].State)
+	assert.Equal(t, "i-1", calls[0].InstanceID)
+	assert.Equal(t, "/dev/sdf", calls[0].AttachmentDevice,
+		"UpdateVolumeState must persist the API-form name (/dev/sdf), not the in-guest path (/dev/vdc) — the attachment.device filter on DescribeVolumes only matches the API form")
+
+	v, ok := m.Get("i-1")
+	require.True(t, ok)
+	require.Len(t, v.Instance.BlockDeviceMappings, 1,
+		"AttachVolume must append exactly one BlockDeviceMapping")
+	bdm := v.Instance.BlockDeviceMappings[0]
+	require.NotNil(t, bdm.DeviceName)
+	assert.Equal(t, "/dev/vdc", *bdm.DeviceName,
+		"BlockDeviceMappings[].DeviceName must carry the guest virtio path so `lsblk` inside the VM matches DescribeInstances (mulga-599 / PR #55)")
+	require.NotNil(t, bdm.Ebs)
+	require.NotNil(t, bdm.Ebs.VolumeId)
+	assert.Equal(t, "vol-1", *bdm.Ebs.VolumeId)
+}
+
 // TestTryBlockdevDel covers the bounded retry loop that handles QEMU's
 // transient "node is in use" GenericError after device_del. Each sub-test
 // configures a QMP responder that fails the first N attempts with the


### PR DESCRIPTION
## Summary

- `DescribeInstanceAttribute` was queue-grouped on `spinifex-workers`, so each request landed on one daemon at random. The handler only consults per-daemon state (`vmMgr` / `stoppedStore`), so 1/N requests succeeded and the rest returned `InvalidInstanceID.NotFound`. Terraform's AWS provider refreshes `aws_instance` with three attribute reads per cycle, which on a 5-node cluster fails ~99% of the time.
- Move the daemon subscription into the fan-out block (no queue group) and rewrite the gateway to mirror `DescribeInstances`: inbox + N replies + drop `NotFound`. Aggregator returns the first parsed success, falls back to `NotFound` only when every daemon confirms absence, and propagates deterministic client errors (`InvalidParameterValue`, `MissingParameter`) when no daemon succeeds.

Tracking bead: `mulga-siv-151`. Plan doc: `docs/development/bugs/spinifex-describeinstanceattribute-fanout.md` (mulga root).

Companion bead `mulga-siv-152` adds a multinode + tofu-examples nightly cell so this regression class is CI-visible going forward (separate PR).

## Test plan

- [x] `make preflight` — clean (tests + lint + govulncheck).
- [x] New gateway tests: `MultipleNodes_OwnerWins`, `AllNodesNotFound`, `ClientErrorPropagates`, `NoResponders`, `SingleNode` (rewritten without queue group).
- [x] Daemon-side tests in `daemon_handlers_test.go` updated to drop the `spinifex-workers` queue-group string (10 sites) so the test harness matches production wiring.
- [x] Manual: `tofu apply -var-file=envs/spinifex.tfvars` from `~/Development/workload-demo` after `make deploy` — confirm no `InvalidInstanceID.NotFound` on `aws_instance` refresh.