### PR TITLE
feat(elbv2): HTTPS data plane — TLS termination + cert PEM delivery (Phase B)

### DIFF
--- a/spinifex/handlers/elbv2/agent_types.go
+++ b/spinifex/handlers/elbv2/agent_types.go
@@ -32,10 +32,20 @@ type GetLBConfigInput struct {
 	LBID *string `locationName:"LBID" type:"string"`
 }
 
-// GetLBConfigOutput returns the pre-computed HAProxy config and its hash.
+// GetLBConfigOutput returns the pre-computed HAProxy config and its hash, plus
+// any TLS certificate files the config's `ssl crt` directives reference.
 type GetLBConfigOutput struct {
-	ConfigText *string `type:"string"`
-	ConfigHash *string `type:"string"`
+	ConfigText *string     `type:"string"`
+	ConfigHash *string     `type:"string"`
+	CertFiles  []*CertFile `locationName:"CertFiles" type:"list"`
+}
+
+// CertFile is one TLS certificate PEM delivered to the LB agent. Path is the
+// absolute destination (under lbagent.CertDir) the agent writes 0600 before
+// reload; PEM is the combined cert+chain+key material.
+type CertFile struct {
+	Path *string `locationName:"Path" type:"string"`
+	PEM  *string `locationName:"PEM" type:"string"`
 }
 
 // toHealthReport converts the heartbeat input's server list to the lbagent

--- a/spinifex/handlers/elbv2/haproxy.go
+++ b/spinifex/handlers/elbv2/haproxy.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 	"text/template"
+
+	"github.com/mulgadc/spinifex/spinifex/lbagent"
 )
 
 // Every interpolated string field in the templates below MUST be regex-validated
@@ -34,7 +36,7 @@ defaults
     timeout server 60s
 {{range .Frontends}}
 frontend {{.Name}}
-    bind *:{{.Port}}
+    bind *:{{.Port}}{{if .CertPath}} ssl crt {{.CertPath}}{{end}}
 {{- range .Rules}}
 {{- range .ACLs}}
     acl {{.Name}} {{.Expr}}
@@ -74,7 +76,7 @@ defaults
     timeout server 60s
 {{range .Frontends}}
 frontend {{.Name}}
-    bind *:{{.Port}}
+    bind *:{{.Port}}{{if .CertPath}} ssl crt {{.CertPath}}{{end}}
     default_backend {{.DefaultBackend}}
 {{end}}
 {{range .Backends}}
@@ -103,6 +105,10 @@ type HAProxyConfig struct {
 	SocketPath string
 	Frontends  []HAProxyFrontend
 	Backends   []HAProxyBackend
+	// CertFiles maps each absolute `ssl crt` path referenced by a secure
+	// frontend to its combined PEM (cert+chain+key). Not rendered into the
+	// template — carried out to the caller for delivery to the LB agent.
+	CertFiles map[string]string
 }
 
 // HAProxyFrontend represents a listener frontend.
@@ -110,6 +116,8 @@ type HAProxyFrontend struct {
 	Name           string
 	BindAddr       string
 	Port           int64
+	Protocol       string // listener protocol (HTTP/HTTPS/TCP/TLS); drives TLS termination
+	CertPath       string // combined-PEM path for `ssl crt`; empty for non-secure frontends
 	DefaultBackend string
 	Rules          []HAProxyRule
 }
@@ -173,48 +181,61 @@ type HAProxyServer struct {
 
 // GenerateHAProxyConfig builds an HAProxy config string from the LB, its
 // listeners, target groups, and per-listener rules. For NLBs it generates a
-// TCP-mode config and ignores rules (NLB has no L7 routing).
+// TCP-mode config and ignores rules (NLB has no L7 routing). TLS termination
+// is off (no certificates resolved) — use GenerateHAProxyConfigWithCerts for
+// HTTPS listeners.
 func GenerateHAProxyConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, rulesByListener map[string][]*RuleRecord, bindAddr string) (string, error) {
+	config, _, err := GenerateHAProxyConfigWithCerts(lb, listeners, tgByArn, rulesByListener, bindAddr, nil)
+	return config, err
+}
+
+// GenerateHAProxyConfigWithCerts is GenerateHAProxyConfig plus TLS termination.
+// certPEMByArn maps each listener certificate ARN to its combined PEM; secure
+// frontends render `ssl crt <path>` and the returned certFiles map carries each
+// path → PEM for delivery to the LB agent. A secure listener whose default cert
+// ARN is absent from certPEMByArn renders without `ssl crt` (HAProxy would fail
+// to bind, surfacing the missing material).
+func GenerateHAProxyConfigWithCerts(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, rulesByListener map[string][]*RuleRecord, bindAddr string, certPEMByArn map[string]string) (string, map[string]string, error) {
 	if lb.Type == LoadBalancerTypeNetwork {
-		return generateNLBConfig(lb, listeners, tgByArn, bindAddr)
+		return generateNLBConfig(lb, listeners, tgByArn, bindAddr, certPEMByArn)
 	}
-	return generateALBConfig(lb, listeners, tgByArn, rulesByListener, bindAddr)
+	return generateALBConfig(lb, listeners, tgByArn, rulesByListener, bindAddr, certPEMByArn)
 }
 
 // generateALBConfig builds an HTTP-mode HAProxy config for ALBs.
-func generateALBConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, rulesByListener map[string][]*RuleRecord, bindAddr string) (string, error) {
-	cfg, err := buildHAProxyConfig(lb, listeners, tgByArn, rulesByListener, bindAddr, false)
+func generateALBConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, rulesByListener map[string][]*RuleRecord, bindAddr string, certPEMByArn map[string]string) (string, map[string]string, error) {
+	cfg, err := buildHAProxyConfig(lb, listeners, tgByArn, rulesByListener, bindAddr, false, certPEMByArn)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	var buf strings.Builder
 	if err := haproxyHTTPTmpl.Execute(&buf, cfg); err != nil {
-		return "", fmt.Errorf("execute haproxy template: %w", err)
+		return "", nil, fmt.Errorf("execute haproxy template: %w", err)
 	}
 
-	return buf.String(), nil
+	return buf.String(), cfg.CertFiles, nil
 }
 
 // generateNLBConfig builds a TCP-mode HAProxy config for NLBs.
-func generateNLBConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, bindAddr string) (string, error) {
-	cfg, err := buildHAProxyConfig(lb, listeners, tgByArn, nil, bindAddr, true)
+func generateNLBConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, bindAddr string, certPEMByArn map[string]string) (string, map[string]string, error) {
+	cfg, err := buildHAProxyConfig(lb, listeners, tgByArn, nil, bindAddr, true, certPEMByArn)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	var buf strings.Builder
 	if err := haproxyTCPTmpl.Execute(&buf, cfg); err != nil {
-		return "", fmt.Errorf("execute haproxy tcp template: %w", err)
+		return "", nil, fmt.Errorf("execute haproxy tcp template: %w", err)
 	}
 
-	return buf.String(), nil
+	return buf.String(), cfg.CertFiles, nil
 }
 
 // buildHAProxyConfig constructs the HAProxyConfig struct shared by ALB and NLB
 // generation. For ALBs, rulesByListener provides per-listener rules sorted by
 // priority; nil/empty for NLBs.
-func buildHAProxyConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, rulesByListener map[string][]*RuleRecord, bindAddr string, isTCP bool) (HAProxyConfig, error) {
+func buildHAProxyConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgByArn map[string]*TargetGroupRecord, rulesByListener map[string][]*RuleRecord, bindAddr string, isTCP bool, certPEMByArn map[string]string) (HAProxyConfig, error) {
 	socketDir := filepath.Join(os.TempDir(), "spinifex-haproxy")
 	// Use "lb" prefix for both ALB and NLB — must match the agent's socket path.
 	socketPath := filepath.Join(socketDir, fmt.Sprintf("lb-%s.sock", lb.LoadBalancerID))
@@ -316,7 +337,22 @@ func buildHAProxyConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgB
 			Name:           sanitizeName("ft", l.ListenerArn),
 			BindAddr:       bindAddr,
 			Port:           l.Port,
+			Protocol:       l.Protocol,
 			DefaultBackend: defaultBackendName,
+		}
+
+		// Secure listeners terminate TLS: resolve the default cert to a stable
+		// per-listener PEM path and stage it for delivery. Without resolved
+		// material the frontend renders plain (HAProxy then fails to bind,
+		// surfacing the gap rather than silently serving cleartext).
+		if protocolRequiresCert(l.Protocol) {
+			if pem, path := resolveFrontendCert(lb, l, certPEMByArn); pem != "" {
+				frontend.CertPath = path
+				if cfg.CertFiles == nil {
+					cfg.CertFiles = make(map[string]string)
+				}
+				cfg.CertFiles[path] = pem
+			}
 		}
 
 		if !isTCP {
@@ -349,6 +385,34 @@ func buildHAProxyConfig(lb *LoadBalancerRecord, listeners []*ListenerRecord, tgB
 	}
 
 	return cfg, nil
+}
+
+// frontendCertPath returns the stable absolute path of a listener's combined
+// PEM file under the agent's cert dir. Daemon-rendered and agent-written paths
+// must match exactly.
+func frontendCertPath(lb *LoadBalancerRecord, l *ListenerRecord) string {
+	return filepath.Join(lbagent.CertDir, fmt.Sprintf("lb-%s-%s.pem", lb.LoadBalancerID, l.ListenerID))
+}
+
+// resolveFrontendCert picks a listener's default certificate, resolves its PEM
+// from certPEMByArn, and returns (pem, path). Returns ("", "") when the listener
+// has no certificate or its default ARN is unresolved.
+func resolveFrontendCert(lb *LoadBalancerRecord, l *ListenerRecord, certPEMByArn map[string]string) (pem, path string) {
+	if len(l.Certificates) == 0 || certPEMByArn == nil {
+		return "", ""
+	}
+	arn := l.Certificates[0].CertificateArn
+	for _, c := range l.Certificates {
+		if c.IsDefault {
+			arn = c.CertificateArn
+			break
+		}
+	}
+	pem, ok := certPEMByArn[arn]
+	if !ok || pem == "" {
+		return "", ""
+	}
+	return pem, frontendCertPath(lb, l)
 }
 
 // registerRuleBackend resolves the HAProxy backend a rule's single action

--- a/spinifex/handlers/elbv2/haproxy_certs_test.go
+++ b/spinifex/handlers/elbv2/haproxy_certs_test.go
@@ -1,0 +1,196 @@
+package handlers_elbv2
+
+import (
+	"encoding/xml"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	handlers_acm "github.com/mulgadc/spinifex/spinifex/handlers/acm"
+	"github.com/mulgadc/spinifex/spinifex/lbagent"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const certTestArn = "arn:aws:acm:ap-southeast-2:123456789012:certificate/cccc-3333"
+
+func httpsListener() *ListenerRecord {
+	return &ListenerRecord{
+		ListenerArn:     "arn:aws:elasticloadbalancing:us-east-1:123:listener/app/my-alb/lb-abc123/lst-https",
+		ListenerID:      "lst-https",
+		Protocol:        ProtocolHTTPS,
+		Port:            443,
+		Certificates:    []ListenerCertificate{{CertificateArn: certTestArn, IsDefault: true}},
+		SslPolicy:       DefaultSslPolicy,
+		DefaultActions:  []ListenerAction{{Type: ActionTypeFixedResponse, FixedResponse: &FixedResponseAction{StatusCode: "200"}}},
+		LoadBalancerArn: "arn:lb",
+	}
+}
+
+func TestGenerateHAProxyConfigWithCerts_HTTPSRendersSslCrt(t *testing.T) {
+	lb := &LoadBalancerRecord{LoadBalancerID: "lb-abc123", Name: "my-alb"}
+	listeners := []*ListenerRecord{httpsListener()}
+	certPEM := "CERTPEM\nKEYPEM\n"
+
+	config, certFiles, err := GenerateHAProxyConfigWithCerts(
+		lb, listeners, nil, nil, "0.0.0.0",
+		map[string]string{certTestArn: certPEM},
+	)
+	require.NoError(t, err)
+
+	wantPath := filepath.Join(lbagent.CertDir, "lb-lb-abc123-lst-https.pem")
+	assert.Contains(t, config, "bind *:443 ssl crt "+wantPath)
+	require.Len(t, certFiles, 1)
+	assert.Equal(t, certPEM, certFiles[wantPath])
+}
+
+func TestGenerateHAProxyConfigWithCerts_HTTPHasNoSslCrt(t *testing.T) {
+	lb := &LoadBalancerRecord{LoadBalancerID: "lb-abc123", Name: "my-alb"}
+	listeners := []*ListenerRecord{{
+		ListenerArn:    "arn:aws:elasticloadbalancing:us-east-1:123:listener/app/my-alb/lb-abc123/lst-http",
+		ListenerID:     "lst-http",
+		Protocol:       ProtocolHTTP,
+		Port:           80,
+		DefaultActions: []ListenerAction{{Type: ActionTypeFixedResponse, FixedResponse: &FixedResponseAction{StatusCode: "200"}}},
+	}}
+
+	config, certFiles, err := GenerateHAProxyConfigWithCerts(lb, listeners, nil, nil, "0.0.0.0", nil)
+	require.NoError(t, err)
+	assert.Contains(t, config, "bind *:80")
+	assert.NotContains(t, config, "ssl crt")
+	assert.Empty(t, certFiles)
+}
+
+// A secure listener whose cert ARN is unresolved renders without ssl crt — the
+// gap surfaces at HAProxy bind time rather than silently serving cleartext.
+func TestGenerateHAProxyConfigWithCerts_MissingCertRendersPlain(t *testing.T) {
+	lb := &LoadBalancerRecord{LoadBalancerID: "lb-abc123", Name: "my-alb"}
+	config, certFiles, err := GenerateHAProxyConfigWithCerts(
+		lb, []*ListenerRecord{httpsListener()}, nil, nil, "0.0.0.0", nil,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, config, "ssl crt")
+	assert.Empty(t, certFiles)
+}
+
+func TestGenerateHAProxyConfig_BackwardCompatNoTLS(t *testing.T) {
+	lb := &LoadBalancerRecord{LoadBalancerID: "lb-abc123", Name: "my-alb"}
+	config, err := GenerateHAProxyConfig(lb, []*ListenerRecord{httpsListener()}, nil, nil, "0.0.0.0")
+	require.NoError(t, err)
+	assert.NotContains(t, config, "ssl crt", "legacy entrypoint resolves no certs")
+}
+
+func TestConfigCertHash_ChangesOnRotation(t *testing.T) {
+	const cfg = "frontend ft\n    bind *:443 ssl crt /etc/haproxy/certs/x.pem\n"
+	path := "/etc/haproxy/certs/x.pem"
+
+	base := configCertHash(cfg, map[string]string{path: "PEM-A"})
+	rotated := configCertHash(cfg, map[string]string{path: "PEM-B"})
+	same := configCertHash(cfg, map[string]string{path: "PEM-A"})
+
+	assert.NotEqual(t, base, rotated, "rotating cert content must change the hash")
+	assert.Equal(t, base, same, "identical inputs hash identically")
+
+	// Config-only change also moves the hash.
+	assert.NotEqual(t, base, configCertHash(cfg+"\n", map[string]string{path: "PEM-A"}))
+}
+
+func putTestCert(t *testing.T, svc *ELBv2ServiceImpl, arn, account, leaf, chain, key string) {
+	t.Helper()
+	require.NoError(t, svc.acmStore.PutCert(&handlers_acm.CertRecord{
+		CertificateArn:   arn,
+		AccountID:        account,
+		Certificate:      leaf,
+		CertificateChain: chain,
+		PrivateKey:       key,
+		DomainName:       "example.com",
+	}))
+}
+
+func TestResolveCertPEM_ConcatOrderAndOwnership(t *testing.T) {
+	svc := setupTestService(t)
+	require.NotNil(t, svc.acmStore)
+	putTestCert(t, svc, certTestArn, testAccountID, "LEAF", "CHAIN", "KEY")
+
+	pem, err := svc.resolveCertPEM(certTestArn, testAccountID)
+	require.NoError(t, err)
+	assert.Equal(t, "LEAF\nCHAIN\nKEY\n", pem)
+
+	// Wrong account → treated as not found.
+	_, err = svc.resolveCertPEM(certTestArn, "999999999999")
+	require.Error(t, err)
+
+	// Unknown ARN → not found.
+	_, err = svc.resolveCertPEM("arn:aws:acm:ap-southeast-2:123456789012:certificate/missing", testAccountID)
+	require.Error(t, err)
+}
+
+func TestResolveCertPEM_NoChain(t *testing.T) {
+	svc := setupTestService(t)
+	putTestCert(t, svc, certTestArn, testAccountID, "LEAF", "", "KEY")
+
+	pem, err := svc.resolveCertPEM(certTestArn, testAccountID)
+	require.NoError(t, err)
+	assert.Equal(t, "LEAF\nKEY\n", pem)
+}
+
+func TestResolveListenerCerts_DedupAndResolve(t *testing.T) {
+	svc := setupTestService(t)
+	putTestCert(t, svc, certTestArn, testAccountID, "LEAF", "", "KEY")
+
+	// Two listeners share the same cert ARN — resolved once.
+	got, err := svc.resolveListenerCerts([]*ListenerRecord{httpsListener(), httpsListener()}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "LEAF\nKEY\n", got[certTestArn])
+
+	// HTTP-only listeners → nil map, no error.
+	got, err = svc.resolveListenerCerts([]*ListenerRecord{{Protocol: ProtocolHTTP}}, testAccountID)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestGetLBConfig_DeliversCertFiles(t *testing.T) {
+	svc := setupTestService(t)
+	rec := &LoadBalancerRecord{
+		LoadBalancerID: "lb-deliver1",
+		AccountID:      testAccountID,
+		ConfigText:     "frontend ft\n    bind *:443 ssl crt /etc/haproxy/certs/lb-deliver1-lst.pem\n",
+		ConfigHash:     "hash123",
+		CertFiles:      map[string]string{"/etc/haproxy/certs/lb-deliver1-lst.pem": "LEAF\nKEY\n"},
+	}
+	require.NoError(t, svc.store.PutLoadBalancer(rec))
+
+	out, err := svc.GetLBConfig(&GetLBConfigInput{LBID: aws.String("lb-deliver1")}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.CertFiles, 1)
+	assert.Equal(t, "/etc/haproxy/certs/lb-deliver1-lst.pem", *out.CertFiles[0].Path)
+	assert.Equal(t, "LEAF\nKEY\n", *out.CertFiles[0].PEM)
+
+	// The gateway marshals this output to XML; confirm the member shape the
+	// lb-agent parses (GetLBConfigResult>CertFiles>member>{Path,PEM}).
+	payload := utils.GenerateIAMXMLPayload("GetLBConfig", *out)
+	xmlBytes, err := utils.MarshalToXML(payload)
+	require.NoError(t, err)
+	var parsed struct {
+		Members []struct {
+			Path string `xml:"Path"`
+			PEM  string `xml:"PEM"`
+		} `xml:"GetLBConfigResult>CertFiles>member"`
+	}
+	require.NoError(t, xml.Unmarshal(xmlBytes, &parsed))
+	require.Len(t, parsed.Members, 1)
+	assert.Equal(t, "/etc/haproxy/certs/lb-deliver1-lst.pem", parsed.Members[0].Path)
+	assert.Equal(t, "LEAF\nKEY\n", parsed.Members[0].PEM)
+}
+
+func TestCertFilesToSDK_SortedAndNilSafe(t *testing.T) {
+	assert.Nil(t, certFilesToSDK(nil))
+
+	out := certFilesToSDK(map[string]string{"/b.pem": "B", "/a.pem": "A"})
+	require.Len(t, out, 2)
+	assert.Equal(t, "/a.pem", *out[0].Path)
+	assert.Equal(t, "A", *out[0].PEM)
+	assert.Equal(t, "/b.pem", *out[1].Path)
+}

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -3,12 +3,14 @@ package handlers_elbv2
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"regexp"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
+	handlers_acm "github.com/mulgadc/spinifex/spinifex/handlers/acm"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -96,6 +99,7 @@ var _ ELBv2Service = (*ELBv2ServiceImpl)(nil)
 type ELBv2ServiceImpl struct {
 	config                     *config.Config
 	store                      *Store
+	acmStore                   *handlers_acm.Store              // resolves listener cert ARNs → PEM; nil-safe (HTTPS unavailable when nil)
 	nc                         *nats.Conn                       // NATS connection for JetStream KV store
 	VPCService                 *handlers_ec2_vpc.VPCServiceImpl // nil-safe: ENI ops skipped when nil (e.g. in tests)
 	InstanceLauncher           SystemInstanceLauncher           // nil-safe: system VM ops skipped when nil
@@ -128,6 +132,16 @@ func NewELBv2ServiceImplWithNATS(cfg *config.Config, nc *nats.Conn) (*ELBv2Servi
 		return nil, fmt.Errorf("failed to create ELBv2 store: %w", err)
 	}
 
+	// ACM store shares the same JetStream KV — read cert PEM directly, no
+	// cross-service NATS hop. Non-fatal: a failure here only disables HTTPS
+	// termination (resolveCertPEM returns an error), it must not block the
+	// daemon from serving ELBv2 control-plane requests.
+	acmStore, acmErr := handlers_acm.NewStore(nc)
+	if acmErr != nil {
+		slog.Warn("ELBv2: ACM store unavailable, HTTPS listeners cannot resolve certs", "err", acmErr)
+		acmStore = nil
+	}
+
 	region := "us-east-1"
 	nodeID := ""
 	if cfg != nil {
@@ -141,14 +155,15 @@ func NewELBv2ServiceImplWithNATS(cfg *config.Config, nc *nats.Conn) (*ELBv2Servi
 	hc := newHealthChecker(store)
 
 	return &ELBv2ServiceImpl{
-		config: cfg,
-		store:  store,
-		nc:     nc,
-		nodeID: nodeID,
-		region: region,
-		ctx:    ctx,
-		cancel: cancel,
-		hc:     hc,
+		config:   cfg,
+		store:    store,
+		acmStore: acmStore,
+		nc:       nc,
+		nodeID:   nodeID,
+		region:   region,
+		ctx:      ctx,
+		cancel:   cancel,
+		hc:       hc,
 	}, nil
 }
 
@@ -577,15 +592,22 @@ func (s *ELBv2ServiceImpl) updateStoredConfig(lb *LoadBalancerRecord) error {
 		}
 	}
 
-	configContent, err := GenerateHAProxyConfig(lb, listeners, tgByArn, rulesByListener, bindAddr)
+	certPEMByArn, err := s.resolveListenerCerts(listeners, lb.AccountID)
+	if err != nil {
+		slog.Error("updateStoredConfig: failed to resolve certs", "lbId", lb.LoadBalancerID, "err", err)
+		return fmt.Errorf("resolve certs: %w", err)
+	}
+
+	configContent, certFiles, err := GenerateHAProxyConfigWithCerts(lb, listeners, tgByArn, rulesByListener, bindAddr, certPEMByArn)
 	if err != nil {
 		slog.Error("updateStoredConfig: failed to generate config", "lbId", lb.LoadBalancerID, "err", err)
 		return fmt.Errorf("generate config: %w", err)
 	}
 
-	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(configContent)))
+	hash := configCertHash(configContent, certFiles)
 	lb.ConfigText = configContent
 	lb.ConfigHash = hash
+	lb.CertFiles = certFiles
 
 	if err := s.store.PutLoadBalancer(lb); err != nil {
 		slog.Error("updateStoredConfig: failed to persist LB", "lbId", lb.LoadBalancerID, "err", err)
@@ -593,8 +615,79 @@ func (s *ELBv2ServiceImpl) updateStoredConfig(lb *LoadBalancerRecord) error {
 	}
 
 	slog.Info("updateStoredConfig: config stored",
-		"lbId", lb.LoadBalancerID, "hash", hash[:12], "size", len(configContent))
+		"lbId", lb.LoadBalancerID, "hash", hash[:12], "size", len(configContent), "certs", len(certFiles))
 	return nil
+}
+
+// resolveListenerCerts resolves every distinct certificate ARN referenced by
+// the listeners to its combined PEM via the ACM store. Returns nil when no
+// listener carries a certificate (the common HTTP-only case).
+func (s *ELBv2ServiceImpl) resolveListenerCerts(listeners []*ListenerRecord, accountID string) (map[string]string, error) {
+	var out map[string]string
+	for _, l := range listeners {
+		for _, c := range l.Certificates {
+			if _, ok := out[c.CertificateArn]; ok {
+				continue
+			}
+			pem, err := s.resolveCertPEM(c.CertificateArn, accountID)
+			if err != nil {
+				return nil, fmt.Errorf("cert %s: %w", c.CertificateArn, err)
+			}
+			if out == nil {
+				out = make(map[string]string)
+			}
+			out[c.CertificateArn] = pem
+		}
+	}
+	return out, nil
+}
+
+// resolveCertPEM loads a certificate by ARN from the ACM store and returns its
+// combined PEM (leaf + chain + key) in the order HAProxy `ssl crt` expects.
+// Ownership is enforced: a cert belonging to another account is treated as
+// absent.
+func (s *ELBv2ServiceImpl) resolveCertPEM(arn, accountID string) (string, error) {
+	if s.acmStore == nil {
+		return "", errors.New(awserrors.ErrorELBv2CertificateNotFound)
+	}
+	rec, err := s.acmStore.GetCert(arn)
+	if err != nil {
+		return "", fmt.Errorf("get cert: %w", err)
+	}
+	if rec == nil || rec.AccountID != accountID {
+		return "", errors.New(awserrors.ErrorELBv2CertificateNotFound)
+	}
+
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(rec.Certificate, "\n"))
+	b.WriteByte('\n')
+	if rec.CertificateChain != "" {
+		b.WriteString(strings.TrimRight(rec.CertificateChain, "\n"))
+		b.WriteByte('\n')
+	}
+	b.WriteString(strings.TrimRight(rec.PrivateKey, "\n"))
+	b.WriteByte('\n')
+	return b.String(), nil
+}
+
+// configCertHash hashes the rendered config plus every delivered cert file
+// (path + content, in sorted path order) so a cert rotation changes the hash
+// and triggers an agent reload even when the config text is unchanged.
+func configCertHash(configContent string, certFiles map[string]string) string {
+	h := sha256.New()
+	h.Write([]byte(configContent))
+	paths := make([]string, 0, len(certFiles))
+	for p := range certFiles {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		h.Write([]byte(p))
+		h.Write([]byte{0})
+		h.Write([]byte(certFiles[p]))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // updateStoredConfigForTargetGroup finds all LBs that reference the given target
@@ -718,7 +811,26 @@ func (s *ELBv2ServiceImpl) GetLBConfig(input *GetLBConfigInput, accountID string
 	return &GetLBConfigOutput{
 		ConfigText: aws.String(lb.ConfigText),
 		ConfigHash: aws.String(lb.ConfigHash),
+		CertFiles:  certFilesToSDK(lb.CertFiles),
 	}, nil
+}
+
+// certFilesToSDK converts the stored path→PEM map into the sorted CertFile
+// slice delivered to the agent. Sorted for deterministic output.
+func certFilesToSDK(certFiles map[string]string) []*CertFile {
+	if len(certFiles) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(certFiles))
+	for p := range certFiles {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	out := make([]*CertFile, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, &CertFile{Path: aws.String(p), PEM: aws.String(certFiles[p])})
+	}
+	return out
 }
 
 // lbArnPathSegment returns the ARN path segment for the given LB type:

--- a/spinifex/handlers/elbv2/types.go
+++ b/spinifex/handlers/elbv2/types.go
@@ -109,7 +109,8 @@ type LoadBalancerRecord struct {
 	InstanceID      string            `json:"instance_id,omitempty"` // ALB VM instance ID (system-managed)
 	VPCIP           string            `json:"vpc_ip,omitempty"`      // VPC private IP of the ALB VM
 	ConfigText      string            `json:"config_text,omitempty"` // Pre-computed HAProxy config
-	ConfigHash      string            `json:"config_hash,omitempty"` // SHA256 of ConfigText
+	ConfigHash      string            `json:"config_hash,omitempty"` // SHA256 of ConfigText + cert material
+	CertFiles       map[string]string `json:"cert_files,omitempty"`  // Absolute path → combined PEM (cert+chain+key), delivered with config
 	LastHeartbeat   time.Time         `json:"last_heartbeat"`        // Last agent heartbeat timestamp
 	HostPorts       map[int]int       `json:"host_ports,omitempty"`  // Dev mode: guest port → host port forwarding
 	NodeID          string            `json:"node_id"`               // Daemon node running this ALB

--- a/spinifex/lbagent/agent.go
+++ b/spinifex/lbagent/agent.go
@@ -31,6 +31,12 @@ const (
 	DefaultConfigPath = "/etc/haproxy/haproxy.cfg"
 	DefaultPIDPath    = "/run/haproxy.pid"
 
+	// CertDir is the fixed directory holding TLS certificate PEM files for
+	// HTTPS listeners. The daemon renders `ssl crt` paths under this dir; the
+	// agent writes the delivered PEM files here (0600) before reload and
+	// rejects any delivered path that escapes it.
+	CertDir = "/etc/haproxy/certs"
+
 	// pollInterval is how often the agent sends a heartbeat.
 	pollInterval = 5 * time.Second
 )
@@ -42,6 +48,7 @@ type Agent struct {
 	region     string // SigV4 signing region
 	configPath string
 	pidPath    string
+	certDir    string // dir for TLS cert PEM files; defaults to CertDir (overridable in tests)
 	socketPath string // HAProxy stats socket
 
 	accessKey string
@@ -91,6 +98,7 @@ func New(lbID, gatewayURL, accessKey, secretKey, region string) (*Agent, error) 
 		region:     region,
 		configPath: DefaultConfigPath,
 		pidPath:    DefaultPIDPath,
+		certDir:    CertDir,
 		socketPath: fmt.Sprintf("/tmp/spinifex-haproxy/lb-%s.sock", lbID),
 		accessKey:  accessKey,
 		secretKey:  secretKey,
@@ -162,11 +170,19 @@ type heartbeatResponse struct {
 	ConfigHash string   `xml:"LBAgentHeartbeatResult>ConfigHash"`
 }
 
+// certFile is one delivered TLS certificate PEM parsed from the GetLBConfig
+// response. Path is the absolute destination under CertDir.
+type certFile struct {
+	Path string `xml:"Path"`
+	PEM  string `xml:"PEM"`
+}
+
 // configResponse is the parsed XML response from GetLBConfig.
 type configResponse struct {
-	XMLName    xml.Name `xml:"GetLBConfigResponse"`
-	ConfigText string   `xml:"GetLBConfigResult>ConfigText"`
-	ConfigHash string   `xml:"GetLBConfigResult>ConfigHash"`
+	XMLName    xml.Name   `xml:"GetLBConfigResponse"`
+	ConfigText string     `xml:"GetLBConfigResult>ConfigText"`
+	ConfigHash string     `xml:"GetLBConfigResult>ConfigHash"`
+	CertFiles  []certFile `xml:"GetLBConfigResult>CertFiles>member"`
 }
 
 // sendHeartbeat sends a heartbeat with health report to the gateway.
@@ -216,6 +232,12 @@ func (a *Agent) fetchAndApplyConfig() error {
 		return fmt.Errorf("empty config returned")
 	}
 
+	// Cert files must land before the config that references them via
+	// `ssl crt`, otherwise HAProxy fails to start/reload on a missing path.
+	if err := a.writeCertFiles(resp.CertFiles); err != nil {
+		return fmt.Errorf("write cert files: %w", err)
+	}
+
 	if err := WriteConfig(a.configPath, resp.ConfigText); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
@@ -260,6 +282,34 @@ func (a *Agent) signedPost(params url.Values) ([]byte, error) {
 	}
 
 	return respBody, nil
+}
+
+// writeCertFiles writes each delivered TLS certificate PEM to its path 0600,
+// creating the cert dir as needed. Every path is constrained to a.certDir — a
+// delivered path that escapes it (traversal, absolute elsewhere) is rejected
+// rather than written, so a malformed/hostile response can't drop files across
+// the filesystem.
+func (a *Agent) writeCertFiles(certs []certFile) error {
+	if len(certs) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(a.certDir, 0o750); err != nil {
+		return fmt.Errorf("create cert dir: %w", err)
+	}
+	for _, c := range certs {
+		clean := filepath.Clean(c.Path)
+		if clean != filepath.Join(a.certDir, filepath.Base(clean)) {
+			return fmt.Errorf("cert path %q escapes %s", c.Path, a.certDir)
+		}
+		if c.PEM == "" {
+			return fmt.Errorf("cert %q has empty PEM", c.Path)
+		}
+		if err := os.WriteFile(clean, []byte(c.PEM), 0o600); err != nil {
+			return fmt.Errorf("write cert %q: %w", clean, err)
+		}
+		slog.Info("Wrote TLS cert", "path", clean, "bytes", len(c.PEM))
+	}
+	return nil
 }
 
 // WriteConfig atomically writes an HAProxy config file.

--- a/spinifex/lbagent/agent_certs_test.go
+++ b/spinifex/lbagent/agent_certs_test.go
@@ -1,0 +1,63 @@
+package lbagent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCertTestAgent(t *testing.T) *Agent {
+	t.Helper()
+	a, err := New("lb-1", "https://gw.local", "AK", "SK", "us-east-1")
+	require.NoError(t, err)
+	a.certDir = t.TempDir()
+	return a
+}
+
+func TestWriteCertFiles_WritesPEM0600(t *testing.T) {
+	a := newCertTestAgent(t)
+	path := filepath.Join(a.certDir, "lb-1-lst.pem")
+
+	err := a.writeCertFiles([]certFile{{Path: path, PEM: "LEAF\nKEY\n"}})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "LEAF\nKEY\n", string(data))
+
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm())
+	}
+}
+
+func TestWriteCertFiles_Empty(t *testing.T) {
+	a := newCertTestAgent(t)
+	assert.NoError(t, a.writeCertFiles(nil))
+}
+
+func TestWriteCertFiles_RejectsTraversal(t *testing.T) {
+	a := newCertTestAgent(t)
+	cases := []string{
+		filepath.Join(a.certDir, "../escape.pem"),
+		"/etc/passwd",
+		filepath.Join(a.certDir, "sub/dir/x.pem"),
+	}
+	for _, p := range cases {
+		err := a.writeCertFiles([]certFile{{Path: p, PEM: "X"}})
+		require.Error(t, err, "path %q must be rejected", p)
+		assert.Contains(t, err.Error(), "escapes")
+	}
+}
+
+func TestWriteCertFiles_RejectsEmptyPEM(t *testing.T) {
+	a := newCertTestAgent(t)
+	err := a.writeCertFiles([]certFile{{Path: filepath.Join(a.certDir, "x.pem"), PEM: ""}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty PEM")
+}


### PR DESCRIPTION
## Summary

Phase B of the ELBv2 HTTPS epic (mulga-siv-180). Completes TLS termination end-to-end now that the ACM cert store (siv-184, #285) exists.

- **Resolve** listener `Certificates[].CertificateArn` → PEM via the ACM store (shared JetStream KV bucket `spinifex-acm` — read directly, no cross-service NATS hop). Ownership-scoped; nil-safe when the store is unavailable.
- **Render** `bind *:<port> ssl crt <path>` for secure frontends (combined cert+chain+key PEM). HTTP frontends unchanged.
- **Deliver** cert files in the `GetLBConfig` response (`CertFiles[]{Path,PEM}`, XML-serialized). `ConfigHash` folds in cert content so rotation triggers a reload.
- **Apply**: lb-agent writes each cert `0600` (path-constrained to its cert dir — traversal rejected) **before** the config + reload.

## Test
- haproxy render: `ssl crt` for HTTPS, none for HTTP, missing-cert renders plain.
- `resolveCertPEM` concat order + ownership; `resolveListenerCerts` dedup.
- `configCertHash` changes on rotation; `GetLBConfig` delivery + XML member round-trip to the agent parse shape.
- lb-agent `writeCertFiles`: 0600, empty-PEM + traversal rejection.
- `make preflight` green.

Branched off #285; rebased onto dev after merge. Plan: `docs/development/feature/elbv2-https-listener-certs.md`.