### PR TITLE
fix: resolve EIP NAT MAC from OVN LSP so all floating IPs survive reboot

### DIFF
--- a/spinifex/handlers/ec2/eip/service_impl.go
+++ b/spinifex/handlers/ec2/eip/service_impl.go
@@ -213,7 +213,6 @@ func (s *EIPServiceImpl) AssociateAddress(input *ec2.AssociateAddressInput, acco
 	record.InstanceId = instanceID
 	record.PrivateIp = privateIP
 	record.VpcId = vpcID
-	record.MacAddress = macAddr
 	record.State = "associated"
 
 	data, err := json.Marshal(record)
@@ -271,7 +270,6 @@ func (s *EIPServiceImpl) DisassociateAddress(input *ec2.DisassociateAddressInput
 	record.InstanceId = ""
 	record.PrivateIp = ""
 	record.VpcId = ""
-	record.MacAddress = ""
 	record.State = "allocated"
 
 	data, err := json.Marshal(record)

--- a/spinifex/handlers/ec2/eip/types.go
+++ b/spinifex/handlers/ec2/eip/types.go
@@ -9,20 +9,15 @@ const (
 
 // EIPRecord represents a stored Elastic IP address allocation.
 type EIPRecord struct {
-	AllocationId  string `json:"allocation_id"`
-	PublicIp      string `json:"public_ip"`
-	PoolName      string `json:"pool_name"`
-	AssociationId string `json:"association_id,omitempty"`
-	ENIId         string `json:"eni_id,omitempty"`
-	InstanceId    string `json:"instance_id,omitempty"`
-	PrivateIp     string `json:"private_ip,omitempty"`
-	// MacAddress is the associated ENI's MAC, captured at associate-time so
-	// the vpcd reconcile can re-apply the distributed-shape dnat_and_snat
-	// (external_mac/logical_port) after a host reboot without re-querying the
-	// ENI. Empty while the EIP is unassociated.
-	MacAddress string            `json:"mac_address,omitempty"`
-	VpcId      string            `json:"vpc_id,omitempty"`
-	State      string            `json:"state"` // "allocated", "associated"
-	Tags       map[string]string `json:"tags"`
-	CreatedAt  time.Time         `json:"created_at"`
+	AllocationId  string            `json:"allocation_id"`
+	PublicIp      string            `json:"public_ip"`
+	PoolName      string            `json:"pool_name"`
+	AssociationId string            `json:"association_id,omitempty"`
+	ENIId         string            `json:"eni_id,omitempty"`
+	InstanceId    string            `json:"instance_id,omitempty"`
+	PrivateIp     string            `json:"private_ip,omitempty"`
+	VpcId         string            `json:"vpc_id,omitempty"`
+	State         string            `json:"state"` // "allocated", "associated"
+	Tags          map[string]string `json:"tags"`
+	CreatedAt     time.Time         `json:"created_at"`
 }

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/mulgadc/spinifex/spinifex/network/ovn"
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
@@ -165,6 +166,25 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 			"spinifex:public_ip": eip.ExternalIP,
 		},
 	}
+
+	// Distributed dnat_and_snat binds per-chassis via the ENI's MAC + logical
+	// port. The authoritative MAC is the ENI port's port_security (ADR-0006
+	// I1/I2), so resolve it from OVN when the caller didn't supply one — this is
+	// what lets auto-assigned and ELBv2 floating IPs recover the distributed
+	// shape after a host reboot, not just store-backed EIPs. Resolving before
+	// the idempotency check also means a stale centralised row no longer matches
+	// the distributed predicate, forcing the delete-then-add upgrade.
+	if m.mode == NATModeDistributed && eip.PortName != "" && eip.MAC == "" {
+		if lsp, err := m.ovn.GetLogicalSwitchPort(ctx, eip.PortName); err != nil {
+			slog.Warn("policy: AddEIP MAC resolve failed — applying centralised shape",
+				"external_ip", eip.ExternalIP, "port", eip.PortName, "err", err)
+		} else if len(lsp.PortSecurity) > 0 {
+			if fields := strings.Fields(lsp.PortSecurity[0]); len(fields) > 0 {
+				eip.MAC = fields[0]
+			}
+		}
+	}
+
 	distributed := m.mode == NATModeDistributed && eip.PortName != "" && eip.MAC != ""
 	if distributed {
 		mac := eip.MAC

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -220,6 +220,39 @@ func TestNATManager_AddEIP_Distributed_SetsPortAndMAC(t *testing.T) {
 	assert.Equal(t, "aa:bb:cc:dd:ee:ff", *got.ExternalMAC)
 }
 
+func TestNATManager_AddEIP_Distributed_ResolvesMACFromLSP(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	// The ENI port carries the authoritative MAC in port_security. When the
+	// caller supplies no MAC (reconcile / auto-assigned / ELBv2 floating IP on
+	// host-reboot recovery), AddEIP must resolve it from there and still program
+	// the distributed shape.
+	require.NoError(t, m.CreateLogicalSwitch(ctx, &nbdb.LogicalSwitch{Name: "ls-subnet-1"}))
+	require.NoError(t, m.CreateLogicalSwitchPort(ctx, "ls-subnet-1", &nbdb.LogicalSwitchPort{
+		Name:         "port-eni-abc",
+		Addresses:    []string{"aa:bb:cc:dd:ee:ff 10.0.0.5"},
+		PortSecurity: []string{"aa:bb:cc:dd:ee:ff 10.0.0.5"},
+	}))
+	nm, err := NewNATManager(m, NATModeDistributed)
+	require.NoError(t, err)
+
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID:      "vpc-1",
+		ExternalIP: "1.2.3.4",
+		LogicalIP:  "10.0.0.5",
+		PortName:   "port-eni-abc",
+		// MAC intentionally empty — resolved from the LSP.
+	}))
+
+	got := findNAT(m, "dnat_and_snat", "10.0.0.5")
+	require.NotNil(t, got)
+	require.NotNil(t, got.ExternalMAC)
+	require.NotNil(t, got.LogicalPort)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", *got.ExternalMAC)
+	assert.Equal(t, "port-eni-abc", *got.LogicalPort)
+}
+
 func TestNATManager_AddEIP_Centralized_LeavesPortAndMACUnset(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()

--- a/spinifex/network/reconcile/intent.go
+++ b/spinifex/network/reconcile/intent.go
@@ -491,10 +491,9 @@ func loadEIPs(js nats.JetStreamContext, localVPCs map[string]struct{}, out map[s
 		if rec.ENIId != "" {
 			spec.PortName = topology.Port(rec.ENIId)
 		}
-		// MAC drives the distributed dnat_and_snat shape in policy.AddEIP; an
-		// empty MAC re-applies the rule centralised (external_mac/logical_port
-		// unset), which is the host-reboot connectivity regression this avoids.
-		spec.MAC = rec.MacAddress
+		// MAC is resolved from the ENI port's port_security in policy.AddEIP,
+		// uniformly for every public IP — see that function for the distributed
+		// dnat_and_snat shape and the host-reboot recovery it drives.
 		out[rec.PrivateIp] = spec
 	}
 	return nil


### PR DESCRIPTION
## Problem (mulga-siv-265)

Follow-up to #333. E2E Nightly run [27244177680](https://github.com/mulgadc/spinifex/actions/runs/27244177680) cell-18 `TestRebootResilience` failed: after a host reboot, OVN `dnat_and_snat` for **auto-assigned** public IPs and **ELBv2 floating** IPs reconverged to the centralised shape (`external_mac` empty), so all three external IPs (`.231/.232/.233`) went 100% unreachable north-south (`ALB post-reboot: 0/2 healthy`).

#333 fixed this only for store-backed Elastic IPs, by persisting the ENI MAC in `EIPRecord`. The reboot suite allocates no EIP, so that MAC-carrying path is bypassed.

## Root cause

`policy.AddEIP` enables the distributed shape only when `eip.MAC != ""`. For non-EIP public IPs the reconcile spec carried no MAC → `distributed=false` → idempotent-skip on a `LogicalIP+vpc` match → `external_mac` never programmed.

## Fix

The ENI MAC is **already authoritative in OVN** — the ENI port's `port_security` (`apply.go`, `manager_live.go`), per ADR-0006 I1/I2. So:

- `policy.AddEIP` resolves the MAC from `GetLogicalSwitchPort(eip.PortName).PortSecurity[0]` when the caller supplies none — uniformly for EIP, auto-assigned, and ELBv2 IPs. Resolving **before** the idempotency check also forces a stale centralised row to upgrade (delete-then-add) instead of skip.
- `reconcile.loadEIPs` no longer sources the MAC from `EIPRecord`.
- Removed the now-redundant `EIPRecord.MacAddress` field + its set/clear. The associate-time `vpc.add-nat` event still carries the MAC directly (fast path).

## Invariants (ADR-0006)

- S5 — L3/policy never create/delete OVN objects: `GetLogicalSwitchPort` is a read. `network/invariants/policy_no_create_test.go` green.
- I1/I2 — `port_security` MAC is authoritative: this reads that authority instead of duplicating it.
- S3/S9 unchanged.

## Testing

`make preflight` green (lint, vet, race, govulncheck, invariants). New unit `TestNATManager_AddEIP_Distributed_ResolvesMACFromLSP`. E2E: cell-18 reboot suite.