### PR TITLE
fix: claim SB gateway-port chassis after host reboot (nudge ovn-controller)

### DIFF
--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -1,0 +1,54 @@
+package host
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
+)
+
+// GatewayClaimProber checks and repairs the Southbound chassis claim for OVN
+// gateway router ports by shelling out to ovn-sbctl / ovn-appctl. It backs the
+// reconcile.GatewayClaimVerifier interface; the compile-time check lives at the
+// wiring site (vpcd), since this host-layer package cannot import the reconcile
+// cross-cutter without re-tangling the layer tree.
+type GatewayClaimProber struct {
+	sbAddr string
+}
+
+// NewGatewayClaimProber returns a prober that queries the OVN Southbound DB at
+// sbAddr (empty uses the local default socket).
+func NewGatewayClaimProber(sbAddr string) *GatewayClaimProber {
+	return &GatewayClaimProber{sbAddr: sbAddr}
+}
+
+// GatewayPortClaimed reports whether the SB Port_Binding for lrpName has a
+// non-empty chassis. An unclaimed binding (chassis == []) means ovn-controller
+// has not installed flows for the gateway redirect, so the floating IPs behind
+// it are unreachable. ctx is part of the verifier contract; ovn-sbctl is a
+// short-lived local query and is not cancelled mid-flight.
+func (p *GatewayClaimProber) GatewayPortClaimed(_ context.Context, lrpName string) (bool, error) {
+	args := []string{"--no-leader-only"}
+	if p.sbAddr != "" {
+		args = append(args, "--db="+p.sbAddr)
+	}
+	args = append(args, "--bare", "--columns=chassis", "find", "Port_Binding", "logical_port="+lrpName)
+	// Output() not CombinedOutput(): sudo PAM audit noise on stderr would
+	// otherwise be read as a non-empty chassis value.
+	out, err := utils.SudoCommand("ovn-sbctl", args...).Output()
+	if err != nil {
+		return false, fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lrpName, err)
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+// NudgeRecompute asks the local ovn-controller to re-evaluate logical flows via
+// the incremental engine, forcing a re-claim of unbound Port_Bindings.
+func (p *GatewayClaimProber) NudgeRecompute(_ context.Context) error {
+	out, err := utils.SudoCommand("ovn-appctl", "-t", "ovn-controller", "inc-engine/recompute").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ovn-appctl recompute: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -4,10 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+)
+
+// Bounds for the post-rebind Southbound chassis-claim wait. A host reboot's SB
+// claim normally converges within a few seconds once ovn-controller reconnects;
+// the recompute nudge covers the stuck case. Package vars so tests can shorten.
+var (
+	gatewayClaimTimeout  = 30 * time.Second
+	gatewayClaimInterval = 2 * time.Second
 )
 
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
@@ -253,6 +262,53 @@ func (r *reconciler) rebindGatewayChassis(ctx context.Context, vpcID string) {
 		priority := max(20-(i*5), 1)
 		if err := r.ovn.SetGatewayChassis(ctx, gwPortName, chassis, priority); err != nil {
 			slog.Warn("reconcile/apply: SetGatewayChassis failed", "vpc_id", vpcID, "chassis", chassis, "err", err)
+		}
+	}
+	r.ensureGatewayClaimed(ctx, gwPortName)
+}
+
+// ensureGatewayClaimed drives the gateway port's Southbound Port_Binding to a
+// claimed chassis after SetGatewayChassis. SetGatewayChassis only asserts the
+// Northbound intent; after a host reboot ovn-controller can leave the SB binding
+// unclaimed, installing no flows for the centralised gateway redirect so every
+// floating IP on the VPC is unreachable. This polls the SB claim and, once,
+// nudges ovn-controller to recompute, then logs and returns on timeout rather
+// than blocking reconcile indefinitely. No-op when no verifier is wired (the
+// steady-state path is a single claimed check per gateway port per cycle).
+func (r *reconciler) ensureGatewayClaimed(ctx context.Context, gwPortName string) {
+	if r.gwClaim == nil {
+		return
+	}
+	deadline := time.Now().Add(gatewayClaimTimeout)
+	nudged := false
+	for {
+		claimed, err := r.gwClaim.GatewayPortClaimed(ctx, gwPortName)
+		if err != nil {
+			slog.Warn("reconcile/apply: gateway SB claim check failed", "port", gwPortName, "err", err)
+			return
+		}
+		if claimed {
+			if nudged {
+				slog.Info("reconcile/apply: gateway SB chassis claim converged after recompute", "port", gwPortName)
+			}
+			return
+		}
+		if !nudged {
+			slog.Warn("reconcile/apply: gateway SB binding unclaimed; nudging ovn-controller recompute", "port", gwPortName)
+			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
+				slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "port", gwPortName, "err", err)
+			}
+			nudged = true
+		}
+		if time.Now().After(deadline) {
+			slog.Error("reconcile/apply: gateway SB chassis claim did not converge; floating IPs may be unreachable",
+				"port", gwPortName, "timeout", gatewayClaimTimeout)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(gatewayClaimInterval):
 		}
 	}
 }

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -1,0 +1,137 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeClaimVerifier scripts a sequence of GatewayPortClaimed results and counts
+// NudgeRecompute calls. claimedAfter controls when the port flips to claimed:
+// once nudgeCount reaches it (or immediately for 0), claimed reports true.
+type fakeClaimVerifier struct {
+	claimedAfter int // nudges required before the port reports claimed; <0 never
+	checkErr     error
+	nudgeErr     error
+	checks       int
+	nudges       int
+}
+
+func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, _ string) (bool, error) {
+	f.checks++
+	if f.checkErr != nil {
+		return false, f.checkErr
+	}
+	if f.claimedAfter < 0 {
+		return false, nil
+	}
+	return f.nudges >= f.claimedAfter, nil
+}
+
+func (f *fakeClaimVerifier) NudgeRecompute(_ context.Context) error {
+	f.nudges++
+	return f.nudgeErr
+}
+
+func withFastClaimBounds(t *testing.T) {
+	t.Helper()
+	to, iv := gatewayClaimTimeout, gatewayClaimInterval
+	gatewayClaimTimeout = 200 * time.Millisecond
+	gatewayClaimInterval = 1 * time.Millisecond
+	t.Cleanup(func() { gatewayClaimTimeout, gatewayClaimInterval = to, iv })
+}
+
+func TestEnsureGatewayClaimed_NoVerifierIsNoop(t *testing.T) {
+	r := &reconciler{} // gwClaim nil
+	r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
+	// Reaching here without panic is the assertion.
+}
+
+func TestEnsureGatewayClaimed_AlreadyClaimedNoNudge(t *testing.T) {
+	withFastClaimBounds(t)
+	f := &fakeClaimVerifier{claimedAfter: 0}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
+
+	if f.nudges != 0 {
+		t.Errorf("claimed port nudged %d times, want 0", f.nudges)
+	}
+	if f.checks != 1 {
+		t.Errorf("checks = %d, want 1 (single claimed read)", f.checks)
+	}
+}
+
+func TestEnsureGatewayClaimed_NudgeThenConverge(t *testing.T) {
+	withFastClaimBounds(t)
+	// Unclaimed until one recompute nudge, then claimed.
+	f := &fakeClaimVerifier{claimedAfter: 1}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, then converge)", f.nudges)
+	}
+}
+
+func TestEnsureGatewayClaimed_NeverConvergesNudgesOnceThenGivesUp(t *testing.T) {
+	withFastClaimBounds(t)
+	f := &fakeClaimVerifier{claimedAfter: -1} // never claims
+	r := &reconciler{gwClaim: f}
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGatewayClaimed did not return within deadline; blocking reconcile")
+	}
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, do not spam)", f.nudges)
+	}
+	if f.checks < 2 {
+		t.Errorf("checks = %d, want >=2 (polled past the first nudge)", f.checks)
+	}
+}
+
+func TestEnsureGatewayClaimed_CheckErrorBailsOut(t *testing.T) {
+	withFastClaimBounds(t)
+	f := &fakeClaimVerifier{checkErr: errors.New("ovn-sbctl down")}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
+
+	if f.nudges != 0 {
+		t.Errorf("nudges = %d, want 0 (bail out on check error, do not nudge blindly)", f.nudges)
+	}
+}
+
+func TestEnsureGatewayClaimed_ContextCancelStops(t *testing.T) {
+	to, iv := gatewayClaimTimeout, gatewayClaimInterval
+	gatewayClaimTimeout = 10 * time.Second
+	gatewayClaimInterval = 50 * time.Millisecond
+	t.Cleanup(func() { gatewayClaimTimeout, gatewayClaimInterval = to, iv })
+
+	f := &fakeClaimVerifier{claimedAfter: -1}
+	r := &reconciler{gwClaim: f}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGatewayClaimed(ctx, "gw-vpc-a")
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGatewayClaimed ignored context cancellation")
+	}
+}

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -27,6 +27,23 @@ type Reconciler interface {
 	ReconcileApplyOnly(ctx context.Context, intent IntentState) error
 }
 
+// GatewayClaimVerifier confirms that ovn-controller has claimed the Southbound
+// Port_Binding for a gateway router port, and nudges a recompute when it has
+// not. After a host reboot the Northbound gateway_chassis intent can be correct
+// while the SB binding is left unclaimed — ovn-controller then installs no
+// logical flows for the centralised gateway redirect and the VPC's floating IPs
+// go dark. The reconciler runs this after SetGatewayChassis to drive the binding
+// to claimed. Implementations shell out to ovn-sbctl/ovn-appctl; the
+// compile-time check lives at the wiring site (vpcd) since the host
+// implementation cannot import this cross-cutter package.
+type GatewayClaimVerifier interface {
+	// GatewayPortClaimed reports whether the SB Port_Binding for lrpName has a
+	// non-empty chassis.
+	GatewayPortClaimed(ctx context.Context, lrpName string) (bool, error)
+	// NudgeRecompute asks the local ovn-controller to re-evaluate logical flows.
+	NudgeRecompute(ctx context.Context) error
+}
+
 // Config is the construction-time bag for the reconciler. All fields except
 // Chassis are required.
 type Config struct {
@@ -45,6 +62,10 @@ type Config struct {
 	NodeHostname string
 	// Chassis is the SBDB-discovered chassis list for gateway LRP rebinding.
 	Chassis []string
+	// GatewayClaim verifies/repairs the Southbound chassis claim for gateway
+	// ports after rebinding. Optional: nil skips the post-reboot claim check
+	// (focused reconcile tests leave it unset; production wires the host prober).
+	GatewayClaim GatewayClaimVerifier
 	// DNSServer is the OVN dhcp_options dns_server value ("{a, b}") emitted on
 	// subnet DHCPOptions rows. Empty falls back to the topology default, so the
 	// reconciler and live topology paths emit the same value (no drift).
@@ -62,6 +83,7 @@ type reconciler struct {
 	localAZ   string
 	host      string
 	chassis   []string
+	gwClaim   GatewayClaimVerifier
 	dnsServer string
 }
 
@@ -101,6 +123,7 @@ func New(cfg Config) (Reconciler, error) {
 		localAZ:   cfg.LocalAZ,
 		host:      cfg.NodeHostname,
 		chassis:   cfg.Chassis,
+		gwClaim:   cfg.GatewayClaim,
 		dnsServer: dnsServer,
 	}, nil
 }

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -87,6 +87,10 @@ func sudoCommand(name string, args ...string) *exec.Cmd {
 
 var serviceName = "vpcd"
 
+// host.GatewayClaimProber backs the reconciler's SB chassis-claim verifier; the
+// check lives here because host (L0) cannot import reconcile (cross-cutter).
+var _ reconcile.GatewayClaimVerifier = (*host.GatewayClaimProber)(nil)
+
 // BootstrapVPC holds the default VPC infrastructure IDs from spinifex.toml.
 // vpcd uses this to ensure OVN topology exists on first boot (before NATS KV
 // has any data) and on subsequent boots where OVN state may have been lost.
@@ -640,6 +644,7 @@ func launchService(cfg *Config) error {
 		LocalAZ:      cfg.AZ,
 		NodeHostname: holder,
 		Chassis:      chassisNames,
+		GatewayClaim: host.NewGatewayClaimProber(cfg.OVNSBAddr),
 		DNSServer:    pickDNSServer(cfg.ExternalPools),
 	})
 	if err != nil {


### PR DESCRIPTION
## Problem

cell-18 `TestRebootResilience` fails post-host-reboot: ALB targets never go healthy within 5m. RCA across runs 27250238163 + 27251769281 (via the reboot-suite heartbeat/OVN diagnostic, PR #337) pinned it:

- `ofproto/trace` for a floating IP **drops at br-int table 0** — no pipeline match.
- Every gateway/chassisredirect SB `Port_Binding.chassis` is **empty** (`gw-vpc-*`, `gw-port-vpc-*`).
- NB intent is **correct** (gateway_chassis set, dnat_and_snat rows present); vpcd re-asserted with the live chassis id; ovn-controller is up with tap flows installed (east-west works).
- All three floating IPs are 100% packet-loss from the host.

So ovn-controller, after a simultaneous controller+northd restart, never **re-claims** the existing gateway `Port_Binding`s → no logical→physical flows for the centralised gateway redirect → floating IPs dark. `rebindGatewayChassis` asserted NB intent but never verified the SB **claim** converged.

## Fix

After `SetGatewayChassis`, the reconciler now verifies the gateway port's SB `Port_Binding` has a non-empty chassis; if not, it nudges the local ovn-controller (`inc-engine/recompute`) and polls until the claim converges or a bounded deadline elapses (logs an error rather than blocking reconcile). Runs every drift cycle + at startup, so it self-heals on the 5-min tick even if startup missed it.

## Shape

- `reconcile.GatewayClaimVerifier` interface (consumer-side) — `GatewayPortClaimed` / `NudgeRecompute`. Optional Config field; nil = skip (reconcile stays NB-pure + mockable).
- `host.GatewayClaimProber` — exec impl (`ovn-sbctl find Port_Binding` / `ovn-appctl recompute`), wired in vpcd with the compile-time check (host L0 can't import the reconcile cross-cutter — ADR-0006 S1).
- No NB object create/delete (ADR-0006 S5). `make preflight` green (lint 0 issues, race, vet).
- Unit tests cover: no-verifier no-op, already-claimed no-nudge, nudge-then-converge, never-converges (nudge once, give up), check-error bail, context-cancel.

## Validation

The single-node live host can't reproduce (forwarding self-heals in ~1s). Confirmation is the next reboot-suite nightly: fix is good when post-reboot SB `Port_Binding.chassis` is non-empty for the gw port, `ofproto/trace` reaches a tap output, and host→FIP ping succeeds — all captured by `diag-ovn-flows.txt`.

Bead: mulga-siv-268. Diagnostic: PR #337.