### PR TITLE
ci(eks-ami): build on self-hosted ci-single runner

### DIFF
--- a/.github/workflows/publish-eks-ami.yml
+++ b/.github/workflows/publish-eks-ami.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   publish:
     name: Build + publish eks-node AMI
-    runs-on: ubuntu-24.04
+    runs-on: [ self-hosted, ci-single-1 ]
 
     steps:
       - name: Checkout Spinifex

--- a/.github/workflows/publish-eks-ami.yml
+++ b/.github/workflows/publish-eks-ami.yml
@@ -51,8 +51,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          cache-dependency-path: "spinifex/go.sum"
           go-version-file: "spinifex/go.mod"
+          # Self-hosted runner: the Go module + build cache already persists on
+          # local disk between runs. setup-go's cache-save ("Post Setup Go")
+          # otherwise re-uploads hundreds of MB to the Actions cache backend,
+          # taking longer than the build itself.
+          cache: false
 
       - name: Setup Go Workspace
         run: go work init ./spinifex ./viperblock ./predastore

--- a/.github/workflows/publish-eks-ami.yml
+++ b/.github/workflows/publish-eks-ami.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   publish:
     name: Build + publish eks-node AMI
-    runs-on: [ self-hosted, ci-single-1 ]
+    runs-on: [ self-hosted, ci-single ]
 
     steps:
       - name: Checkout Spinifex

--- a/scripts/build-system-image.sh
+++ b/scripts/build-system-image.sh
@@ -26,10 +26,11 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 export LIBGUESTFS_BACKEND="${LIBGUESTFS_BACKEND:-direct}"
 
 usage() {
-    echo "Usage: $0 <manifest.conf> [--import]"
+    echo "Usage: $0 <manifest.conf> [--import] [--no-cache]"
     echo ""
     echo "  manifest.conf  Path to image manifest (see scripts/images/ for examples)"
     echo "  --import       Import the built image as an AMI"
+    echo "  --no-cache     Always rebuild; ignore a recently-built cached raw"
     exit 1
 }
 
@@ -47,10 +48,12 @@ fi
 
 DO_IMPORT=false
 QUIET=false
+NO_CACHE=false
 for arg in "$@"; do
     case "$arg" in
-        --import) DO_IMPORT=true ;;
-        --quiet)  QUIET=true ;;
+        --import)   DO_IMPORT=true ;;
+        --quiet)    QUIET=true ;;
+        --no-cache) NO_CACHE=true ;;
     esac
 done
 
@@ -184,7 +187,9 @@ echo "Lock acquired"
 
 # If the raw image was built recently (< 10 min), skip the entire build.
 # This avoids duplicate work when concurrent CI jobs build the same image.
-if [[ -f "$OUTPUT_RAW" ]] && [[ $(( $(date +%s) - $(stat -c %Y "$OUTPUT_RAW") )) -lt 600 ]]; then
+# --no-cache (e.g. the publish path) forces a fresh build so a stale raw from
+# a prior/concurrent run on a persistent runner is never republished.
+if [[ "$NO_CACHE" == false ]] && [[ -f "$OUTPUT_RAW" ]] && [[ $(( $(date +%s) - $(stat -c %Y "$OUTPUT_RAW") )) -lt 600 ]]; then
     echo "=== Skipping build — $OUTPUT_RAW is fresh (< 10 min old) ==="
 
     # Restore stdout if suppressed, then jump to import

--- a/scripts/publish-system-image.sh
+++ b/scripts/publish-system-image.sh
@@ -89,7 +89,9 @@ fi
 
 if [[ "$DO_BUILD" == true ]]; then
     echo "=== Building ${IMAGE_NAME} ==="
-    "${SCRIPT_DIR}/build-system-image.sh" "$MANIFEST"
+    # --no-cache: publishing must never reuse a stale raw left by a prior or
+    # concurrent build on a persistent runner.
+    "${SCRIPT_DIR}/build-system-image.sh" "$MANIFEST" --no-cache
 fi
 
 if [[ ! -f "$RAW_IMAGE" ]]; then


### PR DESCRIPTION
GitHub-hosted ubuntu-24.04 can't run the libguestfs appliance network (passt PID-file denial + no SLIRP outbound), so `virt-customize --network` failed. Build on the self-hosted `ci-single` runner (KVM + real network) where the existing libguestfs flow works unmodified.

Also:
- `--no-cache` on the publish path so a stale raw is never republished on the persistent runner.
- `cache: false` on setup-go (Post Setup Go cache-save took ~2.5min vs 36s build; local disk already persists it).

Verified: dry-run build green on ci-single.