### PR TITLE
fix(reconcile): demote post-reboot gateway SB claim verify to nudge-once + enrich diagnostic

### DIFF
--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -23,24 +23,48 @@ func NewGatewayClaimProber(sbAddr string) *GatewayClaimProber {
 	return &GatewayClaimProber{sbAddr: sbAddr}
 }
 
-// GatewayPortClaimed reports whether the SB Port_Binding for lrpName has a
-// non-empty chassis. An unclaimed binding (chassis == []) means ovn-controller
-// has not installed flows for the gateway redirect, so the floating IPs behind
-// it are unreachable. ctx is part of the verifier contract; ovn-sbctl is a
-// short-lived local query and is not cancelled mid-flight.
-func (p *GatewayClaimProber) GatewayPortClaimed(_ context.Context, lrpName string) (bool, error) {
-	args := []string{"--no-leader-only"}
-	if p.sbAddr != "" {
-		args = append(args, "--db="+p.sbAddr)
-	}
-	args = append(args, "--bare", "--columns=chassis", "find", "Port_Binding", "logical_port="+lrpName)
+// GatewayPortClaim reports whether the SB Port_Binding for lrpName looks claimed
+// by ovn-controller, and returns the raw row (logical_port/type/chassis/up/
+// requested_chassis) for diagnosis. claimed is keyed off a non-empty chassis
+// column; the detail string is logged by the caller so the true
+// claimed-vs-forwarding signal for this gateway shape can be confirmed from a
+// live run before the predicate is hardened. ctx is part of the verifier
+// contract; ovn-sbctl is a short-lived local query and is not cancelled
+// mid-flight.
+func (p *GatewayClaimProber) GatewayPortClaim(_ context.Context, lrpName string) (claimed bool, detail string, err error) {
 	// Output() not CombinedOutput(): sudo PAM audit noise on stderr would
-	// otherwise be read as a non-empty chassis value.
-	out, err := utils.SudoCommand("ovn-sbctl", args...).Output()
+	// otherwise pollute the parsed row.
+	out, err := utils.SudoCommand("ovn-sbctl", gatewayClaimArgs(p.sbAddr, lrpName)...).Output()
 	if err != nil {
-		return false, fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lrpName, err)
+		return false, "", fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lrpName, err)
 	}
-	return strings.TrimSpace(string(out)) != "", nil
+	detail = strings.TrimSpace(string(out))
+	return chassisClaimed(detail), detail, nil
+}
+
+// gatewayClaimArgs builds the ovn-sbctl argv that reads the gateway port's SB
+// Port_Binding row. sbAddr empty targets the local default socket.
+func gatewayClaimArgs(sbAddr, lrpName string) []string {
+	args := []string{"--no-leader-only"}
+	if sbAddr != "" {
+		args = append(args, "--db="+sbAddr)
+	}
+	return append(args, "--columns=logical_port,type,chassis,up,requested_chassis",
+		"find", "Port_Binding", "logical_port="+lrpName)
+}
+
+// chassisClaimed parses ovn-sbctl --columns output ("key : value" lines) and
+// reports whether the chassis column is a non-empty set.
+func chassisClaimed(row string) bool {
+	for line := range strings.SplitSeq(row, "\n") {
+		key, val, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(key) != "chassis" {
+			continue
+		}
+		val = strings.TrimSpace(val)
+		return val != "" && val != "[]"
+	}
+	return false
 }
 
 // NudgeRecompute asks the local ovn-controller to re-evaluate logical flows via

--- a/spinifex/network/host/gateway_claim_test.go
+++ b/spinifex/network/host/gateway_claim_test.go
@@ -1,0 +1,69 @@
+package host
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestGatewayClaimArgs(t *testing.T) {
+	base := []string{"--columns=logical_port,type,chassis,up,requested_chassis",
+		"find", "Port_Binding", "logical_port=gw-vpc-a"}
+
+	got := gatewayClaimArgs("", "gw-vpc-a")
+	want := append([]string{"--no-leader-only"}, base...)
+	if !slices.Equal(got, want) {
+		t.Errorf("no sbAddr: got %v, want %v", got, want)
+	}
+
+	got = gatewayClaimArgs("tcp:1.2.3.4:6642", "gw-vpc-a")
+	want = append([]string{"--no-leader-only", "--db=tcp:1.2.3.4:6642"}, base...)
+	if !slices.Equal(got, want) {
+		t.Errorf("with sbAddr: got %v, want %v", got, want)
+	}
+}
+
+func TestChassisClaimed(t *testing.T) {
+	tests := []struct {
+		name string
+		row  string
+		want bool
+	}{
+		{
+			name: "claimed single chassis",
+			row:  "logical_port        : gw-vpc-a\ntype                : l3gateway\nchassis             : 891a28a4-1111\nup                  : true\nrequested_chassis   : 891a28a4-1111",
+			want: true,
+		},
+		{
+			name: "unclaimed empty set",
+			row:  "logical_port        : gw-vpc-a\ntype                : l3gateway\nchassis             : []\nup                  : false\nrequested_chassis   : []",
+			want: false,
+		},
+		{
+			name: "unclaimed empty string",
+			row:  "chassis             : ",
+			want: false,
+		},
+		{
+			name: "no chassis column",
+			row:  "logical_port        : gw-vpc-a\ntype                : l3gateway",
+			want: false,
+		},
+		{
+			name: "empty row",
+			row:  "",
+			want: false,
+		},
+		{
+			name: "claimed amid other columns",
+			row:  "up                  : true\nchassis             : abc-def\ntype                : l3gateway",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chassisClaimed(tt.row); got != tt.want {
+				t.Errorf("chassisClaimed(%q) = %v, want %v", tt.row, got, tt.want)
+			}
+		})
+	}
+}

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -11,13 +11,10 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
-// Bounds for the post-rebind Southbound chassis-claim wait. A host reboot's SB
-// claim normally converges within a few seconds once ovn-controller reconnects;
-// the recompute nudge covers the stuck case. Package vars so tests can shorten.
-var (
-	gatewayClaimTimeout  = 30 * time.Second
-	gatewayClaimInterval = 2 * time.Second
-)
+// gatewayClaimRecheck is how long to wait after the recompute nudge before
+// re-reading the SB claim once. Best-effort: the nudge is the active repair;
+// the recheck only confirms/logs. Package var so tests can shorten.
+var gatewayClaimRecheck = 3 * time.Second
 
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
 // routers are left alone.
@@ -267,49 +264,54 @@ func (r *reconciler) rebindGatewayChassis(ctx context.Context, vpcID string) {
 	r.ensureGatewayClaimed(ctx, gwPortName)
 }
 
-// ensureGatewayClaimed drives the gateway port's Southbound Port_Binding to a
-// claimed chassis after SetGatewayChassis. SetGatewayChassis only asserts the
+// ensureGatewayClaimed best-effort repairs the gateway port's Southbound
+// Port_Binding after SetGatewayChassis. SetGatewayChassis only asserts the
 // Northbound intent; after a host reboot ovn-controller can leave the SB binding
-// unclaimed, installing no flows for the centralised gateway redirect so every
-// floating IP on the VPC is unreachable. This polls the SB claim and, once,
-// nudges ovn-controller to recompute, then logs and returns on timeout rather
-// than blocking reconcile indefinitely. No-op when no verifier is wired (the
-// steady-state path is a single claimed check per gateway port per cycle).
+// unclaimed, installing no flows for the centralised gateway redirect so the
+// VPC's floating IPs are unreachable. When the binding looks unclaimed this
+// nudges ovn-controller to recompute exactly once and re-reads after a short
+// delay — the nudge is the active repair; the re-read only confirms and logs.
+// The raw Port_Binding row is logged both times so the true
+// claimed-vs-forwarding signal for this gateway shape can be confirmed from a
+// live run before the predicate is hardened. No spin, no fatal: a still-
+// unconfirmed claim is a single WARN, not a blocking error. No-op when no
+// verifier is wired.
 func (r *reconciler) ensureGatewayClaimed(ctx context.Context, gwPortName string) {
 	if r.gwClaim == nil {
 		return
 	}
-	deadline := time.Now().Add(gatewayClaimTimeout)
-	nudged := false
-	for {
-		claimed, err := r.gwClaim.GatewayPortClaimed(ctx, gwPortName)
-		if err != nil {
-			slog.Warn("reconcile/apply: gateway SB claim check failed", "port", gwPortName, "err", err)
-			return
-		}
-		if claimed {
-			if nudged {
-				slog.Info("reconcile/apply: gateway SB chassis claim converged after recompute", "port", gwPortName)
-			}
-			return
-		}
-		if !nudged {
-			slog.Warn("reconcile/apply: gateway SB binding unclaimed; nudging ovn-controller recompute", "port", gwPortName)
-			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
-				slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "port", gwPortName, "err", err)
-			}
-			nudged = true
-		}
-		if time.Now().After(deadline) {
-			slog.Error("reconcile/apply: gateway SB chassis claim did not converge; floating IPs may be unreachable",
-				"port", gwPortName, "timeout", gatewayClaimTimeout)
-			return
-		}
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(gatewayClaimInterval):
-		}
+	claimed, detail, err := r.gwClaim.GatewayPortClaim(ctx, gwPortName)
+	if err != nil {
+		slog.Warn("reconcile/apply: gateway SB claim check failed", "port", gwPortName, "err", err)
+		return
+	}
+	slog.Debug("reconcile/apply: gateway SB claim", "port", gwPortName, "claimed", claimed, "binding", detail)
+	if claimed {
+		return
+	}
+
+	slog.Warn("reconcile/apply: gateway SB binding unclaimed; nudging ovn-controller recompute",
+		"port", gwPortName, "binding", detail)
+	if nerr := r.gwClaim.NudgeRecompute(ctx); nerr != nil {
+		slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "port", gwPortName, "err", nerr)
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(gatewayClaimRecheck):
+	}
+
+	claimed, detail, err = r.gwClaim.GatewayPortClaim(ctx, gwPortName)
+	switch {
+	case err != nil:
+		slog.Warn("reconcile/apply: gateway SB claim recheck failed", "port", gwPortName, "err", err)
+	case claimed:
+		slog.Info("reconcile/apply: gateway SB chassis claim converged after recompute", "port", gwPortName)
+	default:
+		slog.Warn("reconcile/apply: gateway SB claim unconfirmed after recompute (verify signal may differ for this gateway shape)",
+			"port", gwPortName, "binding", detail)
 	}
 }
 

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -7,26 +7,27 @@ import (
 	"time"
 )
 
-// fakeClaimVerifier scripts a sequence of GatewayPortClaimed results and counts
-// NudgeRecompute calls. claimedAfter controls when the port flips to claimed:
-// once nudgeCount reaches it (or immediately for 0), claimed reports true.
+// fakeClaimVerifier scripts GatewayPortClaim results and counts NudgeRecompute
+// calls. claimedAfter controls when the port flips to claimed: once nudges
+// reaches it (or immediately for 0), claimed reports true; <0 never claims.
 type fakeClaimVerifier struct {
-	claimedAfter int // nudges required before the port reports claimed; <0 never
+	claimedAfter int
 	checkErr     error
 	nudgeErr     error
 	checks       int
 	nudges       int
 }
 
-func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, _ string) (bool, error) {
+func (f *fakeClaimVerifier) GatewayPortClaim(_ context.Context, _ string) (bool, string, error) {
 	f.checks++
 	if f.checkErr != nil {
-		return false, f.checkErr
+		return false, "", f.checkErr
 	}
 	if f.claimedAfter < 0 {
-		return false, nil
+		return false, "chassis : []", nil
 	}
-	return f.nudges >= f.claimedAfter, nil
+	claimed := f.nudges >= f.claimedAfter
+	return claimed, "chassis : []", nil
 }
 
 func (f *fakeClaimVerifier) NudgeRecompute(_ context.Context) error {
@@ -36,10 +37,9 @@ func (f *fakeClaimVerifier) NudgeRecompute(_ context.Context) error {
 
 func withFastClaimBounds(t *testing.T) {
 	t.Helper()
-	to, iv := gatewayClaimTimeout, gatewayClaimInterval
-	gatewayClaimTimeout = 200 * time.Millisecond
-	gatewayClaimInterval = 1 * time.Millisecond
-	t.Cleanup(func() { gatewayClaimTimeout, gatewayClaimInterval = to, iv })
+	orig := gatewayClaimRecheck
+	gatewayClaimRecheck = 1 * time.Millisecond
+	t.Cleanup(func() { gatewayClaimRecheck = orig })
 }
 
 func TestEnsureGatewayClaimed_NoVerifierIsNoop(t *testing.T) {
@@ -59,44 +59,47 @@ func TestEnsureGatewayClaimed_AlreadyClaimedNoNudge(t *testing.T) {
 		t.Errorf("claimed port nudged %d times, want 0", f.nudges)
 	}
 	if f.checks != 1 {
-		t.Errorf("checks = %d, want 1 (single claimed read)", f.checks)
+		t.Errorf("checks = %d, want 1 (single claimed read, no recheck)", f.checks)
 	}
 }
 
-func TestEnsureGatewayClaimed_NudgeThenConverge(t *testing.T) {
+func TestEnsureGatewayClaimed_NudgeOnceThenConverge(t *testing.T) {
 	withFastClaimBounds(t)
-	// Unclaimed until one recompute nudge, then claimed.
+	// Unclaimed on first read, claimed after the single recompute nudge.
 	f := &fakeClaimVerifier{claimedAfter: 1}
 	r := &reconciler{gwClaim: f}
 
 	r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
 
 	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (nudge once, then converge)", f.nudges)
+		t.Errorf("nudges = %d, want exactly 1", f.nudges)
+	}
+	if f.checks != 2 {
+		t.Errorf("checks = %d, want 2 (initial read + one recheck)", f.checks)
 	}
 }
 
-func TestEnsureGatewayClaimed_NeverConvergesNudgesOnceThenGivesUp(t *testing.T) {
+func TestEnsureGatewayClaimed_NeverConvergesNudgesOnceNoSpin(t *testing.T) {
 	withFastClaimBounds(t)
 	f := &fakeClaimVerifier{claimedAfter: -1} // never claims
-	r := &reconciler{gwClaim: f}
 
 	done := make(chan struct{})
 	go func() {
+		r := &reconciler{gwClaim: f}
 		r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
 		close(done)
 	}()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("ensureGatewayClaimed did not return within deadline; blocking reconcile")
+		t.Fatal("ensureGatewayClaimed spun; must nudge once + recheck once and return")
 	}
 
 	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (nudge once, do not spam)", f.nudges)
+		t.Errorf("nudges = %d, want exactly 1 (no spin, no repeated nudges)", f.nudges)
 	}
-	if f.checks < 2 {
-		t.Errorf("checks = %d, want >=2 (polled past the first nudge)", f.checks)
+	if f.checks != 2 {
+		t.Errorf("checks = %d, want exactly 2 (initial read + one recheck, no loop)", f.checks)
 	}
 }
 
@@ -112,11 +115,25 @@ func TestEnsureGatewayClaimed_CheckErrorBailsOut(t *testing.T) {
 	}
 }
 
+func TestEnsureGatewayClaimed_NudgeErrorReturnsNoRecheck(t *testing.T) {
+	withFastClaimBounds(t)
+	f := &fakeClaimVerifier{claimedAfter: -1, nudgeErr: errors.New("ovn-appctl down")}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayClaimed(context.Background(), "gw-vpc-a")
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want 1", f.nudges)
+	}
+	if f.checks != 1 {
+		t.Errorf("checks = %d, want 1 (nudge failed → no recheck)", f.checks)
+	}
+}
+
 func TestEnsureGatewayClaimed_ContextCancelStops(t *testing.T) {
-	to, iv := gatewayClaimTimeout, gatewayClaimInterval
-	gatewayClaimTimeout = 10 * time.Second
-	gatewayClaimInterval = 50 * time.Millisecond
-	t.Cleanup(func() { gatewayClaimTimeout, gatewayClaimInterval = to, iv })
+	orig := gatewayClaimRecheck
+	gatewayClaimRecheck = 10 * time.Second // long, so cancel wins the recheck wait
+	t.Cleanup(func() { gatewayClaimRecheck = orig })
 
 	f := &fakeClaimVerifier{claimedAfter: -1}
 	r := &reconciler{gwClaim: f}
@@ -132,6 +149,6 @@ func TestEnsureGatewayClaimed_ContextCancelStops(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("ensureGatewayClaimed ignored context cancellation")
+		t.Fatal("ensureGatewayClaimed ignored context cancellation during recheck wait")
 	}
 }

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -37,9 +37,10 @@ type Reconciler interface {
 // compile-time check lives at the wiring site (vpcd) since the host
 // implementation cannot import this cross-cutter package.
 type GatewayClaimVerifier interface {
-	// GatewayPortClaimed reports whether the SB Port_Binding for lrpName has a
-	// non-empty chassis.
-	GatewayPortClaimed(ctx context.Context, lrpName string) (bool, error)
+	// GatewayPortClaim reports whether the SB Port_Binding for lrpName looks
+	// claimed by ovn-controller, plus a raw detail string (the Port_Binding row)
+	// the caller logs for diagnosis.
+	GatewayPortClaim(ctx context.Context, lrpName string) (claimed bool, detail string, err error)
 	// NudgeRecompute asks the local ovn-controller to re-evaluate logical flows.
 	NudgeRecompute(ctx context.Context) error
 }


### PR DESCRIPTION
Follow-up to #339.

#339 added an SB Port_Binding chassis-claim verify after `rebindGatewayChassis` with a 30s×N poll + ERROR on non-convergence. CI run `27253185469` showed the recompute **nudge** restores centralised-gateway forwarding (0/2 → 2/2 healthy, both backends served), but the **verify predicate false-negatives** for this gateway shape: no chassisredirect port exists, and `ovn-sbctl find Port_Binding ... --columns=chassis` reads empty even while forwarding works. Result: 90s wasted spin + false ERROR logs on a healthy dataplane.

## Change
- Demote `ensureGatewayClaimed` to **nudge ovn-controller recompute once**, single ~3s recheck, **WARN** (not ERROR) if still unconfirmed — no 30s×N spin.
- Enrich the SB query to dump `logical_port/type/chassis/up/requested_chassis` so the next reboot-suite run reveals the correct claimed-vs-forwarding signal before the predicate is hardened.
- Extract `gatewayClaimArgs` + add `chassisClaimed`/`gatewayClaimArgs` unit coverage.

The recompute nudge — the mechanism proven to restore forwarding — is unchanged. Only the verify/log behaviour is corrected.

ADR-0006: re-asserts existing NB bindings + reads/nudges SB/controller; no NB object create/delete (S5 respected).

Validation: single-node host can't repro (recovers forwarding too fast); next reboot-suite nightly is the read-out via the enriched diagnostic.