### PR TITLE
ci: install kmod (depmod) before microVM image build (e2e + nightly + ddil)

### DIFF
--- a/.github/workflows/e2e-ddil.yml
+++ b/.github/workflows/e2e-ddil.yml
@@ -76,6 +76,14 @@ jobs:
           echo "${BIN_DIR}" >> "${GITHUB_PATH}"
           "${BIN_DIR}/gotestsum" --version
 
+      - name: Install kmod (depmod)
+        # build-microvm-image's mandatory-tool preflight requires depmod (from
+        # the kmod package); self-hosted runners don't ship it. Idempotent —
+        # no-op once baked into the runner/gold image.
+        run: |
+          command -v depmod >/dev/null 2>&1 || \
+            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
+
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster
         run: |

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -78,6 +78,15 @@ jobs:
           sparse-checkout: scripts/tofu-cluster
           path: mulga
 
+      - name: Install kmod (depmod)
+        if: steps.gate.outputs.selected == 'true'
+        # build-microvm-image's mandatory-tool preflight requires depmod (from
+        # the kmod package); self-hosted runners don't ship it. Idempotent —
+        # no-op once baked into the runner/gold image.
+        run: |
+          command -v depmod >/dev/null 2>&1 || \
+            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
+
       - name: Build Install Artifacts
         if: steps.gate.outputs.selected == 'true'
         working-directory: mulga/scripts/tofu-cluster

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -113,6 +113,14 @@ jobs:
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
 
+      - name: Install kmod (depmod)
+        # build-microvm-image's mandatory-tool preflight requires depmod (from
+        # the kmod package) to generate modules.dep; self-hosted runners don't
+        # ship it. Idempotent — no-op once baked into the runner/gold image.
+        run: |
+          command -v depmod >/dev/null 2>&1 || \
+            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
+
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster
         run: |
@@ -511,6 +519,14 @@ jobs:
           docker image prune -af || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
+
+      - name: Install kmod (depmod)
+        # build-microvm-image's mandatory-tool preflight requires depmod (from
+        # the kmod package) to generate modules.dep; self-hosted runners don't
+        # ship it. Idempotent — no-op once baked into the runner/gold image.
+        run: |
+          command -v depmod >/dev/null 2>&1 || \
+            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
 
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster
@@ -927,6 +943,14 @@ jobs:
           docker image prune -af || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
+
+      - name: Install kmod (depmod)
+        # build-microvm-image's mandatory-tool preflight requires depmod (from
+        # the kmod package) to generate modules.dep; self-hosted runners don't
+        # ship it. Idempotent — no-op once baked into the runner/gold image.
+        run: |
+          command -v depmod >/dev/null 2>&1 || \
+            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
 
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster


### PR DESCRIPTION
## Summary

Fixes the `dev` E2E failure (run 27091370925): jobs aborted at **Build Install Artifacts** with `ERROR: required tool not found: depmod`, before any suite ran.

#305 made `depmod` a hard requirement in `scripts/build-microvm-image.sh`, but the self-hosted `ci-single`/`ci-multi` runners don't ship the `kmod` package.

## Coverage audit

Every workflow that runs the depmod-requiring build (`make build-microvm-image`, via `build-install-artifacts.sh`) on a self-hosted runner:

| Workflow | Runner | Calls build-microvm-image | Action |
|---|---|---|---|
| `e2e.yml` | ci-single/multi/eks | yes (build-install-artifacts) | **guard added** (3 sites) |
| `e2e-nightly.yml` | ci-single/multi/pseudo | yes (build-install-artifacts) | **guard added** |
| `e2e-ddil.yml` | ci-multi | yes (build-install-artifacts) | **guard added** |
| `release.yml` distro | GitHub-hosted ubuntu | yes (`make build-microvm-image`) | no — GH images ship kmod |
| `e2e-baremetal.yml` | ci-baremetal | no (separate squashfs path) | no — runner already has kmod (green today) |

## Change

Idempotent `Install kmod (depmod)` step before each `Build Install Artifacts`:

```sh
command -v depmod >/dev/null 2>&1 || \
  { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
```

No-ops once `kmod` is present. Also baked into the gold image (mulga `image-builder/scripts/provision.sh`) so future-provisioned hosts have it.