### PR TITLE
fix(eks): make aws eks get-token → kubectl auth work end-to-end (Sprint 6f)

### DIFF
--- a/cmd/eks-token-webhook/main.go
+++ b/cmd/eks-token-webhook/main.go
@@ -194,6 +194,7 @@ func (a *authenticator) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status := authenticate(review.Spec.Token, a.verify, a.lookup)
+	slog.Info("TokenReview decision", "authenticated", status.Authenticated, "username", status.User.Username)
 
 	resp := tokenReview{
 		APIVersion: "authentication.k8s.io/v1",

--- a/cmd/eks-token-webhook/main.go
+++ b/cmd/eks-token-webhook/main.go
@@ -194,7 +194,12 @@ func (a *authenticator) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	status := authenticate(review.Spec.Token, a.verify, a.lookup)
-	slog.Info("TokenReview decision", "authenticated", status.Authenticated, "username", status.User.Username)
+	if status.Authenticated {
+		// Confirm the token for the audiences the apiserver asked about; an empty
+		// status.audiences is rejected when --api-audiences is configured.
+		status.Audiences = review.Spec.Audiences
+	}
+	slog.Info("TokenReview decision", "authenticated", status.Authenticated, "username", status.User.Username, "audiences", status.Audiences)
 
 	resp := tokenReview{
 		APIVersion: "authentication.k8s.io/v1",

--- a/cmd/eks-token-webhook/tokenreview.go
+++ b/cmd/eks-token-webhook/tokenreview.go
@@ -19,7 +19,12 @@ type tokenReviewSpec struct {
 type tokenReviewStatus struct {
 	Authenticated bool     `json:"authenticated"`
 	User          userInfo `json:"user,omitzero"`
-	Error         string   `json:"error,omitempty"`
+	// Audiences echoes the request's spec.audiences on success. When the
+	// apiserver runs with --api-audiences, it sends spec.audiences and discards
+	// an authenticated=true response that does not confirm a matching audience —
+	// so an empty Audiences here surfaces as a 401 despite a valid principal.
+	Audiences []string `json:"audiences,omitempty"`
+	Error     string   `json:"error,omitempty"`
 }
 
 type userInfo struct {

--- a/scripts/images/eks-node/eks-token-webhook.initd
+++ b/scripts/images/eks-node/eks-token-webhook.initd
@@ -11,8 +11,11 @@ command="/usr/local/bin/eks-token-webhook"
 command_args="--addr=127.0.0.1:8443"
 command_background="yes"
 pidfile="/run/eks-token-webhook.pid"
-output_log="/var/log/eks-token-webhook.log"
-error_log="/var/log/eks-token-webhook.log"
+# Headless appliance: no SSH. Route the webhook's stdout/stderr to the serial
+# console so its startup + per-request decisions land in the host-captured
+# console log (the only off-VM window into webhook health).
+output_log="/dev/console"
+error_log="/dev/console"
 
 # NATS creds + cluster identity come from the cloud-init-seeded first-boot env.
 # Sourced here and exported so start-stop-daemon hands them to the binary, which

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -81,6 +81,13 @@ const (
 	// messages. Path matches k3s-first-boot.sh SPINIFEX_NATS_CA.
 	k3sNATSCAPath = "/etc/spinifex-eks/nats-ca.pem"
 
+	// k3sTokenWebhookKubeconfigPath is the apiserver token-webhook config the
+	// eks-token-webhook service (ordered `before k3s`) writes before the
+	// apiserver starts. Wired via the authentication-token-webhook-config-file
+	// apiserver arg so bearer tokens minted by `aws eks get-token` resolve
+	// through the webhook. Must match the webhook's EKS_WEBHOOK_KUBECONFIG default.
+	k3sTokenWebhookKubeconfigPath = "/etc/spinifex-eks/token-webhook.kubeconfig" //nolint:gosec // file path, not a credential
+
 	// k3sConfigPath is the K3s server config file cloud-init writes; K3s
 	// reads it at startup (overrides the AMI-baked config.yaml.skel).
 	k3sConfigPath = "/etc/rancher/k3s/config.yaml"
@@ -397,6 +404,8 @@ func buildK3sUserData(in K3sServerInput) string {
 		"  - service-account-issuer=" + in.OIDCIssuer,
 		"  - api-audiences=sts.amazonaws.com",
 		"  - anonymous-auth=true",
+		"  - authentication-token-webhook-config-file=" + k3sTokenWebhookKubeconfigPath,
+		"  - authentication-token-webhook-cache-ttl=5m",
 	}, "\n")
 
 	files := []userDataFile{

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -406,6 +406,9 @@ func buildK3sUserData(in K3sServerInput) string {
 		"  - anonymous-auth=true",
 		"  - authentication-token-webhook-config-file=" + k3sTokenWebhookKubeconfigPath,
 		"  - authentication-token-webhook-cache-ttl=5m",
+		// Pin v1 so the apiserver decodes the webhook's authentication.k8s.io/v1
+		// TokenReview response; the default v1beta1 rejects the GVK mismatch (401).
+		"  - authentication-token-webhook-version=v1",
 	}, "\n")
 
 	files := []userDataFile{

--- a/spinifex/handlers/eks/k3s_server_vm_test.go
+++ b/spinifex/handlers/eks/k3s_server_vm_test.go
@@ -297,6 +297,10 @@ func TestLaunchK3sServerVM_UserDataContainsAllArtifacts(t *testing.T) {
 	assert.NotContains(t, udata, "service-account-key-file="+k3sOIDCSigningKeyPath)
 	assert.Contains(t, udata, "service-account-issuer=https://oidc.spinifex.local/clusters/111122223333/alpha")
 	assert.Contains(t, udata, "api-audiences=sts.amazonaws.com")
+	// IAM bearer-token auth: the generated config overrides the AMI skel, so the
+	// token-webhook arg MUST be emitted here or `aws eks get-token` 401s with the
+	// webhook never invoked.
+	assert.Contains(t, udata, "authentication-token-webhook-config-file="+k3sTokenWebhookKubeconfigPath)
 
 	assert.Contains(t, udata, "path: "+k3sNATSCAPath)
 	assert.Contains(t, udata, "-----BEGIN CERTIFICATE-----")


### PR DESCRIPTION
## Sprint 6f — `aws eks update-kubeconfig` + GetToken (mulga-cs-eks-6f, GH #102)

Brings the IAM-backed `kubectl` auth chain live: `aws eks update-kubeconfig` builds a kubeconfig from `DescribeCluster` (CA + endpoint) with an `aws eks get-token` exec helper; `kubectl` then authenticates through the cluster's token webhook → Mulga STS → AccessEntry → TokenReview.

### Verified end-to-end against a live g1 cluster
```
$ kubectl get nodes
NAME                   STATUS   ROLES                       AGE   VERSION
spinifex-vm-...        Ready    control-plane,etcd,master   59s   v1.32.5+k3s1
$ kubectl auth whoami
Username  arn:aws:iam::000000000001:user/admin
Groups    [system:masters system:authenticated]
$ kubectl auth can-i '*' '*'
yes
```

### Three defects fixed (each independently produced a silent 401)
1. **Webhook authenticator not wired into the apiserver.** The daemon-generated `/etc/rancher/k3s/config.yaml` overrides the AMI-baked `config.yaml.skel`, but its `kube-apiserver-arg` list omitted `authentication-token-webhook-config-file`. The running apiserver never loaded the webhook → every bearer token 401'd without the webhook ever being invoked. Wired the arg (+ a guarding test).
2. **TokenReview missing `status.audiences`.** With `--api-audiences=sts.amazonaws.com`, the apiserver discards an `authenticated=true` response that does not confirm a matching audience. The webhook now echoes the request audiences on success.
3. **Webhook version mismatch.** `--authentication-token-webhook-version` defaults to `v1beta1`, but the webhook responds with `authentication.k8s.io/v1`. The apiserver rejected the GVK mismatch. Pinned `v1`.

### Plus: webhook observability
The eks-node AMI is headless (no SSH); routed the `eks-token-webhook` log to the serial console (host-captured) and added a per-request `TokenReview decision` audit line. This is what made the above diagnosable.

Preflight green.