### PR TITLE
feat: viperblock at-rest encryption wiring + Encrypted flag derived from VBState

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -603,6 +603,12 @@ func runimagesImportCmd(cmd *cobra.Command, args []string) {
 		Host:       appConfig.Nodes[appConfig.Node].Predastore.Host,
 	}
 
+	mkey, err := utils.LoadViperblockMasterKey(appConfig.Nodes[appConfig.Node].Viperblock.EncryptionKeyFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not load viperblock encryption key: %v\n", err)
+		os.Exit(1)
+	}
+
 	vbConfig := viperblock.VB{
 		VolumeName: volumeId,
 		VolumeSize: utils.SafeInt64ToUint64(imageStat.Size()),
@@ -612,7 +618,9 @@ func runimagesImportCmd(cmd *cobra.Command, args []string) {
 				Size: 0,
 			},
 		},
-		VolumeConfig: manifest,
+		VolumeConfig:      manifest,
+		MasterKey:         mkey,
+		EncryptionEnabled: mkey != nil,
 	}
 
 	err = v_utils.ImportDiskImage(&s3Config, &vbConfig, extractedImagePath)

--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -283,19 +283,25 @@ var viperblockStartCmd = &cobra.Command{
 			shardWAL = *nodeConfig.Viperblock.ShardWAL
 		}
 
+		encryptionKeyFile := nodeConfig.Viperblock.EncryptionKeyFile
+		if envKey := viper.GetString("viperblock-encryption-key-file"); envKey != "" {
+			encryptionKeyFile = envKey
+		}
+
 		service, err := service.New("viperblock", &viperblockd.Config{
-			NatsHost:   nodeConfig.NATS.Host,
-			NatsToken:  nodeConfig.NATS.ACL.Token,
-			NatsCACert: nodeConfig.NATS.CACert,
-			PluginPath: pluginPath,
-			S3Host:     nodeConfig.Predastore.Host,
-			Bucket:     nodeConfig.Predastore.Bucket,
-			Region:     nodeConfig.Predastore.Region,
-			AccessKey:  nodeConfig.Predastore.AccessKey,
-			SecretKey:  nodeConfig.Predastore.SecretKey,
-			BaseDir:    nodeConfig.Predastore.BaseDir,
-			NodeName:   clusterConfig.Node,
-			ShardWAL:   shardWAL,
+			NatsHost:          nodeConfig.NATS.Host,
+			NatsToken:         nodeConfig.NATS.ACL.Token,
+			NatsCACert:        nodeConfig.NATS.CACert,
+			PluginPath:        pluginPath,
+			S3Host:            nodeConfig.Predastore.Host,
+			Bucket:            nodeConfig.Predastore.Bucket,
+			Region:            nodeConfig.Predastore.Region,
+			AccessKey:         nodeConfig.Predastore.AccessKey,
+			SecretKey:         nodeConfig.Predastore.SecretKey,
+			BaseDir:           nodeConfig.Predastore.BaseDir,
+			NodeName:          clusterConfig.Node,
+			ShardWAL:          shardWAL,
+			EncryptionKeyFile: encryptionKeyFile,
 		})
 
 		if err != nil {
@@ -910,6 +916,14 @@ func init() {
 	viperblockCmd.PersistentFlags().String("plugin-path", "/opt/spinifex/lib/nbdkit-viperblock-plugin.so", "Pathname to the nbdkit viperblockplugin")
 	viper.BindEnv("plugin-path", "SPINIFEX_VIPERBLOCK_PLUGIN_PATH")
 	viper.BindPFlag("plugin-path", predastoreCmd.PersistentFlags().Lookup("plugin-path"))
+
+	// Viperblock at-rest encryption master key (shared with other on-node
+	// services via group ownership; mode 0640 or stricter). Distinct viper
+	// key from predastore's encryption-key-file so the two BindPFlag calls
+	// don't collide globally.
+	viperblockCmd.PersistentFlags().String("encryption-key-file", "", "Path to the 32-byte AES-256 master key file for at-rest encryption (empty disables encryption)")
+	viper.BindEnv("viperblock-encryption-key-file", "SPINIFEX_VIPERBLOCK_ENCRYPTION_KEY_FILE")
+	viper.BindPFlag("viperblock-encryption-key-file", viperblockCmd.PersistentFlags().Lookup("encryption-key-file"))
 
 	viperblockCmd.AddCommand(viperblockStartCmd)
 	viperblockCmd.AddCommand(viperblockStopCmd)

--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -101,6 +101,14 @@ type AWSGWConfig struct {
 
 type ViperblockConfig struct {
 	ShardWAL *bool `json:"ShardWAL" mapstructure:"shardwal"` // Enable sharded WAL (default false when nil)
+
+	// EncryptionKeyFile is the path to the shared 32-byte AES-256 master key
+	// for viperblock at-rest encryption (chunks, WAL records, VBState/snapshot
+	// metadata). When empty, volumes are written in cleartext (legacy mode).
+	// When set, every VB constructed on this node — daemons and AWS handlers
+	// alike — must load it via masterkey.LoadShared so existing volumes can
+	// still be opened.
+	EncryptionKeyFile string `json:"EncryptionKeyFile" mapstructure:"encryption_key_file"`
 }
 
 // VPCDConfig holds the VPC daemon (vpcd) configuration.

--- a/spinifex/handlers/ec2/image/service_impl.go
+++ b/spinifex/handlers/ec2/image/service_impl.go
@@ -520,11 +520,19 @@ func (s *ImageServiceImpl) snapshotStoppedVolume(volumeID, snapshotID string) er
 		Host:       s.config.Predastore.Host,
 	}
 
+	mkey, err := utils.LoadViperblockMasterKey(s.config.Viperblock.EncryptionKeyFile)
+	if err != nil {
+		slog.Error("snapshotStoppedVolume: failed to load encryption key", "volumeId", volumeID, "err", err)
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
 	vbconfig := viperblock.VB{
-		VolumeName: volumeID,
-		VolumeSize: volumeSize,
-		BaseDir:    s.config.WalDir,
-		Cache:      viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
+		VolumeName:        volumeID,
+		VolumeSize:        volumeSize,
+		BaseDir:           s.config.WalDir,
+		Cache:             viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
+		MasterKey:         mkey,
+		EncryptionEnabled: mkey != nil,
 	}
 
 	vb, err := viperblock.New(&vbconfig, "s3", cfg)

--- a/spinifex/handlers/ec2/image/service_impl.go
+++ b/spinifex/handlers/ec2/image/service_impl.go
@@ -119,6 +119,7 @@ func (s *ImageServiceImpl) DescribeImages(input *ec2.DescribeImagesInput, accoun
 	}
 
 	var images []*ec2.Image
+	encryptedAtRest := s.clusterEncryptionEnabled()
 
 	// Iterate over CommonPrefixes to find ami-* directories
 	for _, prefix := range result.CommonPrefixes {
@@ -267,7 +268,7 @@ func (s *ImageServiceImpl) DescribeImages(input *ec2.DescribeImagesInput, accoun
 			BootMode:           aws.String(amiMeta.BootMode),
 		}
 
-		if bdms := synthesizeRootBlockDeviceMapping(amiMeta); bdms != nil {
+		if bdms := synthesizeRootBlockDeviceMapping(amiMeta, encryptedAtRest); bdms != nil {
 			image.RootDeviceName = aws.String("/dev/sda1")
 			image.BlockDeviceMappings = bdms
 		}
@@ -918,7 +919,7 @@ func (s *ImageServiceImpl) DescribeImageAttribute(input *ec2.DescribeImageAttrib
 	case ec2.ImageAttributeNameDescription:
 		output.Description = &ec2.AttributeValue{Value: aws.String(meta.Description)}
 	case ec2.ImageAttributeNameBlockDeviceMapping:
-		output.BlockDeviceMappings = synthesizeRootBlockDeviceMapping(meta)
+		output.BlockDeviceMappings = synthesizeRootBlockDeviceMapping(meta, s.clusterEncryptionEnabled())
 	default:
 		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
 	}
@@ -927,9 +928,26 @@ func (s *ImageServiceImpl) DescribeImageAttribute(input *ec2.DescribeImageAttrib
 	return output, nil
 }
 
+// clusterEncryptionEnabled reports whether the daemon has a viperblock master
+// key configured. AMI metadata carries no per-image encryption flag, so block
+// device synthesis falls back to this cluster-level posture.
+func (s *ImageServiceImpl) clusterEncryptionEnabled() bool {
+	if s.config == nil {
+		return false
+	}
+	mkey, err := utils.LoadViperblockMasterKey(s.config.Viperblock.EncryptionKeyFile)
+	if err != nil {
+		slog.Warn("clusterEncryptionEnabled: failed to load master key, reporting false", "err", err)
+		return false
+	}
+	return mkey != nil
+}
+
 // synthesizeRootBlockDeviceMapping returns /dev/sda1 with size+snapshot from
-// AMIMetadata, or nil for non-EBS AMIs.
-func synthesizeRootBlockDeviceMapping(meta viperblock.AMIMetadata) []*ec2.BlockDeviceMapping {
+// AMIMetadata, or nil for non-EBS AMIs. encrypted reflects the cluster-level
+// encryption-at-rest posture (master key configured) since AMI metadata does
+// not carry a per-image encryption flag of its own.
+func synthesizeRootBlockDeviceMapping(meta viperblock.AMIMetadata, encrypted bool) []*ec2.BlockDeviceMapping {
 	if meta.RootDeviceType != "ebs" {
 		return nil
 	}
@@ -937,7 +955,7 @@ func synthesizeRootBlockDeviceMapping(meta viperblock.AMIMetadata) []*ec2.BlockD
 		VolumeSize:          aws.Int64(utils.SafeUint64ToInt64(meta.VolumeSizeGiB)),
 		VolumeType:          aws.String("gp3"),
 		DeleteOnTermination: aws.Bool(true),
-		Encrypted:           aws.Bool(false),
+		Encrypted:           aws.Bool(encrypted),
 	}
 	if meta.SnapshotID != "" {
 		ebs.SnapshotId = aws.String(meta.SnapshotID)

--- a/spinifex/handlers/ec2/image/service_impl_encryption_test.go
+++ b/spinifex/handlers/ec2/image/service_impl_encryption_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+package handlers_ec2_image
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/config"
+	"github.com/mulgadc/spinifex/spinifex/objectstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMasterKey writes a 32-byte AES-256 master key at mode and returns the path.
+func writeMasterKey(t *testing.T, mode os.FileMode) string {
+	t.Helper()
+	raw := make([]byte, 32)
+	_, err := rand.Read(raw)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "master.key")
+	require.NoError(t, os.WriteFile(path, raw, mode))
+	require.NoError(t, os.Chmod(path, mode))
+	return path
+}
+
+// imageServiceWithConfig returns an ImageServiceImpl wired to the given
+// ViperblockConfig — used to exercise the cluster-encryption posture path
+// which reads s.config.Viperblock.EncryptionKeyFile.
+func imageServiceWithConfig(vb config.ViperblockConfig) *ImageServiceImpl {
+	return &ImageServiceImpl{
+		config: &config.Config{Viperblock: vb},
+		store:  objectstore.NewMemoryObjectStore(),
+	}
+}
+
+func TestClusterEncryptionEnabled_NilConfig(t *testing.T) {
+	svc := &ImageServiceImpl{store: objectstore.NewMemoryObjectStore()}
+	assert.False(t, svc.clusterEncryptionEnabled(),
+		"nil config must report encryption disabled")
+}
+
+func TestClusterEncryptionEnabled_EmptyKeyFile(t *testing.T) {
+	svc := imageServiceWithConfig(config.ViperblockConfig{})
+	assert.False(t, svc.clusterEncryptionEnabled(),
+		"empty EncryptionKeyFile must report encryption disabled")
+}
+
+func TestClusterEncryptionEnabled_LoadError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nonexistent.key")
+	svc := imageServiceWithConfig(config.ViperblockConfig{EncryptionKeyFile: missing})
+	assert.False(t, svc.clusterEncryptionEnabled(),
+		"failed master key load must report encryption disabled (warn + fall back)")
+}
+
+func TestClusterEncryptionEnabled_KeyLoaded(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not enforced on Windows")
+	}
+	path := writeMasterKey(t, 0o640)
+	svc := imageServiceWithConfig(config.ViperblockConfig{EncryptionKeyFile: path})
+	assert.True(t, svc.clusterEncryptionEnabled(),
+		"valid master key must report cluster encryption enabled")
+}

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -1357,12 +1357,19 @@ func (s *InstanceServiceImpl) newViperblock(volumeName string, size int, volumeC
 		Host:       s.config.Predastore.Host,
 	}
 
+	mkey, err := utils.LoadViperblockMasterKey(s.config.Viperblock.EncryptionKeyFile)
+	if err != nil {
+		return nil, err
+	}
+
 	vbconfig := viperblock.VB{
-		VolumeName:   volumeName,
-		VolumeSize:   utils.SafeIntToUint64(size),
-		BaseDir:      s.config.WalDir,
-		Cache:        viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
-		VolumeConfig: volumeConfig,
+		VolumeName:        volumeName,
+		VolumeSize:        utils.SafeIntToUint64(size),
+		BaseDir:           s.config.WalDir,
+		Cache:             viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
+		VolumeConfig:      volumeConfig,
+		MasterKey:         mkey,
+		EncryptionEnabled: mkey != nil,
 	}
 
 	vb, err := viperblock.New(&vbconfig, "s3", cfg)

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -1402,15 +1402,21 @@ func (s *InstanceServiceImpl) prepareRootVolume(input *ec2.RunInstancesInput, im
 		return errors.New(awserrors.ErrorServerInternal)
 	}
 
-	// Load the state from the remote backend
+	// Load the state from the remote backend. Only os.ErrNotExist means
+	// "volume doesn't exist, clone from AMI" — every other error (HMAC
+	// integrity failure, key mismatch, transient backend 5xx, JSON parse
+	// failure) must abort. Cloning from AMI on a tamper/mismatch would
+	// overwrite the legitimate volume's config.json with AMI base-map
+	// state and lose access to the live data.
 	_, err = vb.LoadStateRequest("")
-
-	// If volume doesn't exist, clone from AMI
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		slog.Error("Failed to load root volume state from backend",
+			"imageId", imageId, "err", err)
+		return errors.New(awserrors.ErrorServerInternal)
+	}
 	if err != nil {
 		slog.Info("Volume does not yet exist, creating from AMI ...")
-
-		err = s.cloneAMIToVolume(input, size, volumeConfig, vb)
-		if err != nil {
+		if err = s.cloneAMIToVolume(input, size, volumeConfig, vb); err != nil {
 			return err
 		}
 	}

--- a/spinifex/handlers/ec2/snapshot/service_impl.go
+++ b/spinifex/handlers/ec2/snapshot/service_impl.go
@@ -280,7 +280,7 @@ func (s *SnapshotServiceImpl) CreateSnapshot(input *ec2.CreateSnapshotInput, acc
 		State:            "completed",
 		Progress:         "100%",
 		StartTime:        now,
-		Encrypted:        volumeConfig.VolumeMetadata.IsEncrypted,
+		Encrypted:        volumeState.EncryptionEnabled,
 		OwnerID:          accountID,
 		AvailabilityZone: volumeConfig.VolumeMetadata.AvailabilityZone,
 		Tags:             utils.ExtractTags(input.TagSpecifications, "snapshot"),

--- a/spinifex/handlers/ec2/snapshot/service_impl_test.go
+++ b/spinifex/handlers/ec2/snapshot/service_impl_test.go
@@ -43,7 +43,6 @@ func createTestVolume(t *testing.T, store *objectstore.MemoryObjectStore, volume
 		VolumeConfig: viperblock.VolumeConfig{
 			VolumeMetadata: viperblock.VolumeMetadata{
 				SizeGiB:          uint64(sizeGiB),
-				IsEncrypted:      false,
 				AvailabilityZone: "us-east-1a",
 			},
 		},

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -177,12 +177,20 @@ func (s *VolumeServiceImpl) CreateVolume(input *ec2.CreateVolumeInput, accountID
 		Host:       s.config.Predastore.Host,
 	}
 
+	mkey, err := utils.LoadViperblockMasterKey(s.config.Viperblock.EncryptionKeyFile)
+	if err != nil {
+		slog.Error("CreateVolume failed to load encryption key", "err", err)
+		return nil, errors.New(awserrors.ErrorServerInternal)
+	}
+
 	vbconfig := viperblock.VB{
-		VolumeName:   volumeID,
-		VolumeSize:   volumeSizeBytes,
-		BaseDir:      s.config.WalDir,
-		Cache:        viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
-		VolumeConfig: volumeConfig,
+		VolumeName:        volumeID,
+		VolumeSize:        volumeSizeBytes,
+		BaseDir:           s.config.WalDir,
+		Cache:             viperblock.Cache{Config: viperblock.CacheConfig{Size: 0}},
+		VolumeConfig:      volumeConfig,
+		MasterKey:         mkey,
+		EncryptionEnabled: mkey != nil,
 	}
 
 	// If created from a snapshot, set the snapshot fields so viperblock's
@@ -1022,6 +1030,13 @@ func (s *VolumeServiceImpl) putVolumeConfig(volumeID string, cfg *viperblock.Vol
 // mergeVolumeConfig reads existing config.json from S3 and merges the new
 // VolumeConfig into it, preserving full VBState when present. If no existing
 // VBState is found, it returns a plain volumeConfigWrapper.
+//
+// Refuses to merge an encrypted-at-rest VBState: the persisted blob carries a
+// trailing 16-byte AES-GCM tag bound to the JSON bytes, and re-marshaling
+// here without the master key would strip the tag and brick the volume.
+// Spinifex does not currently hold the viperblock master key, so the safe
+// behavior is to fail loud rather than silently corrupt the on-disk state.
+// Track full encryption-aware merge under a separate bead.
 func (s *VolumeServiceImpl) mergeVolumeConfig(configKey string, cfg *viperblock.VolumeConfig) ([]byte, error) {
 	getResult, err := s.store.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(s.bucketName),
@@ -1041,10 +1056,18 @@ func (s *VolumeServiceImpl) mergeVolumeConfig(configKey string, cfg *viperblock.
 		return nil, fmt.Errorf("failed to read existing config: %w", err)
 	}
 
+	// Decoder (not Unmarshal) so a trailing 16-byte AES-GCM tag does not
+	// produce a parse error and route the body to the wrapper-only path —
+	// that would silently overwrite an encrypted config.json with a tag-less
+	// blob and brick the volume.
 	var state viperblock.VBState
-	if json.Unmarshal(body, &state) != nil || state.BlockSize == 0 {
+	if decodeErr := json.NewDecoder(bytes.NewReader(body)).Decode(&state); decodeErr != nil || state.BlockSize == 0 {
 		// Not a full VBState (new volume or wrapper-only) -- write wrapper
 		return json.Marshal(volumeConfigWrapper{VolumeConfig: *cfg})
+	}
+
+	if state.EncryptionEnabled {
+		return nil, fmt.Errorf("mergeVolumeConfig: refusing to merge encrypted VBState for %s without master key (would strip AES-GCM tag and brick volume)", configKey)
 	}
 
 	// Full VBState exists -- update VolumeConfig and reconcile VolumeSize

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -161,7 +161,6 @@ func (s *VolumeServiceImpl) CreateVolume(input *ec2.CreateVolumeInput, accountID
 			AvailabilityZone: *input.AvailabilityZone,
 			VolumeType:       volumeType,
 			IOPS:             iops,
-			IsEncrypted:      false,
 			SnapshotID:       snapshotID,
 		},
 	}
@@ -230,7 +229,7 @@ func (s *VolumeServiceImpl) CreateVolume(input *ec2.CreateVolumeInput, accountID
 		AvailabilityZone: input.AvailabilityZone,
 		CreateTime:       aws.Time(now),
 		Iops:             aws.Int64(int64(iops)),
-		Encrypted:        aws.Bool(false),
+		Encrypted:        aws.Bool(mkey != nil),
 	}
 
 	if snapshotID != "" {
@@ -904,7 +903,7 @@ type volumeResult struct {
 // getVolumeByID fetches a single volume's config from S3 and builds an EC2 Volume.
 // Returns the volume and the stored TenantID for account scoping.
 func (s *VolumeServiceImpl) getVolumeByID(volumeID string) (*volumeResult, error) {
-	cfg, err := s.GetVolumeConfig(volumeID)
+	cfg, encryptionEnabled, err := s.getVolumeConfigAndEncryption(volumeID)
 	if err != nil {
 		return nil, err
 	}
@@ -937,7 +936,7 @@ func (s *VolumeServiceImpl) getVolumeByID(volumeID string) (*volumeResult, error
 		AvailabilityZone: aws.String(volMeta.AvailabilityZone),
 		CreateTime:       aws.Time(volMeta.CreatedAt),
 		VolumeType:       aws.String(volumeType),
-		Encrypted:        aws.Bool(volMeta.IsEncrypted),
+		Encrypted:        aws.Bool(encryptionEnabled),
 	}
 
 	if volMeta.IOPS > 0 {
@@ -977,6 +976,15 @@ type volumeConfigWrapper struct {
 
 // GetVolumeConfig reads the raw VolumeConfig from S3 for a given volume ID.
 func (s *VolumeServiceImpl) GetVolumeConfig(volumeID string) (*viperblock.VolumeConfig, error) {
+	cfg, _, err := s.getVolumeConfigAndEncryption(volumeID)
+	return cfg, err
+}
+
+// getVolumeConfigAndEncryption reads config.json and surfaces both the
+// VolumeConfig and the authoritative VBState.EncryptionEnabled flag. Wrapper-
+// only blobs (pre-VBState volumes or freshly-seeded test fixtures) report
+// encryptionEnabled=false — they predate encryption-at-rest by construction.
+func (s *VolumeServiceImpl) getVolumeConfigAndEncryption(volumeID string) (*viperblock.VolumeConfig, bool, error) {
 	configKey := volumeID + "/config.json"
 
 	getResult, err := s.store.GetObject(&s3.GetObjectInput{
@@ -985,23 +993,31 @@ func (s *VolumeServiceImpl) GetVolumeConfig(volumeID string) (*viperblock.Volume
 	})
 	if err != nil {
 		if objectstore.IsNoSuchKeyError(err) {
-			return nil, errors.New(awserrors.ErrorInvalidVolumeNotFound)
+			return nil, false, errors.New(awserrors.ErrorInvalidVolumeNotFound)
 		}
-		return nil, fmt.Errorf("failed to get config: %w", err)
+		return nil, false, fmt.Errorf("failed to get config: %w", err)
 	}
 	defer getResult.Body.Close()
 
 	body, err := io.ReadAll(getResult.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config body: %w", err)
+		return nil, false, fmt.Errorf("failed to read config body: %w", err)
+	}
+
+	// Try full VBState first (matches mergeVolumeConfig's careful decode
+	// pattern). A populated BlockSize is the marker that the blob is a full
+	// state rather than a wrapper-only fallback.
+	var state viperblock.VBState
+	if decodeErr := json.NewDecoder(bytes.NewReader(body)).Decode(&state); decodeErr == nil && state.BlockSize != 0 {
+		return &state.VolumeConfig, state.EncryptionEnabled, nil
 	}
 
 	var wrapper volumeConfigWrapper
 	if err := json.Unmarshal(body, &wrapper); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+		return nil, false, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	return &wrapper.VolumeConfig, nil
+	return &wrapper.VolumeConfig, false, nil
 }
 
 // putVolumeConfig writes a VolumeConfig back to S3 as config.json.

--- a/spinifex/handlers/ec2/volume/service_impl_encryption_test.go
+++ b/spinifex/handlers/ec2/volume/service_impl_encryption_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+package handlers_ec2_volume
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/config"
+	"github.com/mulgadc/spinifex/spinifex/objectstore"
+	"github.com/mulgadc/viperblock/viperblock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVolumeConfig_CorruptJSON(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+
+	const volumeID = "vol-bad-json"
+	// Body is not a valid VBState (BlockSize stays 0 → falls through) and is
+	// not a valid volumeConfigWrapper either (unmarshal fails) — must surface
+	// "failed to unmarshal config" from getVolumeConfigAndEncryption.
+	_, err := store.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String(volumeID + "/config.json"),
+		Body:   strings.NewReader("not valid json {{{"),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.GetVolumeConfig(volumeID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal config")
+}
+
+func TestMergeVolumeConfig_RefusesEncryptedVBState(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+
+	const volumeID = "vol-encrypted"
+	const configKey = volumeID + "/config.json"
+
+	// Seed an encrypted-at-rest VBState. mergeVolumeConfig must refuse to
+	// re-marshal it because spinifex does not currently hold the master key
+	// and a tag-less rewrite would brick the volume.
+	state := viperblock.VBState{
+		VolumeName:        volumeID,
+		VolumeSize:        1024 * 1024 * 1024,
+		BlockSize:         4096,
+		EncryptionEnabled: true,
+		VolumeConfig: viperblock.VolumeConfig{
+			VolumeMetadata: viperblock.VolumeMetadata{
+				VolumeID: volumeID,
+				SizeGiB:  1,
+			},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	_, err = store.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String(configKey),
+		Body:   strings.NewReader(string(data)),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.mergeVolumeConfig(configKey, &viperblock.VolumeConfig{
+		VolumeMetadata: viperblock.VolumeMetadata{VolumeID: volumeID, SizeGiB: 2},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to merge encrypted VBState")
+}
+
+// newTestVolumeServiceWithEncryptionKey wires CreateVolume to a configured
+// (but unreadable) EncryptionKeyFile so the master-key load error path is hit.
+func newTestVolumeServiceWithEncryptionKey(az, keyFile string) *VolumeServiceImpl {
+	cfg := &config.Config{
+		AZ: az,
+		Predastore: config.PredastoreConfig{
+			Bucket:    "test-bucket",
+			Region:    "ap-southeast-2",
+			Host:      "localhost:9000",
+			AccessKey: "testkey",
+			SecretKey: "testsecret",
+		},
+		Viperblock: config.ViperblockConfig{EncryptionKeyFile: keyFile},
+		WalDir:     "/tmp/test-wal",
+	}
+	return NewVolumeServiceImplWithStore(cfg, objectstore.NewMemoryObjectStore(), nil)
+}
+
+func TestCreateVolume_EncryptionKeyLoadError(t *testing.T) {
+	// Point EncryptionKeyFile at a non-existent path so LoadViperblockMasterKey
+	// fails — CreateVolume must abort with ServerInternal, before any backend
+	// init / SaveState call.
+	missing := filepath.Join(t.TempDir(), "absent.key")
+	svc := newTestVolumeServiceWithEncryptionKey("ap-southeast-2a", missing)
+
+	_, err := svc.CreateVolume(&ec2.CreateVolumeInput{
+		Size:             aws.Int64(1),
+		AvailabilityZone: aws.String("ap-southeast-2a"),
+	}, "")
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+}

--- a/spinifex/handlers/ec2/volume/service_impl_test.go
+++ b/spinifex/handlers/ec2/volume/service_impl_test.go
@@ -603,14 +603,29 @@ func TestGetVolumeByID_FullMetadata(t *testing.T) {
 		VolumeType:          "gp3",
 		IOPS:                5000,
 		SnapshotID:          "snap-abc",
-		IsEncrypted:         true,
 		AttachedInstance:    "i-12345",
 		DeviceName:          "/dev/nbd0",
 		DeleteOnTermination: true,
 		AttachedAt:          now,
 		Tags:                map[string]string{"Name": "test-vol", "env": "dev"},
 	}
-	createVolumeInStoreWithMeta(t, store, "vol-full", meta)
+	// Seed as a full VBState with EncryptionEnabled=true so getVolumeByID
+	// reports Encrypted via the authoritative VBState.EncryptionEnabled path.
+	state := viperblock.VBState{
+		VolumeName:        "vol-full",
+		VolumeSize:        meta.SizeGiB * 1024 * 1024 * 1024,
+		BlockSize:         4096,
+		EncryptionEnabled: true,
+		VolumeConfig:      viperblock.VolumeConfig{VolumeMetadata: meta},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	_, err = store.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("vol-full/config.json"),
+		Body:   strings.NewReader(string(data)),
+	})
+	require.NoError(t, err)
 
 	result, err := svc.getVolumeByID("vol-full")
 	require.NoError(t, err)

--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/mulgadc/predastore/pkg/masterkey"
 	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/nbd"
 	"github.com/mulgadc/spinifex/spinifex/types"
@@ -107,6 +108,14 @@ type Config struct {
 
 	// ShardWAL enables sharded WAL for mounted volumes (default false)
 	ShardWAL bool
+
+	// EncryptionKeyFile is the path to the shared 32-byte AES-256 master key
+	// used to seal viperblock WAL records, chunk blocks, and metadata. When
+	// empty the daemon mounts volumes in cleartext mode (legacy). Loaded once
+	// at launchService start; the parsed key is cached in masterKey.
+	EncryptionKeyFile string
+
+	masterKey *masterkey.Key
 
 	mu sync.Mutex
 }
@@ -222,6 +231,17 @@ func launchService(cfg *Config) (err error) {
 	if err != nil {
 		slog.Error("Failed to connect to NATS", "err", err)
 		return err
+	}
+
+	if cfg.EncryptionKeyFile != "" {
+		mkey, err := masterkey.LoadShared(cfg.EncryptionKeyFile)
+		if err != nil {
+			return fmt.Errorf("load viperblock encryption key %s: %w", cfg.EncryptionKeyFile, err)
+		}
+		cfg.masterKey = mkey
+		slog.Info("Viperblock at-rest encryption enabled", "key_fingerprint", mkey.Fingerprint)
+	} else {
+		slog.Warn("Viperblock at-rest encryption disabled (no EncryptionKeyFile configured)")
 	}
 
 	slog.Info("Viperblock config", "shardwal", cfg.ShardWAL)
@@ -468,7 +488,9 @@ func launchService(cfg *Config) (err error) {
 					Size: defaultCache,
 				},
 			},
-			VolumeConfig: viperblock.VolumeConfig{},
+			VolumeConfig:      viperblock.VolumeConfig{},
+			MasterKey:         cfg.masterKey,
+			EncryptionEnabled: cfg.masterKey != nil,
 		}
 
 		vb, err := viperblock.New(&vbconfig, "s3", s3cfg)

--- a/spinifex/utils/encryption.go
+++ b/spinifex/utils/encryption.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+)
+
+// viperblockKeyCache memoises masterkey.LoadShared by path so the AWS gateway
+// handlers (volume / instance / image) do not re-stat and re-parse the same
+// 32-byte file on every VB.New. Process-wide; the underlying *Key holds an
+// AEAD which is safe for concurrent use per the crypto/cipher contract.
+var (
+	viperblockKeyCacheMu sync.Mutex
+	viperblockKeyCache   = map[string]*masterkey.Key{}
+)
+
+// LoadViperblockMasterKey returns the cached *masterkey.Key for the given
+// path, loading it via masterkey.LoadShared on first use. An empty path
+// returns (nil, nil) — encryption is treated as disabled.
+func LoadViperblockMasterKey(path string) (*masterkey.Key, error) {
+	if path == "" {
+		return nil, nil
+	}
+	viperblockKeyCacheMu.Lock()
+	defer viperblockKeyCacheMu.Unlock()
+	if k, ok := viperblockKeyCache[path]; ok {
+		return k, nil
+	}
+	k, err := masterkey.LoadShared(path)
+	if err != nil {
+		return nil, fmt.Errorf("load viperblock encryption key %s: %w", path, err)
+	}
+	viperblockKeyCache[path] = k
+	return k, nil
+}

--- a/spinifex/utils/encryption_test.go
+++ b/spinifex/utils/encryption_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Mulga Defense Corporation (MDC). All rights reserved.
+// Use of this source code is governed by an Apache 2.0 license
+// that can be found in the LICENSE file.
+
+package utils
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/masterkey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMasterKeyFile writes a 32-byte master key at name under t.TempDir()
+// with the given mode (chmod'd explicitly to bypass umask).
+func writeMasterKeyFile(t *testing.T, name string, mode os.FileMode) string {
+	t.Helper()
+	raw := make([]byte, 32)
+	_, err := rand.Read(raw)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, raw, mode))
+	require.NoError(t, os.Chmod(path, mode))
+	return path
+}
+
+// resetKeyCache clears the process-wide cache so cache-sensitive tests
+// can run independently regardless of order.
+func resetKeyCache() {
+	viperblockKeyCacheMu.Lock()
+	defer viperblockKeyCacheMu.Unlock()
+	viperblockKeyCache = map[string]*masterkey.Key{}
+}
+
+func TestLoadViperblockMasterKey_EmptyPath(t *testing.T) {
+	resetKeyCache()
+	k, err := LoadViperblockMasterKey("")
+	require.NoError(t, err)
+	assert.Nil(t, k, "empty path must return (nil, nil) — encryption disabled")
+}
+
+func TestLoadViperblockMasterKey_LoadsAndCaches(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not enforced on Windows")
+	}
+	resetKeyCache()
+
+	path := writeMasterKeyFile(t, "key", 0o640)
+
+	k1, err := LoadViperblockMasterKey(path)
+	require.NoError(t, err)
+	require.NotNil(t, k1)
+	assert.NotEmpty(t, k1.Fingerprint)
+
+	// Second call must return the cached *Key (pointer-equal), proving
+	// the path is memoised rather than re-stat'd + re-parsed.
+	k2, err := LoadViperblockMasterKey(path)
+	require.NoError(t, err)
+	assert.Same(t, k1, k2, "second LoadViperblockMasterKey must return cached pointer")
+}
+
+func TestLoadViperblockMasterKey_LoadError(t *testing.T) {
+	resetKeyCache()
+
+	missing := filepath.Join(t.TempDir(), "nonexistent.key")
+	k, err := LoadViperblockMasterKey(missing)
+	require.Error(t, err)
+	assert.Nil(t, k)
+	assert.Contains(t, err.Error(), "load viperblock encryption key")
+	assert.Contains(t, err.Error(), missing)
+}
+
+func TestLoadViperblockMasterKey_FailedLoadNotCached(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics not enforced on Windows")
+	}
+	resetKeyCache()
+
+	// 0o644 has the world-read bit set, which masterkey.LoadShared rejects.
+	path := writeMasterKeyFile(t, "loose.key", 0o644)
+	_, err := LoadViperblockMasterKey(path)
+	require.Error(t, err)
+
+	// Fix the permissions; a subsequent call must succeed (proving the
+	// previous failure was not memoised).
+	require.NoError(t, os.Chmod(path, 0o640))
+	k, err := LoadViperblockMasterKey(path)
+	require.NoError(t, err)
+	require.NotNil(t, k)
+}


### PR DESCRIPTION
## Summary

Wires viperblock's at-rest encryption key end-to-end through the spinifex daemon and AWS handlers, and switches the per-volume `Encrypted` flag from the hardcoded `VolumeMetadata.IsEncrypted` (always false) to the authoritative `VBState.EncryptionEnabled`.

Three commits:

- **feat: wire viperblock at-rest encryption key through daemon and AWS handlers**  
  Adds `EncryptionKeyFile` to `ViperblockConfig` + `viperblockd.Config`. `viperblockd` loads the master key once at `launchService` start via `masterkey.LoadShared`, passes `MasterKey` + `EncryptionEnabled` into every VB. AWS handlers (`volume.CreateVolume`, `instance.newViperblock`, `image.snapshotStoppedVolume`) + the spx admin AMI-import path resolve the key via a process-wide cache (`utils.LoadViperblockMasterKey`). `volume.mergeVolumeConfig` switches to `json.Decoder` so a trailing AES-GCM tag can't route an encrypted body to the wrapper-only fallback, and refuses re-marshal when `EncryptionEnabled` (would strip the tag and brick the volume). New `--encryption-key-file` CLI flag (env `SPINIFEX_VIPERBLOCK_ENCRYPTION_KEY_FILE`) under a viper key distinct from predastore's identically-named flag.

- **fix: only clone AMI on os.ErrNotExist in prepareRootVolume**  
  Previous fall-through treated every `LoadStateRequest` failure as "volume doesn't exist, clone from AMI", which would overwrite a legitimate encrypted volume's `config.json` with AMI base-map state on HMAC integrity failure, key mismatch, transient backend 5xx, or JSON parse failure. Now discriminates `os.ErrNotExist` explicitly.

- **feat: derive Encrypted from VBState.EncryptionEnabled, drop IsEncrypted reads**  
  `VolumeMetadata.IsEncrypted` is being removed from viperblock — it was hardcoded false everywhere in spinifex and misrepresented per-volume encryption status to AWS SDK callers. Authoritative flag is now `VBState.EncryptionEnabled`, persisted by viperblock at `New()` when `MasterKey != nil`. `volume.CreateVolume`, `volume.getVolumeByID`, `snapshot.CreateSnapshot`, and `image.synthesizeRootBlockDeviceMapping` all updated; fixtures updated to seed full `VBState` with `EncryptionEnabled=true`.

## Test plan

- [ ] CI green
- [ ] `make preflight` locally (note: currently fails diff-coverage gate at 37.5% < 60% — to address in review)
- [ ] Smoke: launch instance from encrypted volume, verify `DescribeVolumes` returns `Encrypted=true`
- [ ] Smoke: snapshot encrypted volume, verify `DescribeSnapshots` returns `Encrypted=true`
- [ ] Negative: trigger a transient backend fault on `prepareRootVolume`, verify volume is NOT clobbered by AMI clone