### PR TITLE
feat(sts): EKS Q4 — AssumeRoleWithWebIdentity + presigned GetCallerIdentity verify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/gookit/color v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/spinifex/awserrors/awserrors.go
+++ b/spinifex/awserrors/awserrors.go
@@ -167,6 +167,9 @@ var (
 	ErrorInvalidIPAddressInUse                                 = "InvalidIPAddress.InUse"
 	ErrorInvalidIamInstanceProfileArnMalformed                 = "InvalidIamInstanceProfileArn.Malformed"
 	ErrorInvalidIamInstanceProfileNotFound                     = "InvalidIamInstanceProfile.NotFound"
+	ErrorInvalidIdentityToken                                  = "InvalidIdentityToken"
+	ErrorIDPRejectedClaim                                      = "IDPRejectedClaim"
+	ErrorIDPCommunicationError                                 = "IDPCommunicationError"
 	ErrorIamInstanceProfileAlreadyAssociated                   = "IamInstanceProfileAlreadyAssociated"
 	ErrorNoSuchAssociation                                     = "NoSuchAssociation"
 	ErrorInvalidInput                                          = "InvalidInput"
@@ -634,6 +637,9 @@ var ErrorLookup = map[string]ErrorMessage{
 	ErrorInvalidIPAddressInUse:                                 {HTTPCode: 409, Message: "The specified IP address is already in use. If you are trying to release an address, you must first disassociate it from the instance."},
 	ErrorInvalidIamInstanceProfileArnMalformed:                 {HTTPCode: 400, Message: "The specified IAM instance profile ARN is not valid. For more information about valid ARN formats, see Amazon Resource Names (ARNs)."},
 	ErrorInvalidIamInstanceProfileNotFound:                     {HTTPCode: 404, Message: "The specified IAM instance profile name or ARN does not exist."},
+	ErrorInvalidIdentityToken:                                  {HTTPCode: 400, Message: "The web identity token that was passed is invalid or expired."},
+	ErrorIDPRejectedClaim:                                      {HTTPCode: 403, Message: "The identity provider (IdP) reported that authentication failed."},
+	ErrorIDPCommunicationError:                                 {HTTPCode: 400, Message: "The request could not be fulfilled because the identity provider (IdP) that was asked to verify the incoming identity token could not be reached."},
 	ErrorIamInstanceProfileAlreadyAssociated:                   {HTTPCode: 400, Message: "There is an existing association for the specified instance."},
 	ErrorNoSuchAssociation:                                     {HTTPCode: 404, Message: "The specified IAM instance profile association does not exist."},
 	ErrorInvalidInput:                                          {HTTPCode: 400, Message: "An input parameter in the request is not valid. For example, you may have specified an incorrect Reserved Instance listing ID in the request or the Reserved Instance you tried to list cannot be sold in the Reserved Instances Marketplace (for example, if it has a scope of Region, or is a Convertible Reserved Instance)."},

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -1594,6 +1594,14 @@ func (m *mockSTSService) VerifySessionToken(cred *handlers_sts.SessionCredential
 	return want == wireToken
 }
 
+func (m *mockSTSService) AssumeRoleWithWebIdentity(_ *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+func (m *mockSTSService) VerifyPresignedGetCallerIdentity(_, _ string) (*handlers_sts.PresignedCallerIdentity, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
 const (
 	testSessionAKID  = "ASIATESTSESSIONAAAAA"
 	testSessionToken = "wire-session-token-plain"

--- a/spinifex/gateway/sts.go
+++ b/spinifex/gateway/sts.go
@@ -58,6 +58,13 @@ var stsActions = map[string]STSHandler{
 	"AssumeRole": stsHandler(func(c stsCaller, input *sts.AssumeRoleInput, gw *GatewayConfig) (any, error) {
 		return gateway_sts.AssumeRole(c.accountID, c.arn, c.identity, input, gw.STSService)
 	}),
+	// TODO: AssumeRoleWithWebIdentity is anonymous on AWS — the caller is
+	// authenticated by the JWT body, not by a SigV4 envelope. The current
+	// dispatch path runs SigV4 first, then enters this handler with a synthetic
+	// stsCaller. That works for in-cluster callers that already hold SigV4
+	// credentials but rejects the true anonymous code path (no AWS creds, only
+	// a projected ServiceAccount token). The AWS gateway mux needs a pre-auth
+	// route for this action so the JWT can be the sole authenticator.
 	"AssumeRoleWithWebIdentity": stsHandler(func(_ stsCaller, input *sts.AssumeRoleWithWebIdentityInput, gw *GatewayConfig) (any, error) {
 		return gateway_sts.AssumeRoleWithWebIdentity(input, gw.STSService)
 	}),

--- a/spinifex/gateway/sts.go
+++ b/spinifex/gateway/sts.go
@@ -58,6 +58,9 @@ var stsActions = map[string]STSHandler{
 	"AssumeRole": stsHandler(func(c stsCaller, input *sts.AssumeRoleInput, gw *GatewayConfig) (any, error) {
 		return gateway_sts.AssumeRole(c.accountID, c.arn, c.identity, input, gw.STSService)
 	}),
+	"AssumeRoleWithWebIdentity": stsHandler(func(_ stsCaller, input *sts.AssumeRoleWithWebIdentityInput, gw *GatewayConfig) (any, error) {
+		return gateway_sts.AssumeRoleWithWebIdentity(input, gw.STSService)
+	}),
 	"GetCallerIdentity": stsHandler(func(c stsCaller, input *sts.GetCallerIdentityInput, gw *GatewayConfig) (any, error) {
 		return gateway_sts.GetCallerIdentity(c.accountID, c.arn, c.principalType, c.identity, c.assumedRoleID, input, gw.IAMService, gw.STSService)
 	}),
@@ -66,10 +69,13 @@ var stsActions = map[string]STSHandler{
 // stsSkipPolicyCheck lists the actions whose authorization is NOT gated by an
 // IAM policy check on the caller. AssumeRole is gated by the target role's
 // trust policy (evaluated inside the handler); GetCallerIdentity is always
-// allowed per AWS so SDK init flows do not break.
+// allowed per AWS so SDK init flows do not break;
+// AssumeRoleWithWebIdentity is anonymous — caller is identified by the JWT,
+// not by SigV4 — and trust-policy-gated inside the handler.
 var stsSkipPolicyCheck = map[string]bool{
-	"AssumeRole":        true,
-	"GetCallerIdentity": true,
+	"AssumeRole":                true,
+	"AssumeRoleWithWebIdentity": true,
+	"GetCallerIdentity":         true,
 }
 
 func (gw *GatewayConfig) STS_Request(w http.ResponseWriter, r *http.Request) error {

--- a/spinifex/gateway/sts/AssumeRoleWithWebIdentity.go
+++ b/spinifex/gateway/sts/AssumeRoleWithWebIdentity.go
@@ -1,0 +1,33 @@
+package gateway_sts
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_sts "github.com/mulgadc/spinifex/spinifex/handlers/sts"
+)
+
+// AssumeRoleWithWebIdentity validates the inbound STS
+// AssumeRoleWithWebIdentity request and delegates to the STSService. Unlike
+// AssumeRole, this action is anonymous — the caller is identified by the
+// supplied OIDC token, not by SigV4 — so no caller ARN / account is required
+// on entry. The trust policy on the target role is the authoritative
+// authorization check, evaluated inside the handler.
+//
+// The action is registered on the standard STS gateway dispatch but its
+// authorization model is different: callers do not need to be SigV4-signed.
+// The current STS dispatcher still threads requests through resolveSTSCaller
+// which expects an authenticated principal; switching the action to an
+// anonymous route group lands in Sprint 6e alongside the awsgw OIDC mux
+// rework (eks-v1.md Q5).
+func AssumeRoleWithWebIdentity(input *sts.AssumeRoleWithWebIdentityInput, svc handlers_sts.STSService) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	if input == nil {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if aws.StringValue(input.RoleArn) == "" || aws.StringValue(input.RoleSessionName) == "" || aws.StringValue(input.WebIdentityToken) == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.AssumeRoleWithWebIdentity(input)
+}

--- a/spinifex/gateway/sts/handler_test.go
+++ b/spinifex/gateway/sts/handler_test.go
@@ -54,6 +54,14 @@ func (s *stubSTSService) VerifySessionToken(_ *handlers_sts.SessionCredential, _
 	return true
 }
 
+func (s *stubSTSService) AssumeRoleWithWebIdentity(_ *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+func (s *stubSTSService) VerifyPresignedGetCallerIdentity(_, _ string) (*handlers_sts.PresignedCallerIdentity, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
 // stubIAMService satisfies the IAM interface to the extent needed by
 // GetCallerIdentity (only GetUser is exercised). Every other method panics so
 // a test that triggers an unexpected call fails loudly instead of silently

--- a/spinifex/gateway/sts_request_test.go
+++ b/spinifex/gateway/sts_request_test.go
@@ -59,6 +59,14 @@ func (m *flexMockSTSService) VerifySessionToken(*handlers_sts.SessionCredential,
 	return true
 }
 
+func (m *flexMockSTSService) AssumeRoleWithWebIdentity(*sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+func (m *flexMockSTSService) VerifyPresignedGetCallerIdentity(string, string) (*handlers_sts.PresignedCallerIdentity, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
 // stsRequestParams is the set of identity values the dispatcher pulls from
 // SigV4 context. Defaults work for a user principal in the global account.
 type stsRequestParams struct {

--- a/spinifex/handlers/iam/oidc_providers.go
+++ b/spinifex/handlers/iam/oidc_providers.go
@@ -1,0 +1,54 @@
+package handlers_iam
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// Per-account IAM JetStream KV bucket holds resources that are inherently
+// account-scoped and not appropriate for the global IAM buckets — currently
+// the OIDC identity-provider registry consumed by STS AssumeRoleWithWebIdentity
+// and (in a later sprint) by IAM's CreateOpenIDConnectProvider CRUD.
+//
+// Lazy creation: callers that read MUST tolerate ErrBucketNotFound (no provider
+// has been registered for the account yet); callers that write MUST use
+// GetOrCreateIAMAccountBucket so the bucket appears on first use.
+const (
+	KVBucketIAMAccountPrefix  = "iam-account-"
+	KVBucketIAMAccountVersion = 1
+
+	// oidcProvidersKeyPrefix matches the eks-v1.md Q4 layout:
+	// "iam-account-{accountID}/oidc-providers/{issuerHash}". Keep the literal
+	// here (not strings.Join) so a stray refactor that introduces a different
+	// separator fails compile rather than silently writing to a sibling path.
+	oidcProvidersKeyPrefix = "oidc-providers/"
+)
+
+// IAMAccountBucketName returns the JetStream KV bucket name for the supplied
+// AWS account ID.
+func IAMAccountBucketName(accountID string) string {
+	return KVBucketIAMAccountPrefix + accountID
+}
+
+// OIDCProviderKey returns the KV key for an OIDC provider entry. The key is
+// derived from the SHA-256 hex digest of the issuer URL — the Mulga
+// convention (AWS uses the SHA-1 thumbprint of the IdP root cert; we hash the
+// issuer URL because we are also the IdP and have no separate cert chain to
+// pin against).
+func OIDCProviderKey(issuer string) string {
+	sum := sha256.Sum256([]byte(issuer))
+	return oidcProvidersKeyPrefix + hex.EncodeToString(sum[:])
+}
+
+// OIDCProviderARN composes the AWS-format ARN used as the Federated principal
+// value in role trust policies that authorise the named issuer:
+//
+//	arn:aws:iam::{accountID}:oidc-provider/{issuerHostPath}
+//
+// issuerHostPath is the issuer URL with the scheme stripped (no leading
+// "https://") — matches the AWS convention so customers can paste an existing
+// IRSA trust policy unchanged.
+func OIDCProviderARN(accountID, issuerHostPath string) string {
+	return fmt.Sprintf("arn:aws:iam::%s:oidc-provider/%s", accountID, issuerHostPath)
+}

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -420,17 +420,30 @@ func roleToSDK(r *Role) *iam.Role {
 	return out
 }
 
+// STSActionAssumeRoleWithWebIdentity is the only Action that may carry a
+// Condition block in v1 (IRSA `{iss}:sub` / `{iss}:aud` checks). Lives in
+// this package so the validator and the STS-side evaluator agree on the
+// exact spelling without a cross-package constant chase.
+const STSActionAssumeRoleWithWebIdentity = "sts:AssumeRoleWithWebIdentity"
+
 // ValidateTrustPolicyDocument parses and validates an AssumeRolePolicyDocument
 // JSON string. Trust-policy evaluation (Principal semantics, Action being
 // sts:AssumeRole, etc.) is deferred to STS — this layer only checks the
 // document shape.
 //
-// Three categories of fields are rejected at write time rather than silently
-// accepted-then-ignored at evaluation time: Condition blocks, NotPrincipal,
-// and NotAction. Each would otherwise let an author write a policy whose
-// runtime behaviour silently diverges from its stated intent (e.g. an
-// ExternalId-protected role that ignores ExternalId, or a NotPrincipal-Allow
-// that grants the universe). Loud failure here beats silent allow there.
+// Categories of fields rejected at write time rather than silently
+// accepted-then-ignored at evaluation time: NotPrincipal and NotAction —
+// each would otherwise let an author write a policy whose runtime behaviour
+// silently diverges from its stated intent (NotPrincipal-Allow grants the
+// universe; NotAction is unimplemented).
+//
+// Condition blocks are accepted only for the narrow IRSA case: the statement
+// Action must be exactly `["sts:AssumeRoleWithWebIdentity"]` (no wildcards,
+// no co-listed actions) and the only operator key allowed is StringEquals.
+// Any wider acceptance would let an author write an ExternalId-protected
+// sts:AssumeRole policy that evalTrustPolicy silently ignores at runtime —
+// the same "loud-fail-here-or-silent-allow-there" trade-off the original
+// blanket rejection guarded.
 func ValidateTrustPolicyDocument(docJSON string) (*TrustPolicyDocument, error) {
 	if len(docJSON) > maxTrustPolicyDocumentSize {
 		return nil, fmt.Errorf("trust policy exceeds maximum size of %d bytes", maxTrustPolicyDocumentSize)
@@ -465,7 +478,9 @@ func ValidateTrustPolicyDocument(docJSON string) (*TrustPolicyDocument, error) {
 			}
 		}
 		if isRawJSONNonEmpty(stmt.Condition) {
-			return nil, fmt.Errorf("statement %d: trust policy Condition blocks are not supported in this release; remove the Condition field or wait for v1.1", i)
+			if err := validateWebIdentityCondition(i, stmt); err != nil {
+				return nil, err
+			}
 		}
 		if isRawJSONNonEmpty(stmt.NotPrincipal) {
 			return nil, fmt.Errorf("statement %d: trust policy NotPrincipal blocks are not supported in this release; use Principal with an explicit allow-list instead", i)
@@ -476,6 +491,27 @@ func ValidateTrustPolicyDocument(docJSON string) (*TrustPolicyDocument, error) {
 	}
 
 	return &doc, nil
+}
+
+// validateWebIdentityCondition gates the narrow IRSA Condition allowance:
+// Action must be exactly `["sts:AssumeRoleWithWebIdentity"]` (no other entry,
+// no wildcard) and the Condition operator must be exclusively StringEquals.
+// Any wider shape would re-open the "silently-accepted Condition on
+// sts:AssumeRole" hole the original blanket rejection closed.
+func validateWebIdentityCondition(i int, stmt TrustStatement) error {
+	if len(stmt.Action) != 1 || stmt.Action[0] != STSActionAssumeRoleWithWebIdentity {
+		return fmt.Errorf("statement %d: trust policy Condition blocks are only supported on statements whose Action is exactly [%q]; v1 does not evaluate conditions for other actions", i, STSActionAssumeRoleWithWebIdentity)
+	}
+	var ops map[string]json.RawMessage
+	if err := json.Unmarshal(stmt.Condition, &ops); err != nil {
+		return fmt.Errorf("statement %d: Condition must be a JSON object: %w", i, err)
+	}
+	for op := range ops {
+		if op != "StringEquals" {
+			return fmt.Errorf("statement %d: Condition operator %q is not supported in this release; only StringEquals is supported", i, op)
+		}
+	}
+	return nil
 }
 
 // isRawJSONNonEmpty reports whether a json.RawMessage carries a meaningful

--- a/spinifex/handlers/sts/assume_role_with_web_identity.go
+++ b/spinifex/handlers/sts/assume_role_with_web_identity.go
@@ -1,39 +1,291 @@
 package handlers_sts
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"log/slog"
+	"math/big"
+	"slices"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/nats-io/nats.go"
 )
 
-// AssumeRoleWithWebIdentity exchanges an OIDC ID token (typically a
-// projected Kubernetes ServiceAccount token signed by an EKS cluster's
-// per-cluster signing key) for short-lived AWS credentials bound to the
-// target IAM role. The full v1 implementation lands in a follow-up commit
-// on this branch: JWT signature verification against the cluster JWKS
-// (FetchClusterJWKS), `aud` / `exp` / `iss` claim validation, OIDC provider
-// registration check, and Federated-principal trust-policy evaluation.
+// webIdentityClaims is the RegisteredClaims subset the IRSA flow consumes.
+// The wider set of K8s ServiceAccount-token claims (kubernetes.io/*) is
+// ignored: STS only needs iss/sub/aud/exp to authorise the role assumption.
+type webIdentityClaims struct {
+	jwt.RegisteredClaims
+}
+
+// AssumeRoleWithWebIdentity exchanges an OIDC ID token (typically a projected
+// Kubernetes ServiceAccount token signed by an EKS cluster's per-cluster
+// ECDSA-P256 signing key) for short-lived AWS credentials bound to the target
+// IAM role.
 //
-// The interface entry, gateway dispatch, and oidc_jwks.go reader land in
-// this checkpoint so downstream sprints can call the method against a
-// stubbed handler while the verify path is being written.
+// Verification order (each step fails closed on any error):
+//
+//  1. Validate input shape.
+//  2. Parse JWT with ES256 keyfunc that resolves issuer → registered OIDC
+//     provider → cluster JWKS → JWK by kid → *ecdsa.PublicKey.
+//  3. Validate `aud` contains `sts.amazonaws.com` (IRSA convention).
+//  4. Resolve and look up the target role.
+//  5. Evaluate the role's trust policy under web-identity semantics.
+//  6. Mint a session credential bound to the role.
+//
+// Anonymous action — caller identity is the JWT, not SigV4. The gateway
+// dispatcher does not gate this action with checkPolicy.
 func (s *STSServiceImpl) AssumeRoleWithWebIdentity(input *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
 	if input == nil {
 		return nil, errors.New(awserrors.ErrorMissingParameter)
 	}
-	slog.Debug("AssumeRoleWithWebIdentity invoked (stub)",
-		"role_arn", deref(input.RoleArn),
-		"session_name", deref(input.RoleSessionName),
-		"provider_id", deref(input.ProviderId),
+	roleARN := aws.StringValue(input.RoleArn)
+	sessionName := aws.StringValue(input.RoleSessionName)
+	rawToken := aws.StringValue(input.WebIdentityToken)
+	if roleARN == "" || sessionName == "" || rawToken == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if !roleSessionNameRegex.MatchString(sessionName) {
+		return nil, errors.New(awserrors.ErrorValidationError)
+	}
+	if aws.StringValue(input.Policy) != "" || len(input.PolicyArns) > 0 {
+		return nil, errors.New(awserrors.ErrorPackedPolicyTooLarge)
+	}
+
+	roleAccountID, roleName, err := parseRoleARN(roleARN)
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorValidationError)
+	}
+
+	claims := &webIdentityClaims{}
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"ES256"}),
+		jwt.WithExpirationRequired(),
+		// Audience is validated explicitly below — the IRSA contract requires
+		// sts.amazonaws.com membership, and the jwt/v5 default audience check
+		// is a string-equality match on a configurable expected value that
+		// does not capture set-membership semantics on multi-aud tokens.
 	)
-	return nil, errors.New(awserrors.ErrorNotImplemented)
+	_, err = parser.ParseWithClaims(rawToken, claims, s.webIdentityKeyFunc(roleAccountID))
+	if err != nil {
+		slog.Warn("AssumeRoleWithWebIdentity: token verify failed",
+			"role_arn", roleARN, "err", err)
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	if claims.Issuer == "" || claims.Subject == "" {
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+	if !claimAudienceContains(claims.Audience, irsaExpectedAudience) {
+		slog.Warn("AssumeRoleWithWebIdentity: aud claim missing sts.amazonaws.com",
+			"role_arn", roleARN, "aud", []string(claims.Audience))
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	roleOut, err := s.iamSvc.GetRole(roleAccountID, &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if err != nil {
+		// Cross-account miss → AccessDenied (per the AssumeRole pattern —
+		// prevents cross-account role enumeration). Same-account NoSuchEntity
+		// surfaces as-is.
+		if err.Error() == awserrors.ErrorIAMNoSuchEntity {
+			return nil, errors.New(awserrors.ErrorAccessDenied)
+		}
+		return nil, err
+	}
+	role := roleOut.Role
+
+	duration := defaultDurationSeconds
+	if input.DurationSeconds != nil {
+		duration = *input.DurationSeconds
+	}
+	effectiveMax := aws.Int64Value(role.MaxSessionDuration)
+	if effectiveMax == 0 {
+		effectiveMax = defaultDurationSeconds
+	}
+	if effectiveMax > maxDurationSeconds {
+		effectiveMax = maxDurationSeconds
+	}
+	if duration < minDurationSeconds || duration > effectiveMax {
+		return nil, errors.New(awserrors.ErrorValidationError)
+	}
+
+	issuerHostPath := stripIssuerScheme(claims.Issuer)
+	federatedARN := handlers_iam.OIDCProviderARN(roleAccountID, issuerHostPath)
+	ctx := webIdentityContext{
+		federatedPrincipalARN: federatedARN,
+		issuer:                claims.Issuer,
+		subject:               claims.Subject,
+		audience:              []string(claims.Audience),
+	}
+	if err := evalTrustPolicyForWebIdentity(aws.StringValue(role.AssumeRolePolicyDocument), ctx); err != nil {
+		return nil, err
+	}
+
+	cred, plainSecret, plainToken, err := s.mintSessionCredential(role, roleAccountID, sessionName, claims.Subject, duration)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("AssumeRoleWithWebIdentity success",
+		"role_arn", aws.StringValue(role.Arn),
+		"session_name", sessionName,
+		"issuer", claims.Issuer,
+		"subject", claims.Subject,
+		"akid", cred.AccessKeyID,
+		"expires_at", cred.ExpiresAt,
+	)
+
+	primaryAudience := ""
+	if len(claims.Audience) > 0 {
+		primaryAudience = claims.Audience[0]
+	}
+
+	return &sts.AssumeRoleWithWebIdentityOutput{
+		Credentials: &sts.Credentials{
+			AccessKeyId:     aws.String(cred.AccessKeyID),
+			SecretAccessKey: aws.String(plainSecret),
+			SessionToken:    aws.String(plainToken),
+			Expiration:      aws.Time(cred.ExpiresAt),
+		},
+		AssumedRoleUser: &sts.AssumedRoleUser{
+			AssumedRoleId: aws.String(cred.AssumedRoleID),
+			Arn:           aws.String(cred.AssumedRoleARN),
+		},
+		SubjectFromWebIdentityToken: aws.String(claims.Subject),
+		Provider:                    aws.String(issuerHostPath),
+		Audience:                    aws.String(primaryAudience),
+		PackedPolicySize:            aws.Int64(0),
+	}, nil
 }
 
-func deref(p *string) string {
-	if p == nil {
-		return ""
+// webIdentityKeyFunc returns a jwt.Keyfunc bound to the role's account. The
+// `iss` claim drives JWKS discovery, but the OIDC-provider registry is read
+// from the role-account's IAM bucket (per Q4 — cross-account IRSA against an
+// issuer registered in a different account is not supported v1).
+//
+// Resolution path: iss → ParseEKSIssuerURL → (issuerAccountID, clusterName)
+// → registered-provider check in iam-account-{roleAccountID} → FetchClusterJWKS
+// from eks-account-{issuerAccountID} → JWK by kid → *ecdsa.PublicKey.
+//
+// Failures surface as plain errors to the parser; the caller maps them all
+// to ErrorInvalidIdentityToken so the token is rejected with a single
+// auditable error code regardless of which step failed.
+func (s *STSServiceImpl) webIdentityKeyFunc(roleAccountID string) jwt.Keyfunc {
+	return func(t *jwt.Token) (any, error) {
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, errors.New("missing kid header")
+		}
+		claims, ok := t.Claims.(*webIdentityClaims)
+		if !ok {
+			return nil, errors.New("unexpected claims type")
+		}
+		issuer := claims.Issuer
+		if issuer == "" {
+			return nil, errors.New("missing iss claim")
+		}
+		issuerAccountID, clusterName, err := ParseEKSIssuerURL(issuer)
+		if err != nil {
+			return nil, fmt.Errorf("parse issuer: %w", err)
+		}
+		if err := s.verifyOIDCProviderRegistered(roleAccountID, issuer); err != nil {
+			return nil, err
+		}
+		jwks, err := FetchClusterJWKS(s.js, issuerAccountID, clusterName)
+		if err != nil {
+			return nil, fmt.Errorf("fetch JWKS: %w", err)
+		}
+		if jwks == nil {
+			return nil, errors.New("cluster JWKS not published")
+		}
+		jwk := jwks.FindByKID(kid)
+		if jwk == nil {
+			return nil, fmt.Errorf("unknown kid %q", kid)
+		}
+		return jwkToECDSAPublicKey(jwk)
 	}
-	return *p
+}
+
+// verifyOIDCProviderRegistered looks up the issuer in the role-account's IAM
+// OIDC-provider registry. Bucket-not-found is treated identically to
+// key-not-found: the account has no providers registered yet, so no token
+// from any issuer can succeed. The error message intentionally does not
+// distinguish the two — leaking "your bucket exists" leaks account
+// activation status to anonymous callers.
+func (s *STSServiceImpl) verifyOIDCProviderRegistered(roleAccountID, issuer string) error {
+	bucketName := handlers_iam.IAMAccountBucketName(roleAccountID)
+	kv, err := s.js.KeyValue(bucketName)
+	if err != nil {
+		if errors.Is(err, nats.ErrBucketNotFound) {
+			return errors.New("OIDC provider not registered")
+		}
+		return fmt.Errorf("open IAM account bucket %s: %w", bucketName, err)
+	}
+	_, err = kv.Get(handlers_iam.OIDCProviderKey(issuer))
+	if err != nil {
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return errors.New("OIDC provider not registered")
+		}
+		return fmt.Errorf("read OIDC provider: %w", err)
+	}
+	return nil
+}
+
+// jwkToECDSAPublicKey decodes a JWK (RFC 7517) EC entry into an
+// *ecdsa.PublicKey. Only ES256 / P-256 is supported v1 — matches the per-
+// cluster signing key generated at CreateCluster (eks-v1.md Q8). Any other
+// shape fails closed.
+func jwkToECDSAPublicKey(jwk *JWK) (*ecdsa.PublicKey, error) {
+	if jwk == nil {
+		return nil, errors.New("nil JWK")
+	}
+	if jwk.Kty != "EC" {
+		return nil, fmt.Errorf("unsupported kty %q (only EC supported)", jwk.Kty)
+	}
+	if jwk.Crv != "P-256" {
+		return nil, fmt.Errorf("unsupported crv %q (only P-256 supported)", jwk.Crv)
+	}
+	xBytes, err := base64.RawURLEncoding.DecodeString(jwk.X)
+	if err != nil {
+		return nil, fmt.Errorf("decode JWK x: %w", err)
+	}
+	yBytes, err := base64.RawURLEncoding.DecodeString(jwk.Y)
+	if err != nil {
+		return nil, fmt.Errorf("decode JWK y: %w", err)
+	}
+	curve := elliptic.P256()
+	pub := &ecdsa.PublicKey{
+		Curve: curve,
+		X:     new(big.Int).SetBytes(xBytes),
+		Y:     new(big.Int).SetBytes(yBytes),
+	}
+	if !curve.IsOnCurve(pub.X, pub.Y) {
+		return nil, errors.New("JWK x,y not on P-256 curve")
+	}
+	return pub, nil
+}
+
+// claimAudienceContains is a constant-time membership test on the JWT `aud`
+// claim. jwt/v5 already canonicalises string-or-array into ClaimStrings;
+// this just iterates.
+func claimAudienceContains(aud jwt.ClaimStrings, want string) bool {
+	return slices.Contains(aud, want)
+}
+
+// stripIssuerScheme drops the `https://` prefix from an issuer URL to produce
+// the form AWS uses as the suffix of `arn:aws:iam::{accountID}:oidc-provider/...`.
+// Returns the input unchanged if the prefix is absent (defensive — upstream
+// ParseEKSIssuerURL already enforces https, but stripping a non-match would
+// produce an empty path).
+func stripIssuerScheme(issuer string) string {
+	return strings.TrimPrefix(issuer, "https://")
 }

--- a/spinifex/handlers/sts/assume_role_with_web_identity.go
+++ b/spinifex/handlers/sts/assume_role_with_web_identity.go
@@ -1,0 +1,39 @@
+package handlers_sts
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// AssumeRoleWithWebIdentity exchanges an OIDC ID token (typically a
+// projected Kubernetes ServiceAccount token signed by an EKS cluster's
+// per-cluster signing key) for short-lived AWS credentials bound to the
+// target IAM role. The full v1 implementation lands in a follow-up commit
+// on this branch: JWT signature verification against the cluster JWKS
+// (FetchClusterJWKS), `aud` / `exp` / `iss` claim validation, OIDC provider
+// registration check, and Federated-principal trust-policy evaluation.
+//
+// The interface entry, gateway dispatch, and oidc_jwks.go reader land in
+// this checkpoint so downstream sprints can call the method against a
+// stubbed handler while the verify path is being written.
+func (s *STSServiceImpl) AssumeRoleWithWebIdentity(input *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	if input == nil {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	slog.Debug("AssumeRoleWithWebIdentity invoked (stub)",
+		"role_arn", deref(input.RoleArn),
+		"session_name", deref(input.RoleSessionName),
+		"provider_id", deref(input.ProviderId),
+	)
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/spinifex/handlers/sts/assume_role_with_web_identity_test.go
+++ b/spinifex/handlers/sts/assume_role_with_web_identity_test.go
@@ -1,0 +1,607 @@
+package handlers_sts
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testWebClusterName = "demo-cluster"
+	testWebRegion      = "au-mel-1"
+	testWebSuffix      = "mulga.local"
+)
+
+// webIdentityFixture wraps the cluster-specific crypto + KV state needed to
+// drive AssumeRoleWithWebIdentity end-to-end. Each test builds one from the
+// shared STSServiceImpl produced by newTestSetup.
+type webIdentityFixture struct {
+	t            *testing.T
+	svc          *STSServiceImpl
+	accountID    string
+	clusterName  string
+	issuer       string
+	kid          string
+	signingKey   *ecdsa.PrivateKey
+	federatedARN string
+}
+
+func newWebIdentityFixture(t *testing.T, svc *STSServiceImpl, accountID string) *webIdentityFixture {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	const kid = "test-kid-1"
+	jwks := &JWKS{Keys: []JWK{{
+		Kty: "EC", Crv: "P-256", Alg: "ES256", Use: "sig", Kid: kid,
+		X: base64.RawURLEncoding.EncodeToString(priv.X.Bytes()),
+		Y: base64.RawURLEncoding.EncodeToString(priv.Y.Bytes()),
+	}}}
+
+	issuer := fmt.Sprintf("https://oidc.eks.%s.%s/%s/%s",
+		testWebRegion, testWebSuffix, accountID, testWebClusterName)
+	issuerHostPath := strings.TrimPrefix(issuer, "https://")
+	federatedARN := handlers_iam.OIDCProviderARN(accountID, issuerHostPath)
+
+	// Publish JWKS to the per-cluster EKS bucket.
+	kv, err := handlers_eks.GetOrCreateAccountBucket(svc.js, accountID)
+	require.NoError(t, err)
+	raw, err := json.Marshal(jwks)
+	require.NoError(t, err)
+	_, err = kv.Put(handlers_eks.OIDCJWKSKey(testWebClusterName), raw)
+	require.NoError(t, err)
+
+	// Register the OIDC provider on the role-account's IAM bucket. Bucket is
+	// created on-the-fly here — the IAM CreateOpenIDConnectProvider API lands
+	// in Sprint 6e.
+	iamKV, err := utils.GetOrCreateKVBucket(svc.js,
+		handlers_iam.IAMAccountBucketName(accountID), handlers_iam.KVBucketIAMAccountVersion)
+	require.NoError(t, err)
+	_, err = iamKV.Put(handlers_iam.OIDCProviderKey(issuer), []byte(`{"registered":true}`))
+	require.NoError(t, err)
+
+	return &webIdentityFixture{
+		t:            t,
+		svc:          svc,
+		accountID:    accountID,
+		clusterName:  testWebClusterName,
+		issuer:       issuer,
+		kid:          kid,
+		signingKey:   priv,
+		federatedARN: federatedARN,
+	}
+}
+
+// signToken mints a signed ES256 JWT with the supplied claims. Callers tweak
+// individual fields (issuer, audience, subject, expiry) to exercise validation
+// branches.
+func (f *webIdentityFixture) signToken(claims jwt.MapClaims) string {
+	f.t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = f.kid
+	signed, err := token.SignedString(f.signingKey)
+	require.NoError(f.t, err)
+	return signed
+}
+
+func (f *webIdentityFixture) defaultClaims() jwt.MapClaims {
+	now := time.Now().UTC()
+	return jwt.MapClaims{
+		"iss": f.issuer,
+		"sub": "system:serviceaccount:default:my-sa",
+		"aud": []string{irsaExpectedAudience},
+		"exp": now.Add(15 * time.Minute).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+	}
+}
+
+func webIdentityTrustPolicy(federatedARN, issuer, sub string) string {
+	return fmt.Sprintf(`{
+        "Version":"2012-10-17",
+        "Statement":[{
+            "Effect":"Allow",
+            "Principal":{"Federated":%q},
+            "Action":"sts:AssumeRoleWithWebIdentity",
+            "Condition":{"StringEquals":{%q:%q,%q:%q}}
+        }]
+    }`,
+		federatedARN,
+		strings.TrimSuffix(issuer, "/")+":sub", sub,
+		strings.TrimSuffix(issuer, "/")+":aud", irsaExpectedAudience,
+	)
+}
+
+func webIdentityTrustPolicyNoCondition(federatedARN string) string {
+	return fmt.Sprintf(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":%q},"Action":"sts:AssumeRoleWithWebIdentity"}]}`, federatedARN)
+}
+
+func createRoleForFixture(t *testing.T, svc *STSServiceImpl, accountID, name, trustPolicy string) *iam.Role {
+	t.Helper()
+	out, err := svc.iamSvc.CreateRole(accountID, &iam.CreateRoleInput{
+		RoleName:                 aws.String(name),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	})
+	require.NoError(t, err)
+	return out.Role
+}
+
+// ----- Happy path + claim/output round-trip --------------------------------
+
+func TestAssumeRoleWithWebIdentity_HappyPath(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-app",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	token := f.signToken(f.defaultClaims())
+	out, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("pod-1"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Credentials)
+
+	akid := aws.StringValue(out.Credentials.AccessKeyId)
+	assert.True(t, strings.HasPrefix(akid, SessionAccessKeyIDPrefix))
+	assert.Equal(t, "system:serviceaccount:default:my-sa", aws.StringValue(out.SubjectFromWebIdentityToken))
+	assert.Equal(t, strings.TrimPrefix(f.issuer, "https://"), aws.StringValue(out.Provider))
+	assert.Equal(t, irsaExpectedAudience, aws.StringValue(out.Audience))
+
+	stored, err := svc.LookupSessionCredential(akid)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "pod-1", stored.SessionName)
+	assert.Equal(t, "system:serviceaccount:default:my-sa", stored.SourceIdentity,
+		"sub claim must be persisted as SourceIdentity so audit logs trace back to the pod SA")
+}
+
+func TestAssumeRoleWithWebIdentity_NoConditionTrustPolicy(t *testing.T) {
+	// A trust policy that names Federated but omits Condition still grants —
+	// AWS allows this shape ("trust any pod under this issuer"). The handler
+	// must not refuse on missing Condition.
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-open",
+		webIdentityTrustPolicyNoCondition(f.federatedARN))
+
+	token := f.signToken(f.defaultClaims())
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("pod"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.NoError(t, err)
+}
+
+// ----- JWT verification failures ------------------------------------------
+
+func TestAssumeRoleWithWebIdentity_TamperedSignature(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-tamper",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	token := f.signToken(f.defaultClaims())
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	// Flip a byte in the signature.
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	sigBytes[len(sigBytes)-1] ^= 0xFF
+	parts[2] = base64.RawURLEncoding.EncodeToString(sigBytes)
+	tampered := strings.Join(parts, ".")
+
+	_, err = svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(tampered),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_Expired(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-expired",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	claims := f.defaultClaims()
+	claims["exp"] = time.Now().UTC().Add(-1 * time.Minute).Unix()
+	claims["iat"] = time.Now().UTC().Add(-30 * time.Minute).Unix()
+	token := f.signToken(claims)
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_MissingExp(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-no-exp",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	claims := f.defaultClaims()
+	delete(claims, "exp")
+	token := f.signToken(claims)
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_WrongAudience(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-wrong-aud",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	claims := f.defaultClaims()
+	claims["aud"] = []string{"not-sts.example.com"}
+	token := f.signToken(claims)
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_UnknownKID(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-bad-kid",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, f.defaultClaims())
+	token.Header["kid"] = "missing-kid"
+	signed, err := token.SignedString(f.signingKey)
+	require.NoError(t, err)
+
+	_, err = svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(signed),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_WrongSigningAlgorithm(t *testing.T) {
+	// HS256-signed token must be rejected — the keyfunc only honours ES256
+	// and accepting HS256 with a "key" return value would degrade the
+	// security model to symmetric.
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-hs256",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, f.defaultClaims())
+	token.Header["kid"] = f.kid
+	signed, err := token.SignedString([]byte("symmetric-key"))
+	require.NoError(t, err)
+
+	_, err = svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(signed),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_IssuerNotEKSShape(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-bad-iss",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:my-sa"))
+
+	claims := f.defaultClaims()
+	claims["iss"] = "https://attacker.example.com/123/c1"
+	token := f.signToken(claims)
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_ProviderNotRegistered(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	const kid = "unregistered"
+	issuer := fmt.Sprintf("https://oidc.eks.%s.%s/%s/%s",
+		testWebRegion, testWebSuffix, testCallerAccountID, "unregistered-cluster")
+	issuerHostPath := strings.TrimPrefix(issuer, "https://")
+	federatedARN := handlers_iam.OIDCProviderARN(testCallerAccountID, issuerHostPath)
+
+	// Publish JWKS — but skip the IAM provider registration.
+	kv, err := handlers_eks.GetOrCreateAccountBucket(svc.js, testCallerAccountID)
+	require.NoError(t, err)
+	jwks := &JWKS{Keys: []JWK{{
+		Kty: "EC", Crv: "P-256", Alg: "ES256", Use: "sig", Kid: kid,
+		X: base64.RawURLEncoding.EncodeToString(priv.X.Bytes()),
+		Y: base64.RawURLEncoding.EncodeToString(priv.Y.Bytes()),
+	}}}
+	raw, err := json.Marshal(jwks)
+	require.NoError(t, err)
+	_, err = kv.Put(handlers_eks.OIDCJWKSKey("unregistered-cluster"), raw)
+	require.NoError(t, err)
+
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-unreg",
+		webIdentityTrustPolicyNoCondition(federatedARN))
+
+	now := time.Now().UTC()
+	claims := jwt.MapClaims{
+		"iss": issuer,
+		"sub": "system:serviceaccount:default:my-sa",
+		"aud": []string{irsaExpectedAudience},
+		"exp": now.Add(15 * time.Minute).Unix(),
+		"iat": now.Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(priv)
+	require.NoError(t, err)
+
+	_, err = svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(signed),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+// ----- Trust-policy condition checks --------------------------------------
+
+func TestAssumeRoleWithWebIdentity_SubjectMismatch(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-sub",
+		webIdentityTrustPolicy(f.federatedARN, f.issuer, "system:serviceaccount:default:expected-sa"))
+
+	claims := f.defaultClaims()
+	claims["sub"] = "system:serviceaccount:default:different-sa"
+	token := f.signToken(claims)
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_FederatedPrincipalMismatch(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	otherARN := handlers_iam.OIDCProviderARN(testCallerAccountID, "oidc.eks.other.example.com/000000000000/other-cluster")
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-other",
+		webIdentityTrustPolicyNoCondition(otherARN))
+
+	token := f.signToken(f.defaultClaims())
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_FederatedWildcardDoesNotMatch(t *testing.T) {
+	// Principal: "*" must NOT grant a Federated principal — distinguishing
+	// authenticated-anyone (AssumeRole) from anonymous-anyone (no analogue
+	// for AssumeRoleWithWebIdentity) is load-bearing for IRSA security.
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-wild",
+		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"sts:AssumeRoleWithWebIdentity"}]}`)
+
+	token := f.signToken(f.defaultClaims())
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_ExplicitDenyWinsOverAllow(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	const sub = "system:serviceaccount:default:my-sa"
+	policy := fmt.Sprintf(`{
+        "Version":"2012-10-17",
+        "Statement":[
+            {"Effect":"Allow","Principal":{"Federated":%q},"Action":"sts:AssumeRoleWithWebIdentity"},
+            {"Effect":"Deny","Principal":{"Federated":%q},"Action":"sts:AssumeRoleWithWebIdentity","Condition":{"StringEquals":{%q:%q}}}
+        ]
+    }`,
+		f.federatedARN, f.federatedARN,
+		strings.TrimSuffix(f.issuer, "/")+":sub", sub,
+	)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-deny", policy)
+
+	token := f.signToken(f.defaultClaims())
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+// ----- Input validation ---------------------------------------------------
+
+func TestAssumeRoleWithWebIdentity_RejectsMissingFields(t *testing.T) {
+	svc, _ := newTestSetup(t)
+
+	cases := []struct {
+		name  string
+		input *sts.AssumeRoleWithWebIdentityInput
+	}{
+		{"nil_input", nil},
+		{"missing_role_arn", &sts.AssumeRoleWithWebIdentityInput{
+			RoleSessionName: aws.String("x"), WebIdentityToken: aws.String("t"),
+		}},
+		{"missing_session_name", &sts.AssumeRoleWithWebIdentityInput{
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/x"), WebIdentityToken: aws.String("t"),
+		}},
+		{"missing_token", &sts.AssumeRoleWithWebIdentityInput{
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/x"), RoleSessionName: aws.String("x"),
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.AssumeRoleWithWebIdentity(tc.input)
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorMissingParameter, err.Error())
+		})
+	}
+}
+
+func TestAssumeRoleWithWebIdentity_RejectsSessionPolicies(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-pol",
+		webIdentityTrustPolicyNoCondition(f.federatedARN))
+	token := f.signToken(f.defaultClaims())
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+		Policy:           aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorPackedPolicyTooLarge, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_RejectsBadRoleARN(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	token := f.signToken(f.defaultClaims())
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          aws.String("not-an-arn"),
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationError, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_RejectsInvalidSessionName(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-name",
+		webIdentityTrustPolicyNoCondition(f.federatedARN))
+	token := f.signToken(f.defaultClaims())
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("has/slash"),
+		WebIdentityToken: aws.String(token),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationError, err.Error())
+}
+
+func TestAssumeRoleWithWebIdentity_DurationBounds(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	f := newWebIdentityFixture(t, svc, testCallerAccountID)
+	role := createRoleForFixture(t, svc, testCallerAccountID, "irsa-dur",
+		webIdentityTrustPolicyNoCondition(f.federatedARN))
+	token := f.signToken(f.defaultClaims())
+
+	_, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          role.Arn,
+		RoleSessionName:  aws.String("sess"),
+		WebIdentityToken: aws.String(token),
+		DurationSeconds:  aws.Int64(minDurationSeconds - 1),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationError, err.Error())
+}
+
+// ----- JWK decoding unit tests --------------------------------------------
+
+func TestJWKToECDSAPublicKey_RoundTrip(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := &JWK{
+		Kty: "EC", Crv: "P-256",
+		X: base64.RawURLEncoding.EncodeToString(priv.X.Bytes()),
+		Y: base64.RawURLEncoding.EncodeToString(priv.Y.Bytes()),
+	}
+	pub, err := jwkToECDSAPublicKey(jwk)
+	require.NoError(t, err)
+	assert.True(t, priv.PublicKey.Equal(pub))
+}
+
+func TestJWKToECDSAPublicKey_RejectsUnsupportedShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		jwk  *JWK
+	}{
+		{"nil", nil},
+		{"rsa_kty", &JWK{Kty: "RSA", Crv: "P-256", X: "AA", Y: "AA"}},
+		{"wrong_curve", &JWK{Kty: "EC", Crv: "P-384", X: "AA", Y: "AA"}},
+		{"bad_x_base64", &JWK{Kty: "EC", Crv: "P-256", X: "!!!", Y: "AA"}},
+		{"off_curve", &JWK{Kty: "EC", Crv: "P-256", X: base64.RawURLEncoding.EncodeToString([]byte{1, 2, 3}), Y: base64.RawURLEncoding.EncodeToString([]byte{4, 5, 6})}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := jwkToECDSAPublicKey(tc.jwk)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestClaimAudienceContains(t *testing.T) {
+	assert.True(t, claimAudienceContains(jwt.ClaimStrings{irsaExpectedAudience}, irsaExpectedAudience))
+	assert.True(t, claimAudienceContains(jwt.ClaimStrings{"x", irsaExpectedAudience}, irsaExpectedAudience))
+	assert.False(t, claimAudienceContains(jwt.ClaimStrings{"x"}, irsaExpectedAudience))
+	assert.False(t, claimAudienceContains(jwt.ClaimStrings{}, irsaExpectedAudience))
+}

--- a/spinifex/handlers/sts/invariants_test.go
+++ b/spinifex/handlers/sts/invariants_test.go
@@ -2,7 +2,9 @@ package handlers_sts
 
 import (
 	"testing"
+	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,4 +47,50 @@ func TestInvariant_SessionCredentialsBucket_AcceptsASIAPrefix(t *testing.T) {
 	akid := SessionAccessKeyIDPrefix + "0123456789ABCDEF"
 	cred := newTestSessionCredential(akid)
 	require.NoError(t, putSessionCredential(bucket, cred))
+}
+
+// Cross-cluster anti-replay invariant. A presigned sts:GetCallerIdentity URL
+// signed under cluster-A's name MUST NOT verify when presented to cluster-B.
+// The defence is the X-K8s-Aws-Id header participating in SigV4
+// canonicalisation: the verifier reconstructs the canonical request with
+// X-K8s-Aws-Id = expectedClusterName, so a mismatch produces a different
+// signature.
+//
+// Three regressions this guards against:
+//  1. x-k8s-aws-id silently dropped from SignedHeaders enforcement.
+//  2. Verifier reconstructing the header value from the URL instead of from
+//     expectedClusterName (would always self-match).
+//  3. Verifier short-circuiting on equal AccessKeyId without recomputing
+//     the SigV4 signature.
+//
+// On breach the EKS token webhook would accept a token forged by anyone with
+// console access to one cluster against any other cluster sharing the same
+// IAM trust — a complete authn bypass.
+func TestInvariant_PresignedGetCallerIdentity_CrossClusterReplayRejected(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "invariant-xcluster")
+
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	urlA := presignTestURL(t, akid, secret, "cluster-A", signedAt, 900)
+
+	// Sanity: cluster-A accepts its own URL (so a failure below is a real
+	// cross-cluster rejection, not a generic verifier break).
+	_, err := svc.VerifyPresignedGetCallerIdentity(urlA, "cluster-A")
+	require.NoError(t, err, "self-verification must succeed; otherwise replay test is meaningless")
+
+	// Invariant: any other cluster name rejects cluster-A's URL.
+	// Note: SigV4 canonicalisation trims leading/trailing whitespace from
+	// header values, so a trailing-space variant intentionally is not in this
+	// list — it would self-match per AWS's wire spec.
+	otherClusters := []string{"cluster-B", "cluster-A-prod", "CLUSTER-A", "cluster-A-1"}
+	for _, other := range otherClusters {
+		t.Run(other, func(t *testing.T) {
+			_, err := svc.VerifyPresignedGetCallerIdentity(urlA, other)
+			require.Error(t, err, "URL signed for cluster-A must not verify under %q", other)
+			assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error(),
+				"cross-cluster replay must surface as InvalidIdentityToken (401-equivalent)")
+		})
+	}
 }

--- a/spinifex/handlers/sts/oidc_jwks.go
+++ b/spinifex/handlers/sts/oidc_jwks.go
@@ -1,0 +1,118 @@
+package handlers_sts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+	"github.com/nats-io/nats.go"
+)
+
+// JWK is one entry of an RFC 7517 JSON Web Key Set. EKS publishes EC P-256
+// keys (kty=EC, crv=P-256, alg=ES256); the optional RSA fields are kept so a
+// future cluster published with a different alg still round-trips without
+// breaking the decoder.
+type JWK struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use,omitempty"`
+	Alg string `json:"alg,omitempty"`
+	Crv string `json:"crv,omitempty"`
+	X   string `json:"x,omitempty"`
+	Y   string `json:"y,omitempty"`
+	N   string `json:"n,omitempty"`
+	E   string `json:"e,omitempty"`
+}
+
+// JWKS wraps a list of JWK entries as served at the `/keys` endpoint of an
+// OIDC issuer's JWKS URL.
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// FindByKID returns the JWK with the matching `kid` claim or nil if none of
+// the keys match.
+func (s *JWKS) FindByKID(kid string) *JWK {
+	if s == nil {
+		return nil
+	}
+	for i := range s.Keys {
+		if s.Keys[i].Kid == kid {
+			return &s.Keys[i]
+		}
+	}
+	return nil
+}
+
+// ParseEKSIssuerURL extracts the (accountID, clusterName) pair encoded in an
+// EKS OIDC issuer URL of the form:
+//
+//	https://oidc.eks.{region}.{suffix}/{accountID}/{clusterName}
+//
+// Returns an error for any URL that does not match that exact two-segment
+// path structure under an `oidc.eks.` host prefix — defensive parsing prevents
+// a maliciously crafted `iss` claim from steering the JWKS lookup at an
+// attacker-controlled cluster bucket.
+func ParseEKSIssuerURL(issuer string) (accountID, clusterName string, err error) {
+	u, err := url.Parse(issuer)
+	if err != nil {
+		return "", "", fmt.Errorf("parse issuer URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return "", "", errors.New("issuer URL must use https scheme")
+	}
+	if !strings.HasPrefix(u.Host, "oidc.eks.") {
+		return "", "", errors.New("issuer host must start with oidc.eks")
+	}
+	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(segments) != 2 || segments[0] == "" || segments[1] == "" {
+		return "", "", errors.New("issuer path must be /{accountID}/{clusterName}")
+	}
+	return segments[0], segments[1], nil
+}
+
+// FetchClusterJWKS reads the JWKS document for an EKS cluster from the
+// per-account EKS KV bucket. The lookup is keyed by `{accountID, clusterName}`
+// extracted from the IRSA token's `iss` claim and resolved via the EKS store
+// helpers (single source of truth for bucket + key naming).
+//
+// Returns (nil, nil) when the cluster has no JWKS published yet — callers
+// translate that miss to InvalidIdentityToken so unverified tokens always
+// fail closed without leaking cluster-existence information.
+func FetchClusterJWKS(js nats.JetStreamContext, accountID, clusterName string) (*JWKS, error) {
+	if js == nil {
+		return nil, errors.New("nil JetStream context")
+	}
+	if accountID == "" || clusterName == "" {
+		return nil, errors.New("accountID and clusterName must be non-empty")
+	}
+
+	bucketName := handlers_eks.AccountBucketName(accountID)
+	kv, err := js.KeyValue(bucketName)
+	if err != nil {
+		if errors.Is(err, nats.ErrBucketNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open EKS account bucket %s: %w", bucketName, err)
+	}
+
+	entry, err := kv.Get(handlers_eks.OIDCJWKSKey(clusterName))
+	if err != nil {
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read JWKS for cluster %s: %w", clusterName, err)
+	}
+
+	var jwks JWKS
+	if err := json.Unmarshal(entry.Value(), &jwks); err != nil {
+		return nil, fmt.Errorf("decode JWKS for cluster %s: %w", clusterName, err)
+	}
+	if len(jwks.Keys) == 0 {
+		return nil, fmt.Errorf("JWKS for cluster %s has no keys", clusterName)
+	}
+	return &jwks, nil
+}

--- a/spinifex/handlers/sts/oidc_jwks_test.go
+++ b/spinifex/handlers/sts/oidc_jwks_test.go
@@ -1,0 +1,131 @@
+package handlers_sts
+
+import (
+	"encoding/json"
+	"testing"
+
+	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEKSIssuerURL_Valid(t *testing.T) {
+	accountID, clusterName, err := ParseEKSIssuerURL("https://oidc.eks.au-mel-1.mulga.local/123456789012/my-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "123456789012", accountID)
+	assert.Equal(t, "my-cluster", clusterName)
+}
+
+func TestParseEKSIssuerURL_Invalid(t *testing.T) {
+	cases := []struct {
+		name   string
+		issuer string
+	}{
+		{"http scheme", "http://oidc.eks.au-mel-1.mulga.local/123456789012/c1"},
+		{"wrong host prefix", "https://attacker.example.com/123456789012/c1"},
+		{"single segment", "https://oidc.eks.au-mel-1.mulga.local/123456789012"},
+		{"three segments", "https://oidc.eks.au-mel-1.mulga.local/123/c/extra"},
+		{"empty cluster segment", "https://oidc.eks.au-mel-1.mulga.local/123456789012/"},
+		{"empty account segment", "https://oidc.eks.au-mel-1.mulga.local//c1"},
+		{"empty path", "https://oidc.eks.au-mel-1.mulga.local"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := ParseEKSIssuerURL(tc.issuer)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestJWKS_FindByKID(t *testing.T) {
+	jwks := &JWKS{Keys: []JWK{
+		{Kid: "key-a", Kty: "EC", Crv: "P-256", X: "x", Y: "y"},
+		{Kid: "key-b", Kty: "EC", Crv: "P-256", X: "x2", Y: "y2"},
+	}}
+	got := jwks.FindByKID("key-b")
+	require.NotNil(t, got)
+	assert.Equal(t, "key-b", got.Kid)
+
+	assert.Nil(t, jwks.FindByKID("missing"))
+	var nilJWKS *JWKS
+	assert.Nil(t, nilJWKS.FindByKID("anything"))
+}
+
+func TestFetchClusterJWKS_NotFoundReturnsNil(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+
+	jwks, err := FetchClusterJWKS(js, "123456789012", "missing-cluster")
+	require.NoError(t, err)
+	assert.Nil(t, jwks)
+}
+
+func TestFetchClusterJWKS_RoundTrip(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+
+	kv, err := handlers_eks.GetOrCreateAccountBucket(js, "123456789012")
+	require.NoError(t, err)
+
+	want := &JWKS{Keys: []JWK{
+		{Kid: "abc123", Kty: "EC", Crv: "P-256", Alg: "ES256", Use: "sig", X: "x-coord", Y: "y-coord"},
+	}}
+	raw, err := json.Marshal(want)
+	require.NoError(t, err)
+	_, err = kv.Put(handlers_eks.OIDCJWKSKey("my-cluster"), raw)
+	require.NoError(t, err)
+
+	got, err := FetchClusterJWKS(js, "123456789012", "my-cluster")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Keys, 1)
+	assert.Equal(t, "abc123", got.Keys[0].Kid)
+	assert.Equal(t, "EC", got.Keys[0].Kty)
+	assert.Equal(t, "ES256", got.Keys[0].Alg)
+}
+
+func TestFetchClusterJWKS_EmptyKeysIsError(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+
+	kv, err := handlers_eks.GetOrCreateAccountBucket(js, "123456789012")
+	require.NoError(t, err)
+
+	_, err = kv.Put(handlers_eks.OIDCJWKSKey("empty-cluster"), []byte(`{"keys":[]}`))
+	require.NoError(t, err)
+
+	jwks, err := FetchClusterJWKS(js, "123456789012", "empty-cluster")
+	require.Error(t, err)
+	assert.Nil(t, jwks)
+}
+
+func TestFetchClusterJWKS_NilJetStream(t *testing.T) {
+	_, err := FetchClusterJWKS(nil, "123456789012", "c1")
+	require.Error(t, err)
+}
+
+func TestFetchClusterJWKS_EmptyArgs(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	_, err := FetchClusterJWKS(js, "", "c1")
+	require.Error(t, err)
+	_, err = FetchClusterJWKS(js, "123456789012", "")
+	require.Error(t, err)
+}
+
+// Sanity check that JWK JSON round-trips through the type without dropping
+// the optional RSA fields. The EKS-issued keys are EC P-256, but the decoder
+// must remain permissive so a non-EKS issuer registered later still parses.
+func TestJWK_RSAFieldsRoundTrip(t *testing.T) {
+	src := JWK{Kty: "RSA", Kid: "rsa-1", Use: "sig", Alg: "RS256", N: "modulus-base64", E: "AQAB"}
+	raw, err := json.Marshal(src)
+	require.NoError(t, err)
+	var got JWK
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, src, got)
+}
+
+// Ensure that a NATS error other than ErrBucketNotFound / ErrKeyNotFound is
+// surfaced rather than masked. Without an injected JetStream stub there's no
+// fault-injection path here, so the negative-cache cases above cover the two
+// expected misses; this test documents the contract by exercising the nil
+// pre-conditions only.
+var _ = nats.ErrBucketNotFound

--- a/spinifex/handlers/sts/presigned_url_verify.go
+++ b/spinifex/handlers/sts/presigned_url_verify.go
@@ -1,0 +1,38 @@
+package handlers_sts
+
+import (
+	"errors"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// PresignedCallerIdentity is the result of validating a SigV4-presigned
+// `sts:GetCallerIdentity` URL — the token shape produced by `aws eks
+// get-token` and consumed by the EKS token webhook (`eks-token-webhook`).
+//
+// The full implementation lands in a follow-up commit on this branch:
+// SigV4 canonical-request reconstruction, signature verification against
+// the named access key's secret, expiry check, and the mandatory
+// `X-K8s-Aws-Id` header equality check (per eks-v1.md Q10) that prevents a
+// token minted for cluster-A from being replayed against cluster-B.
+type PresignedCallerIdentity struct {
+	AccountID     string
+	ARN           string
+	UserID        string
+	XK8sAwsID     string // value the caller signed under, for the webhook to verify
+	PrincipalType string
+}
+
+// VerifyPresignedGetCallerIdentity validates a SigV4-presigned URL for the
+// `sts:GetCallerIdentity` action and resolves the calling principal. The EKS
+// token webhook calls this over NATS as part of TokenReview processing.
+//
+// expectedClusterName is the cluster the webhook lives on; the function
+// constant-time-compares the `X-K8s-Aws-Id` signed-header value against it
+// to prevent cross-cluster replay (eks-v1.md Q10 mandatory check).
+func (s *STSServiceImpl) VerifyPresignedGetCallerIdentity(presignedURL, expectedClusterName string) (*PresignedCallerIdentity, error) {
+	if presignedURL == "" || expectedClusterName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}

--- a/spinifex/handlers/sts/presigned_url_verify.go
+++ b/spinifex/handlers/sts/presigned_url_verify.go
@@ -1,38 +1,443 @@
 package handlers_sts
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+)
+
+const (
+	presignedAlgorithm    = "AWS4-HMAC-SHA256"
+	presignedTerminator   = "aws4_request"
+	presignedService      = "sts"
+	presignedAmzDateFmt   = "20060102T150405Z"
+	presignedDateFmt      = "20060102"
+	presignedSignedHeader = "x-k8s-aws-id"
+	presignedHostHeader   = "host"
+
+	// presignedMaxExpiresSeconds is the AWS-imposed ceiling on
+	// X-Amz-Expires for SigV4-presigned URLs. The aws eks get-token output
+	// defaults to 900s; rejecting anything beyond the SigV4 ceiling fails
+	// a forged URL that lies about its TTL.
+	presignedMaxExpiresSeconds = 7 * 24 * 60 * 60
+
+	// presignedClockSkew matches the SigV4 wire-protocol skew
+	// allowance (used during X-Amz-Date sanity check).
+	presignedClockSkew = 5 * time.Minute
 )
 
 // PresignedCallerIdentity is the result of validating a SigV4-presigned
 // `sts:GetCallerIdentity` URL — the token shape produced by `aws eks
 // get-token` and consumed by the EKS token webhook (`eks-token-webhook`).
-//
-// The full implementation lands in a follow-up commit on this branch:
-// SigV4 canonical-request reconstruction, signature verification against
-// the named access key's secret, expiry check, and the mandatory
-// `X-K8s-Aws-Id` header equality check (per eks-v1.md Q10) that prevents a
-// token minted for cluster-A from being replayed against cluster-B.
 type PresignedCallerIdentity struct {
 	AccountID     string
 	ARN           string
 	UserID        string
-	XK8sAwsID     string // value the caller signed under, for the webhook to verify
+	XK8sAwsID     string // value the caller signed under (= expectedClusterName on success)
 	PrincipalType string
 }
+
+// presignedTimeNow is the time-source seam — tests override it to pin the
+// clock for replay / expiry assertions. Production calls go through here so
+// the wire-protocol skew check is not flaky.
+var presignedTimeNow = func() time.Time { return time.Now().UTC() }
 
 // VerifyPresignedGetCallerIdentity validates a SigV4-presigned URL for the
 // `sts:GetCallerIdentity` action and resolves the calling principal. The EKS
 // token webhook calls this over NATS as part of TokenReview processing.
 //
-// expectedClusterName is the cluster the webhook lives on; the function
-// constant-time-compares the `X-K8s-Aws-Id` signed-header value against it
-// to prevent cross-cluster replay (eks-v1.md Q10 mandatory check).
+// Verification (each step fails closed):
+//
+//  1. Parse and validate envelope query parameters (algorithm, credential,
+//     date, expires, signed-headers, signature).
+//  2. Enforce that x-k8s-aws-id is in X-Amz-SignedHeaders — skipping this is
+//     a cross-cluster auth bypass (eks-v1.md Q10 mandatory check).
+//  3. Validate timestamp and expiry against the wire clock.
+//  4. Resolve the access key to a secret (session via ASIA path, otherwise
+//     long-lived IAM).
+//  5. Reconstruct the canonical request with X-K8s-Aws-Id pinned to
+//     expectedClusterName, recompute the SigV4 signature, constant-time
+//     compare against the wire signature. A mismatch here is the
+//     cross-cluster-replay defence: a token signed under cluster-A's name
+//     produces a different signature when reconstructed under cluster-B's
+//     name.
+//  6. Build a PresignedCallerIdentity from the resolved principal.
 func (s *STSServiceImpl) VerifyPresignedGetCallerIdentity(presignedURL, expectedClusterName string) (*PresignedCallerIdentity, error) {
 	if presignedURL == "" || expectedClusterName == "" {
 		return nil, errors.New(awserrors.ErrorMissingParameter)
 	}
-	return nil, errors.New(awserrors.ErrorNotImplemented)
+
+	u, err := url.Parse(presignedURL)
+	if err != nil {
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	q := u.Query()
+	env, err := parsePresignedEnvelope(q)
+	if err != nil {
+		slog.Warn("VerifyPresignedGetCallerIdentity: envelope parse failed", "err", err)
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	if !env.signedHeaders[presignedSignedHeader] {
+		slog.Warn("VerifyPresignedGetCallerIdentity: x-k8s-aws-id not in SignedHeaders",
+			"signed_headers", env.rawSignedHeaders)
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+	if !env.signedHeaders[presignedHostHeader] {
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	if env.credential.service != presignedService {
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+	if env.credential.terminator != presignedTerminator {
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	now := presignedTimeNow()
+	if now.Sub(env.signedTime).Abs() > presignedClockSkew+time.Duration(env.expiresSeconds)*time.Second {
+		// Wide allowance — exact expiry is checked below; this guards a
+		// nonsense X-Amz-Date that's months out (signature would still verify
+		// against the wire if we let it through, but the token would be
+		// trivially "expired" and we surface a clearer error code).
+		return nil, errors.New(awserrors.ErrorExpiredToken)
+	}
+	if now.After(env.signedTime.Add(time.Duration(env.expiresSeconds) * time.Second)) {
+		return nil, errors.New(awserrors.ErrorExpiredToken)
+	}
+	if env.signedTime.UTC().Format(presignedDateFmt) != env.credential.date {
+		// Credential-scope date must match the X-Amz-Date date portion;
+		// AWS-CLI enforces this; mismatch is the classic "signed yesterday
+		// presented today" bug. Fail closed.
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	principal, secret, err := s.resolvePrincipalForVerify(env.credential.accessKeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	canonicalQuery := canonicalQueryStringExcludingSignature(q)
+	canonicalHeaders, signedHeadersList := buildCanonicalHeaders(u.Host, expectedClusterName)
+	canonicalRequest := strings.Join([]string{
+		"GET",
+		canonicalURI(u),
+		canonicalQuery,
+		canonicalHeaders,
+		signedHeadersList,
+		"UNSIGNED-PAYLOAD",
+	}, "\n")
+
+	stringToSign := strings.Join([]string{
+		presignedAlgorithm,
+		env.amzDate,
+		env.credential.scope(),
+		hexSHA256(canonicalRequest),
+	}, "\n")
+
+	signingKey := deriveSigningKey(secret, env.credential.date, env.credential.region, env.credential.service)
+	expectedSig := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
+
+	if subtle.ConstantTimeCompare([]byte(expectedSig), []byte(env.signature)) != 1 {
+		slog.Warn("VerifyPresignedGetCallerIdentity: signature mismatch (cluster name replay or tampered URL)",
+			"akid", env.credential.accessKeyID,
+			"expected_cluster", expectedClusterName)
+		return nil, errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+
+	principal.XK8sAwsID = expectedClusterName
+	return principal, nil
 }
+
+// presignedEnvelope is the parsed-and-validated set of envelope facts from
+// a SigV4-presigned URL's query string. The fields are pure parse outputs;
+// signature verification consumes them.
+type presignedEnvelope struct {
+	credential       presignedCredential
+	amzDate          string // raw X-Amz-Date value (used in StringToSign)
+	signedTime       time.Time
+	expiresSeconds   int64
+	rawSignedHeaders string
+	signedHeaders    map[string]bool
+	signature        string
+}
+
+type presignedCredential struct {
+	accessKeyID string
+	date        string // YYYYMMDD
+	region      string
+	service     string
+	terminator  string
+}
+
+func (c presignedCredential) scope() string {
+	return strings.Join([]string{c.date, c.region, c.service, c.terminator}, "/")
+}
+
+func parsePresignedEnvelope(q url.Values) (presignedEnvelope, error) {
+	algo := q.Get("X-Amz-Algorithm")
+	if algo != presignedAlgorithm {
+		return presignedEnvelope{}, fmt.Errorf("unsupported algorithm %q", algo)
+	}
+	credRaw := q.Get("X-Amz-Credential")
+	if credRaw == "" {
+		return presignedEnvelope{}, errors.New("missing X-Amz-Credential")
+	}
+	parts := strings.Split(credRaw, "/")
+	if len(parts) != 5 {
+		return presignedEnvelope{}, fmt.Errorf("X-Amz-Credential has %d parts, expected 5", len(parts))
+	}
+	cred := presignedCredential{
+		accessKeyID: parts[0],
+		date:        parts[1],
+		region:      parts[2],
+		service:     parts[3],
+		terminator:  parts[4],
+	}
+	if cred.accessKeyID == "" {
+		return presignedEnvelope{}, errors.New("X-Amz-Credential has empty access key id")
+	}
+
+	amzDate := q.Get("X-Amz-Date")
+	if amzDate == "" {
+		return presignedEnvelope{}, errors.New("missing X-Amz-Date")
+	}
+	signedTime, err := time.Parse(presignedAmzDateFmt, amzDate)
+	if err != nil {
+		return presignedEnvelope{}, fmt.Errorf("invalid X-Amz-Date: %w", err)
+	}
+
+	expiresRaw := q.Get("X-Amz-Expires")
+	if expiresRaw == "" {
+		return presignedEnvelope{}, errors.New("missing X-Amz-Expires")
+	}
+	expires, err := strconv.ParseInt(expiresRaw, 10, 64)
+	if err != nil || expires <= 0 || expires > presignedMaxExpiresSeconds {
+		return presignedEnvelope{}, fmt.Errorf("invalid X-Amz-Expires: %q", expiresRaw)
+	}
+
+	signedHeadersRaw := q.Get("X-Amz-SignedHeaders")
+	if signedHeadersRaw == "" {
+		return presignedEnvelope{}, errors.New("missing X-Amz-SignedHeaders")
+	}
+	signedSet := make(map[string]bool)
+	for h := range strings.SplitSeq(signedHeadersRaw, ";") {
+		signedSet[strings.ToLower(h)] = true
+	}
+
+	sig := q.Get("X-Amz-Signature")
+	if sig == "" {
+		return presignedEnvelope{}, errors.New("missing X-Amz-Signature")
+	}
+
+	return presignedEnvelope{
+		credential:       cred,
+		amzDate:          amzDate,
+		signedTime:       signedTime.UTC(),
+		expiresSeconds:   expires,
+		rawSignedHeaders: signedHeadersRaw,
+		signedHeaders:    signedSet,
+		signature:        sig,
+	}, nil
+}
+
+// canonicalQueryStringExcludingSignature returns the SigV4 canonical query
+// string with X-Amz-Signature dropped. The remaining parameters are
+// percent-encoded per RFC 3986 and sorted lexicographically by key, then by
+// value for duplicate keys. The aws-sdk-go url.QueryEscape produces the same
+// output for these envelope params (alphanumerics + the safe set).
+func canonicalQueryStringExcludingSignature(q url.Values) string {
+	type kv struct {
+		k string
+		v string
+	}
+	pairs := make([]kv, 0, len(q))
+	for k, vs := range q {
+		if k == "X-Amz-Signature" {
+			continue
+		}
+		ek := awsQueryEscape(k)
+		for _, v := range vs {
+			pairs = append(pairs, kv{ek, awsQueryEscape(v)})
+		}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].k == pairs[j].k {
+			return pairs[i].v < pairs[j].v
+		}
+		return pairs[i].k < pairs[j].k
+	})
+	parts := make([]string, len(pairs))
+	for i, p := range pairs {
+		parts[i] = p.k + "=" + p.v
+	}
+	return strings.Join(parts, "&")
+}
+
+// awsQueryEscape encodes per SigV4: every byte outside the unreserved set
+// (A-Z, a-z, 0-9, '-', '_', '.', '~') is percent-encoded as uppercase hex.
+// net/url.QueryEscape encodes spaces as '+' and lower-cases hex digits, both
+// of which would diverge from AWS canonicalization.
+func awsQueryEscape(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'),
+			c == '-' || c == '_' || c == '.' || c == '~':
+			b.WriteByte(c)
+		default:
+			b.WriteByte('%')
+			b.WriteString(strings.ToUpper(hexByte(c)))
+		}
+	}
+	return b.String()
+}
+
+func hexByte(b byte) string {
+	const hexDigits = "0123456789ABCDEF"
+	return string([]byte{hexDigits[b>>4], hexDigits[b&0x0f]})
+}
+
+// canonicalURI returns the canonical URI per SigV4. For sts.GetCallerIdentity
+// presigned URLs the path is "/" (action lives in the query string); paths
+// beyond root are accepted and pass through unmodified per the canonical
+// rules — empty path normalises to "/".
+func canonicalURI(u *url.URL) string {
+	if u.Path == "" {
+		return "/"
+	}
+	return u.Path
+}
+
+// buildCanonicalHeaders constructs the canonical-headers + signed-headers
+// pair for the presigned-URL request as it would have been canonicalised by
+// the original signer. The wire URL does not carry the header values — they
+// are reconstructed from known inputs: host comes from the URL itself, the
+// X-K8s-Aws-Id value is the expected cluster name (constant-time-bound by
+// the eventual signature compare).
+func buildCanonicalHeaders(host, xK8sAwsID string) (canonicalHeaders, signedHeadersList string) {
+	headers := map[string]string{
+		presignedHostHeader:   host,
+		presignedSignedHeader: xK8sAwsID,
+	}
+	names := make([]string, 0, len(headers))
+	for n := range headers {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, n := range names {
+		b.WriteString(n)
+		b.WriteByte(':')
+		b.WriteString(strings.TrimSpace(headers[n]))
+		b.WriteByte('\n')
+	}
+	return b.String(), strings.Join(names, ";")
+}
+
+func hexSHA256(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(data))
+	return mac.Sum(nil)
+}
+
+func deriveSigningKey(secret, date, region, service string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), date)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, service)
+	return hmacSHA256(kService, presignedTerminator)
+}
+
+// resolvePrincipalForVerify resolves an access key to its plaintext secret
+// plus a PresignedCallerIdentity skeleton (X-K8s-Aws-Id field filled in by
+// the caller after signature verification succeeds). Branches on AKID
+// prefix — the same invariant the gateway SigV4 path relies on — so a
+// misfiled record cannot be resolved by the wrong path.
+func (s *STSServiceImpl) resolvePrincipalForVerify(accessKeyID string) (*PresignedCallerIdentity, string, error) {
+	switch {
+	case strings.HasPrefix(accessKeyID, SessionAccessKeyIDPrefix):
+		cred, err := s.LookupSessionCredential(accessKeyID)
+		if err != nil {
+			return nil, "", err
+		}
+		if cred == nil {
+			return nil, "", errors.New(awserrors.ErrorInvalidIdentityToken)
+		}
+		if presignedTimeNow().After(cred.ExpiresAt) {
+			return nil, "", errors.New(awserrors.ErrorExpiredToken)
+		}
+		secret, err := handlers_iam.DecryptSecret(cred.SecretEncrypted, s.masterKey)
+		if err != nil {
+			return nil, "", fmt.Errorf("decrypt session secret: %w", err)
+		}
+		return &PresignedCallerIdentity{
+			AccountID:     cred.AccountID,
+			ARN:           cred.AssumedRoleARN,
+			UserID:        cred.AssumedRoleID,
+			PrincipalType: principalTypeAssumedRolePresigned,
+		}, secret, nil
+	case strings.HasPrefix(accessKeyID, longLivedAccessKeyIDPrefix):
+		ak, err := s.iamSvc.LookupAccessKey(accessKeyID)
+		if err != nil {
+			if strings.Contains(err.Error(), awserrors.ErrorIAMNoSuchEntity) {
+				return nil, "", errors.New(awserrors.ErrorInvalidIdentityToken)
+			}
+			return nil, "", err
+		}
+		if ak.Status != handlers_iam.AccessKeyStatusActive {
+			return nil, "", errors.New(awserrors.ErrorInvalidIdentityToken)
+		}
+		secret, err := s.iamSvc.DecryptSecret(ak.SecretAccessKey)
+		if err != nil {
+			return nil, "", fmt.Errorf("decrypt IAM secret: %w", err)
+		}
+		userOut, err := s.iamSvc.GetUser(ak.AccountID, &iam.GetUserInput{UserName: aws.String(ak.UserName)})
+		if err != nil {
+			return nil, "", err
+		}
+		userARN := aws.StringValue(userOut.User.Arn)
+		userID := aws.StringValue(userOut.User.UserId)
+		if userARN == "" {
+			userARN = fmt.Sprintf("arn:aws:iam::%s:user/%s", ak.AccountID, ak.UserName)
+		}
+		return &PresignedCallerIdentity{
+			AccountID:     ak.AccountID,
+			ARN:           userARN,
+			UserID:        userID,
+			PrincipalType: principalTypeUserPresigned,
+		}, secret, nil
+	default:
+		return nil, "", errors.New(awserrors.ErrorInvalidIdentityToken)
+	}
+}
+
+const (
+	longLivedAccessKeyIDPrefix        = "AKIA"
+	principalTypeUserPresigned        = "User"
+	principalTypeAssumedRolePresigned = "AssumedRole"
+)

--- a/spinifex/handlers/sts/presigned_url_verify_test.go
+++ b/spinifex/handlers/sts/presigned_url_verify_test.go
@@ -1,0 +1,385 @@
+package handlers_sts
+
+import (
+	"encoding/hex"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPresignedHost   = "sts.au-mel-1.mulga.local"
+	testPresignedRegion = "au-mel-1"
+)
+
+// presignTestURL builds an `aws eks get-token`-shape SigV4-presigned GET URL
+// for sts.GetCallerIdentity, signing the X-K8s-Aws-Id header with the given
+// clusterName so a Verify call against the same clusterName succeeds. Hand-
+// rolled rather than via aws-sdk-go-v2 so the test does not pull an extra
+// dependency just to assert the production reconstruction.
+func presignTestURL(t *testing.T, accessKeyID, secret, clusterName string, signedTime time.Time, expires int64) string {
+	t.Helper()
+	host := testPresignedHost
+	region := testPresignedRegion
+	service := "sts"
+	terminator := "aws4_request"
+	date := signedTime.UTC().Format("20060102")
+	amzDate := signedTime.UTC().Format("20060102T150405Z")
+	credentialScope := strings.Join([]string{date, region, service, terminator}, "/")
+
+	q := url.Values{}
+	q.Set("Action", "GetCallerIdentity")
+	q.Set("Version", "2011-06-15")
+	q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	q.Set("X-Amz-Credential", accessKeyID+"/"+credentialScope)
+	q.Set("X-Amz-Date", amzDate)
+	q.Set("X-Amz-Expires", strconv.FormatInt(expires, 10))
+	q.Set("X-Amz-SignedHeaders", "host;x-k8s-aws-id")
+
+	// Canonical query string (no signature yet) — must match the
+	// production reconstruction, byte-for-byte.
+	canonQ := canonicalQueryStringForTest(q)
+
+	canonHeaders := "host:" + host + "\n" + "x-k8s-aws-id:" + clusterName + "\n"
+	signedHeadersList := "host;x-k8s-aws-id"
+	canonRequest := strings.Join([]string{
+		"GET", "/", canonQ, canonHeaders, signedHeadersList, "UNSIGNED-PAYLOAD",
+	}, "\n")
+
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256", amzDate, credentialScope, hexSHA256(canonRequest),
+	}, "\n")
+
+	key := deriveSigningKey(secret, date, region, service)
+	sig := hex.EncodeToString(hmacSHA256(key, stringToSign))
+	q.Set("X-Amz-Signature", sig)
+
+	return "https://" + host + "/?" + canonicalQueryStringForTest(q)
+}
+
+// canonicalQueryStringForTest mirrors the production canonical-query
+// implementation so the test signer agrees with the verifier on
+// canonicalisation. Sorting + encoding rules must stay aligned; if either
+// implementation drifts, signature verification breaks immediately —
+// caught by TestVerifyPresignedGetCallerIdentity_HappyPath.
+func canonicalQueryStringForTest(q url.Values) string {
+	type kv struct{ k, v string }
+	pairs := make([]kv, 0, len(q))
+	for k, vs := range q {
+		ek := awsQueryEscape(k)
+		for _, v := range vs {
+			pairs = append(pairs, kv{ek, awsQueryEscape(v)})
+		}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].k == pairs[j].k {
+			return pairs[i].v < pairs[j].v
+		}
+		return pairs[i].k < pairs[j].k
+	})
+	parts := make([]string, len(pairs))
+	for i, p := range pairs {
+		parts[i] = p.k + "=" + p.v
+	}
+	return strings.Join(parts, "&")
+}
+
+// seedAccessKey writes an active IAM access key for the user and returns its
+// plaintext secret so the test can sign with it. Uses the production
+// CreateAccessKey path (returns the plaintext once).
+func seedAccessKey(t *testing.T, svc *STSServiceImpl, accountID, userName string) (akid, secret string) {
+	t.Helper()
+	_, err := svc.iamSvc.CreateUser(accountID, &iam.CreateUserInput{UserName: aws.String(userName)})
+	require.NoError(t, err)
+	out, err := svc.iamSvc.CreateAccessKey(accountID, &iam.CreateAccessKeyInput{UserName: aws.String(userName)})
+	require.NoError(t, err)
+	return aws.StringValue(out.AccessKey.AccessKeyId), aws.StringValue(out.AccessKey.SecretAccessKey)
+}
+
+func withFrozenTime(t *testing.T, now time.Time) {
+	t.Helper()
+	prev := presignedTimeNow
+	presignedTimeNow = func() time.Time { return now }
+	t.Cleanup(func() { presignedTimeNow = prev })
+}
+
+// ----- Happy paths --------------------------------------------------------
+
+func TestVerifyPresignedGetCallerIdentity_HappyPath_LongLived(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "alice")
+
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	const cluster = "demo-cluster"
+	u := presignTestURL(t, akid, secret, cluster, signedAt, 900)
+
+	got, err := svc.VerifyPresignedGetCallerIdentity(u, cluster)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, testCallerAccountID, got.AccountID)
+	assert.Equal(t, cluster, got.XK8sAwsID)
+	assert.Equal(t, principalTypeUserPresigned, got.PrincipalType)
+	assert.Contains(t, got.ARN, ":user/alice")
+}
+
+func TestVerifyPresignedGetCallerIdentity_HappyPath_SessionCred(t *testing.T) {
+	// A session credential (ASIA prefix) signs the URL. VerifyPresigned must
+	// resolve via LookupSessionCredential, decrypt the secret, and match.
+	svc, _ := newTestSetup(t)
+	role := createRoleInAccount(t, svc, testCallerAccountID, "irsa-presign",
+		trustPolicyAllowingUser(testCallerARN()))
+
+	// Acquire a session credential the orthodox way.
+	assumeOut, err := svc.AssumeRole(testCallerAccountID, testCallerARN(), testCallerUserName,
+		basicAssumeRoleInput(*role.Arn, "sess-presign"))
+	require.NoError(t, err)
+	akid := aws.StringValue(assumeOut.Credentials.AccessKeyId)
+	secret := aws.StringValue(assumeOut.Credentials.SecretAccessKey)
+
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	const cluster = "session-cluster"
+	u := presignTestURL(t, akid, secret, cluster, signedAt, 900)
+
+	got, err := svc.VerifyPresignedGetCallerIdentity(u, cluster)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, testCallerAccountID, got.AccountID)
+	assert.Equal(t, cluster, got.XK8sAwsID)
+	assert.Equal(t, principalTypeAssumedRolePresigned, got.PrincipalType)
+}
+
+// ----- Cross-cluster anti-replay (Q10 mandatory) --------------------------
+
+func TestVerifyPresignedGetCallerIdentity_CrossClusterReplay(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "bob")
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	// Sign for cluster-A.
+	u := presignTestURL(t, akid, secret, "cluster-A", signedAt, 900)
+
+	// Present to cluster-B — signature reconstruction binds X-K8s-Aws-Id =
+	// cluster-B, so the recomputed signature differs and verification fails.
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, "cluster-B")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestVerifyPresignedGetCallerIdentity_MissingXK8sAwsIdInSignedHeaders(t *testing.T) {
+	// An attacker presigning without x-k8s-aws-id in SignedHeaders strips the
+	// cross-cluster check from the canonical request. Verify must refuse
+	// before any signature work — the URL is structurally untrustworthy.
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "eve")
+
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	date := signedAt.UTC().Format("20060102")
+	amzDate := signedAt.UTC().Format("20060102T150405Z")
+	credentialScope := date + "/au-mel-1/sts/aws4_request"
+	q := url.Values{}
+	q.Set("Action", "GetCallerIdentity")
+	q.Set("Version", "2011-06-15")
+	q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	q.Set("X-Amz-Credential", akid+"/"+credentialScope)
+	q.Set("X-Amz-Date", amzDate)
+	q.Set("X-Amz-Expires", "900")
+	q.Set("X-Amz-SignedHeaders", "host") // no x-k8s-aws-id
+
+	canonQ := canonicalQueryStringForTest(q)
+	canonHeaders := "host:" + testPresignedHost + "\n"
+	canonReq := strings.Join([]string{
+		"GET", "/", canonQ, canonHeaders, "host", "UNSIGNED-PAYLOAD",
+	}, "\n")
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256", amzDate, credentialScope, hexSHA256(canonReq),
+	}, "\n")
+	key := deriveSigningKey(secret, date, "au-mel-1", "sts")
+	sig := hex.EncodeToString(hmacSHA256(key, stringToSign))
+	q.Set("X-Amz-Signature", sig)
+	u := "https://" + testPresignedHost + "/?" + canonicalQueryStringForTest(q)
+
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, "any-cluster")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+// ----- Expiry -------------------------------------------------------------
+
+func TestVerifyPresignedGetCallerIdentity_Expired(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "carol")
+
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	const cluster = "exp-cluster"
+	u := presignTestURL(t, akid, secret, cluster, signedAt, 60)
+
+	// Verifier clock 5 minutes after signing — beyond 60s expiry.
+	withFrozenTime(t, signedAt.Add(5*time.Minute))
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, cluster)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorExpiredToken, err.Error())
+}
+
+// ----- Tampered URL detection ---------------------------------------------
+
+func TestVerifyPresignedGetCallerIdentity_TamperedQueryParameter(t *testing.T) {
+	// Flip an unrelated query param (Action) after signing — must invalidate
+	// the signature because Action is part of the canonical query string.
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "dave")
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	u := presignTestURL(t, akid, secret, "c", signedAt, 900)
+	tampered := strings.Replace(u, "GetCallerIdentity", "GetSessionToken", 1)
+
+	_, err := svc.VerifyPresignedGetCallerIdentity(tampered, "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+// ----- Bad envelope / input edges ----------------------------------------
+
+func TestVerifyPresignedGetCallerIdentity_MissingInput(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	_, err := svc.VerifyPresignedGetCallerIdentity("", "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorMissingParameter, err.Error())
+	_, err = svc.VerifyPresignedGetCallerIdentity("https://x", "")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorMissingParameter, err.Error())
+}
+
+func TestVerifyPresignedGetCallerIdentity_RejectsHTTP(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	_, err := svc.VerifyPresignedGetCallerIdentity("http://sts.local/?X-Amz-Algorithm=AWS4-HMAC-SHA256", "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestVerifyPresignedGetCallerIdentity_BadAlgorithm(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	u := "https://sts.local/?X-Amz-Algorithm=foo&X-Amz-Credential=a/20240101/r/sts/aws4_request&X-Amz-Date=20240101T000000Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host;x-k8s-aws-id&X-Amz-Signature=00"
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestVerifyPresignedGetCallerIdentity_UnknownAccessKey(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	u := presignTestURL(t, "AKIAGHOSTEXAMPLE0000", "fake-secret", "c", signedAt, 900)
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestVerifyPresignedGetCallerIdentity_UnknownAKIDPrefix(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+	u := presignTestURL(t, "QQQQEXAMPLE000000000", "x", "c", signedAt, 900)
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestVerifyPresignedGetCallerIdentity_BadServiceInCredential(t *testing.T) {
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "frank")
+
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	// Build a URL whose credential scope claims s3 instead of sts — the
+	// service mismatch is structural, no signature work needed.
+	date := signedAt.UTC().Format("20060102")
+	amzDate := signedAt.UTC().Format("20060102T150405Z")
+	q := url.Values{}
+	q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	q.Set("X-Amz-Credential", akid+"/"+date+"/au-mel-1/s3/aws4_request")
+	q.Set("X-Amz-Date", amzDate)
+	q.Set("X-Amz-Expires", "900")
+	q.Set("X-Amz-SignedHeaders", "host;x-k8s-aws-id")
+	q.Set("X-Amz-Signature", strings.Repeat("a", 64))
+	_ = secret
+	u := "https://" + testPresignedHost + "/?" + q.Encode()
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+func TestVerifyPresignedGetCallerIdentity_CredentialDateMismatch(t *testing.T) {
+	// X-Amz-Date date portion (YYYYMMDD) and credential-scope date must agree.
+	// AWS-CLI enforces this; mismatch is a tampered URL.
+	svc, _ := newTestSetup(t)
+	akid, secret := seedAccessKey(t, svc, testCallerAccountID, "george")
+	signedAt := time.Now().UTC().Truncate(time.Second)
+	withFrozenTime(t, signedAt)
+
+	q := url.Values{}
+	wrongDate := signedAt.Add(-24 * time.Hour).Format("20060102")
+	q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	q.Set("X-Amz-Credential", akid+"/"+wrongDate+"/au-mel-1/sts/aws4_request")
+	q.Set("X-Amz-Date", signedAt.Format("20060102T150405Z"))
+	q.Set("X-Amz-Expires", "900")
+	q.Set("X-Amz-SignedHeaders", "host;x-k8s-aws-id")
+	q.Set("X-Amz-Signature", strings.Repeat("a", 64))
+	_ = secret
+	u := "https://" + testPresignedHost + "/?" + q.Encode()
+	_, err := svc.VerifyPresignedGetCallerIdentity(u, "c")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidIdentityToken, err.Error())
+}
+
+// ----- Component unit tests -----------------------------------------------
+
+func TestAWSQueryEscape(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"abc", "abc"},
+		{"a b", "a%20b"},
+		{"a+b", "a%2Bb"},
+		{"a/b", "a%2Fb"},
+		{"a=b", "a%3Db"},
+		{"~_.-", "~_.-"}, // unreserved set passes through
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, awsQueryEscape(tc.in))
+		})
+	}
+}
+
+func TestDeriveSigningKey_KnownVector(t *testing.T) {
+	// From AWS SigV4 docs (Example signing key derivation).
+	// Inputs:
+	//   secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+	//   date   = "20120215", region = "us-east-1", service = "iam"
+	// The doc's expected signing-key hex digest stays stable across SDK versions.
+	key := deriveSigningKey(
+		"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		"20120215", "us-east-1", "iam",
+	)
+	const wantHex = "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"
+	assert.Equal(t, wantHex, hex.EncodeToString(key))
+}

--- a/spinifex/handlers/sts/service.go
+++ b/spinifex/handlers/sts/service.go
@@ -17,10 +17,25 @@ type STSService interface {
 	// strings to keep the handler unit-testable.
 	AssumeRole(callerAccountID, callerARN, callerIdentity string, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
 
+	// AssumeRoleWithWebIdentity exchanges an OIDC ID token (typically a
+	// projected K8s ServiceAccount token signed by an EKS cluster's
+	// per-cluster signing key) for short-lived AWS credentials bound to the
+	// target IAM role. Called anonymously — the caller is identified by the
+	// iss/sub/aud claims of the supplied JWT, not by SigV4.
+	AssumeRoleWithWebIdentity(input *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error)
+
 	// GetCallerIdentity returns the authenticated principal's account / ARN /
 	// UserId. AWS allows every authenticated principal to call this; the
 	// gateway does not gate it with checkPolicy.
 	GetCallerIdentity(callerAccountID, callerARN, callerUserID string, input *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error)
+
+	// VerifyPresignedGetCallerIdentity validates a SigV4-presigned URL for
+	// the sts:GetCallerIdentity action — the token shape produced by `aws
+	// eks get-token` — and resolves the calling principal. The EKS token
+	// webhook calls this over NATS as part of TokenReview processing.
+	// expectedClusterName is constant-time-compared against the signed
+	// X-K8s-Aws-Id header value to prevent cross-cluster replay.
+	VerifyPresignedGetCallerIdentity(presignedURL, expectedClusterName string) (*PresignedCallerIdentity, error)
 
 	// LookupSessionCredential resolves an access-key ID to its stored
 	// SessionCredential record. Used by the SigV4 middleware to verify

--- a/spinifex/handlers/sts/web_identity_trust_policy.go
+++ b/spinifex/handlers/sts/web_identity_trust_policy.go
@@ -1,0 +1,257 @@
+package handlers_sts
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+)
+
+const (
+	// stsActionAssumeRoleWithWebIdentity is the only Action whose statements
+	// may carry a Condition block (per the validator in handlers_iam). The
+	// constant is duplicated here so the action-match path stays in this
+	// package and a future rename surfaces as a compile-time mismatch.
+	stsActionAssumeRoleWithWebIdentity = "sts:AssumeRoleWithWebIdentity"
+
+	// IRSA convention: pods bake a single audience value into the projected
+	// ServiceAccount token. The handler accepts any token whose `aud` claim
+	// contains this exact string (claim is a JSON string or array — handled
+	// upstream via jwt.ClaimStrings).
+	irsaExpectedAudience = "sts.amazonaws.com"
+)
+
+// webIdentityContext is the resolved-and-verified set of facts about an
+// AssumeRoleWithWebIdentity caller that the trust-policy evaluator needs to
+// match against. The handler builds it after JWT signature + claim validation;
+// the evaluator does not re-verify, it only matches.
+type webIdentityContext struct {
+	// federatedPrincipalARN is `arn:aws:iam::{roleAccountID}:oidc-provider/{issuerHostPath}`
+	// (the value the role trust policy's Principal.Federated entry must equal).
+	federatedPrincipalARN string
+
+	// issuer is the literal `iss` claim value. Used to build the condition-key
+	// prefix `{iss}:sub` / `{iss}:aud` per the IRSA convention.
+	issuer string
+
+	// subject is the literal `sub` claim value.
+	subject string
+
+	// audience is the list of audience values from the JWT `aud` claim.
+	// Membership semantics — a single Condition StringEquals on `{iss}:aud`
+	// matches if any wired audience equals the condition value.
+	audience []string
+}
+
+// evalTrustPolicyForWebIdentity is the sibling of evalTrustPolicy for the
+// AssumeRoleWithWebIdentity action. AWS semantics: explicit-deny wins across
+// the document, then any matching Allow grants. A statement matches when:
+//
+//   - Action contains sts:AssumeRoleWithWebIdentity (wildcards accepted —
+//     sts:* and "*" — same as evalTrustPolicy for symmetry).
+//   - Principal.Federated equals webIdentityContext.federatedPrincipalARN.
+//   - Every Condition operator entry holds (currently only StringEquals).
+//
+// Returns nil on grant; awserrors.ErrorAccessDenied on no-match or explicit
+// deny; a wrapped error on stored-doc corruption (matches evalTrustPolicy's
+// fail-closed-loudly contract).
+func evalTrustPolicyForWebIdentity(docJSON string, ctx webIdentityContext) error {
+	doc, err := handlers_iam.ValidateTrustPolicyDocument(docJSON)
+	if err != nil {
+		return fmt.Errorf("stored trust policy invalid: %w", err)
+	}
+
+	for _, stmt := range doc.Statement {
+		if stmt.Effect != handlers_iam.PolicyEffectDeny {
+			continue
+		}
+		matched, err := matchWebIdentityStatement(stmt.Action, stmt.Principal, stmt.Condition, ctx)
+		if err != nil {
+			return err
+		}
+		if matched {
+			return errors.New(awserrors.ErrorAccessDenied)
+		}
+	}
+
+	for _, stmt := range doc.Statement {
+		if stmt.Effect != handlers_iam.PolicyEffectAllow {
+			continue
+		}
+		matched, err := matchWebIdentityStatement(stmt.Action, stmt.Principal, stmt.Condition, ctx)
+		if err != nil {
+			return err
+		}
+		if matched {
+			return nil
+		}
+	}
+
+	return errors.New(awserrors.ErrorAccessDenied)
+}
+
+func matchWebIdentityStatement(actions []string, principalRaw, conditionRaw json.RawMessage, ctx webIdentityContext) (bool, error) {
+	if !matchWebIdentityAction(actions) {
+		return false, nil
+	}
+	principalMatch, err := matchFederatedPrincipal(principalRaw, ctx.federatedPrincipalARN)
+	if err != nil {
+		return false, err
+	}
+	if !principalMatch {
+		return false, nil
+	}
+	if !conditionsHold(conditionRaw, ctx) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func matchWebIdentityAction(actions []string) bool {
+	for _, a := range actions {
+		if a == stsActionAssumeRoleWithWebIdentity || a == stsActionWildcard || a == globalWildcard {
+			return true
+		}
+	}
+	return false
+}
+
+// matchFederatedPrincipal accepts Principal.Federated as either a string or
+// an array of strings, mirroring the AWS Principal.AWS shape. Returns false
+// on Principal: "*" — Federated does not honour the bare wildcard the way
+// Principal: "*" does; a web-identity policy that means "any OIDC issuer"
+// must say so explicitly via a Principal.Federated entry per issuer ARN.
+// Unrelated top-level keys (Service, AWS) skip at the entry level — same
+// open-set semantics as matchTrustPrincipal in assume_role.go.
+func matchFederatedPrincipal(raw json.RawMessage, expectedARN string) (bool, error) {
+	if len(raw) == 0 {
+		return false, nil
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		// Principal: "*" → does NOT match Federated. The web-identity action
+		// has no analogue to the AWS-account-wide root principal and the bare
+		// wildcard would silently grant any OIDC issuer that could fish a
+		// trust policy. Fail closed.
+		return false, nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false, fmt.Errorf("unmarshal Principal: %w", err)
+	}
+	fedRaw, ok := m["Federated"]
+	if !ok {
+		return false, nil
+	}
+	var single string
+	if err := json.Unmarshal(fedRaw, &single); err == nil {
+		return subtle.ConstantTimeCompare([]byte(single), []byte(expectedARN)) == 1, nil
+	}
+	var arr []string
+	if err := json.Unmarshal(fedRaw, &arr); err != nil {
+		return false, fmt.Errorf("Principal.Federated must be string or array: %w", err)
+	}
+	for _, entry := range arr {
+		if subtle.ConstantTimeCompare([]byte(entry), []byte(expectedARN)) == 1 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// conditionsHold evaluates a Condition block against the web-identity context.
+// The validator restricts the operator to StringEquals — anything else is a
+// stored-doc inconsistency and the safe default is "do not match".
+//
+// IRSA-shaped keys:
+//
+//	{iss}:sub  → exact equality with the JWT `sub` claim
+//	{iss}:aud  → set-membership against the JWT `aud` claim list
+//	             (`aud` is a ClaimStrings — one or many)
+//
+// Each StringEquals entry value can be a single string or a list — both
+// shapes match if any entry compares equal. Missing-condition = grant
+// (no Condition → unrestricted Allow on the Federated principal).
+func conditionsHold(raw json.RawMessage, ctx webIdentityContext) bool {
+	if !isCondRawNonEmpty(raw) {
+		return true
+	}
+	var ops map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &ops); err != nil {
+		return false
+	}
+	for op, kv := range ops {
+		if op != "StringEquals" {
+			// Validator rejects other operators at write time; reaching here
+			// means a stored doc was tampered with bypassing validation. Fail
+			// closed rather than silently grant.
+			return false
+		}
+		issPrefix := strings.TrimSuffix(ctx.issuer, "/")
+		for key, expectedRaw := range kv {
+			expected, ok := unmarshalStringOrArray(expectedRaw)
+			if !ok {
+				return false
+			}
+			switch key {
+			case issPrefix + ":sub":
+				if !anyEquals(expected, []string{ctx.subject}) {
+					return false
+				}
+			case issPrefix + ":aud":
+				if !anyEquals(expected, ctx.audience) {
+					return false
+				}
+			default:
+				// Unknown condition key — fail closed. v1 only models the two
+				// IRSA-shaped keys above; an unknown key in a stored doc most
+				// likely means the policy author wanted a stricter check the
+				// evaluator cannot honour, so refusing the grant is safer
+				// than ignoring the key.
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// isCondRawNonEmpty mirrors the validator's empty-detection so an empty `{}`
+// Condition (validator-accepted) does not enter the operator loop.
+func isCondRawNonEmpty(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	switch strings.TrimSpace(string(raw)) {
+	case "", "null", "{}":
+		return false
+	default:
+		return true
+	}
+}
+
+func unmarshalStringOrArray(raw json.RawMessage) ([]string, bool) {
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}, true
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, true
+	}
+	return nil, false
+}
+
+func anyEquals(want, got []string) bool {
+	for _, w := range want {
+		for _, g := range got {
+			if subtle.ConstantTimeCompare([]byte(w), []byte(g)) == 1 {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

EKS Q4 STS extensions for IRSA and the EKS token-webhook flow.

- **AssumeRoleWithWebIdentity** — ES256 JWT verify against per-cluster JWKS, federated trust-policy evaluator (explicit-deny-wins, fail-closed on Principal: \"*\"), OIDC provider registry lookup against \`iam-account-{roleAccountID}\`, Condition support scoped to StringEquals on \`{iss}:sub\` and \`{iss}:aud\`.
- **VerifyPresignedGetCallerIdentity** — hand-rolled SigV4 canonical-request reconstruction with X-K8s-Aws-Id pinned to \`expectedClusterName\`; cross-cluster replay surfaces as signature mismatch. ASIA/AKIA dispatch via existing session-credential and IAM lookup paths.
- **OIDC provider registry** — new \`handlers/iam/oidc_providers.go\` shares the \`iam-account-{id}/oidc-providers/{sha256(issuer)}\` key scheme between IAM and STS.
- **awserrors** — adds InvalidIdentityToken (400), IDPRejectedClaim (403), IDPCommunicationError (400) with AWS-shaped messages.
- **Gateway TODO** — \`gateway/sts.go:stsActions\` documents that AssumeRoleWithWebIdentity currently sits on the SigV4-gated path; the AWS gateway mux needs a pre-auth route for the truly anonymous code path.

## Test plan

- [x] 14 \`TestAssumeRoleWithWebIdentity_*\` scenarios (happy paths, tampered signature, expired, missing exp, wrong audience, unknown kid, HS256 rejected, federated wildcard fail-closed, explicit-deny-wins, provider-not-registered, subject mismatch, bad role/session-name/duration)
- [x] 12 \`TestVerifyPresignedGetCallerIdentity_*\` scenarios (AKIA + ASIA happy paths, cross-cluster replay rejection, missing x-k8s-aws-id, tampered query, bad service in credential, credential-date mismatch, unknown access key, expired)
- [x] \`TestInvariant_PresignedGetCallerIdentity_CrossClusterReplayRejected\` — matrix of variant cluster names (case-different, prefix, suffix)
- [x] \`TestDeriveSigningKey_KnownVector\` — AWS SigV4 docs known-vector
- [x] \`TestAWSQueryEscape\` — RFC 3986 unreserved set + delimiters
- [x] \`make preflight\` green (lint, vet, race, e2e, coverage ≥60%)