### PR TITLE
feat: vendor-agnostic instance types + sys.* NATS fan-out

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -98,11 +98,12 @@ type ResourceManager struct {
 	gpuManager    *gpu.Manager // nil if GPU passthrough is disabled or no GPUs present
 
 	// Dynamic instance-type subscription management
-	subsMu       sync.Mutex
-	natsConn     *nats.Conn
-	instanceSubs map[string]*nats.Subscription
-	handler      nats.MsgHandler
-	nodeID       string // node identifier for node-specific topic subscriptions
+	subsMu        sync.Mutex
+	natsConn      *nats.Conn
+	instanceSubs  map[string]*nats.Subscription
+	handler       nats.MsgHandler
+	systemHandler nats.MsgHandler // handles system.LaunchInstance.* requests (ALB-VM fan-out)
+	nodeID        string          // node identifier for node-specific topic subscriptions
 }
 
 // Daemon represents the main daemon service
@@ -1240,8 +1241,13 @@ func (d *Daemon) startCluster() error {
 		d.elbv2Service.VPCService = d.vpcService
 	}
 
-	// Wire LB VM lifecycle: instance launcher for system VMs.
-	d.elbv2Service.InstanceLauncher = d
+	// Wire LB VM lifecycle: route system VM launches through NATS so they
+	// fan out across the cluster instead of always running on whichever node
+	// handled the upstream CreateLoadBalancer call. The daemon's own
+	// system.LaunchInstance.* subscriptions (registered by ResourceManager)
+	// will pick up the request locally when this node has capacity, or hand
+	// off to another node via the spinifex-workers queue group otherwise.
+	d.elbv2Service.InstanceLauncher = handlers_elbv2.NewNATSSystemInstanceLauncher(d.natsConn, 0)
 
 	// Wire system credentials + gateway URL for LB agent SigV4 auth.
 	d.wireLBAgentConfig()
@@ -1309,7 +1315,7 @@ func (d *Daemon) startCluster() error {
 	// Initialize dynamic per-instance-type subscriptions for capacity-aware routing.
 	// Each instance type gets its own NATS topic (ec2.RunInstances.{type}) so requests
 	// are only routed to nodes with available capacity.
-	d.resourceMgr.initSubscriptions(d.natsConn, d.handleEC2RunInstances, d.node)
+	d.resourceMgr.initSubscriptions(d.natsConn, d.handleEC2RunInstances, d.handleSystemLaunchInstance, d.node)
 
 	d.startHeartbeat()
 	d.vmMgr.StartPendingWatchdog(d.ctx)
@@ -2028,21 +2034,31 @@ func (rm *ResourceManager) reloadGPUTypes(models []instancetypes.GPUModel, migPr
 	rm.updateInstanceSubscriptions()
 }
 
-func (rm *ResourceManager) initSubscriptions(nc *nats.Conn, handler nats.MsgHandler, nodeID string) {
+func (rm *ResourceManager) initSubscriptions(nc *nats.Conn, handler nats.MsgHandler, systemHandler nats.MsgHandler, nodeID string) {
 	rm.natsConn = nc
 	rm.handler = handler
+	rm.systemHandler = systemHandler
 	rm.nodeID = nodeID
 	rm.instanceSubs = make(map[string]*nats.Subscription)
 	rm.updateInstanceSubscriptions()
 }
 
 // updateInstanceSubscriptions recalculates which instance types can fit on this
-// node and subscribes/unsubscribes from the corresponding NATS topics. Each type
-// gets two topics:
-//   - ec2.RunInstances.{type} with spinifex-workers queue group (load-balanced, for single-instance launches)
-//   - ec2.RunInstances.{type}.{nodeId} without queue group (targeted, for multi-node distribution)
+// node and subscribes/unsubscribes from the corresponding NATS topics.
 //
-// Both use the same handler. NATS only routes requests to nodes with available capacity.
+// Customer instance types use the ec2.RunInstances.* subject root and the
+// rm.handler callback. Each customer type gets:
+//   - ec2.RunInstances.{type} with spinifex-workers queue group
+//   - ec2.RunInstances.{type}.{nodeId} without queue group (targeted)
+//
+// System instance types (sys.*) are not exposed via the customer EC2 API and
+// instead route under system.LaunchInstance.* with the rm.systemHandler
+// callback. Same shape (queue + node-targeted topic) so ELBv2's ALB-VM
+// launches load-balance across the cluster instead of piling on the handler
+// node that processed the upstream CreateLoadBalancer call.
+//
+// NATS only routes requests to nodes whose subscription is live, so capacity
+// pressure naturally re-distributes load when a host fills up.
 func (rm *ResourceManager) updateInstanceSubscriptions() {
 	if rm.natsConn == nil {
 		return
@@ -2052,17 +2068,26 @@ func (rm *ResourceManager) updateInstanceSubscriptions() {
 	defer rm.subsMu.Unlock()
 
 	for typeName, typeInfo := range rm.instanceTypes {
-		// System types (sys.micro, etc.) are internal-only — not routable via customer API.
-		if instancetypes.IsSystemType(typeName) {
-			continue
-		}
-		queueTopic := fmt.Sprintf("ec2.RunInstances.%s", typeName)
 		canFit := rm.canAllocate(typeInfo, 1) >= 1
 
-		// Queue group subscription (load-balanced across nodes)
+		subjectRoot := "ec2.RunInstances"
+		handler := rm.handler
+		queueGroup := "spinifex-workers"
+		if instancetypes.IsSystemType(typeName) {
+			// System types (sys.micro, etc.) are internal-only — not exposed
+			// via the customer EC2 API and use a dedicated subject root so
+			// ELBv2 can fan out ALB-VM launches across the cluster.
+			if rm.systemHandler == nil {
+				continue
+			}
+			subjectRoot = "system.LaunchInstance"
+			handler = rm.systemHandler
+		}
+
+		queueTopic := fmt.Sprintf("%s.%s", subjectRoot, typeName)
 		_, subscribed := rm.instanceSubs[queueTopic]
 		if canFit && !subscribed {
-			sub, err := rm.natsConn.QueueSubscribe(queueTopic, "spinifex-workers", rm.handler)
+			sub, err := rm.natsConn.QueueSubscribe(queueTopic, queueGroup, handler)
 			if err != nil {
 				slog.Error("Failed to subscribe to instance type topic", "topic", queueTopic, "err", err)
 				continue
@@ -2077,12 +2102,11 @@ func (rm *ResourceManager) updateInstanceSubscriptions() {
 			slog.Info("Unsubscribed from instance type (capacity full)", "topic", queueTopic)
 		}
 
-		// Node-specific subscription (targeted routing for multi-node distribution)
 		if rm.nodeID != "" {
-			nodeTopic := fmt.Sprintf("ec2.RunInstances.%s.%s", typeName, rm.nodeID)
+			nodeTopic := fmt.Sprintf("%s.%s.%s", subjectRoot, typeName, rm.nodeID)
 			_, nodeSubscribed := rm.instanceSubs[nodeTopic]
 			if canFit && !nodeSubscribed {
-				sub, err := rm.natsConn.Subscribe(nodeTopic, rm.handler)
+				sub, err := rm.natsConn.Subscribe(nodeTopic, handler)
 				if err != nil {
 					slog.Error("Failed to subscribe to node-specific topic", "topic", nodeTopic, "err", err)
 					continue

--- a/spinifex/daemon/daemon_system_dispatch.go
+++ b/spinifex/daemon/daemon_system_dispatch.go
@@ -1,0 +1,180 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// systemInstanceLaunchEnvelope is the wire format for
+// system.LaunchInstance.{type}[.{nodeID}] replies. Either Output or Error
+// is set. Encoded as JSON so non-Go consumers stay possible later.
+type systemInstanceLaunchEnvelope struct {
+	Output *handlers_elbv2.SystemInstanceOutput `json:"output,omitempty"`
+	Error  string                               `json:"error,omitempty"`
+}
+
+// systemInstanceTerminateEnvelope is the wire format for
+// system.TerminateInstance.{instanceID} replies. Empty Error means success.
+type systemInstanceTerminateEnvelope struct {
+	Error string `json:"error,omitempty"`
+}
+
+// handleSystemLaunchInstance is the NATS subscriber for
+// system.LaunchInstance.{type}[.{nodeID}] requests. The owning daemon (the
+// one whose queue-group subscription wins, or the one whose nodeID-targeted
+// subscription is hit) runs LaunchSystemInstance locally and the resulting
+// VM stays bound to this node — see handleSystemTerminateInstance for the
+// matching teardown path.
+func (d *Daemon) handleSystemLaunchInstance(msg *nats.Msg) {
+	input := new(handlers_elbv2.SystemInstanceInput)
+	if err := json.Unmarshal(msg.Data, input); err != nil {
+		slog.Error("system.LaunchInstance: invalid JSON payload", "subject", msg.Subject, "err", err)
+		respondWithSystemLaunchError(msg, awserrors.ErrorServerInternal)
+		return
+	}
+
+	output, err := d.LaunchSystemInstance(input)
+	if err != nil {
+		slog.Error("system.LaunchInstance: LaunchSystemInstance failed",
+			"instanceType", input.InstanceType, "subject", msg.Subject, "err", err)
+		respondWithSystemLaunchError(msg, err.Error())
+		return
+	}
+
+	// Bind a per-instance terminate subscription so future
+	// system.TerminateInstance.{id} requests reach the daemon that owns the
+	// VM. cleanupSystemTerminateSubscription unwires on shutdown.
+	if subErr := d.subscribeSystemTerminate(output.InstanceID); subErr != nil {
+		slog.Error("system.LaunchInstance: failed to subscribe terminate subject",
+			"instanceId", output.InstanceID, "err", subErr)
+	}
+
+	respondWithSystemLaunchOutput(msg, output)
+}
+
+// subscribeSystemTerminate registers an owning-node subscription for
+// system.TerminateInstance.{instanceID}. Idempotent — calling for an
+// already-bound subscription is a no-op.
+func (d *Daemon) subscribeSystemTerminate(instanceID string) error {
+	if d.natsConn == nil {
+		return nil
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	subject := fmt.Sprintf("system.TerminateInstance.%s", instanceID)
+	if _, exists := d.natsSubscriptions[subject]; exists {
+		return nil
+	}
+	sub, err := d.natsConn.Subscribe(subject, d.handleSystemTerminateInstance)
+	if err != nil {
+		return fmt.Errorf("subscribe %s: %w", subject, err)
+	}
+	d.natsSubscriptions[subject] = sub
+	return nil
+}
+
+// handleSystemTerminateInstance is the NATS subscriber for
+// system.TerminateInstance.{instanceID}. Only the daemon that owns the VM
+// has a subscription on this subject — other daemons never see the request.
+func (d *Daemon) handleSystemTerminateInstance(msg *nats.Msg) {
+	// Subject suffix is the instance ID; payload is unused but reserved for
+	// future flags. Tolerate empty payloads.
+	parts := splitSubjectTail(msg.Subject, "system.TerminateInstance.")
+	if parts == "" {
+		slog.Error("system.TerminateInstance: subject missing instance ID", "subject", msg.Subject)
+		respondWithSystemTerminateError(msg, awserrors.ErrorInvalidInstanceIDNotFound)
+		return
+	}
+
+	if err := d.TerminateSystemInstance(parts); err != nil {
+		slog.Error("system.TerminateInstance: failed",
+			"instanceId", parts, "err", err)
+		respondWithSystemTerminateError(msg, err.Error())
+		return
+	}
+
+	// Drop the per-instance terminate subscription now the VM is gone.
+	d.mu.Lock()
+	subject := fmt.Sprintf("system.TerminateInstance.%s", parts)
+	if sub, exists := d.natsSubscriptions[subject]; exists {
+		if unsubErr := sub.Unsubscribe(); unsubErr != nil {
+			slog.Warn("system.TerminateInstance: failed to unsubscribe", "subject", subject, "err", unsubErr)
+		}
+		delete(d.natsSubscriptions, subject)
+	}
+	d.mu.Unlock()
+
+	respondWithSystemTerminateOK(msg)
+}
+
+func respondWithSystemLaunchOutput(msg *nats.Msg, out *handlers_elbv2.SystemInstanceOutput) {
+	payload, err := json.Marshal(systemInstanceLaunchEnvelope{Output: out})
+	if err != nil {
+		slog.Error("system.LaunchInstance: marshal output failed", "err", err)
+		respondWithSystemLaunchError(msg, awserrors.ErrorServerInternal)
+		return
+	}
+	if err := msg.Respond(payload); err != nil {
+		slog.Error("system.LaunchInstance: respond failed", "err", err)
+	}
+}
+
+func respondWithSystemLaunchError(msg *nats.Msg, errMsg string) {
+	if errMsg == "" {
+		errMsg = awserrors.ErrorServerInternal
+	}
+	payload, err := json.Marshal(systemInstanceLaunchEnvelope{Error: errMsg})
+	if err != nil {
+		// Fall back to bare error payload so the requester at least sees a non-empty reply.
+		if respErr := msg.Respond(utils.GenerateErrorPayload(awserrors.ErrorServerInternal)); respErr != nil {
+			slog.Error("system.LaunchInstance: respond (error fallback) failed", "err", respErr)
+		}
+		return
+	}
+	if err := msg.Respond(payload); err != nil {
+		slog.Error("system.LaunchInstance: respond (error) failed", "err", err)
+	}
+}
+
+func respondWithSystemTerminateOK(msg *nats.Msg) {
+	payload, err := json.Marshal(systemInstanceTerminateEnvelope{})
+	if err != nil {
+		slog.Error("system.TerminateInstance: marshal ok failed", "err", err)
+		return
+	}
+	if err := msg.Respond(payload); err != nil {
+		slog.Error("system.TerminateInstance: respond failed", "err", err)
+	}
+}
+
+func respondWithSystemTerminateError(msg *nats.Msg, errMsg string) {
+	if errMsg == "" {
+		errMsg = awserrors.ErrorServerInternal
+	}
+	payload, err := json.Marshal(systemInstanceTerminateEnvelope{Error: errMsg})
+	if err != nil {
+		if respErr := msg.Respond(utils.GenerateErrorPayload(awserrors.ErrorServerInternal)); respErr != nil {
+			slog.Error("system.TerminateInstance: respond (error fallback) failed", "err", respErr)
+		}
+		return
+	}
+	if err := msg.Respond(payload); err != nil {
+		slog.Error("system.TerminateInstance: respond (error) failed", "err", err)
+	}
+}
+
+// splitSubjectTail returns the portion of subject after prefix, or empty
+// string if subject does not start with prefix. Helper kept local to avoid
+// touching utils for a one-liner.
+func splitSubjectTail(subject, prefix string) string {
+	if len(subject) <= len(prefix) || subject[:len(prefix)] != prefix {
+		return ""
+	}
+	return subject[len(prefix):]
+}

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -1296,7 +1296,7 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		defer nc.Close()
 
 		handler := func(msg *nats.Msg) {}
-		rm.initSubscriptions(nc, handler, "test-node")
+		rm.initSubscriptions(nc, handler, nil, "test-node")
 
 		// Count how many types actually fit on this machine (excluding system types)
 		fittableTypes := 0
@@ -1330,7 +1330,7 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		defer nc.Close()
 
 		handler := func(msg *nats.Msg) {}
-		rm.initSubscriptions(nc, handler, "test-node")
+		rm.initSubscriptions(nc, handler, nil, "test-node")
 
 		initialCount := len(rm.instanceSubs)
 		require.Greater(t, initialCount, 0)
@@ -1355,7 +1355,7 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		defer nc.Close()
 
 		handler := func(msg *nats.Msg) {}
-		rm.initSubscriptions(nc, handler, "test-node")
+		rm.initSubscriptions(nc, handler, nil, "test-node")
 
 		expectedCount := len(rm.instanceSubs)
 
@@ -1386,7 +1386,7 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		defer nc.Close()
 
 		handler := func(msg *nats.Msg) {}
-		rm.initSubscriptions(nc, handler, "test-node")
+		rm.initSubscriptions(nc, handler, nil, "test-node")
 
 		// Leave only 2 vCPUs and 1 GB schedulable — enough for nano/micro but not larger types.
 		rm.mu.Lock()
@@ -1415,7 +1415,7 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		defer nc.Close()
 
 		handler := func(msg *nats.Msg) {}
-		rm.initSubscriptions(nc, handler, "test-node")
+		rm.initSubscriptions(nc, handler, nil, "test-node")
 
 		initialCount := len(rm.instanceSubs)
 		require.Greater(t, initialCount, 0)
@@ -1459,7 +1459,7 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		defer nc.Close()
 
 		handler := func(msg *nats.Msg) {}
-		rm.initSubscriptions(nc, handler, "test-node")
+		rm.initSubscriptions(nc, handler, nil, "test-node")
 
 		// Fill the node completely
 		rm.mu.Lock()

--- a/spinifex/handlers/elbv2/launcher.go
+++ b/spinifex/handlers/elbv2/launcher.go
@@ -23,63 +23,67 @@ type SystemInstanceLauncher interface {
 // ELBv2 load balancer. There is no AMI or cloud-init path — kernel and
 // initrd come from the bundled spinifex package and per-VM config is
 // delivered via QEMU fw_cfg blobs.
+//
+// JSON tags are explicit because this struct crosses the
+// system.LaunchInstance.* NATS subject root when ELBv2 hands a launch off
+// to the cluster — see daemon/daemon_system_dispatch.go.
 type SystemInstanceInput struct {
-	InstanceType string // e.g. "sys.micro"
-	SubnetID     string // VPC subnet for networking
+	InstanceType string `json:"instance_type"` // e.g. "sys.micro"
+	SubnetID     string `json:"subnet_id"`     // VPC subnet for networking
 
 	// ENI fields — the VM always uses a pre-created ENI (the ALB's primary ENI).
-	ENIID  string
-	ENIMac string
-	ENIIP  string
+	ENIID  string `json:"eni_id"`
+	ENIMac string `json:"eni_mac"`
+	ENIIP  string `json:"eni_ip"`
 
 	// ExtraENIs lists additional pre-created ENIs that should be attached to
 	// the VM alongside the primary ENI. Used for multi-subnet ALBs so the VM
 	// has a NIC (and tap on br-int) in every subnet the LB spans.
-	ExtraENIs []ExtraENIInput
+	ExtraENIs []ExtraENIInput `json:"extra_enis,omitempty"`
 
 	// Scheme is the ALB scheme ("internet-facing" or "internal").
 	// Internet-facing ALBs get a public IP and NAT rules; internal ALBs do not.
-	Scheme string
+	Scheme string `json:"scheme"`
 
 	// AccountID is the owner account of the ALB's ENI. Required so the daemon
 	// can look up and update the ENI record (which is keyed by account).
-	AccountID string
+	AccountID string `json:"account_id"`
 
 	// HostfwdPorts specifies additional guest ports to forward from the host
 	// via the QEMU user-mode dev NIC (dev_networking mode only).
 	// Each entry is a guest port (e.g. 80, 443). The host port is auto-assigned.
-	HostfwdPorts []int
+	HostfwdPorts []int `json:"hostfwd_ports,omitempty"`
 
 	// NICs defines the network interfaces for the microVM.
 	// Index 0 is the primary VPC ENI, index 1 is the management NIC, index 2+ are extra ENIs.
-	NICs []NICConfig
+	NICs []NICConfig `json:"nics,omitempty"`
 
 	// LBAgentEnv is a KEY=value blob written to /etc/conf.d/lb-agent inside
 	// the guest via fw_cfg.
-	LBAgentEnv string
+	LBAgentEnv string `json:"lb_agent_env"`
 
 	// CACert holds PEM-encoded CA certificate bytes delivered to the guest via fw_cfg.
-	CACert string
+	CACert string `json:"ca_cert"`
 }
 
 // ExtraENIInput describes an additional pre-created ENI to attach to a
 // system instance. The primary ENI is still passed via ENIID/ENIMac/ENIIP.
 type ExtraENIInput struct {
-	ENIID    string
-	ENIMac   string
-	ENIIP    string
-	SubnetID string
+	ENIID    string `json:"eni_id"`
+	ENIMac   string `json:"eni_mac"`
+	ENIIP    string `json:"eni_ip"`
+	SubnetID string `json:"subnet_id"`
 }
 
 // NICConfig describes a single network interface for a microVM direct-boot launch.
 // Index 0 is the primary VPC ENI, index 1 is the management NIC, index 2+ are extra ENIs.
 type NICConfig struct {
-	MAC       string // e.g. "02:0a:01:23:45:67"
-	CIDR      string // e.g. "10.0.1.5/24"
-	Gateway   string // e.g. "10.0.1.1"; empty for mgmt NIC
-	IsDefault bool   // true for exactly one NIC (primary VPC ENI)
-	RouteDst  string // specific host route dst, e.g. "10.20.0.5/32"
-	RouteVia  string // next-hop for RouteDst
+	MAC       string `json:"mac"`                 // e.g. "02:0a:01:23:45:67"
+	CIDR      string `json:"cidr"`                // e.g. "10.0.1.5/24"
+	Gateway   string `json:"gateway,omitempty"`   // e.g. "10.0.1.1"; empty for mgmt NIC
+	IsDefault bool   `json:"is_default"`          // true for exactly one NIC (primary VPC ENI)
+	RouteDst  string `json:"route_dst,omitempty"` // specific host route dst, e.g. "10.20.0.5/32"
+	RouteVia  string `json:"route_via,omitempty"` // next-hop for RouteDst
 }
 
 // RecoveryContext carries the per-VM fields the ELBv2 service needs to
@@ -98,11 +102,11 @@ type RecoveryContext struct {
 
 // SystemInstanceOutput contains the result of a successful launch.
 type SystemInstanceOutput struct {
-	InstanceID string // e.g. "i-xxxxx"
-	PrivateIP  string // VPC private IP
-	PublicIP   string // Public IP (only for internet-facing scheme)
+	InstanceID string `json:"instance_id"`         // e.g. "i-xxxxx"
+	PrivateIP  string `json:"private_ip"`          // VPC private IP
+	PublicIP   string `json:"public_ip,omitempty"` // Public IP (only for internet-facing scheme)
 
 	// HostfwdMap maps guest port → host port for any forwarded ports.
 	// Only populated when dev_networking is enabled and HostfwdPorts were requested.
-	HostfwdMap map[int]int
+	HostfwdMap map[int]int `json:"hostfwd_map,omitempty"`
 }

--- a/spinifex/handlers/elbv2/system_instance_launcher_nats.go
+++ b/spinifex/handlers/elbv2/system_instance_launcher_nats.go
@@ -1,0 +1,106 @@
+package handlers_elbv2
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// natsSystemInstanceLauncher implements SystemInstanceLauncher by
+// dispatching LaunchSystemInstance / TerminateSystemInstance over NATS so
+// ALB-VMs fan out across the cluster instead of piling on the daemon node
+// that handled the upstream CreateLoadBalancer call.
+//
+// Subjects:
+//   - system.LaunchInstance.{type}     (queue group spinifex-workers)
+//   - system.TerminateInstance.{id}    (single subscriber: the owning daemon)
+//
+// The daemons subscribe with capacity-aware logic in
+// ResourceManager.updateInstanceSubscriptions; only nodes with free
+// vCPU/memory for the requested type carry the launch subscription, so
+// over-full nodes naturally drop out of the queue group.
+type natsSystemInstanceLauncher struct {
+	nc      *nats.Conn
+	timeout time.Duration
+}
+
+const defaultSystemInstanceTimeout = 60 * time.Second
+
+// NewNATSSystemInstanceLauncher returns a SystemInstanceLauncher that
+// publishes requests over NATS request/reply. timeout caps each round trip;
+// pass 0 to use the default (60s, sized for direct-boot microVM start +
+// EIP allocation latency on a busy cluster).
+func NewNATSSystemInstanceLauncher(nc *nats.Conn, timeout time.Duration) SystemInstanceLauncher {
+	if timeout <= 0 {
+		timeout = defaultSystemInstanceTimeout
+	}
+	return &natsSystemInstanceLauncher{nc: nc, timeout: timeout}
+}
+
+// natsSystemInstanceLaunchEnvelope mirrors the daemon-side wire format so
+// ELBv2 and the daemon agree on JSON shape without sharing a package.
+type natsSystemInstanceLaunchEnvelope struct {
+	Output *SystemInstanceOutput `json:"output,omitempty"`
+	Error  string                `json:"error,omitempty"`
+}
+
+type natsSystemInstanceTerminateEnvelope struct {
+	Error string `json:"error,omitempty"`
+}
+
+func (l *natsSystemInstanceLauncher) LaunchSystemInstance(input *SystemInstanceInput) (*SystemInstanceOutput, error) {
+	if input == nil {
+		return nil, fmt.Errorf("system instance input is nil")
+	}
+	if input.InstanceType == "" {
+		return nil, fmt.Errorf("system instance input missing InstanceType")
+	}
+
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal SystemInstanceInput: %w", err)
+	}
+
+	subject := fmt.Sprintf("system.LaunchInstance.%s", input.InstanceType)
+	reply, err := l.nc.Request(subject, payload, l.timeout)
+	if err != nil {
+		return nil, fmt.Errorf("nats request %s: %w", subject, err)
+	}
+
+	var env natsSystemInstanceLaunchEnvelope
+	if err := json.Unmarshal(reply.Data, &env); err != nil {
+		return nil, fmt.Errorf("decode launch reply: %w", err)
+	}
+	if env.Error != "" {
+		return nil, fmt.Errorf("%s", env.Error)
+	}
+	if env.Output == nil {
+		return nil, fmt.Errorf("launch reply missing output payload")
+	}
+	return env.Output, nil
+}
+
+func (l *natsSystemInstanceLauncher) TerminateSystemInstance(instanceID string) error {
+	if instanceID == "" {
+		return fmt.Errorf("system instance terminate: empty instance ID")
+	}
+
+	subject := fmt.Sprintf("system.TerminateInstance.%s", instanceID)
+	reply, err := l.nc.Request(subject, nil, l.timeout)
+	if err != nil {
+		return fmt.Errorf("nats request %s: %w", subject, err)
+	}
+
+	var env natsSystemInstanceTerminateEnvelope
+	if err := json.Unmarshal(reply.Data, &env); err != nil {
+		return fmt.Errorf("decode terminate reply: %w", err)
+	}
+	if env.Error != "" {
+		return fmt.Errorf("%s", env.Error)
+	}
+	return nil
+}
+
+var _ SystemInstanceLauncher = (*natsSystemInstanceLauncher)(nil)

--- a/spinifex/handlers/elbv2/system_instance_launcher_nats_test.go
+++ b/spinifex/handlers/elbv2/system_instance_launcher_nats_test.go
@@ -1,0 +1,157 @@
+package handlers_elbv2
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubResponder subscribes to a subject and replies with the provided
+// envelope payload. Captures the last request payload for assertions.
+type stubResponder struct {
+	mu        sync.Mutex
+	lastInput SystemInstanceInput
+	called    int
+	sub       *nats.Subscription
+}
+
+func (s *stubResponder) close() {
+	if s.sub != nil {
+		_ = s.sub.Unsubscribe()
+	}
+}
+
+func TestNATSSystemInstanceLauncher_LaunchRoundTrip(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	defer nc.Close()
+
+	resp := &stubResponder{}
+	sub, err := nc.Subscribe("system.LaunchInstance.sys.micro", func(msg *nats.Msg) {
+		resp.mu.Lock()
+		resp.called++
+		_ = json.Unmarshal(msg.Data, &resp.lastInput)
+		resp.mu.Unlock()
+
+		envelope := struct {
+			Output *SystemInstanceOutput `json:"output,omitempty"`
+			Error  string                `json:"error,omitempty"`
+		}{
+			Output: &SystemInstanceOutput{
+				InstanceID: "i-natsdispatched",
+				PrivateIP:  "10.0.1.42",
+			},
+		}
+		payload, _ := json.Marshal(envelope)
+		_ = msg.Respond(payload)
+	})
+	require.NoError(t, err)
+	resp.sub = sub
+	defer resp.close()
+
+	launcher := NewNATSSystemInstanceLauncher(nc, 5*time.Second)
+	out, err := launcher.LaunchSystemInstance(&SystemInstanceInput{
+		InstanceType: "sys.micro",
+		SubnetID:     "subnet-test",
+		ENIID:        "eni-test",
+		Scheme:       SchemeInternal,
+		AccountID:    "000000000001",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "i-natsdispatched", out.InstanceID)
+	assert.Equal(t, "10.0.1.42", out.PrivateIP)
+
+	resp.mu.Lock()
+	defer resp.mu.Unlock()
+	assert.Equal(t, 1, resp.called, "responder must be hit exactly once")
+	assert.Equal(t, "sys.micro", resp.lastInput.InstanceType, "request payload must round trip JSON-encoded")
+	assert.Equal(t, "subnet-test", resp.lastInput.SubnetID)
+	assert.Equal(t, "eni-test", resp.lastInput.ENIID)
+}
+
+func TestNATSSystemInstanceLauncher_LaunchPropagatesRemoteError(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	defer nc.Close()
+
+	sub, err := nc.Subscribe("system.LaunchInstance.sys.micro", func(msg *nats.Msg) {
+		envelope := struct {
+			Output *SystemInstanceOutput `json:"output,omitempty"`
+			Error  string                `json:"error,omitempty"`
+		}{Error: "insufficient capacity for sys.micro"}
+		payload, _ := json.Marshal(envelope)
+		_ = msg.Respond(payload)
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	launcher := NewNATSSystemInstanceLauncher(nc, 2*time.Second)
+	out, err := launcher.LaunchSystemInstance(&SystemInstanceInput{InstanceType: "sys.micro"})
+	require.Error(t, err)
+	assert.Nil(t, out)
+	assert.Contains(t, err.Error(), "insufficient capacity")
+}
+
+func TestNATSSystemInstanceLauncher_LaunchFailsWhenNoResponder(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	defer nc.Close()
+
+	launcher := NewNATSSystemInstanceLauncher(nc, 250*time.Millisecond)
+	_, err := launcher.LaunchSystemInstance(&SystemInstanceInput{InstanceType: "sys.micro"})
+	require.Error(t, err, "no subscriber on the topic must surface as an error, not hang forever")
+	assert.True(t,
+		errors.Is(err, nats.ErrNoResponders) || assert.Contains(t, err.Error(), "no responders") || assert.Contains(t, err.Error(), "timeout"),
+		"error should surface NATS no-responder / timeout signal: %v", err)
+}
+
+func TestNATSSystemInstanceLauncher_TerminateRoundTrip(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	defer nc.Close()
+
+	terminated := make(chan string, 1)
+	sub, err := nc.Subscribe("system.TerminateInstance.i-target", func(msg *nats.Msg) {
+		terminated <- "i-target"
+		payload, _ := json.Marshal(struct {
+			Error string `json:"error,omitempty"`
+		}{})
+		_ = msg.Respond(payload)
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	launcher := NewNATSSystemInstanceLauncher(nc, 5*time.Second)
+	err = launcher.TerminateSystemInstance("i-target")
+	require.NoError(t, err)
+
+	select {
+	case got := <-terminated:
+		assert.Equal(t, "i-target", got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminate subscriber must have been invoked")
+	}
+}
+
+func TestNATSSystemInstanceLauncher_TerminatePropagatesRemoteError(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	defer nc.Close()
+
+	sub, err := nc.Subscribe("system.TerminateInstance.i-missing", func(msg *nats.Msg) {
+		payload, _ := json.Marshal(struct {
+			Error string `json:"error,omitempty"`
+		}{Error: "instance i-missing not found"})
+		_ = msg.Respond(payload)
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	launcher := NewNATSSystemInstanceLauncher(nc, 2*time.Second)
+	err = launcher.TerminateSystemInstance("i-missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/spinifex/instancetypes/definitions.go
+++ b/spinifex/instancetypes/definitions.go
@@ -67,6 +67,31 @@ type cpuGeneration struct {
 	families []string // e.g. ["t3", "c6i", "m6i", "r6i"]
 }
 
+// vendorSiblingFamily maps an x86_64 family to its cross-vendor counterpart
+// (Intel ↔ AMD) within the same generation tier. Resource shape (vCPU /
+// memory ratio per size) is identical between siblings, so a host that can
+// run t3.medium can run t3a.medium on the same KVM substrate. Used by
+// generateForGeneration so any x86_64 host accepts requests for either
+// vendor family — load balances across mixed Intel + AMD clusters.
+//
+// ARM (Graviton t4g/c?g/m?g/r?g) and legacy Intel-only (t2, c4, m4, r4)
+// families have no cross-vendor sibling and are omitted.
+var vendorSiblingFamily = map[string]string{
+	"t3": "t3a", "t3a": "t3",
+	"c5": "c5a", "c5a": "c5",
+	"m5": "m5a", "m5a": "m5",
+	"r5": "r5a", "r5a": "r5",
+	"c6i": "c6a", "c6a": "c6i",
+	"m6i": "m6a", "m6a": "m6i",
+	"r6i": "r6a", "r6a": "r6i",
+	"c7i": "c7a", "c7a": "c7i",
+	"m7i": "m7a", "m7a": "m7i",
+	"r7i": "r7a", "r7a": "r7i",
+	"c8i": "c8a", "c8a": "c8i",
+	"m8i": "m8a", "m8a": "m8i",
+	"r8i": "r8a", "r8a": "r8i",
+}
+
 var (
 	// Intel generations
 	genIntelBroadwell      = cpuGeneration{"Intel Broadwell", []string{"t2", "c4", "m4", "r4"}}

--- a/spinifex/instancetypes/generate.go
+++ b/spinifex/instancetypes/generate.go
@@ -20,11 +20,21 @@ func IsSystemType(name string) bool {
 // generateForGeneration creates the instance type map for the given CPU generation.
 // It generates all instance families matching the generation's family list across
 // burstable, general purpose, compute optimized, and memory optimized categories.
+//
+// On x86_64 hosts the cross-vendor sibling family for each member of
+// gen.families is also emitted (e.g. Intel Skylake's "t3" pulls in "t3a" so
+// AMD-targeted RunInstances requests can land on this host). ARM and
+// legacy Intel-only families have no sibling and are unaffected.
 func generateForGeneration(gen cpuGeneration, arch string) map[string]*ec2.InstanceTypeInfo {
-	// Build a set of allowed families for fast lookup
-	allowed := make(map[string]bool, len(gen.families))
+	// Build a set of allowed families for fast lookup. Include cross-vendor
+	// siblings so a mixed Intel+AMD cluster routes RunInstances of either
+	// vendor family to any x86_64 host with capacity.
+	allowed := make(map[string]bool, len(gen.families)*2)
 	for _, f := range gen.families {
 		allowed[f] = true
+		if sib, ok := vendorSiblingFamily[f]; ok {
+			allowed[sib] = true
+		}
 	}
 
 	instanceTypes := make(map[string]*ec2.InstanceTypeInfo)

--- a/spinifex/instancetypes/generate_test.go
+++ b/spinifex/instancetypes/generate_test.go
@@ -66,18 +66,20 @@ func TestDetectAndGenerate_IncludesSystemTypes(t *testing.T) {
 
 func TestGenerateInstanceTypes_IntelIceLake(t *testing.T) {
 	types := generateForGeneration(genIntelIceLake, "x86_64")
-	// t3(7) + c6i(8) + m6i(8) + r6i(8) = 31
-	assert.Len(t, types, 31)
+	// Native Intel families: t3(7) + c6i(8) + m6i(8) + r6i(8) = 31
+	// Vendor siblings (AMD): t3a(7) + c6a(8) + m6a(8) + r6a(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3.", "c6i.", "m6i.", "r6i."} {
-		assert.True(t, hasFamily(types, prefix), "expected Ice Lake types to include %s family", prefix)
+	for _, prefix := range []string{"t3.", "c6i.", "m6i.", "r6i.", "t3a.", "c6a.", "m6a.", "r6a."} {
+		assert.True(t, hasFamily(types, prefix), "expected Ice Lake (with AMD siblings) to include %s family", prefix)
 	}
 
-	// Verify other generation families are NOT present
+	// Verify other generations' families are NOT present.
 	for name := range types {
-		assert.False(t, strings.HasPrefix(name, "t3a."), "Ice Lake should not have t3a: %s", name)
 		assert.False(t, strings.HasPrefix(name, "c5."), "Ice Lake should not have c5: %s", name)
+		assert.False(t, strings.HasPrefix(name, "c5a."), "Ice Lake should not have c5a: %s", name)
 		assert.False(t, strings.HasPrefix(name, "c7i."), "Ice Lake should not have c7i: %s", name)
+		assert.False(t, strings.HasPrefix(name, "c7a."), "Ice Lake should not have c7a: %s", name)
 	}
 }
 
@@ -93,77 +95,102 @@ func TestGenerateInstanceTypes_IntelBroadwell(t *testing.T) {
 
 func TestGenerateInstanceTypes_IntelSkylake(t *testing.T) {
 	types := generateForGeneration(genIntelSkylake, "x86_64")
-	// t3(7) + c5(8) + m5(8) + r5(8) = 31
-	assert.Len(t, types, 31)
+	// Native Intel families: t3(7) + c5(8) + m5(8) + r5(8) = 31
+	// Vendor siblings (AMD): t3a(7) + c5a(8) + m5a(8) + r5a(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3.", "c5.", "m5.", "r5."} {
-		assert.True(t, hasFamily(types, prefix), "expected Skylake types to include %s family", prefix)
+	for _, prefix := range []string{"t3.", "c5.", "m5.", "r5.", "t3a.", "c5a.", "m5a.", "r5a."} {
+		assert.True(t, hasFamily(types, prefix), "expected Skylake (with AMD siblings) to include %s family", prefix)
 	}
 }
 
 func TestGenerateInstanceTypes_IntelSapphireRapids(t *testing.T) {
 	types := generateForGeneration(genIntelSapphireRapids, "x86_64")
-	// t3(7) + c7i(8) + m7i(8) + r7i(8) = 31
-	assert.Len(t, types, 31)
+	// Native Intel families: t3(7) + c7i(8) + m7i(8) + r7i(8) = 31
+	// Vendor siblings (AMD): t3a(7) + c7a(8) + m7a(8) + r7a(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3.", "c7i.", "m7i.", "r7i."} {
-		assert.True(t, hasFamily(types, prefix), "expected Sapphire Rapids types to include %s family", prefix)
+	for _, prefix := range []string{"t3.", "c7i.", "m7i.", "r7i.", "t3a.", "c7a.", "m7a.", "r7a."} {
+		assert.True(t, hasFamily(types, prefix), "expected Sapphire Rapids (with AMD siblings) to include %s family", prefix)
 	}
 }
 
 func TestGenerateInstanceTypes_IntelGraniteRapids(t *testing.T) {
 	types := generateForGeneration(genIntelGraniteRapids, "x86_64")
-	// t3(7) + c8i(8) + m8i(8) + r8i(8) = 31
-	assert.Len(t, types, 31)
+	// Native Intel families: t3(7) + c8i(8) + m8i(8) + r8i(8) = 31
+	// Vendor siblings (AMD): t3a(7) + c8a(8) + m8a(8) + r8a(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3.", "c8i.", "m8i.", "r8i."} {
-		assert.True(t, hasFamily(types, prefix), "expected Granite Rapids types to include %s family", prefix)
+	for _, prefix := range []string{"t3.", "c8i.", "m8i.", "r8i.", "t3a.", "c8a.", "m8a.", "r8a."} {
+		assert.True(t, hasFamily(types, prefix), "expected Granite Rapids (with AMD siblings) to include %s family", prefix)
 	}
 }
 
 func TestGenerateInstanceTypes_AMDZen(t *testing.T) {
 	types := generateForGeneration(genAMDZen, "x86_64")
-	// t3a(7) + c5a(8) + m5a(8) + r5a(8) = 31
-	assert.Len(t, types, 31)
+	// Native AMD families: t3a(7) + c5a(8) + m5a(8) + r5a(8) = 31
+	// Vendor siblings (Intel): t3(7) + c5(8) + m5(8) + r5(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3a.", "c5a.", "m5a.", "r5a."} {
-		assert.True(t, hasFamily(types, prefix), "expected Zen types to include %s family", prefix)
+	for _, prefix := range []string{"t3a.", "c5a.", "m5a.", "r5a.", "t3.", "c5.", "m5.", "r5."} {
+		assert.True(t, hasFamily(types, prefix), "expected Zen (with Intel siblings) to include %s family", prefix)
 	}
 }
 
 func TestGenerateInstanceTypes_AMDZen4(t *testing.T) {
 	types := generateForGeneration(genAMDZen4, "x86_64")
-	// t3a(7) + c7a(8) + m7a(8) + r7a(8) = 31
-	assert.Len(t, types, 31)
+	// Native AMD families: t3a(7) + c7a(8) + m7a(8) + r7a(8) = 31
+	// Vendor siblings (Intel): t3(7) + c7i(8) + m7i(8) + r7i(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3a.", "c7a.", "m7a.", "r7a."} {
-		assert.True(t, hasFamily(types, prefix), "expected Zen 4 types to include %s family", prefix)
+	for _, prefix := range []string{"t3a.", "c7a.", "m7a.", "r7a.", "t3.", "c7i.", "m7i.", "r7i."} {
+		assert.True(t, hasFamily(types, prefix), "expected Zen 4 (with Intel siblings) to include %s family", prefix)
 	}
 
-	// Verify older AMD families are NOT present
+	// Older AMD or Intel generations must not leak in.
 	for name := range types {
 		assert.False(t, strings.HasPrefix(name, "c5a."), "Zen4 should not have c5a: %s", name)
 		assert.False(t, strings.HasPrefix(name, "c6a."), "Zen4 should not have c6a: %s", name)
+		assert.False(t, strings.HasPrefix(name, "c5."), "Zen4 should not have c5: %s", name)
+		assert.False(t, strings.HasPrefix(name, "c6i."), "Zen4 should not have c6i: %s", name)
 	}
 }
 
 func TestGenerateInstanceTypes_AMDZen3(t *testing.T) {
 	types := generateForGeneration(genAMDZen3, "x86_64")
-	// t3a(7) + c6a(8) + m6a(8) + r6a(8) = 31
-	assert.Len(t, types, 31)
+	// Native AMD families: t3a(7) + c6a(8) + m6a(8) + r6a(8) = 31
+	// Vendor siblings (Intel): t3(7) + c6i(8) + m6i(8) + r6i(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3a.", "c6a.", "m6a.", "r6a."} {
-		assert.True(t, hasFamily(types, prefix), "expected Zen 3 types to include %s family", prefix)
+	for _, prefix := range []string{"t3a.", "c6a.", "m6a.", "r6a.", "t3.", "c6i.", "m6i.", "r6i."} {
+		assert.True(t, hasFamily(types, prefix), "expected Zen 3 (with Intel siblings) to include %s family", prefix)
 	}
 }
 
 func TestGenerateInstanceTypes_AMDZen5(t *testing.T) {
 	types := generateForGeneration(genAMDZen5, "x86_64")
-	// t3a(7) + c8a(8) + m8a(8) + r8a(8) = 31
-	assert.Len(t, types, 31)
+	// Native AMD families: t3a(7) + c8a(8) + m8a(8) + r8a(8) = 31
+	// Vendor siblings (Intel): t3(7) + c8i(8) + m8i(8) + r8i(8) = 31
+	assert.Len(t, types, 62)
 
-	for _, prefix := range []string{"t3a.", "c8a.", "m8a.", "r8a."} {
-		assert.True(t, hasFamily(types, prefix), "expected Zen 5 types to include %s family", prefix)
+	for _, prefix := range []string{"t3a.", "c8a.", "m8a.", "r8a.", "t3.", "c8i.", "m8i.", "r8i."} {
+		assert.True(t, hasFamily(types, prefix), "expected Zen 5 (with Intel siblings) to include %s family", prefix)
+	}
+}
+
+func TestGenerateInstanceTypes_VendorSiblingResourcesMatch(t *testing.T) {
+	// t3 + t3a must carry identical vCPU / memory shape — alias is meaningful
+	// only if the schedule decisions are identical.
+	types := generateForGeneration(genIntelSkylake, "x86_64")
+	for _, size := range []string{"nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"} {
+		intel, intelOK := types["t3."+size]
+		amd, amdOK := types["t3a."+size]
+		require.True(t, intelOK, "missing t3.%s", size)
+		require.True(t, amdOK, "missing t3a.%s sibling", size)
+		assert.Equal(t, *intel.VCpuInfo.DefaultVCpus, *amd.VCpuInfo.DefaultVCpus,
+			"t3.%s and t3a.%s must have identical vCPU count", size, size)
+		assert.Equal(t, *intel.MemoryInfo.SizeInMiB, *amd.MemoryInfo.SizeInMiB,
+			"t3.%s and t3a.%s must have identical memory", size, size)
 	}
 }
 
@@ -204,22 +231,28 @@ func TestGenerateInstanceTypes_ARMV2(t *testing.T) {
 }
 
 func TestGenerateInstanceTypes_UnknownFallback(t *testing.T) {
+	// Unknown Intel: t3 (7) + vendor sibling t3a (7) = 14 types
 	types := generateForGeneration(genUnknownIntel, "x86_64")
-	// Unknown Intel: t3 only = 7 types
-	assert.Len(t, types, 7)
+	assert.Len(t, types, 14)
 	assert.True(t, hasFamily(types, "t3."), "unknown Intel should have t3")
+	assert.True(t, hasFamily(types, "t3a."), "unknown Intel should have t3a sibling")
 
+	// Unknown AMD: t3a (7) + vendor sibling t3 (7) = 14 types
 	types = generateForGeneration(genUnknownAMD, "x86_64")
-	assert.Len(t, types, 7)
+	assert.Len(t, types, 14)
 	assert.True(t, hasFamily(types, "t3a."), "unknown AMD should have t3a")
+	assert.True(t, hasFamily(types, "t3."), "unknown AMD should have t3 sibling")
 
+	// ARM has no sibling — single-family.
 	types = generateForGeneration(genUnknownARM, "arm64")
 	assert.Len(t, types, 7)
 	assert.True(t, hasFamily(types, "t4g."), "unknown ARM should have t4g")
 
+	// Generic fallback: same as unknown Intel.
 	types = generateForGeneration(genUnknown, "x86_64")
-	assert.Len(t, types, 7)
+	assert.Len(t, types, 14)
 	assert.True(t, hasFamily(types, "t3."), "completely unknown should have t3")
+	assert.True(t, hasFamily(types, "t3a."), "completely unknown should have t3a sibling")
 }
 
 func TestGenerateInstanceTypes_VerifyBurstableSizes(t *testing.T) {


### PR DESCRIPTION
## Summary

Two commits closing mulga-siv-157 (vendor-agnostic instance type orchestration on mixed Intel/AMD clusters).

### 1. `feat(instancetypes): emit cross-vendor sibling families on x86_64 hosts`

- x86_64 cpuGeneration family lists now extend at generate time with their cross-vendor counterpart (Intel `t3` ↔ AMD `t3a`, `c5` ↔ `c5a`, `m6i` ↔ `m6a`, etc.) via new `vendorSiblingFamily` map.
- Sibling families share identical vCPU/memory shape per size and the x86_64 arch tag, so any host schedules either vendor without changes to `canAllocate` or the subscription path.
- `ResourceManager.updateInstanceSubscriptions` picks up both vendors automatically — `RunInstances` for `t3.*` and `t3a.*` load-balance across mixed clusters via the existing `spinifex-workers` queue group.
- ARM (Graviton) and legacy Intel-only families (`t2`, `c4`, `m4`, `r4`) have no sibling and are unaffected.

### 2. `feat(daemon,elbv2): NATS fan-out for system instance launch/terminate`

- ELBv2 ALB-VMs (`sys.micro`) previously launched via direct Go calls into the local daemon, pinning every ALB-VM to whichever node handled the upstream `CreateLoadBalancer`. Mixed clusters tripped `insufficient capacity for sys.micro` once host-reserve trimmed schedulable vCPU.
- New subject root:
  - `system.LaunchInstance.{type}` (queue group `spinifex-workers`)
  - `system.LaunchInstance.{type}.{nodeID}` (targeted)
  - `system.TerminateInstance.{instanceID}` (owning-node only)
- `ResourceManager.updateInstanceSubscriptions` treats `sys.*` types via a separate `systemHandler` hook with the same capacity-aware subscribe/unsubscribe behaviour customer types already have — `sys.micro` subscriptions drop when the host saturates.
- `ELBv2ServiceImpl` now consumes `NATSSystemInstanceLauncher` instead of a direct daemon pointer, so any node can carry an ALB-VM.
- `SystemInstanceInput/Output/NICConfig/ExtraENIInput` get explicit JSON tags (wire crosses NATS).

Closes mulga-siv-157.

## Test plan
- [x] `make preflight`
- [x] JSON round-trip + remote-error propagation + terminate routing + no-responder failure mode (`system_instance_launcher_nats_test.go`)
- [x] Updated `generate_test.go` covers sibling-family emission per cpuGeneration
- [ ] Manual smoke on mixed Intel + AMD cluster: `aws ec2 run-instances --instance-type t3a.nano` lands on AMD host; `aws elbv2 create-load-balancer` distributes ALB-VMs across all nodes instead of pinning to the gateway node