### PR TITLE
fix(network): prime host neigh with external_mac on distributed EIP attach

### DIFF
--- a/spinifex/network/host/neigh.go
+++ b/spinifex/network/host/neigh.go
@@ -33,3 +33,31 @@ func FlushNeigh(ctx context.Context, runner Runner, dev, ip string) error {
 	}
 	return nil
 }
+
+// ReplaceNeigh installs (or overwrites) the kernel neighbour entry mapping ip to
+// mac on dev in NUD_REACHABLE state. Wraps `ip neigh replace <ip> lladdr <mac>
+// dev <dev> nud reachable`.
+//
+// This is the deterministic counterpart to FlushNeigh for EIP attach: when an
+// external IP is recycled onto a new owner, OVN advertises the new MAC only via
+// a GARP it emits on LSP binding-chassis migration — a same-chassis rebind
+// emits none, and `ovn-appctl inject-garp` is absent on older OVN builds, so no
+// node answers the host's re-ARP. Flushing then waits for an ARP reply that
+// never comes; programming the known external_mac directly skips the round-trip,
+// and inbound traffic refreshes the entry from there on.
+//
+// L0 method (ADR-0006 S2) — only network/host/ may shell out to host tools.
+// Best-effort: callers must treat errors as warnings, not failures.
+func ReplaceNeigh(ctx context.Context, runner Runner, dev, ip, mac string) error {
+	if dev == "" || ip == "" || mac == "" {
+		return fmt.Errorf("host.ReplaceNeigh: dev, ip and mac required")
+	}
+	if runner == nil {
+		runner = NewExecRunner()
+	}
+	out, err := runner.Run(ctx, "ip", "neigh", "replace", ip, "lladdr", mac, "dev", dev, "nud", "reachable")
+	if err != nil {
+		return fmt.Errorf("ip neigh replace %s lladdr %s dev %s: %s: %w", ip, mac, dev, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/spinifex/network/host/neigh_test.go
+++ b/spinifex/network/host/neigh_test.go
@@ -37,3 +37,37 @@ func TestFlushNeigh_PropagatesRunnerError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestReplaceNeigh_ShellOutShape(t *testing.T) {
+	r := &recordingRunner{}
+	if err := ReplaceNeigh(context.Background(), r, "br-wan", "192.168.0.231", "02:00:0a:d2:01:04"); err != nil {
+		t.Fatalf("ReplaceNeigh: %v", err)
+	}
+	if len(r.args) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(r.args))
+	}
+	got := strings.Join(r.args[0], " ")
+	want := "ip neigh replace 192.168.0.231 lladdr 02:00:0a:d2:01:04 dev br-wan nud reachable"
+	if got != want {
+		t.Fatalf("argv mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestReplaceNeigh_MissingArgs(t *testing.T) {
+	if err := ReplaceNeigh(context.Background(), &recordingRunner{}, "", "192.168.0.231", "02:00:0a:d2:01:04"); err == nil {
+		t.Fatal("expected error for empty dev")
+	}
+	if err := ReplaceNeigh(context.Background(), &recordingRunner{}, "br-wan", "", "02:00:0a:d2:01:04"); err == nil {
+		t.Fatal("expected error for empty ip")
+	}
+	if err := ReplaceNeigh(context.Background(), &recordingRunner{}, "br-wan", "192.168.0.231", ""); err == nil {
+		t.Fatal("expected error for empty mac")
+	}
+}
+
+func TestReplaceNeigh_PropagatesRunnerError(t *testing.T) {
+	r := &recordingRunner{out: []byte("Cannot find device \"br-wan\""), err: errors.New("exit 1")}
+	if err := ReplaceNeigh(context.Background(), r, "br-wan", "192.168.0.231", "02:00:0a:d2:01:04"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -91,6 +91,17 @@ type GARPEmitter func(EIPSpec) error
 // Best-effort: implementations return errors but callers warn and proceed.
 type NeighFlusher func(externalIP string) error
 
+// NeighPrimer installs the host neighbour entry for a distributed EIP directly,
+// mapping ExternalIP to its external_mac. Preferred over NeighFlusher on attach
+// when the MAC is known (distributed mode): a flush merely re-arms ARP, but on
+// OVN builds without inject-garp no node answers the host's re-ARP for a
+// same-chassis recycled IP, so the entry would just decay back to FAILED.
+// Programming the known MAC makes the recycled IP reachable without an ARP
+// round-trip.
+//
+// Best-effort: implementations return errors but callers warn and proceed.
+type NeighPrimer func(eip EIPSpec) error
+
 type Option func(*natManager)
 
 // WithFlowsBarrier injects the post-write flow-install barrier so callers
@@ -114,9 +125,10 @@ func WithGARPEmitter(g GARPEmitter) Option {
 	}
 }
 
-// WithNeighFlusher injects the host neighbour-flush hook fired on EIP attach and
-// detach. Without it, recycled external IPs rely solely on the GARPEmitter,
-// which is a no-op on OVN builds lacking inject-garp.
+// WithNeighFlusher injects the host neighbour-flush hook fired on EIP detach (and
+// on attach when the external_mac is unknown). Without it, recycled external IPs
+// rely solely on the GARPEmitter, which is a no-op on OVN builds lacking
+// inject-garp.
 func WithNeighFlusher(f NeighFlusher) Option {
 	return func(m *natManager) {
 		if f != nil {
@@ -125,12 +137,25 @@ func WithNeighFlusher(f NeighFlusher) Option {
 	}
 }
 
+// WithNeighPrimer injects the host neighbour-prime hook fired on EIP attach in
+// distributed mode (external_mac known). Preferred over the flusher there: it
+// programs the recycled IP's MAC directly instead of waiting on an ARP reply
+// that no node sends when inject-garp is unavailable.
+func WithNeighPrimer(p NeighPrimer) Option {
+	return func(m *natManager) {
+		if p != nil {
+			m.neighPrime = p
+		}
+	}
+}
+
 type natManager struct {
-	ovn     ovn.Client
-	mode    NATMode
-	barrier FlowsBarrier
-	garp    GARPEmitter
-	neigh   NeighFlusher
+	ovn        ovn.Client
+	mode       NATMode
+	barrier    FlowsBarrier
+	garp       GARPEmitter
+	neigh      NeighFlusher
+	neighPrime NeighPrimer
 }
 
 var _ NATManager = (*natManager)(nil)
@@ -142,11 +167,12 @@ func NewNATManager(client ovn.Client, mode NATMode, opts ...Option) (NATManager,
 		return nil, fmt.Errorf("NAT mode is unknown; resolve from host.Wiring.UplinkMode()")
 	}
 	m := &natManager{
-		ovn:     client,
-		mode:    mode,
-		barrier: func() error { return nil },
-		garp:    func(EIPSpec) error { return nil },
-		neigh:   func(string) error { return nil },
+		ovn:        client,
+		mode:       mode,
+		barrier:    func() error { return nil },
+		garp:       func(EIPSpec) error { return nil },
+		neigh:      func(string) error { return nil },
+		neighPrime: func(EIPSpec) error { return nil },
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -205,7 +231,15 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 	if err := m.garp(eip); err != nil {
 		slog.Warn("policy: AddEIP gratuitous-ARP emission failed", "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP, "err", err)
 	}
-	if err := m.neigh(eip.ExternalIP); err != nil {
+	// Distributed mode: the external_mac is known, so program the host
+	// neighbour entry directly instead of flushing and waiting on an ARP reply
+	// no node sends when inject-garp is unavailable. Fall back to a flush when
+	// the MAC is absent (centralised shape).
+	if distributed {
+		if err := m.neighPrime(eip); err != nil {
+			slog.Warn("policy: AddEIP neighbour prime failed", "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP, "err", err)
+		}
+	} else if err := m.neigh(eip.ExternalIP); err != nil {
 		slog.Warn("policy: AddEIP neighbour flush failed", "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP, "err", err)
 	}
 	return nil

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -140,38 +140,74 @@ func TestNATManager_AddEIP_GARP_FailureNonFatal(t *testing.T) {
 	assert.NotNil(t, findNAT(m, "dnat_and_snat", "10.0.0.5"), "NAT row must persist despite GARP failure")
 }
 
-func TestNATManager_NeighFlusher_FiresOnAddAndDelete(t *testing.T) {
+func TestNATManager_NeighPrime_OnDistributedAttach_FlushOnDetach(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()
 	seedRouter(t, m, "vpc-1")
+	var primed []EIPSpec
 	var flushed []string
-	nm, err := NewNATManager(m, NATModeDistributed, WithNeighFlusher(func(externalIP string) error {
-		flushed = append(flushed, externalIP)
-		return nil
+	nm, err := NewNATManager(m, NATModeDistributed,
+		WithNeighPrimer(func(eip EIPSpec) error {
+			primed = append(primed, eip)
+			return nil
+		}),
+		WithNeighFlusher(func(externalIP string) error {
+			flushed = append(flushed, externalIP)
+			return nil
+		}))
+	require.NoError(t, err)
+
+	spec := EIPSpec{
+		VPCID: "vpc-1", ExternalIP: "1.2.3.4", LogicalIP: "10.0.0.5",
+		PortName: "port-eni-abc", MAC: "aa:bb:cc:dd:ee:ff",
+	}
+	require.NoError(t, nm.AddEIP(ctx, spec))
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5"))
+
+	require.Equal(t, []EIPSpec{spec}, primed,
+		"distributed attach must prime the host neighbour with the external_mac, not flush")
+	assert.Equal(t, []string{"1.2.3.4"}, flushed,
+		"detach must still flush the released external IP")
+}
+
+func TestNATManager_NeighFlush_OnCentralizedAttach(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	var primed []EIPSpec
+	var flushed []string
+	nm, err := NewNATManager(m, NATModeCentralized,
+		WithNeighPrimer(func(eip EIPSpec) error {
+			primed = append(primed, eip)
+			return nil
+		}),
+		WithNeighFlusher(func(externalIP string) error {
+			flushed = append(flushed, externalIP)
+			return nil
+		}))
+	require.NoError(t, err)
+
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-1", ExternalIP: "1.2.3.4", LogicalIP: "10.0.0.5",
 	}))
+	assert.Empty(t, primed, "centralized attach has no external_mac to prime")
+	assert.Equal(t, []string{"1.2.3.4"}, flushed,
+		"centralized attach must fall back to a neighbour flush")
+}
+
+func TestNATManager_NeighHooks_FailureNonFatal(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	nm, err := NewNATManager(m, NATModeDistributed,
+		WithNeighPrimer(func(EIPSpec) error { return assert.AnError }),
+		WithNeighFlusher(func(string) error { return assert.AnError }))
 	require.NoError(t, err)
 
 	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
 		VPCID: "vpc-1", ExternalIP: "1.2.3.4", LogicalIP: "10.0.0.5",
 		PortName: "port-eni-abc", MAC: "aa:bb:cc:dd:ee:ff",
-	}))
-	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5"))
-	assert.Equal(t, []string{"1.2.3.4", "1.2.3.4"}, flushed,
-		"NeighFlusher must fire with the external IP on both attach and detach")
-}
-
-func TestNATManager_NeighFlusher_FailureNonFatal(t *testing.T) {
-	ctx := context.Background()
-	m := mock.New()
-	seedRouter(t, m, "vpc-1")
-	nm, err := NewNATManager(m, NATModeDistributed, WithNeighFlusher(func(string) error {
-		return assert.AnError
-	}))
-	require.NoError(t, err)
-
-	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
-		VPCID: "vpc-1", ExternalIP: "1.2.3.4", LogicalIP: "10.0.0.5",
-	}), "neigh flush failure must not propagate from AddEIP")
+	}), "neigh prime failure must not propagate from AddEIP")
 	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5"),
 		"neigh flush failure must not propagate from DeleteEIP")
 }

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -509,6 +509,7 @@ func launchService(cfg *Config) error {
 		policy.WithFlowsBarrier(waitForFlowsHV),
 		policy.WithGARPEmitter(injectGARPEmitter()),
 		policy.WithNeighFlusher(neighFlusher(wanBridge)),
+		policy.WithNeighPrimer(neighPrimer(wanBridge)),
 	)
 	if err != nil {
 		return fmt.Errorf("construct NAT manager: %w", err)
@@ -831,6 +832,23 @@ func neighFlusher(wanBridge string) policy.NeighFlusher {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		return host.FlushNeigh(ctx, nil, wanBridge, externalIP)
+	}
+}
+
+// neighPrimer builds the post-AddEIP host ARP-prime hook for distributed EIPs.
+// It programs the kernel neighbour entry for the external IP to the EIP's
+// external_mac on the Linux WAN bridge, so a recycled IP is reachable
+// immediately without an ARP reply — needed on OVN builds whose ovn-controller
+// lacks inject-garp and therefore never advertises the new MAC. No-op when
+// wanBridge or the MAC is unset.
+func neighPrimer(wanBridge string) policy.NeighPrimer {
+	return func(eip policy.EIPSpec) error {
+		if wanBridge == "" || eip.MAC == "" {
+			return nil
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return host.ReplaceNeigh(ctx, nil, wanBridge, eip.ExternalIP, eip.MAC)
 	}
 }
 


### PR DESCRIPTION
## Problem
E2E run [27113096181](https://github.com/mulgadc/spinifex/actions/runs/27113096181) (single-node eks suite) failed: `kubectl` → cluster endpoint `192.168.0.211:443: no route to host`. Control plane healthy; pure L2 — host neigh `FAILED`, route on-link.

Root cause: the runner's OVN build lacks the `inject-garp` appctl (`"inject-garp" is not a valid command` on every EIP attach). OVN advertises a recycled external IP's new MAC only via the GARP it emits on LSP **binding-chassis migration**; a same-chassis rebind emits none. The neigh-flush fix (`5d125cdb`) then re-arms ARP but no node answers, so the entry decays back to `FAILED`.

## Fix
In **distributed** mode the `external_mac` is known at attach, so program the host neighbour entry directly:
`ip neigh replace <ip> lladdr <mac> dev br-wan nud reachable`
No ARP round-trip; inbound TCP keeps the entry confirmed. Centralized attach (no MAC) and all detaches keep the existing flush. `inject-garp` stays best-effort for multi-host upstream caches.

- `host.ReplaceNeigh` (new) + `policy.NeighPrimer` hook, wired in `vpcd` via `neighPrimer(wanBridge)`.
- Unit tests: shell-out shape, distributed-prime-vs-detach-flush, centralized fallback, non-fatal failures.

## Verification
`make preflight` green. **Not** e2e-verified — needs the EIP-recycle scenario on an OVN build lacking inject-garp (the CI runner). Tracks mulga-siv-242.