### PR TITLE
fix(eks): ListClusters returns retryable ServiceUnavailable during JetStream warmup

### DIFF
--- a/spinifex/handlers/eks/list_clusters_test.go
+++ b/spinifex/handlers/eks/list_clusters_test.go
@@ -1,10 +1,14 @@
 package handlers_eks
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,4 +56,27 @@ func TestEKSServiceImpl_ListClustersMaxResultsClamped(t *testing.T) {
 		assert.Equal(t, want, aws.StringValueSlice(out.Clusters), "MaxResults=%d must clamp to one full page", mr)
 		assert.Nil(t, out.NextToken, "MaxResults=%d single page must not advertise a NextToken", mr)
 	}
+}
+
+// TestEKSReadUnavailableClassification pins the post-restart behaviour: a
+// transient JetStream error (no leader yet) surfaces as a retryable
+// ServiceUnavailable, while a genuine fault stays wrapped (the daemon maps it
+// to InternalError). Regression guard for list-clusters returning a misleading
+// 500 during the KV warmup window.
+func TestEKSReadUnavailableClassification(t *testing.T) {
+	transient := []error{
+		nats.ErrNoResponders,
+		nats.ErrTimeout,
+		nats.ErrNoStreamResponse,
+		nats.ErrConnectionClosed,
+		fmt.Errorf("kv keys: %w", nats.ErrNoResponders), // wrapped, as ListClusters wraps it
+	}
+	for _, e := range transient {
+		assert.True(t, natsTransient(e), "%v must be classified transient", e)
+		assert.EqualError(t, eksReadUnavailableOr(e, "op"), awserrors.ErrorServiceUnavailable)
+	}
+
+	genuine := errors.New("corrupt cluster meta")
+	assert.False(t, natsTransient(genuine))
+	assert.ErrorContains(t, eksReadUnavailableOr(genuine, "list cluster names"), "list cluster names: corrupt cluster meta")
 }

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -533,15 +533,15 @@ func (s *EKSServiceImpl) DescribeCluster(input *eks.DescribeClusterInput, accoun
 func (s *EKSServiceImpl) ListClusters(input *eks.ListClustersInput, accountID string) (*eks.ListClustersOutput, error) {
 	js, err := s.deps.NATSConn.JetStream()
 	if err != nil {
-		return nil, fmt.Errorf("jetstream: %w", err)
+		return nil, eksReadUnavailableOr(err, "jetstream")
 	}
 	acctKV, err := GetOrCreateAccountBucket(js, accountID)
 	if err != nil {
-		return nil, fmt.Errorf("get account bucket: %w", err)
+		return nil, eksReadUnavailableOr(err, "get account bucket")
 	}
 	names, err := listClusterNames(acctKV)
 	if err != nil {
-		return nil, err
+		return nil, eksReadUnavailableOr(err, "list cluster names")
 	}
 	sort.Strings(names)
 
@@ -1232,6 +1232,30 @@ func clusterMetaToAWS(meta *ClusterMeta) *eks.Cluster {
 		}
 	}
 	return out
+}
+
+// natsTransient reports whether err is a transient NATS/JetStream condition
+// rather than a genuine fault. These occur in the post-restart window before
+// the KV stream's Raft group has elected a leader: JetStream requests get no
+// responder, time out, or the stream is briefly unreachable.
+func natsTransient(err error) bool {
+	return err != nil && (errors.Is(err, nats.ErrNoResponders) ||
+		errors.Is(err, nats.ErrTimeout) ||
+		errors.Is(err, nats.ErrNoStreamResponse) ||
+		errors.Is(err, nats.ErrConnectionClosed))
+}
+
+// eksReadUnavailableOr maps a transient NATS/JetStream failure to a retryable
+// ServiceUnavailable (503) so AWS clients back off and retry, instead of the
+// daemon sanitizing an unrecognised wrapped error to a misleading 500
+// InternalError. Non-transient errors pass through wrapped so real faults stay
+// visible.
+func eksReadUnavailableOr(err error, op string) error {
+	if natsTransient(err) {
+		slog.Warn("EKS read temporarily unavailable", "op", op, "err", err)
+		return errors.New(awserrors.ErrorServiceUnavailable)
+	}
+	return fmt.Errorf("%s: %w", op, err)
 }
 
 func listClusterNames(kv nats.KeyValue) ([]string, error) {


### PR DESCRIPTION
## Problem
`aws eks list-clusters` returned `InternalErrorException` for a few seconds after a daemon restart, while `describe-cluster` (by name) worked. During the post-restart window the per-account KV stream's Raft group has no leader yet, so `kv.Keys()` — an ordered consumer over the warming stream — fails with a transient NATS error. `ListClusters` wrapped it as a `fmt.Errorf` string the daemon's `ValidErrorCode` can't map, so it sanitized to `ServerInternal`: a misleading non-retryable 500. `describe-cluster` survived because `kv.Get` is cheaper than the consumer `kv.Keys` spins up.

## Fix
`natsTransient` classifies transient NATS conditions (no-responders / timeout / no-stream-response / connection-closed); `eksReadUnavailableOr` maps them to a retryable `ServiceUnavailable` (503) so AWS clients back off and retry. Genuine faults still pass through wrapped → `InternalError`, staying visible. Applied to all three `ListClusters` read sites (JetStream, account bucket, kv.Keys).

## Tests
`TestEKSReadUnavailableClassification` pins transient→503 and genuine→wrapped. `make preflight` green. Live: deploy + tight post-restart probe loop — zero `InternalError`, steady-state list returns clusters.

Bead: `mulga-siv-209`.