### PR TITLE
fix(microvm): load virtio_net dependency chain in init (LB stuck provisioning)

### DIFF
--- a/build/microvm/init.sh
+++ b/build/microvm/init.sh
@@ -23,6 +23,14 @@ load_mod() {
     return 1
 }
 load_mod qemu_fw_cfg || load_mod fw_cfg_sysfs || true
+# virtio_net depends on net_failover, which depends on failover. The load_mod
+# insmod fallback loads a single .ko with no dependency resolution, and
+# modules.dep is absent when the image is built on a kmod-less host (depmod
+# skipped), so modprobe can't resolve the chain either. Load it explicitly
+# bottom-up so the NIC comes up regardless of how the image was built —
+# without this the agent has no network and the LB hangs in provisioning.
+load_mod failover || true
+load_mod net_failover || true
 load_mod virtio_net || true
 
 NETCFG=/sys/firmware/qemu_fw_cfg/by_name/opt/spinifex/netcfg/raw


### PR DESCRIPTION
## Symptom

Normal CI (single + multi-node) LB suite fails: every LB stuck `state=provisioning` for the full 5m timeout, `reason=` empty. Baremetal LB passes.

## Root cause

LB microVM console (run 27092542383):
```
[init] WARNING: no interface found for MAC 02:af:7e:ef:69:87 (NIC0), skipping
[init] WARNING: no interface found for MAC 02:c4:ff:67:9a:aa (NIC1), skipping
Agent started gateway=https://192.168.0.10:9999
ERROR Heartbeat failed ... dial tcp 192.168.0.10:9999: connect: network is unreachable
```

`virtio_net` never loaded → no NIC → agent has no network → heartbeat never reaches AWSGW → control plane never promotes `provisioning`→`active`.

`virtio_net` depends on `net_failover` → `failover`. `modprobe` resolves that via `modules.dep`; `load_mod()`'s insmod-by-path fallback loads a single `.ko` with **no dependency resolution**. On kmod-less CI runners `depmod` is skipped (#308) so `modules.dep` is absent and neither path resolves the chain — `virtio_net` fails. Baremetal ships kmod → `modules.dep` built → chain resolves → LB works there.

This is also why **internet-facing** LBs stalled too (same image, same missing NIC) — not a routing-specific regression.

## Fix

The image already keeps `failover`/`net_failover` in the strip keep-list. Load the chain explicitly bottom-up in init.sh (`failover` → `net_failover` → `virtio_net`) so the NIC comes up with or without `modules.dep`. Guest-only; no apt, no kmod, no build-toolchain dependency.

## Testing

- `sh -n build/microvm/init.sh` ✓
- e2e run on this branch (single + multi LB suite) — validates the kmod-less build path end-to-end.