### PR TITLE
ci: make microVM depmod best-effort, drop apt kmod install

### DIFF
--- a/.github/workflows/e2e-ddil.yml
+++ b/.github/workflows/e2e-ddil.yml
@@ -76,14 +76,6 @@ jobs:
           echo "${BIN_DIR}" >> "${GITHUB_PATH}"
           "${BIN_DIR}/gotestsum" --version
 
-      - name: Install kmod (depmod)
-        # build-microvm-image's mandatory-tool preflight requires depmod (from
-        # the kmod package); self-hosted runners don't ship it. Idempotent —
-        # no-op once baked into the runner/gold image.
-        run: |
-          command -v depmod >/dev/null 2>&1 || \
-            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
-
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster
         run: |

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -78,15 +78,6 @@ jobs:
           sparse-checkout: scripts/tofu-cluster
           path: mulga
 
-      - name: Install kmod (depmod)
-        if: steps.gate.outputs.selected == 'true'
-        # build-microvm-image's mandatory-tool preflight requires depmod (from
-        # the kmod package); self-hosted runners don't ship it. Idempotent —
-        # no-op once baked into the runner/gold image.
-        run: |
-          command -v depmod >/dev/null 2>&1 || \
-            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
-
       - name: Build Install Artifacts
         if: steps.gate.outputs.selected == 'true'
         working-directory: mulga/scripts/tofu-cluster

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -113,14 +113,6 @@ jobs:
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
 
-      - name: Install kmod (depmod)
-        # build-microvm-image's mandatory-tool preflight requires depmod (from
-        # the kmod package) to generate modules.dep; self-hosted runners don't
-        # ship it. Idempotent — no-op once baked into the runner/gold image.
-        run: |
-          command -v depmod >/dev/null 2>&1 || \
-            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
-
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster
         run: |
@@ -519,14 +511,6 @@ jobs:
           docker image prune -af || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
-
-      - name: Install kmod (depmod)
-        # build-microvm-image's mandatory-tool preflight requires depmod (from
-        # the kmod package) to generate modules.dep; self-hosted runners don't
-        # ship it. Idempotent — no-op once baked into the runner/gold image.
-        run: |
-          command -v depmod >/dev/null 2>&1 || \
-            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
 
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster
@@ -943,14 +927,6 @@ jobs:
           docker image prune -af || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
-
-      - name: Install kmod (depmod)
-        # build-microvm-image's mandatory-tool preflight requires depmod (from
-        # the kmod package) to generate modules.dep; self-hosted runners don't
-        # ship it. Idempotent — no-op once baked into the runner/gold image.
-        run: |
-          command -v depmod >/dev/null 2>&1 || \
-            { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends kmod; }
 
       - name: Build Install Artifacts
         working-directory: mulga/scripts/tofu-cluster

--- a/scripts/build-microvm-image.sh
+++ b/scripts/build-microvm-image.sh
@@ -33,7 +33,7 @@ mkdir -p "$BUILD_DIR"
 # faked-root environment so no real device node is ever created on the host
 # filesystem (which previously required sudo mknod and risked clobbering host
 # /dev/null on cleanup).
-for tool in cpio gzip find fakeroot depmod; do
+for tool in cpio gzip find fakeroot; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "ERROR: required tool not found: $tool" >&2
         exit 1
@@ -231,17 +231,26 @@ for kver_dir in "$CHROOT_DIR/lib/modules"/*/; do
     # host-kmod dependency entirely and the guest needs no decompressor either.
     find "$kernel_dir" -name "*.ko.gz" -exec gunzip -f {} +
 
-    # Regenerate module dependency map from the surviving modules. A usable
-    # modules.dep is mandatory: the guest init's load_mod() tries modprobe
-    # first, and busybox modprobe silently no-ops without it. Fail loudly here
-    # rather than ship an image that depends on init's insmod fallback alone.
-    if ! depmod -b "$CHROOT_DIR" "$kver"; then
-        echo "ERROR: depmod failed for $kver" >&2
-        exit 1
-    fi
-    if [ ! -s "$kver_dir/modules.dep" ]; then
-        echo "ERROR: ${kver_dir}modules.dep missing or empty after depmod" >&2
-        exit 1
+    # Regenerate the module dependency map when a host depmod is available. A
+    # populated modules.dep lets the guest init's load_mod() resolve modules via
+    # modprobe; without it, load_mod() falls back to insmod-by-path (see
+    # build/microvm/init.sh), so modules.dep is an optimisation, not a boot
+    # requirement. depmod (kmod) is absent on some self-hosted CI runners and
+    # cannot be apt-installed there — skip rather than hard-fail. When depmod
+    # IS present, still assert a non-empty result so the trixie-kmod-can't-read
+    # -compressed-modules bug (empty modules.dep from .ko.gz) fails loudly.
+    if command -v depmod >/dev/null 2>&1; then
+        if ! depmod -b "$CHROOT_DIR" "$kver"; then
+            echo "ERROR: depmod failed for $kver" >&2
+            exit 1
+        fi
+        if [ ! -s "$kver_dir/modules.dep" ]; then
+            echo "ERROR: ${kver_dir}modules.dep missing or empty after depmod" >&2
+            exit 1
+        fi
+    else
+        echo "[build-microvm-image] depmod not found; skipping modules.dep" \
+             "(guest init load_mod() will insmod modules by path)" >&2
     fi
 done
 


### PR DESCRIPTION
## Problem

PR #307 added inline `sudo apt-get install kmod` steps to e2e, e2e-nightly, and e2e-ddil so that `build-microvm-image.sh` could find `depmod`. Self-hosted runners can't reliably apt-install — "apt never works in CI".

## Insight

`modules.dep` (depmod output) is an **optimisation, not a boot requirement**. The guest init's `load_mod()` (`build/microvm/init.sh`) already falls back to insmod-by-path when modprobe can't resolve a module. So a missing `modules.dep` does not break boot.

## Change

- Drop `depmod` from the mandatory-tool preflight in `build-microvm-image.sh`.
- Run depmod **only when present**; still assert non-empty `modules.dep` in that case so the trixie-kmod empty-dep bug (#305) still fails loudly.
- Warn + skip when depmod is absent (guest uses insmod fallback).
- Remove the apt `kmod` install steps from all three workflows.

Gold-image bake still installs kmod (`provision.sh`), so production images get a proper `modules.dep`; only kmod-less CI runners take the fallback path.

## Testing

- `bash -n scripts/build-microvm-image.sh` ✓
- YAML parse of all three workflows ✓
- e2e run on this branch validates the kmod-less build path end-to-end.