### PR TITLE
fix: persist EKS control-plane VM refs before egress alloc to prevent leak

### DIFF
--- a/spinifex/handlers/eks/create_cluster_test.go
+++ b/spinifex/handlers/eks/create_cluster_test.go
@@ -101,6 +101,46 @@ func TestCreateCluster_FailedCreateThenDeleteReclaimsNLB(t *testing.T) {
 	assert.ErrorIs(t, getErr, ErrClusterNotFound)
 }
 
+// A post-placement failure (egress allocation) must leave the just-launched
+// control-plane VM refs persisted in the FAILED meta. Otherwise the live
+// sys.medium VMs are unrecorded and neither DeleteCluster nor the FAILED-cluster
+// reclaim can reach them — they leak.
+func TestCreateCluster_EgressFailureLeavesControlPlaneRecorded(t *testing.T) {
+	f := newEKSServiceFixture(t)
+
+	// Placement succeeds and launches the CP VM, then egress allocation fails.
+	f.eip.allocateErr = errors.New("no addresses in hidden pool")
+
+	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
+	require.Error(t, err)
+	require.NotEmpty(t, f.inst.launchCalls, "control-plane VM was launched before the egress step")
+
+	meta, getErr := GetClusterMeta(f.kv, "alpha")
+	require.NoError(t, getErr, "meta must remain so the leaked CP VM has an owning record")
+	assert.Equal(t, ClusterStatusFailed, meta.Status)
+	assert.NotEmpty(t, meta.ControlPlaneInstanceID, "CP instance ID must be persisted before the egress step")
+	assert.NotEmpty(t, meta.ControlPlaneNodes, "CP node list must be persisted before the egress step")
+}
+
+// End-to-end: a create that fails at egress, then delete-cluster, must terminate
+// the control-plane VM the partial create launched — driven by the CP refs the
+// early persist recorded.
+func TestCreateCluster_EgressFailedThenDeleteTerminatesControlPlane(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	f.eip.allocateErr = errors.New("no addresses in hidden pool")
+
+	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
+	require.Error(t, err)
+	require.NotEmpty(t, f.inst.launchCalls, "create launched a CP VM")
+
+	_, err = f.svc.DeleteCluster(deleteInput("alpha"), testAccountID)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, f.inst.terminateCalls, "DeleteCluster must terminate the CP VM recorded by the failed create")
+	_, getErr := GetClusterMeta(f.kv, "alpha")
+	assert.ErrorIs(t, getErr, ErrClusterNotFound)
+}
+
 // A live (CREATING/ACTIVE) cluster of the same name blocks create with a
 // cluster-scoped ResourceInUseException, not the ELBv2 target-group message.
 func TestCreateCluster_ExistingClusterReturnsResourceInUse(t *testing.T) {

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -506,6 +506,16 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 	meta.ControlPlaneENIIP = primary.ENIIP
 	meta.ControlPlaneMgmtIP = primary.MgmtIP
 
+	// Persist the CP VM + ENI + spread-group refs now, before any further fallible
+	// step. The VMs are live the moment placeControlPlane returns; without this a
+	// failure between here and the next PutClusterMeta (e.g. egress allocation)
+	// leaves them launched but unrecorded, so neither DeleteCluster nor the
+	// FAILED-cluster reclaim could reach them and the sys.medium VMs leak.
+	if err := PutClusterMeta(acctKV, meta); err != nil {
+		s.markFailed(acctKV, name)
+		return nil, logCreateErr(name, accountID, "persist control-plane ids", err)
+	}
+
 	// Egress: the control-plane VM must pull container images. Allocate a
 	// hidden pool address and wire an egress-only SNAT for its /32 (no DNAT —
 	// the VM stays unreachable inbound; the NLB is its only front door).
@@ -523,11 +533,11 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 		ExternalIp: egressIP,
 	})
 
-	// Record the VM + ENI + egress IP before registering the target so a failed
-	// register (or anything after) leaves them recoverable by DeleteCluster.
+	// Record the egress allocation before registering the target so a failed
+	// register (or anything after) leaves it recoverable by DeleteCluster.
 	if err := PutClusterMeta(acctKV, meta); err != nil {
 		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "persist control-plane ids", err)
+		return nil, logCreateErr(name, accountID, "persist egress allocation", err)
 	}
 
 	cpENIIPs := make([]string, 0, len(cpNodes))


### PR DESCRIPTION
## Summary
CreateCluster set the control-plane VM/ENI/spread-group refs into the cluster meta but first persisted them to KV only **after** `allocateClusterEgressIP`. A failure between placement and that persist (egress alloc, NLB register, etc.) left the live `sys.medium` CP VMs unrecorded, so neither DeleteCluster nor the FAILED-cluster reclaim could reach them — they leaked and reserved host capacity (schedulableHosts decays 3->2->1, starving the HA path itself).

## Fix
Persist the meta immediately after `placeControlPlane` returns, before egress allocation. Because `purgeClusterInfra`/`teardownSpreadGroup` key off the persisted `ControlPlaneNodes` + `ControlPlaneSpreadGroup`, this also lets the FAILED-cluster reclaim free reserved spread capacity.

The all-or-nothing spread path was already safe (`rollbackControlPlaneSpread` terminates every launched VM); the single-CP fallback branches launch nothing before falling back. The persist-timing window was the remaining gap.

## Tests
- `TestCreateCluster_EgressFailureLeavesControlPlaneRecorded` — FAILED meta retains CP refs after a post-placement failure.
- `TestCreateCluster_EgressFailedThenDeleteTerminatesControlPlane` — failed create + delete terminates the recorded CP VM, sweeps meta.
- Negative control: both fail with the early persist removed.
- `make preflight` green.

## Follow-up (out of scope)
Corrupt-KV instances that reject TerminateInstances with InternalError still need a reconcile/sweep reaper — tracked under epic mulga-siv-267 (267.3/267.4).

Closes mulga-siv-267.2