### PR TITLE
feat(route53): gateway + handler + EclipsoCtl scaffolding (Sprint 1a)

### DIFF
--- a/build/systemd/eclipso.service
+++ b/build/systemd/eclipso.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=Eclipso (Authoritative DNS for Mulga)
+PartOf=spinifex.target
+After=spinifex-nats.service spinifex-predastore.service
+# Wants= rather than Requires= so eclipso restarts do not cascade to
+# predastore/nats; spxd handles the bootstrap ordering on cold-boot.
+Wants=spinifex-nats.service spinifex-predastore.service
+
+[Service]
+Type=simple
+User=eclipso
+Group=eclipso
+# Binary built by `make deploy` (Eclipso submodule). EnvironmentFile is
+# written by spxd at install time after the dns-resolver IAM principal
+# exists (route53-v0.md R7). Until that file lands on disk, systemd
+# treats EnvironmentFile= with the leading "-" as best-effort so the
+# unit can be enabled before its env materialises.
+ExecStart=/usr/local/bin/eclipso
+EnvironmentFile=-/etc/spinifex/eclipso.env
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+# Bind UDP/TCP 53 + DoT 853 as a non-root user — the only capability
+# the binary needs is CAP_NET_BIND_SERVICE.
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Hardening
+NoNewPrivileges=yes
+ProtectSystem=full
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictNamespaces=yes
+ProtectClock=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectProc=invisible
+SystemCallArchitectures=native
+MemoryDenyWriteExecute=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+ProtectHostname=yes
+KeyringMode=private
+RemoveIPC=yes
+LimitCORE=0
+LimitNOFILE=65536
+ReadOnlyPaths=/etc/spinifex/eclipso/eclipso.crt /etc/spinifex/eclipso/eclipso.key /etc/spinifex/eclipso.env
+
+[Install]
+WantedBy=spinifex.target

--- a/docs/service-interfaces.yaml
+++ b/docs/service-interfaces.yaml
@@ -31,10 +31,12 @@ services:
       - "ec2.*"
       - "elbv2.*"
       - "iam.*"
+      - "dns.*"
     depends_on:
       - "ec2.*"
       - "elbv2.*"
       - "iam.*"
+      - "dns.*"
 
   spinifex_daemon:
     path: spinifex/services/spinifex
@@ -51,6 +53,7 @@ services:
       - spinifex/handlers/ec2
       - spinifex/handlers/elbv2
       - spinifex/handlers/iam
+      - spinifex/handlers/route53
     subscribes:
       # EC2 instance lifecycle.
       - "ec2.RunInstances"
@@ -95,6 +98,15 @@ services:
       - "elbv2.CreateListener"
       - "elbv2.DeleteListener"
       - "elbv2.DescribeListeners"
+      # Route53 control plane (Sprint 1a stubs; bodies in 1b/1c).
+      - "dns.CreateHostedZone"
+      - "dns.GetHostedZone"
+      - "dns.ListHostedZones"
+      - "dns.UpdateHostedZoneComment"
+      - "dns.DeleteHostedZone"
+      - "dns.ChangeResourceRecordSets"
+      - "dns.ListResourceRecordSets"
+      - "dns.GetChange"
     publishes:
       # → vpcd
       - "vpc.create"

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -49,6 +49,7 @@ import (
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
 	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
+	handlers_route53 "github.com/mulgadc/spinifex/spinifex/handlers/route53"
 	"github.com/mulgadc/spinifex/spinifex/instancetypes"
 	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
 	"github.com/mulgadc/spinifex/spinifex/network/host"
@@ -132,6 +133,8 @@ type Daemon struct {
 	eipService            *handlers_ec2_eip.EIPServiceImpl
 	elbv2Service          *handlers_elbv2.ELBv2ServiceImpl
 	eksService            *handlers_eks.EKSServiceImpl
+	route53Service        *handlers_route53.Route53ServiceImpl
+	eclipsoCtl            *EclipsoCtl
 	routeTableService     *handlers_ec2_routetable.RouteTableServiceImpl
 	natGatewayService     *handlers_ec2_natgw.NatGatewayServiceImpl
 	externalIPAM          *handlers_ec2_vpc.ExternalIPAM
@@ -885,6 +888,22 @@ func (d *Daemon) subscribeAll() error {
 		)
 	}
 
+	// Route53 gateway → daemon subscriptions. Every handler currently
+	// returns NotImplemented; topics are subscribed up-front so the
+	// wiring layer is stable while real bodies land in 1b/1c.
+	if d.route53Service != nil {
+		subs = append(subs,
+			natsSub{handlers_route53.SubjectCreateHostedZone, d.handleRoute53CreateHostedZone, "spinifex-workers"},
+			natsSub{handlers_route53.SubjectGetHostedZone, d.handleRoute53GetHostedZone, "spinifex-workers"},
+			natsSub{handlers_route53.SubjectListHostedZones, d.handleRoute53ListHostedZones, "spinifex-workers"},
+			natsSub{handlers_route53.SubjectUpdateHostedZoneComment, d.handleRoute53UpdateHostedZoneComment, "spinifex-workers"},
+			natsSub{handlers_route53.SubjectDeleteHostedZone, d.handleRoute53DeleteHostedZone, "spinifex-workers"},
+			natsSub{handlers_route53.SubjectChangeResourceRecordSets, d.handleRoute53ChangeResourceRecordSets, "spinifex-workers"},
+			natsSub{handlers_route53.SubjectListResourceRecordSets, d.handleRoute53ListResourceRecordSets, "spinifex-workers"},
+			natsSub{handlers_route53.SubjectGetChange, d.handleRoute53GetChange, "spinifex-workers"},
+		)
+	}
+
 	// EIP operations require external IPAM (pool mode). Only subscribe when available;
 	// without a subscriber the gateway returns a NATS timeout → clean error to the client.
 	if d.eipService != nil {
@@ -1067,6 +1086,8 @@ func (d *Daemon) assertNoClusterServicesInitialised() error {
 		return errors.New("d.elbv2Service must be nil before startCluster")
 	case d.eksService != nil:
 		return errors.New("d.eksService must be nil before startCluster")
+	case d.route53Service != nil:
+		return errors.New("d.route53Service must be nil before startCluster")
 	}
 	return nil
 }
@@ -1327,6 +1348,18 @@ func (d *Daemon) startCluster() error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize EKS service: %w", err)
 	}
+
+	// Route53 service (Sprint 1a): NATS-only at this stage; predastore
+	// zone-store + Eclipso reload-event tracker hooks land in 1b/1c.
+	// Method bodies return NotImplemented so callers exercising the
+	// gateway dispatch get a stable AWS-shaped reply.
+	d.route53Service = handlers_route53.NewRoute53ServiceImplWithNATS(d.natsConn)
+
+	// EclipsoCtl handles systemctl invocations for the eclipso.service
+	// unit. Sprint 1a wires the controller; spxd bootstrap order
+	// (NATS → predastore → IAM seed → dns-zones bucket → env file →
+	// EclipsoCtl.Start) lands in 1b.
+	d.eclipsoCtl = NewEclipsoCtl()
 
 	// Ensure default VPC exists for system and admin accounts
 	// (matches AWS: every account has a default VPC with IGW + default SG)

--- a/spinifex/daemon/daemon_handlers_route53.go
+++ b/spinifex/daemon/daemon_handlers_route53.go
@@ -1,0 +1,39 @@
+package daemon
+
+import "github.com/nats-io/nats.go"
+
+// --- Hosted zones (Sprint 1b bodies) ---
+
+func (d *Daemon) handleRoute53CreateHostedZone(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.CreateHostedZone)
+}
+
+func (d *Daemon) handleRoute53GetHostedZone(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.GetHostedZone)
+}
+
+func (d *Daemon) handleRoute53ListHostedZones(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.ListHostedZones)
+}
+
+func (d *Daemon) handleRoute53UpdateHostedZoneComment(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.UpdateHostedZoneComment)
+}
+
+func (d *Daemon) handleRoute53DeleteHostedZone(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.DeleteHostedZone)
+}
+
+// --- Resource record sets + GetChange (Sprint 1c bodies) ---
+
+func (d *Daemon) handleRoute53ChangeResourceRecordSets(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.ChangeResourceRecordSets)
+}
+
+func (d *Daemon) handleRoute53ListResourceRecordSets(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.ListResourceRecordSets)
+}
+
+func (d *Daemon) handleRoute53GetChange(msg *nats.Msg) {
+	handleNATSRequest(msg, d.route53Service.GetChange)
+}

--- a/spinifex/daemon/eclipso.go
+++ b/spinifex/daemon/eclipso.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// EclipsoServiceName is the systemd unit that owns the eclipso DNS process.
+// Installed by scripts/systemd/eclipso.service; activated by EclipsoCtl.
+const EclipsoServiceName = "eclipso.service"
+
+// eclipsoReadyTimeout caps how long Start() waits for is-active before
+// returning an error so a stuck Eclipso does not block daemon startup.
+const eclipsoReadyTimeout = 30 * time.Second
+
+// eclipsoReadyPoll is the gap between is-active probes during Start().
+const eclipsoReadyPoll = 500 * time.Millisecond
+
+// EclipsoCtl drives the eclipso.service systemd unit. Start/Stop signal
+// systemctl; IsRunning probes is-active; Reload sends SIGHUP via
+// `systemctl reload` so Eclipso re-reads its zone files without a full
+// restart. Sprint 1a wires the controller surface; spxd start-order
+// integration (after NATS + predastore + IAM seed + dns-zones bucket
+// + /etc/spinifex/eclipso.env write) lands in 1b.
+type EclipsoCtl struct {
+	unit string
+}
+
+// NewEclipsoCtl returns a controller bound to EclipsoServiceName.
+func NewEclipsoCtl() *EclipsoCtl {
+	return &EclipsoCtl{unit: EclipsoServiceName}
+}
+
+// Start signals systemd to bring the unit up and waits up to
+// eclipsoReadyTimeout for it to report active. Returns an error if the
+// systemctl invocation fails or the unit never reaches active.
+func (e *EclipsoCtl) Start(ctx context.Context) error {
+	if err := runSystemctl(ctx, "start", e.unit); err != nil {
+		return fmt.Errorf("systemctl start %s: %w", e.unit, err)
+	}
+	deadline := time.Now().Add(eclipsoReadyTimeout)
+	for {
+		if e.IsRunning(ctx) {
+			slog.Info("eclipso started", "unit", e.unit)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("eclipso %s did not become active within %s", e.unit, eclipsoReadyTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(eclipsoReadyPoll):
+		}
+	}
+}
+
+// Stop signals systemd to bring the unit down. Returns the systemctl
+// error verbatim — caller decides whether to escalate.
+func (e *EclipsoCtl) Stop(ctx context.Context) error {
+	if err := runSystemctl(ctx, "stop", e.unit); err != nil {
+		return fmt.Errorf("systemctl stop %s: %w", e.unit, err)
+	}
+	slog.Info("eclipso stopped", "unit", e.unit)
+	return nil
+}
+
+// IsRunning returns true when systemctl reports the unit active.
+// systemctl is-active exit codes: 0 = active, non-zero = anything else.
+func (e *EclipsoCtl) IsRunning(ctx context.Context) bool {
+	out, err := exec.CommandContext(ctx, "systemctl", "is-active", e.unit).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "active"
+}
+
+// Reload asks systemd to send the unit's reload signal (SIGHUP on the
+// default Eclipso unit) so it re-scans zone files without a restart.
+func (e *EclipsoCtl) Reload(ctx context.Context) error {
+	if err := runSystemctl(ctx, "reload", e.unit); err != nil {
+		return fmt.Errorf("systemctl reload %s: %w", e.unit, err)
+	}
+	return nil
+}
+
+// runSystemctl is the shared dispatch shim so unit tests can intercept
+// process invocation through a single seam.
+var runSystemctl = func(ctx context.Context, action, unit string) error {
+	return exec.CommandContext(ctx, "systemctl", action, unit).Run()
+}

--- a/spinifex/daemon/eclipso_test.go
+++ b/spinifex/daemon/eclipso_test.go
@@ -1,0 +1,54 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestEclipsoCtl_StartStopReload_InvokesSystemctl(t *testing.T) {
+	original := runSystemctl
+	t.Cleanup(func() { runSystemctl = original })
+
+	var calls []string
+	runSystemctl = func(_ context.Context, action, unit string) error {
+		calls = append(calls, action+" "+unit)
+		return nil
+	}
+
+	ctl := NewEclipsoCtl()
+
+	if err := ctl.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+	if err := ctl.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload returned error: %v", err)
+	}
+
+	wantPrefix := []string{"stop " + EclipsoServiceName, "reload " + EclipsoServiceName}
+	if len(calls) != len(wantPrefix) {
+		t.Fatalf("calls = %v, want %d entries", calls, len(wantPrefix))
+	}
+	for i, want := range wantPrefix {
+		if calls[i] != want {
+			t.Errorf("calls[%d] = %q, want %q", i, calls[i], want)
+		}
+	}
+}
+
+func TestEclipsoCtl_Start_PropagatesError(t *testing.T) {
+	original := runSystemctl
+	t.Cleanup(func() { runSystemctl = original })
+
+	want := errors.New("systemctl: boom")
+	runSystemctl = func(_ context.Context, _, _ string) error { return want }
+
+	ctl := NewEclipsoCtl()
+	err := ctl.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start returned nil error, want propagated systemctl failure")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("Start error = %v, want it to wrap %v", err, want)
+	}
+}

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -75,6 +75,7 @@ var supportedServices = map[string]bool{
 	"account":              true,
 	"elasticloadbalancing": true,
 	"eks":                  true,
+	"route53":              true,
 	"spinifex":             true,
 }
 
@@ -202,7 +203,8 @@ func (gw *GatewayConfig) writeClusterUnavailable(w http.ResponseWriter, _ *http.
 	}
 
 	var xmlBody string
-	if svc == "iam" || svc == "sts" {
+	switch svc {
+	case "iam", "sts":
 		iam := IAMErrorResponse{
 			Error: IAMErrorDetail{
 				Type:    "Sender",
@@ -217,7 +219,9 @@ func (gw *GatewayConfig) writeClusterUnavailable(w http.ResponseWriter, _ *http.
 			out = []byte(`<ErrorResponse><Error><Type>Sender</Type><Code>ServiceUnavailable</Code><Message>` + clusterUnavailableMsg + `</Message></Error><RequestId>` + requestID + `</RequestId></ErrorResponse>`)
 		}
 		xmlBody = xml.Header + string(out)
-	} else {
+	case "route53":
+		xmlBody = string(GenerateRoute53ErrorResponse(awserrors.ErrorServiceUnavailable, clusterUnavailableMsg, requestID))
+	default:
 		// ec2, elasticloadbalancing, account, spinifex — all share the EC2 envelope.
 		xmlBody = xml.Header + `<Response><Errors><Error><Code>` + awserrors.ErrorServiceUnavailable +
 			`</Code><Message>` + clusterUnavailableMsg + `</Message></Error></Errors><RequestID>` +
@@ -237,7 +241,7 @@ func (gw *GatewayConfig) writeThrottleError(w http.ResponseWriter, r *http.Reque
 	svc, _ := r.Context().Value(ctxService).(string)
 
 	errorCode := awserrors.ErrorRequestLimitExceeded
-	if svc == "iam" || svc == "sts" || svc == "eks" {
+	if svc == "iam" || svc == "sts" || svc == "eks" || svc == "route53" {
 		errorCode = awserrors.ErrorThrottling
 	}
 	errorMsg := awserrors.ErrorLookup[errorCode]
@@ -254,9 +258,12 @@ func (gw *GatewayConfig) writeThrottleError(w http.ResponseWriter, r *http.Reque
 	}
 
 	var xmlErr []byte
-	if svc == "iam" || svc == "sts" {
+	switch svc {
+	case "iam", "sts":
 		xmlErr = GenerateIAMErrorResponse(errorCode, errorMsg.Message, requestID)
-	} else { // ec2, elasticloadbalancing, account, spinifex
+	case "route53":
+		xmlErr = GenerateRoute53ErrorResponse(errorCode, errorMsg.Message, requestID)
+	default: // ec2, elasticloadbalancing, account, spinifex
 		xmlErr = GenerateEC2ErrorResponse(errorCode, errorMsg.Message, requestID)
 	}
 
@@ -305,6 +312,8 @@ func (gw *GatewayConfig) Request(w http.ResponseWriter, r *http.Request) {
 		err = gw.ELBv2_Request(w, r)
 	case "eks":
 		err = gw.EKS_Request(w, r)
+	case "route53":
+		err = gw.Route53_Request(w, r)
 	case "spinifex":
 		err = gw.Spinifex_Request(w, r)
 	default:
@@ -469,9 +478,12 @@ func (gw *GatewayConfig) ErrorHandler(w http.ResponseWriter, r *http.Request, er
 	}
 
 	var xmlError []byte
-	if svc == "iam" || svc == "sts" {
+	switch svc {
+	case "iam", "sts":
 		xmlError = GenerateIAMErrorResponse(err.Error(), errorMsg.Message, requestId)
-	} else {
+	case "route53":
+		xmlError = GenerateRoute53ErrorResponse(err.Error(), errorMsg.Message, requestId)
+	default:
 		xmlError = GenerateEC2ErrorResponse(err.Error(), errorMsg.Message, requestId)
 	}
 

--- a/spinifex/gateway/route53.go
+++ b/spinifex/gateway/route53.go
@@ -1,0 +1,162 @@
+package gateway
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_route53 "github.com/mulgadc/spinifex/spinifex/gateway/route53"
+)
+
+// Route53PathPrefix is the AWS Route53 API version prefix. Every wire
+// path arrives as /2013-04-01/... and is stripped before the route
+// table matches the remaining sub-path.
+const Route53PathPrefix = "/2013-04-01"
+
+// GenerateRoute53ErrorResponse exposes the Route53 REST/XML error
+// envelope to the shared gateway plumbing (writeClusterUnavailable,
+// writeThrottleError, ErrorHandler).
+func GenerateRoute53ErrorResponse(code, message, requestID string) []byte {
+	return gateway_route53.GenerateErrorResponse(code, message, requestID)
+}
+
+// route53Route encodes one HTTP method + path-regex → AWS action
+// dispatch. The pattern matches against the path with Route53PathPrefix
+// stripped (e.g. /hostedzone/Z123, not /2013-04-01/hostedzone/Z123).
+type route53Route struct {
+	method  string
+	pattern *regexp.Regexp
+	action  string
+	handler route53RouteHandler
+}
+
+// route53RouteHandler invokes the per-action gateway function. It
+// receives the path-capture values in declaration order, the request
+// body, the parent gateway config, the caller's accountID, and the URL
+// query values (for ListResourceRecordSets pagination params).
+type route53RouteHandler func(gw *GatewayConfig, accountID string, params []string, body []byte, query map[string][]string) (any, error)
+
+// route53Routes is the dispatch table. Order matters: more-specific
+// paths come before bare-resource matches with the same prefix
+// (e.g. /hostedzone/{Id}/rrset before /hostedzone/{Id}).
+var route53Routes = []route53Route{
+	// Hosted zones
+	{"POST", regexp.MustCompile(`^/hostedzone$`), "CreateHostedZone",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, _ map[string][]string) (any, error) {
+			return gateway_route53.CreateHostedZone(gw.NATSConn, acct, b)
+		}},
+	{"GET", regexp.MustCompile(`^/hostedzone$`), "ListHostedZones",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, _ map[string][]string) (any, error) {
+			return gateway_route53.ListHostedZones(gw.NATSConn, acct)
+		}},
+
+	// Resource record sets — must precede the bare /hostedzone/{Id}
+	// matches so the deeper path wins.
+	{"POST", regexp.MustCompile(`^/hostedzone/([^/]+)/rrset/?$`), "ChangeResourceRecordSets",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, _ map[string][]string) (any, error) {
+			return gateway_route53.ChangeResourceRecordSets(gw.NATSConn, acct, p[0], b)
+		}},
+	{"GET", regexp.MustCompile(`^/hostedzone/([^/]+)/rrset/?$`), "ListResourceRecordSets",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, q map[string][]string) (any, error) {
+			return gateway_route53.ListResourceRecordSets(gw.NATSConn, acct, p[0], q)
+		}},
+
+	// Hosted zone (single)
+	{"GET", regexp.MustCompile(`^/hostedzone/([^/]+)$`), "GetHostedZone",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, _ map[string][]string) (any, error) {
+			return gateway_route53.GetHostedZone(gw.NATSConn, acct, p[0])
+		}},
+	{"POST", regexp.MustCompile(`^/hostedzone/([^/]+)$`), "UpdateHostedZoneComment",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, _ map[string][]string) (any, error) {
+			return gateway_route53.UpdateHostedZoneComment(gw.NATSConn, acct, p[0], b)
+		}},
+	{"DELETE", regexp.MustCompile(`^/hostedzone/([^/]+)$`), "DeleteHostedZone",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, _ map[string][]string) (any, error) {
+			return gateway_route53.DeleteHostedZone(gw.NATSConn, acct, p[0])
+		}},
+
+	// Change tracking
+	{"GET", regexp.MustCompile(`^/change/([^/]+)$`), "GetChange",
+		func(gw *GatewayConfig, acct string, p []string, b []byte, _ map[string][]string) (any, error) {
+			return gateway_route53.GetChange(gw.NATSConn, acct, p[0])
+		}},
+}
+
+// lookupRoute53Action walks route53Routes in declaration order. Returns
+// the matched action name + captured path params + handler, or
+// ("", nil, nil, false) on no-match.
+func lookupRoute53Action(method, path string) (string, []string, route53RouteHandler, bool) {
+	stripped := strings.TrimPrefix(path, Route53PathPrefix)
+	if stripped == path {
+		return "", nil, nil, false
+	}
+	for _, route := range route53Routes {
+		if route.method != method {
+			continue
+		}
+		m := route.pattern.FindStringSubmatch(stripped)
+		if m == nil {
+			continue
+		}
+		var params []string
+		if len(m) > 1 {
+			params = m[1:]
+		}
+		return route.action, params, route.handler, true
+	}
+	return "", nil, nil, false
+}
+
+// Route53_Request is the chi catch-all dispatcher for Route53 REST/XML
+// requests. Parses method+path, resolves to an AWS action, reads the
+// body, invokes the per-action handler, and serialises the typed
+// output as XML. Errors are returned as plain awserrors codes; the
+// caller (gateway.Request) routes them through the shared ErrorHandler.
+func (gw *GatewayConfig) Route53_Request(w http.ResponseWriter, r *http.Request) error {
+	action, params, handler, ok := lookupRoute53Action(r.Method, r.URL.Path)
+	if !ok {
+		slog.Debug("Route53: no route for request", "method", r.Method, "path", r.URL.Path)
+		return errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	if err := gw.checkPolicy(r, "route53", action); err != nil {
+		return err
+	}
+
+	if gw.NATSConn == nil {
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.Error("Route53_Request: no account ID in auth context")
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	body, err := gateway_route53.ReadBody(r)
+	if err != nil {
+		slog.Error("Route53_Request: failed to read body", "err", err)
+		return errors.New(awserrors.ErrorInvalidInput)
+	}
+
+	output, err := handler(gw, accountID, params, body, r.URL.Query())
+	if err != nil {
+		return err
+	}
+
+	xmlBody, err := gateway_route53.MarshalResponseXML(output)
+	if err != nil {
+		slog.Error("Route53_Request: failed to marshal response", "action", action, "err", err)
+		return errors.New(awserrors.ErrorInternalError)
+	}
+
+	w.Header().Set("Content-Type", gateway_route53.XMLContentType)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(xmlBody); err != nil {
+		slog.Error("Route53_Request: failed to write response", "err", err)
+	}
+	return nil
+}

--- a/spinifex/gateway/route53/change.go
+++ b/spinifex/gateway/route53/change.go
@@ -1,0 +1,14 @@
+package gateway_route53
+
+import (
+	"errors"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
+)
+
+// GetChange is wired live in Sprint 1c. PENDING/INSYNC transitions key
+// off the per-zone loaded-version tracker (D2 in route53-v0.md).
+func GetChange(_ *nats.Conn, _ string, _ string) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}

--- a/spinifex/gateway/route53/handler.go
+++ b/spinifex/gateway/route53/handler.go
@@ -1,0 +1,97 @@
+// Package gateway_route53 holds the HTTP-side glue between awsgw and the
+// Route53 handlers package. Route53 speaks AWS REST/XML over /2013-04-01/*
+// (route53-v0.md R1). Per-action handlers in zone.go / recordset.go /
+// change.go marshal their typed *route53.<X>Output via MarshalResponseXML
+// and return the bytes to the top-level dispatcher in gateway/route53.go.
+package gateway_route53
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// XMLContentType is the response content type Route53 emits for both
+// success and error paths.
+const XMLContentType = "application/xml"
+
+// route53XMLNamespace is the XML namespace AWS Route53 advertises in
+// every response envelope.
+const route53XMLNamespace = "https://route53.amazonaws.com/doc/2013-04-01/"
+
+// ErrorResponse is the AWS Route53 error envelope.
+type ErrorResponse struct {
+	XMLName   xml.Name    `xml:"ErrorResponse"`
+	XMLNS     string      `xml:"xmlns,attr"`
+	Error     ErrorDetail `xml:"Error"`
+	RequestID string      `xml:"RequestId"`
+}
+
+// ErrorDetail mirrors the AWS Route53 <Error> sub-element shape.
+type ErrorDetail struct {
+	Type    string `xml:"Type"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
+// GenerateErrorResponse marshals the AWS Route53 error envelope.
+func GenerateErrorResponse(code, message, requestID string) []byte {
+	env := ErrorResponse{
+		XMLNS:     route53XMLNamespace,
+		Error:     ErrorDetail{Type: "Sender", Code: code, Message: message},
+		RequestID: requestID,
+	}
+	out, err := xml.MarshalIndent(env, "", "  ")
+	if err != nil {
+		slog.Error("Route53: failed to marshal error envelope", "code", code, "err", err)
+		return fmt.Appendf(nil,
+			`<?xml version="1.0"?><ErrorResponse xmlns=%q><Error><Type>Sender</Type><Code>%s</Code><Message>%s</Message></Error><RequestId>%s</RequestId></ErrorResponse>`,
+			route53XMLNamespace, code, message, requestID)
+	}
+	return append([]byte(xml.Header), out...)
+}
+
+// MarshalResponseXML serialises obj as XML with the Route53 namespace
+// prepended via xml.Header. Caller is responsible for matching the
+// AWS-shaped XML element names on obj's struct tags.
+func MarshalResponseXML(obj any) ([]byte, error) {
+	body, err := xml.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal route53 xml: %w", err)
+	}
+	return append([]byte(xml.Header), body...), nil
+}
+
+// ReadBody slurps the request body, returning an empty byte slice for
+// nil-bodied requests (GET / DELETE typically). Mirrors EKS ParseJSONBody
+// shape minus the type-parameter, since each per-action handler picks
+// its own decode strategy (URL params vs body XML).
+func ReadBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	return body, nil
+}
+
+// DecodeBodyXML unmarshals body into out, returning
+// ErrorMalformedInput-wrapped error on parse failure. Empty body is
+// permitted — the typed input stays zero-valued.
+func DecodeBodyXML[T any](body []byte) (*T, error) {
+	out := new(T)
+	if len(body) == 0 {
+		return out, nil
+	}
+	if err := xml.Unmarshal(body, out); err != nil {
+		return nil, errors.New(awserrors.ErrorInvalidInput)
+	}
+	return out, nil
+}

--- a/spinifex/gateway/route53/recordset.go
+++ b/spinifex/gateway/route53/recordset.go
@@ -1,0 +1,20 @@
+package gateway_route53
+
+import (
+	"errors"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
+)
+
+// ChangeResourceRecordSets is wired live in Sprint 1c. Single ChangeBatch
+// per call, per-zone NATS queue group serializes writes on the daemon
+// side (route53-v0.md R5 / D2).
+func ChangeResourceRecordSets(_ *nats.Conn, _ string, _ string, _ []byte) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+// ListResourceRecordSets is wired live in Sprint 1c.
+func ListResourceRecordSets(_ *nats.Conn, _ string, _ string, _ map[string][]string) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}

--- a/spinifex/gateway/route53/zone.go
+++ b/spinifex/gateway/route53/zone.go
@@ -1,0 +1,35 @@
+package gateway_route53
+
+import (
+	"errors"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
+)
+
+// CreateHostedZone is wired live in Sprint 1b. The 1a stub returns
+// NotImplemented so callers exercising route lookup get a proper
+// awserrors-shaped reply instead of a generic 404.
+func CreateHostedZone(_ *nats.Conn, _ string, _ []byte) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+// GetHostedZone is wired live in Sprint 1b.
+func GetHostedZone(_ *nats.Conn, _ string, _ string) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+// ListHostedZones is wired live in Sprint 1b.
+func ListHostedZones(_ *nats.Conn, _ string) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+// UpdateHostedZoneComment is wired live in Sprint 1b.
+func UpdateHostedZoneComment(_ *nats.Conn, _ string, _ string, _ []byte) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+// DeleteHostedZone is wired live in Sprint 1b.
+func DeleteHostedZone(_ *nats.Conn, _ string, _ string) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}

--- a/spinifex/gateway/route53_test.go
+++ b/spinifex/gateway/route53_test.go
@@ -1,0 +1,56 @@
+package gateway
+
+import "testing"
+
+func TestRoute53Routes(t *testing.T) {
+	cases := []struct {
+		method     string
+		path       string
+		wantAction string
+		wantParams []string
+		wantOK     bool
+	}{
+		{"POST", "/2013-04-01/hostedzone", "CreateHostedZone", nil, true},
+		{"GET", "/2013-04-01/hostedzone", "ListHostedZones", nil, true},
+		{"GET", "/2013-04-01/hostedzone/Z123ABC456DEF", "GetHostedZone", []string{"Z123ABC456DEF"}, true},
+		{"POST", "/2013-04-01/hostedzone/Z123ABC456DEF", "UpdateHostedZoneComment", []string{"Z123ABC456DEF"}, true},
+		{"DELETE", "/2013-04-01/hostedzone/Z123ABC456DEF", "DeleteHostedZone", []string{"Z123ABC456DEF"}, true},
+		{"POST", "/2013-04-01/hostedzone/Z123ABC456DEF/rrset", "ChangeResourceRecordSets", []string{"Z123ABC456DEF"}, true},
+		{"POST", "/2013-04-01/hostedzone/Z123ABC456DEF/rrset/", "ChangeResourceRecordSets", []string{"Z123ABC456DEF"}, true},
+		{"GET", "/2013-04-01/hostedzone/Z123ABC456DEF/rrset", "ListResourceRecordSets", []string{"Z123ABC456DEF"}, true},
+		{"GET", "/2013-04-01/change/C123ABC", "GetChange", []string{"C123ABC"}, true},
+
+		// Wrong prefix → not matched (would fall through to InvalidAction).
+		{"GET", "/hostedzone", "", nil, false},
+		// Wrong method → not matched.
+		{"PATCH", "/2013-04-01/hostedzone", "", nil, false},
+		// Unknown sub-resource → not matched.
+		{"POST", "/2013-04-01/garbage", "", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			action, params, handler, ok := lookupRoute53Action(tc.method, tc.path)
+			if ok != tc.wantOK {
+				t.Fatalf("lookupRoute53Action ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if action != tc.wantAction {
+				t.Errorf("action = %q, want %q", action, tc.wantAction)
+			}
+			if len(params) != len(tc.wantParams) {
+				t.Fatalf("params len = %d, want %d (got %v)", len(params), len(tc.wantParams), params)
+			}
+			for i, p := range params {
+				if p != tc.wantParams[i] {
+					t.Errorf("params[%d] = %q, want %q", i, p, tc.wantParams[i])
+				}
+			}
+			if handler == nil {
+				t.Errorf("handler is nil")
+			}
+		})
+	}
+}

--- a/spinifex/handlers/route53/service.go
+++ b/spinifex/handlers/route53/service.go
@@ -1,0 +1,21 @@
+package handlers_route53
+
+import "github.com/aws/aws-sdk-go/service/route53"
+
+// Route53Service is the AWS Route53 contract exposed by Spinifex.
+// Sprint 1a only declares the surface; all methods return
+// awserrors.ErrorNotImplemented. Real bodies land in 1b (hosted zone
+// CRUD) and 1c (resource-record-set CRUD + GetChange).
+type Route53Service interface {
+	// Hosted zone CRUD (Sprint 1b)
+	CreateHostedZone(input *route53.CreateHostedZoneInput, accountID string) (*route53.CreateHostedZoneOutput, error)
+	GetHostedZone(input *route53.GetHostedZoneInput, accountID string) (*route53.GetHostedZoneOutput, error)
+	ListHostedZones(input *route53.ListHostedZonesInput, accountID string) (*route53.ListHostedZonesOutput, error)
+	UpdateHostedZoneComment(input *route53.UpdateHostedZoneCommentInput, accountID string) (*route53.UpdateHostedZoneCommentOutput, error)
+	DeleteHostedZone(input *route53.DeleteHostedZoneInput, accountID string) (*route53.DeleteHostedZoneOutput, error)
+
+	// Resource-record-set CRUD + change tracking (Sprint 1c)
+	ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput, accountID string) (*route53.ChangeResourceRecordSetsOutput, error)
+	ListResourceRecordSets(input *route53.ListResourceRecordSetsInput, accountID string) (*route53.ListResourceRecordSetsOutput, error)
+	GetChange(input *route53.GetChangeInput, accountID string) (*route53.GetChangeOutput, error)
+}

--- a/spinifex/handlers/route53/service_impl.go
+++ b/spinifex/handlers/route53/service_impl.go
@@ -1,0 +1,65 @@
+package handlers_route53
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
+)
+
+// Route53ServiceImpl is the daemon-side Route53Service. Sprint 1a wires
+// the struct + interface satisfaction; methods return NotImplemented
+// until 1b/1c. Predastore + Eclipso reload-event tracker hooks land
+// alongside their respective sprints.
+type Route53ServiceImpl struct {
+	nc *nats.Conn
+}
+
+var _ Route53Service = (*Route53ServiceImpl)(nil)
+
+// NewRoute53ServiceImplWithNATS constructs the daemon-side service. The
+// NATS connection is the same shared handle used by the rest of the
+// daemon; predastore access is wired in 1b via a separate constructor
+// arg once the dns-zones bucket exists.
+func NewRoute53ServiceImplWithNATS(nc *nats.Conn) *Route53ServiceImpl {
+	return &Route53ServiceImpl{nc: nc}
+}
+
+func notImpl() error { return errors.New(awserrors.ErrorNotImplemented) }
+
+// --- Hosted zones (Sprint 1b) ---
+
+func (s *Route53ServiceImpl) CreateHostedZone(_ *route53.CreateHostedZoneInput, _ string) (*route53.CreateHostedZoneOutput, error) {
+	return nil, notImpl()
+}
+
+func (s *Route53ServiceImpl) GetHostedZone(_ *route53.GetHostedZoneInput, _ string) (*route53.GetHostedZoneOutput, error) {
+	return nil, notImpl()
+}
+
+func (s *Route53ServiceImpl) ListHostedZones(_ *route53.ListHostedZonesInput, _ string) (*route53.ListHostedZonesOutput, error) {
+	return nil, notImpl()
+}
+
+func (s *Route53ServiceImpl) UpdateHostedZoneComment(_ *route53.UpdateHostedZoneCommentInput, _ string) (*route53.UpdateHostedZoneCommentOutput, error) {
+	return nil, notImpl()
+}
+
+func (s *Route53ServiceImpl) DeleteHostedZone(_ *route53.DeleteHostedZoneInput, _ string) (*route53.DeleteHostedZoneOutput, error) {
+	return nil, notImpl()
+}
+
+// --- Resource record sets + change tracking (Sprint 1c) ---
+
+func (s *Route53ServiceImpl) ChangeResourceRecordSets(_ *route53.ChangeResourceRecordSetsInput, _ string) (*route53.ChangeResourceRecordSetsOutput, error) {
+	return nil, notImpl()
+}
+
+func (s *Route53ServiceImpl) ListResourceRecordSets(_ *route53.ListResourceRecordSetsInput, _ string) (*route53.ListResourceRecordSetsOutput, error) {
+	return nil, notImpl()
+}
+
+func (s *Route53ServiceImpl) GetChange(_ *route53.GetChangeInput, _ string) (*route53.GetChangeOutput, error) {
+	return nil, notImpl()
+}

--- a/spinifex/handlers/route53/service_impl_test.go
+++ b/spinifex/handlers/route53/service_impl_test.go
@@ -1,0 +1,67 @@
+package handlers_route53
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// TestRoute53ServiceImpl_StubsReturnNotImplemented locks Sprint 1a's
+// stub contract: every method on Route53ServiceImpl returns
+// awserrors.ErrorNotImplemented. Sprint 1b/1c flips these cases out as
+// real bodies land — one method moves out of this list per sprint
+// instead of breaking the suite wholesale.
+func TestRoute53ServiceImpl_StubsReturnNotImplemented(t *testing.T) {
+	svc := NewRoute53ServiceImplWithNATS(nil)
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"CreateHostedZone", func() error {
+			_, err := svc.CreateHostedZone(&route53.CreateHostedZoneInput{}, "acct")
+			return err
+		}},
+		{"GetHostedZone", func() error {
+			_, err := svc.GetHostedZone(&route53.GetHostedZoneInput{}, "acct")
+			return err
+		}},
+		{"ListHostedZones", func() error {
+			_, err := svc.ListHostedZones(&route53.ListHostedZonesInput{}, "acct")
+			return err
+		}},
+		{"UpdateHostedZoneComment", func() error {
+			_, err := svc.UpdateHostedZoneComment(&route53.UpdateHostedZoneCommentInput{}, "acct")
+			return err
+		}},
+		{"DeleteHostedZone", func() error {
+			_, err := svc.DeleteHostedZone(&route53.DeleteHostedZoneInput{}, "acct")
+			return err
+		}},
+		{"ChangeResourceRecordSets", func() error {
+			_, err := svc.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{}, "acct")
+			return err
+		}},
+		{"ListResourceRecordSets", func() error {
+			_, err := svc.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{}, "acct")
+			return err
+		}},
+		{"GetChange", func() error {
+			_, err := svc.GetChange(&route53.GetChangeInput{}, "acct")
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil {
+				t.Fatal("got nil, want NotImplemented")
+			}
+			if !errors.Is(err, errors.New(awserrors.ErrorNotImplemented)) && err.Error() != awserrors.ErrorNotImplemented {
+				t.Errorf("err = %q, want %q", err.Error(), awserrors.ErrorNotImplemented)
+			}
+		})
+	}
+}

--- a/spinifex/handlers/route53/service_nats.go
+++ b/spinifex/handlers/route53/service_nats.go
@@ -1,0 +1,82 @@
+package handlers_route53
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// defaultTimeout governs request-side timeouts on dns.* RPCs. Mirrors
+// the EKS/IAM/STS handler conventions.
+const defaultTimeout = 30 * time.Second
+
+// NATS subject names used by gateway → daemon dispatch. Kept as
+// exported constants so callers (subscribers + publishers) share one
+// definition. Per-zone queue group `route53-zone-{zoneID}` for serialized
+// recordset writes is wired in 1c.
+const (
+	SubjectCreateHostedZone         = "dns.CreateHostedZone"
+	SubjectGetHostedZone            = "dns.GetHostedZone"
+	SubjectListHostedZones          = "dns.ListHostedZones"
+	SubjectUpdateHostedZoneComment  = "dns.UpdateHostedZoneComment"
+	SubjectDeleteHostedZone         = "dns.DeleteHostedZone"
+	SubjectChangeResourceRecordSets = "dns.ChangeResourceRecordSets"
+	SubjectListResourceRecordSets   = "dns.ListResourceRecordSets"
+	SubjectGetChange                = "dns.GetChange"
+
+	// SubjectZoneLoadedPrefix is the prefix Eclipso publishes after each
+	// successful zone reload — full subject = SubjectZoneLoadedPrefix + zoneID.
+	// Loaded-version tracker subscribes here in 1c (D2 in route53-v0.md).
+	SubjectZoneLoadedPrefix = "dns.zone.loaded."
+)
+
+// NATSRoute53Service is the gateway-side adapter that forwards each
+// Route53Service method as a NATS request to the daemon's subscriber.
+type NATSRoute53Service struct {
+	natsConn *nats.Conn
+}
+
+var _ Route53Service = (*NATSRoute53Service)(nil)
+
+// NewNATSRoute53Service returns a Route53Service backed by NATS RPC.
+func NewNATSRoute53Service(conn *nats.Conn) Route53Service {
+	return &NATSRoute53Service{natsConn: conn}
+}
+
+// --- Hosted zones ---
+
+func (s *NATSRoute53Service) CreateHostedZone(input *route53.CreateHostedZoneInput, accountID string) (*route53.CreateHostedZoneOutput, error) {
+	return utils.NATSRequest[route53.CreateHostedZoneOutput](s.natsConn, SubjectCreateHostedZone, input, defaultTimeout, accountID)
+}
+
+func (s *NATSRoute53Service) GetHostedZone(input *route53.GetHostedZoneInput, accountID string) (*route53.GetHostedZoneOutput, error) {
+	return utils.NATSRequest[route53.GetHostedZoneOutput](s.natsConn, SubjectGetHostedZone, input, defaultTimeout, accountID)
+}
+
+func (s *NATSRoute53Service) ListHostedZones(input *route53.ListHostedZonesInput, accountID string) (*route53.ListHostedZonesOutput, error) {
+	return utils.NATSRequest[route53.ListHostedZonesOutput](s.natsConn, SubjectListHostedZones, input, defaultTimeout, accountID)
+}
+
+func (s *NATSRoute53Service) UpdateHostedZoneComment(input *route53.UpdateHostedZoneCommentInput, accountID string) (*route53.UpdateHostedZoneCommentOutput, error) {
+	return utils.NATSRequest[route53.UpdateHostedZoneCommentOutput](s.natsConn, SubjectUpdateHostedZoneComment, input, defaultTimeout, accountID)
+}
+
+func (s *NATSRoute53Service) DeleteHostedZone(input *route53.DeleteHostedZoneInput, accountID string) (*route53.DeleteHostedZoneOutput, error) {
+	return utils.NATSRequest[route53.DeleteHostedZoneOutput](s.natsConn, SubjectDeleteHostedZone, input, defaultTimeout, accountID)
+}
+
+// --- Resource record sets + GetChange ---
+
+func (s *NATSRoute53Service) ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput, accountID string) (*route53.ChangeResourceRecordSetsOutput, error) {
+	return utils.NATSRequest[route53.ChangeResourceRecordSetsOutput](s.natsConn, SubjectChangeResourceRecordSets, input, defaultTimeout, accountID)
+}
+
+func (s *NATSRoute53Service) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput, accountID string) (*route53.ListResourceRecordSetsOutput, error) {
+	return utils.NATSRequest[route53.ListResourceRecordSetsOutput](s.natsConn, SubjectListResourceRecordSets, input, defaultTimeout, accountID)
+}
+
+func (s *NATSRoute53Service) GetChange(input *route53.GetChangeInput, accountID string) (*route53.GetChangeOutput, error) {
+	return utils.NATSRequest[route53.GetChangeOutput](s.natsConn, SubjectGetChange, input, defaultTimeout, accountID)
+}

--- a/spinifex/handlers/route53/types.go
+++ b/spinifex/handlers/route53/types.go
@@ -1,0 +1,62 @@
+// Package handlers_route53 owns the AWS Route53 contract surface on
+// Spinifex: hosted-zone CRUD, resource-record-set CRUD, and ChangeInfo
+// lookups. Sprint 1a scaffolds the interface + stub bodies; real bodies
+// land in Sprints 1b/1c per docs/development/feature/route53-v0.md.
+package handlers_route53
+
+import "time"
+
+// Hosted-zone-ID prefix matching AWS shape: "Z" + 21 base32 chars.
+const HostedZoneIDPrefix = "Z"
+
+// ChangeID prefix matching AWS shape: "C" + 14 hex chars.
+const ChangeIDPrefix = "C"
+
+// PredastoreBucket is the predastore bucket name that holds all zone TOML
+// files plus sidecar metadata + change records. Created at admin init.
+const PredastoreBucket = "dns-zones"
+
+// MetadataPrefix is the sub-path inside PredastoreBucket that holds
+// Route53 zone metadata (name, vpcID, comment, change history) as JSON.
+// Filenames: {hostedZoneID}.json.
+const MetadataPrefix = "_metadata/"
+
+// ChangesPrefix is the sub-path inside PredastoreBucket that holds
+// ChangeInfo records keyed by changeID. Filenames: {changeID}.json.
+const ChangesPrefix = "_changes/"
+
+// ChangeStatus is the GetChange status value: PENDING until Eclipso
+// confirms reload of the zone version the change produced; INSYNC after.
+type ChangeStatus string
+
+const (
+	ChangeStatusPending ChangeStatus = "PENDING"
+	ChangeStatusInSync  ChangeStatus = "INSYNC"
+)
+
+// ZoneRecord holds the persisted Route53 zone metadata stored at
+// {PredastoreBucket}/{MetadataPrefix}{hostedZoneID}.json.
+type ZoneRecord struct {
+	ID              string    `json:"id"`
+	Name            string    `json:"name"`
+	Comment         string    `json:"comment,omitempty"`
+	PrivateZone     bool      `json:"private_zone"`
+	VPCID           string    `json:"vpc_id,omitempty"`
+	VPCRegion       string    `json:"vpc_region,omitempty"`
+	CallerReference string    `json:"caller_reference"`
+	CreatedAt       time.Time `json:"created_at"`
+	RecordCount     int64     `json:"record_count"`
+}
+
+// ChangeRecord holds the persisted ChangeInfo state stored at
+// {PredastoreBucket}/{ChangesPrefix}{changeID}.json. Status starts as
+// PENDING and flips to INSYNC after Eclipso publishes
+// dns.zone.loaded.{zoneID} carrying a version >= ZoneVersion.
+type ChangeRecord struct {
+	ID          string       `json:"id"`
+	ZoneID      string       `json:"zone_id"`
+	Status      ChangeStatus `json:"status"`
+	SubmittedAt time.Time    `json:"submitted_at"`
+	ZoneVersion uint64       `json:"zone_version"`
+	Comment     string       `json:"comment,omitempty"`
+}


### PR DESCRIPTION
Phase 1 EKS MVP Route53 v0 — Sprint 1a (mulga-cs-route53-1a / mulgadc/mulga#68).

## Summary

Stub-first scaffolding for Route53 v0 so downstream sprints (1b hosted zone CRUD, 1c resource-record-sets + GetChange, EclipsoCtl ordering in spxd bootstrap) can call into a stable contract while real bodies land sprint by sprint.

- \`spinifex/handlers/route53\`: \`Route53Service\` interface + \`Route53ServiceImpl\` + \`NATSRoute53Service\` adapter + subject constants. Every method returns \`NotImplemented\`.
- \`spinifex/gateway/route53\`: per-action handler stubs + REST/XML envelope helpers (Route53 xmlns is distinct from IAM/STS).
- \`spinifex/gateway/route53.go\`: REST dispatcher matching \`/2013-04-01/*\` against an EKS-style route regex table.
- \`spinifex/daemon/eclipso.go\`: \`EclipsoCtl\` driving systemctl on \`eclipso.service\` (Start/Stop/IsRunning/Reload) with an interceptable \`runSystemctl\` seam for unit tests.
- \`build/systemd/eclipso.service\`: dedicated unit with \`CAP_NET_BIND_SERVICE\`, \`EnvironmentFile=-/etc/spinifex/eclipso.env\`, \`Restart=on-failure\`.
- \`spinifex/daemon\`: \`route53Service\` field, NATS subscription block, and \`daemon_handlers_route53.go\` forwarding to the typed service.
- \`docs/service-interfaces.yaml\`: register \`dns.*\` subjects so the e2e selector knows route53 changes touch \`spinifex_daemon\` + \`awsgw\`.

## Plan / spec

- Plan doc: \`docs/development/feature/route53-v0.md\`
- Fast-path anchor: \`docs/development/feature/eks-mvp-fast-path.md\` (step 4)

## Test plan

- [x] \`make preflight\` green
- [x] \`TestRoute53Routes\` covers happy paths + negative cases for the dispatcher
- [x] \`TestRoute53ServiceImpl_StubsReturnNotImplemented\` locks the 1a stub contract
- [x] \`TestEclipsoCtl_*\` exercises Start/Stop/Reload via the \`runSystemctl\` seam