### PR TITLE
feat(eks): default K3s built-in ingress ON until aws-lb-controller ships

### DIFF
--- a/spinifex/handlers/eks/create_cluster_test.go
+++ b/spinifex/handlers/eks/create_cluster_test.go
@@ -24,7 +24,7 @@ func createInput(name string) *eks.CreateClusterInput {
 	}
 }
 
-func TestCreateCluster_BuiltinIngressDefaultsOff(t *testing.T) {
+func TestCreateCluster_BuiltinIngressDefaultsOn(t *testing.T) {
 	f := newEKSServiceFixture(t)
 
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
@@ -32,7 +32,20 @@ func TestCreateCluster_BuiltinIngressDefaultsOff(t *testing.T) {
 
 	meta, err := GetClusterMeta(f.kv, "alpha")
 	require.NoError(t, err)
-	assert.False(t, meta.BuiltinIngress, "parity default: built-in ingress off")
+	assert.True(t, meta.BuiltinIngress, "interim default: built-in ingress on until aws-lb-controller ships")
+}
+
+func TestCreateCluster_BuiltinIngressOptOutFromTag(t *testing.T) {
+	f := newEKSServiceFixture(t)
+
+	in := createInput("alpha")
+	in.Tags = map[string]*string{managedIngressTagKey: aws.String("false")}
+	_, err := f.svc.CreateCluster(in, testAccountID, "")
+	require.NoError(t, err)
+
+	meta, err := GetClusterMeta(f.kv, "alpha")
+	require.NoError(t, err)
+	assert.False(t, meta.BuiltinIngress, "managed-ingress=false opts out for AWS parity")
 }
 
 func TestCreateCluster_BuiltinIngressFromTag(t *testing.T) {
@@ -45,7 +58,7 @@ func TestCreateCluster_BuiltinIngressFromTag(t *testing.T) {
 
 	meta, err := GetClusterMeta(f.kv, "alpha")
 	require.NoError(t, err)
-	assert.True(t, meta.BuiltinIngress, "managed-ingress tag opts into built-in ingress")
+	assert.True(t, meta.BuiltinIngress, "managed-ingress=true keeps built-in ingress")
 }
 
 // A create that fails after the NLB is provisioned must leave the NLB ARNs

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -137,10 +137,11 @@ type K3sServerInput struct {
 	SecretKey     string
 	GatewayCACert string
 	InstanceType  string
-	// BuiltinIngress keeps K3s' bundled traefik + servicelb enabled (dev /
-	// interim in-VPC app exposure). Default false disables them for AWS parity,
+	// BuiltinIngress keeps K3s' bundled traefik + servicelb enabled (interim
+	// in-VPC app exposure). When false the config disables them for AWS parity,
 	// where Service type=LoadBalancer / Ingress are satisfied by the AWS Load
-	// Balancer Controller instead.
+	// Balancer Controller instead. The CreateCluster default is ON until that
+	// controller ships (see managedIngressTagKey).
 	BuiltinIngress bool
 }
 

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -276,16 +276,18 @@ func logCreateErr(name, accountID, stage string, err error) error {
 	return fmt.Errorf("%s: %w", stage, err)
 }
 
-// managedIngressTagKey is the CreateCluster tag that opts a cluster into K3s'
-// bundled traefik + servicelb (dev / interim in-VPC app exposure). Value "true"
-// (case-insensitive) enables it; absent or any other value keeps AWS parity
-// (built-ins disabled, ingress via the AWS Load Balancer Controller).
+// managedIngressTagKey is the CreateCluster tag that controls K3s' bundled
+// traefik + servicelb (interim in-VPC app exposure). They are ON by default so
+// workloads are reachable before the AWS Load Balancer Controller add-on ships;
+// value "false" (case-insensitive) opts out for AWS parity. TODO: flip the
+// default back off (parity) once the aws-lb-controller add-on lands — see
+// docs/development/feature/eks-dataplane-ingress.md.
 const managedIngressTagKey = "spinifex.io/managed-ingress"
 
-// builtinIngressEnabled reports whether the CreateCluster tags opt into the K3s
-// built-in ingress stack.
+// builtinIngressEnabled reports whether a cluster keeps the K3s built-in ingress
+// stack. Default ON; the tag opts out with "false".
 func builtinIngressEnabled(tags map[string]*string) bool {
-	return strings.EqualFold(aws.StringValue(tags[managedIngressTagKey]), "true")
+	return !strings.EqualFold(aws.StringValue(tags[managedIngressTagKey]), "false")
 }
 
 func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID, callerPrincipalARN string) (*eks.CreateClusterOutput, error) {


### PR DESCRIPTION
Interim: flip `builtinIngressEnabled` to **default ON** so EKS workloads have a working ingress/servicelb path before the aws-load-balancer-controller add-on (mulga-siv-221) lands.

- Opt out per-cluster for AWS parity with CreateCluster tag `spinifex.io/managed-ingress=false`.
- Updated comments (`managedIngressTagKey`, `K3sServerInput.BuiltinIngress`) + tests (`TestCreateCluster_BuiltinIngressDefaultsOn`, `…OptOutFromTag`, `…FromTag`).
- **Revert when mulga-siv-219/221 land** — note added to docs/development/feature/eks-dataplane-ingress.md Phase 0 and bead mulga-siv-241 (related to 219/221).

Tracks mulga-siv-241. `make preflight` green.