### PR TITLE
fix: async platform create handlers to stop responder starvation (mulga-siv-267.4)

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2304,7 +2304,9 @@ func (rm *ResourceManager) initSubscriptions(nc *nats.Conn, handler nats.MsgHand
 // node that processed the upstream CreateLoadBalancer call.
 //
 // NATS only routes requests to nodes whose subscription is live, so capacity
-// pressure naturally re-distributes load when a host fills up.
+// pressure on the queue (anycast) subject naturally re-distributes load when a
+// host fills up. The node-targeted (unicast) subject is deliberately exempt
+// from that gating — see the per-subject rationale below.
 func (rm *ResourceManager) updateInstanceSubscriptions() {
 	if rm.natsConn == nil {
 		return
@@ -2349,9 +2351,20 @@ func (rm *ResourceManager) updateInstanceSubscriptions() {
 		}
 
 		if rm.nodeID != "" {
+			// The node-targeted (unicast) launch subject stays subscribed for any
+			// type this node can ever host, independent of current free capacity.
+			// Unlike the queue (anycast) subject above — where dropping the
+			// subscription when full lets NATS reroute the launch to a node with
+			// room — a node-targeted request names THIS node specifically (a
+			// committed spread/placement reservation, e.g. an EKS HA control-plane
+			// leg). If the subscription were torn down under capacity pressure that
+			// request would fail with 'no responders' instead of reaching the
+			// daemon, even when the reserved slot is still good. Capacity is
+			// enforced at launch time by allocate(), which rejects an over-capacity
+			// launch with an insufficient-capacity error the caller can act on.
+			// Subscribe once when the type first fits; never drop it on capacity.
 			nodeTopic := fmt.Sprintf("%s.%s.%s", subjectRoot, typeName, rm.nodeID)
-			_, nodeSubscribed := rm.instanceSubs[nodeTopic]
-			if canFit && !nodeSubscribed {
+			if _, nodeSubscribed := rm.instanceSubs[nodeTopic]; canFit && !nodeSubscribed {
 				sub, err := rm.natsConn.Subscribe(nodeTopic, handler)
 				if err != nil {
 					slog.Error("Failed to subscribe to node-specific topic", "topic", nodeTopic, "err", err)
@@ -2359,12 +2372,6 @@ func (rm *ResourceManager) updateInstanceSubscriptions() {
 				}
 				rm.instanceSubs[nodeTopic] = sub
 				slog.Debug("Subscribed to node-specific instance type", "topic", nodeTopic)
-			} else if !canFit && nodeSubscribed {
-				if err := rm.instanceSubs[nodeTopic].Unsubscribe(); err != nil {
-					slog.Error("Failed to unsubscribe from node-specific topic", "topic", nodeTopic, "err", err)
-				}
-				delete(rm.instanceSubs, nodeTopic)
-				slog.Info("Unsubscribed from node-specific instance type (capacity full)", "topic", nodeTopic)
 			}
 		}
 	}

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -156,6 +156,14 @@ type Daemon struct {
 	cancel                context.CancelFunc
 	shutdownWg            sync.WaitGroup
 
+	// systemDispatchWg tracks in-flight host-pinned system.LaunchInstance /
+	// system.TerminateInstance handlers. Each request runs in its own goroutine
+	// so a long VM boot never head-of-line blocks the responder's subscription
+	// (267.4). Not awaited at shutdown — these are request-scoped and the reply
+	// is bounded by the requester's timeout; the WaitGroup exists so tests can
+	// deterministically await dispatch completion.
+	systemDispatchWg sync.WaitGroup
+
 	// vmMgr owns the in-memory map of VMs running on this node.
 	vmMgr *vm.Manager
 

--- a/spinifex/daemon/daemon_system_dispatch.go
+++ b/spinifex/daemon/daemon_system_dispatch.go
@@ -37,7 +37,27 @@ type systemInstanceTerminateEnvelope struct {
 // subscription is hit) runs LaunchSystemInstance locally and the resulting
 // VM stays bound to this node — see handleSystemTerminateInstance for the
 // matching teardown path.
+//
+// The launch runs in its own goroutine so the subscription's delivery goroutine
+// returns immediately: a multi-minute VM boot must not head-of-line block the
+// host-pinned launch subject, or concurrent launches to the same node fail with
+// 'no responders' even though the daemon is up (267.4). The NATS request/reply
+// contract is preserved — the goroutine responds with the launch result.
 func (d *Daemon) handleSystemLaunchInstance(msg *nats.Msg) {
+	d.systemDispatchWg.Go(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("system.LaunchInstance: handler panic", "subject", msg.Subject, "panic", r)
+				respondWithSystemLaunchError(msg, awserrors.ErrorServerInternal)
+			}
+		}()
+		d.serveSystemLaunchInstance(msg)
+	})
+}
+
+// serveSystemLaunchInstance is the synchronous body of handleSystemLaunchInstance,
+// run on a per-request goroutine.
+func (d *Daemon) serveSystemLaunchInstance(msg *nats.Msg) {
 	input := new(handlers_elbv2.SystemInstanceInput)
 	if err := json.Unmarshal(msg.Data, input); err != nil {
 		slog.Error("system.LaunchInstance: invalid JSON payload", "subject", msg.Subject, "err", err)
@@ -138,7 +158,24 @@ func (d *Daemon) subscribeSystemTerminateLocked(instanceID string) error {
 // handleSystemTerminateInstance is the NATS subscriber for
 // system.TerminateInstance.{instanceID}. Only the daemon that owns the VM
 // has a subscription on this subject — other daemons never see the request.
+//
+// Like the launch path, teardown runs in its own goroutine so a slow terminate
+// never head-of-line blocks the responder (267.4).
 func (d *Daemon) handleSystemTerminateInstance(msg *nats.Msg) {
+	d.systemDispatchWg.Go(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("system.TerminateInstance: handler panic", "subject", msg.Subject, "panic", r)
+				respondWithSystemTerminateError(msg, awserrors.ErrorServerInternal)
+			}
+		}()
+		d.serveSystemTerminateInstance(msg)
+	})
+}
+
+// serveSystemTerminateInstance is the synchronous body of
+// handleSystemTerminateInstance, run on a per-request goroutine.
+func (d *Daemon) serveSystemTerminateInstance(msg *nats.Msg) {
 	// Subject suffix is the instance ID; payload is unused but reserved for
 	// future flags. Tolerate empty payloads.
 	parts := splitSubjectTail(msg.Subject, "system.TerminateInstance.")

--- a/spinifex/daemon/daemon_system_dispatch_test.go
+++ b/spinifex/daemon/daemon_system_dispatch_test.go
@@ -355,6 +355,100 @@ func TestLaunchSystemInstanceOnNode_RemoteWithoutConn(t *testing.T) {
 	require.Error(t, err, "remote placement requires a NATS connection")
 }
 
+// TestHandleSystemLaunchInstance_PanicRecovered drives a valid launch against a
+// daemon with no resourceMgr so LaunchSystemInstance nil-derefs. The per-request
+// goroutine must recover the panic, reply with an error, and drain the dispatch
+// WaitGroup — a panic in a detached launch must never crash the daemon (267.4).
+func TestHandleSystemLaunchInstance_PanicRecovered(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	d := &Daemon{natsConn: nc, natsSubscriptions: make(map[string]*nats.Subscription)}
+
+	replyCh := make(chan []byte, 1)
+	sub, err := nc.Subscribe("test.launch.panic.reply", func(msg *nats.Msg) { replyCh <- msg.Data })
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	payload, err := json.Marshal(&handlers_elbv2.SystemInstanceInput{InstanceType: "sys.medium"})
+	require.NoError(t, err)
+	msg := msgWithConn(nc, &nats.Msg{
+		Subject: "system.LaunchInstance.sys.medium",
+		Reply:   "test.launch.panic.reply",
+		Sub:     sub,
+		Data:    payload,
+	})
+
+	d.handleSystemLaunchInstance(msg)
+
+	select {
+	case data := <-replyCh:
+		var env struct {
+			Error string `json:"error,omitempty"`
+		}
+		require.NoError(t, json.Unmarshal(data, &env))
+		assert.NotEmpty(t, env.Error, "recovered panic must reply with an error envelope")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected error response after recovered panic")
+	}
+
+	drained := make(chan struct{})
+	go func() { d.systemDispatchWg.Wait(); close(drained) }()
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("systemDispatchWg did not drain after handler returned")
+	}
+}
+
+// TestHandleSystemLaunchInstance_ConcurrentDispatch fires several launch
+// requests at once and asserts each gets its own reply — the per-request
+// goroutine model must not serialize requests on a single subscription
+// goroutine (the head-of-line block this fix removes).
+func TestHandleSystemLaunchInstance_ConcurrentDispatch(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	d := &Daemon{natsConn: nc, natsSubscriptions: make(map[string]*nats.Subscription)}
+
+	const n = 8
+	replyCh := make(chan []byte, n)
+	sub, err := nc.Subscribe("test.launch.concurrent.reply", func(msg *nats.Msg) { replyCh <- msg.Data })
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	for i := range n {
+		msg := msgWithConn(nc, &nats.Msg{
+			Subject: "system.LaunchInstance.sys.medium",
+			Reply:   "test.launch.concurrent.reply",
+			Sub:     sub,
+			Data:    []byte("{not valid"),
+		})
+		_ = i
+		d.handleSystemLaunchInstance(msg)
+	}
+
+	got := 0
+	for got < n {
+		select {
+		case <-replyCh:
+			got++
+		case <-time.After(3 * time.Second):
+			t.Fatalf("expected %d replies, got %d", n, got)
+		}
+	}
+
+	drained := make(chan struct{})
+	go func() { d.systemDispatchWg.Wait(); close(drained) }()
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("systemDispatchWg did not drain")
+	}
+}
+
 // msgWithConn returns msg with its internal connection set so msg.Respond
 // publishes through nc. nats.Msg.Respond requires a backing connection set
 // either via Subscribe delivery or by hand for synthetic test messages.

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -1292,6 +1292,20 @@ func TestRunInstances_CountValidation(t *testing.T) {
 	})
 }
 
+// countSubsBySuffix splits a subscription map into (without-suffix, with-suffix)
+// counts. Node-targeted (unicast) topics carry the node ID as a trailing
+// suffix; queue (anycast) topics do not — so this distinguishes the two.
+func countSubsBySuffix(subs map[string]*nats.Subscription, suffix string) (without, with int) {
+	for topic := range subs {
+		if strings.HasSuffix(topic, suffix) {
+			with++
+		} else {
+			without++
+		}
+	}
+	return without, with
+}
+
 // TestInstanceTypeSubscriptions tests dynamic NATS subscription management
 // based on node capacity.
 func TestInstanceTypeSubscriptions(t *testing.T) {
@@ -1353,8 +1367,15 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 
 		rm.updateInstanceSubscriptions()
 
-		assert.Equal(t, 0, len(rm.instanceSubs),
-			"should unsubscribe from all types when node is full")
+		// Queue (anycast) subscriptions drop when the node fills so NATS reroutes
+		// launches to a node with room. Node-targeted (unicast) subscriptions
+		// persist regardless of capacity so a committed placement that names this
+		// node still reaches a responder — capacity is enforced at launch time.
+		queueSubs, nodeSubs := countSubsBySuffix(rm.instanceSubs, ".test-node")
+		assert.Equal(t, 0, queueSubs,
+			"queue subscriptions should drop when the node is full")
+		assert.Greater(t, nodeSubs, 0,
+			"node-targeted subscriptions persist regardless of capacity")
 	})
 
 	t.Run("ResubscribesWhenFreed", func(t *testing.T) {
@@ -1375,7 +1396,9 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		rm.allocatedMem = rm.hostMemGB - rm.reservedMem
 		rm.mu.Unlock()
 		rm.updateInstanceSubscriptions()
-		assert.Equal(t, 0, len(rm.instanceSubs))
+		queueSubs, nodeSubs := countSubsBySuffix(rm.instanceSubs, ".test-node")
+		assert.Equal(t, 0, queueSubs, "queue subscriptions drop when the node is full")
+		assert.Greater(t, nodeSubs, 0, "node-targeted subscriptions persist when full")
 
 		// Free all resources
 		rm.mu.Lock()
@@ -1478,15 +1501,63 @@ func TestInstanceTypeSubscriptions(t *testing.T) {
 		rm.allocatedMem = rm.hostMemGB - rm.reservedMem
 		rm.mu.Unlock()
 		rm.updateInstanceSubscriptions()
-		assert.Equal(t, 0, len(rm.instanceSubs))
+		queueSubs, _ := countSubsBySuffix(rm.instanceSubs, ".test-node")
+		assert.Equal(t, 0, queueSubs, "queue subscriptions drop when the node is full")
 
-		// Publishing to an instance type topic should get no responders
+		// Publishing to an instance type's queue (anycast) topic should get no
+		// responders — that subject is torn down on capacity so launches reroute.
 		instanceType := getTestInstanceType(t)
 		topic := fmt.Sprintf("ec2.RunInstances.%s", instanceType)
 
 		_, err = nc.Request(topic, []byte("{}"), 500*time.Millisecond)
 		assert.ErrorIs(t, err, nats.ErrNoResponders,
 			"request to a type with no subscribed nodes should return ErrNoResponders")
+	})
+
+	// A full node must still answer a node-targeted (unicast) launch: a committed
+	// placement reservation names this node specifically, so dropping the
+	// subscription would turn a real capacity decision into 'no responders' and
+	// fail the reservation spuriously (e.g. an EKS HA control-plane leg).
+	t.Run("NodeTargetedRespondsWhenFull", func(t *testing.T) {
+		rm, err := NewResourceManager(nil, nil, nil)
+		require.NoError(t, err)
+		nc, err := nats.Connect(natsURL)
+		require.NoError(t, err)
+		defer nc.Close()
+
+		handler := func(msg *nats.Msg) {}
+		rm.initSubscriptions(nc, handler, nil, "test-node")
+
+		// Pick a type that fits at init so it gets both a queue and a
+		// node-targeted subscription.
+		var fitType string
+		for key, it := range rm.instanceTypes {
+			if !instancetypes.IsSystemType(key) && rm.canAllocate(it, 1) >= 1 {
+				fitType = key
+				break
+			}
+		}
+		require.NotEmpty(t, fitType, "host must fit at least one instance type")
+		queueTopic := fmt.Sprintf("ec2.RunInstances.%s", fitType)
+		nodeTopic := fmt.Sprintf("ec2.RunInstances.%s.test-node", fitType)
+		require.Contains(t, rm.instanceSubs, queueTopic)
+		require.Contains(t, rm.instanceSubs, nodeTopic)
+
+		// Fill the node completely.
+		rm.mu.Lock()
+		rm.allocatedVCPU = rm.hostVCPU - rm.reservedVCPU
+		rm.allocatedMem = rm.hostMemGB - rm.reservedMem
+		rm.mu.Unlock()
+		rm.updateInstanceSubscriptions()
+
+		// A live entry in instanceSubs is a live NATS subscription on nc, so a
+		// request to that subject reaches a responder. The queue (anycast) subject
+		// drops so launches reroute; the node-targeted (unicast) subject persists
+		// so a committed placement still gets a real capacity decision.
+		assert.NotContains(t, rm.instanceSubs, queueTopic,
+			"queue subject should be unsubscribed when the node is full")
+		assert.Contains(t, rm.instanceSubs, nodeTopic,
+			"node-targeted subject must stay subscribed when the node is full")
 	})
 }
 

--- a/spinifex/handlers/eks/claim_race_test.go
+++ b/spinifex/handlers/eks/claim_race_test.go
@@ -45,6 +45,7 @@ func TestCreateCluster_ConcurrentSameNameSingleOwner(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+	f.svc.WaitLaunches()
 
 	ok, inUse := classifyCreateErrs(t, errs)
 	assert.Equal(t, 1, ok, "exactly one create owns the name")
@@ -76,6 +77,7 @@ func TestCreateCluster_ConcurrentReclaimSingleOwner(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+	f.svc.WaitLaunches()
 
 	ok, inUse := classifyCreateErrs(t, errs)
 	assert.Equal(t, 1, ok, "exactly one retry reclaims the FAILED cluster")
@@ -105,6 +107,7 @@ func TestCreateNodegroup_ConcurrentSameNameSingleOwner(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+	f.svc.WaitLaunches()
 
 	ok, inUse := classifyCreateErrs(t, errs)
 	assert.Equal(t, 1, ok, "exactly one create owns the nodegroup")

--- a/spinifex/handlers/eks/create_cluster_test.go
+++ b/spinifex/handlers/eks/create_cluster_test.go
@@ -71,8 +71,11 @@ func TestCreateCluster_NLBArnPersistedBeforeLaterFailure(t *testing.T) {
 	// NLB-arn persist checkpoint, but before the final PutClusterMeta.
 	f.inst.launchErr = errors.New("no capacity")
 
+	// CreateCluster accepts the request (CREATING) and launches asynchronously;
+	// the launch failure surfaces as FAILED status, not the call's return value.
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
-	require.Error(t, err)
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	meta, getErr := GetClusterMeta(f.kv, "alpha")
 	require.NoError(t, getErr, "meta must remain so the leaked NLB has an owning record")
@@ -88,7 +91,8 @@ func TestCreateCluster_FailedCreateThenDeleteReclaimsNLB(t *testing.T) {
 	f.inst.launchErr = errors.New("no capacity")
 
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
-	require.Error(t, err)
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	// The NLB the partial create provisioned exists in the fake.
 	require.NotEmpty(t, f.nlb.createLBCalls, "create provisioned an NLB")
@@ -112,7 +116,8 @@ func TestCreateCluster_EgressFailureLeavesControlPlaneRecorded(t *testing.T) {
 	f.eip.allocateErr = errors.New("no addresses in hidden pool")
 
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
-	require.Error(t, err)
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
 	require.NotEmpty(t, f.inst.launchCalls, "control-plane VM was launched before the egress step")
 
 	meta, getErr := GetClusterMeta(f.kv, "alpha")
@@ -130,7 +135,8 @@ func TestCreateCluster_EgressFailedThenDeleteTerminatesControlPlane(t *testing.T
 	f.eip.allocateErr = errors.New("no addresses in hidden pool")
 
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
-	require.Error(t, err)
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
 	require.NotEmpty(t, f.inst.launchCalls, "create launched a CP VM")
 
 	_, err = f.svc.DeleteCluster(deleteInput("alpha"), testAccountID)
@@ -162,16 +168,19 @@ func TestCreateCluster_FailedClusterIsReclaimedOnRetry(t *testing.T) {
 	// First attempt fails at VM launch, leaving a FAILED meta with NLB ARNs.
 	f.inst.launchErr = errors.New("no capacity")
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
-	require.Error(t, err)
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
 	failed, err := GetClusterMeta(f.kv, "alpha")
 	require.NoError(t, err)
 	require.Equal(t, ClusterStatusFailed, failed.Status)
 
-	// Retry now succeeds: the reclaim path purges the failed attempt's NLB and
-	// the create starts clean.
+	// Retry now succeeds: the reclaim (in the synchronous claim phase) purges the
+	// failed attempt's NLB and the create starts clean. The relaunch then runs to
+	// completion, leaving the cluster CREATING (ACTIVE is the reconciler's job).
 	f.inst.launchErr = nil
 	_, err = f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
 	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	got, err := GetClusterMeta(f.kv, "alpha")
 	require.NoError(t, err)
@@ -231,15 +240,16 @@ func TestDescribeCluster_HealthyActiveClusterHasNoIssues(t *testing.T) {
 	assert.Nil(t, desc.Cluster.Health, "healthy cluster must not report a ClusterHealth issue")
 }
 
-// A missing eks-server AMI is an operator/config gap, not an unrecoverable
-// internal fault: CreateCluster must surface ServiceUnavailable (not a generic
-// ServerInternal) and mark the half-built cluster FAILED (bead 165.4).
+// A missing eks-server AMI is an operator/config gap surfaced during the async
+// launch: CreateCluster accepts the request (CREATING) and the background launch
+// marks the half-built cluster FAILED so the reclaim path can retry (bead 165.4).
 func TestCreateCluster_MissingAMIReturnsServiceUnavailable(t *testing.T) {
 	f := newEKSServiceFixture(t)
 	f.ami.describeOut = &ec2.DescribeImagesOutput{} // no images tagged managed-by=eks
 
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
-	require.EqualError(t, err, awserrors.ErrorServiceUnavailable)
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	meta, getErr := GetClusterMeta(f.kv, "alpha")
 	require.NoError(t, getErr)
@@ -252,6 +262,7 @@ func TestCreateCluster_HappyPathPersistsActiveCreatingMeta(t *testing.T) {
 	out, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, "")
 	require.NoError(t, err)
 	require.NotNil(t, out)
+	f.svc.WaitLaunches()
 
 	meta, err := GetClusterMeta(f.kv, "alpha")
 	require.NoError(t, err)
@@ -270,6 +281,7 @@ func TestCreateCluster_SeedsCreatorAdminAccessEntry(t *testing.T) {
 
 	_, err := f.svc.CreateCluster(createInput("alpha"), testAccountID, caller)
 	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	rec, err := GetAccessEntryRecord(f.kv, "alpha", caller)
 	require.NoError(t, err)
@@ -289,6 +301,7 @@ func TestCreateCluster_SkipsCreatorAdminWhenDisabled(t *testing.T) {
 
 	_, err := f.svc.CreateCluster(in, testAccountID, caller)
 	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	_, err = GetAccessEntryRecord(f.kv, "alpha", caller)
 	assert.ErrorIs(t, err, ErrAccessEntryNotFound)
@@ -299,6 +312,7 @@ func TestCreateCluster_AllocatesHiddenEgressEIP(t *testing.T) {
 
 	_, err := f.svc.CreateCluster(createInput("egress"), testAccountID, "")
 	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	meta, err := GetClusterMeta(f.kv, "egress")
 	require.NoError(t, err)

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -240,32 +240,79 @@ func (s *EKSServiceImpl) createNodegroup(acctKV nats.KeyValue, input *eks.Create
 		return nil, errors.New(awserrors.ErrorEKSResourceInUse)
 	}
 
+	// Claim won — the nodegroup is now CREATING. SG provisioning, token decrypt,
+	// AMI lookup and worker launch are a multi-minute job that must not run in the
+	// gateway request path (it head-of-line blocks the shared responder and the
+	// gateway times out and re-publishes — 267.4). Snapshot the CREATING reply
+	// before the launch, which mutates rec (InstanceIDs/Status), then run the
+	// provisioning on a background goroutine. Failures surface via the record's
+	// CREATE_FAILED status, which DeleteNodegroup reclaims.
+	out := &eks.CreateNodegroupOutput{Nodegroup: nodegroupRecordToAWS(rec)}
+
+	s.launchWG.Go(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.markNodegroupFailed(acctKV, cluster, ng, fmt.Sprintf("launch panic: %v", r))
+			}
+		}()
+		s.launchNodegroupInfra(nodegroupLaunchCtx{
+			accountID: accountID,
+			cluster:   cluster,
+			ng:        ng,
+			meta:      meta,
+			rec:       rec,
+			desired:   int(desired),
+			acctKV:    acctKV,
+		})
+	})
+
+	return out, nil
+}
+
+// nodegroupLaunchCtx carries the immutable inputs for an asynchronous nodegroup
+// provisioning launch (launchNodegroupInfra). rec is mutated by the launch and
+// must not be read by the caller after the goroutine starts.
+type nodegroupLaunchCtx struct {
+	accountID string
+	cluster   string
+	ng        string
+	meta      *ClusterMeta
+	rec       *NodegroupRecord
+	desired   int
+	acctKV    nats.KeyValue
+}
+
+// launchNodegroupInfra runs the slow provisioning tail of createNodegroup on a
+// background goroutine after the record claim has been won: ensure SGs, decrypt
+// the node token, resolve the eks-node AMI, launch the workers, and persist the
+// terminal record state. Every failure marks the record CREATE_FAILED so the
+// reclaim path (DeleteNodegroup) can tear it down.
+func (s *EKSServiceImpl) launchNodegroupInfra(lc nodegroupLaunchCtx) {
+	acctKV, accountID, cluster, ng, meta, rec := lc.acctKV, lc.accountID, lc.cluster, lc.ng, lc.meta, lc.rec
+
 	cpSGID, ngSGID, err := EnsureClusterSGs(s.deps.VPCSG, accountID, cluster, meta.ResourcesVpcConfig.VpcId)
 	if err != nil {
 		s.markNodegroupFailed(acctKV, cluster, ng, "ensure cluster SGs: "+err.Error())
-		return nil, fmt.Errorf("ensure cluster SGs: %w", err)
+		return
 	}
 	if err := EnsureNodegroupSGRules(s.deps.VPCSG, accountID, cluster, cpSGID, ngSGID); err != nil {
 		s.markNodegroupFailed(acctKV, cluster, ng, "ensure nodegroup SG rules: "+err.Error())
-		return nil, fmt.Errorf("ensure nodegroup SG rules: %w", err)
+		return
 	}
 
 	token, err := s.decryptNodeToken(acctKV, cluster)
 	if err != nil {
 		s.markNodegroupFailed(acctKV, cluster, ng, "decrypt node token: "+err.Error())
-		return nil, fmt.Errorf("decrypt node token: %w", err)
+		return
 	}
 
 	amiID, err := lookupEKSServerAMI(s.deps.Image, accountID)
 	if err != nil {
 		s.markNodegroupFailed(acctKV, cluster, ng, "resolve eks-node AMI: "+err.Error())
-		if errors.Is(err, ErrEKSServerAMINotFound) {
-			return nil, errors.New(awserrors.ErrorServiceUnavailable)
-		}
-		return nil, fmt.Errorf("resolve eks-node AMI: %w", err)
+		return
 	}
 
-	instanceIDs, err := s.launchWorkers(accountID, rec, meta, ngSGID, amiID, token, int(desired))
+	instanceIDs, err := s.launchWorkers(accountID, rec, meta, ngSGID, amiID, token, lc.desired)
 	rec.InstanceIDs = instanceIDs
 	if err != nil {
 		// Persist whatever launched so DeleteNodegroup can reclaim it, then fail.
@@ -275,7 +322,7 @@ func (s *EKSServiceImpl) createNodegroup(acctKV nats.KeyValue, input *eks.Create
 		if perr := PutNodegroupRecord(acctKV, rec); perr != nil {
 			slog.Error("createNodegroup: persist CREATE_FAILED record", "cluster", cluster, "nodegroup", ng, "err", perr)
 		}
-		return nil, fmt.Errorf("launch workers: %w", err)
+		return
 	}
 
 	// v1 marks ACTIVE on successful RunInstances (instance-level), not on
@@ -284,10 +331,8 @@ func (s *EKSServiceImpl) createNodegroup(acctKV nats.KeyValue, input *eks.Create
 	rec.Status = eks.NodegroupStatusActive
 	rec.ModifiedAt = time.Now().UTC()
 	if err := PutNodegroupRecord(acctKV, rec); err != nil {
-		return nil, err
+		slog.Error("createNodegroup: persist ACTIVE record", "cluster", cluster, "nodegroup", ng, "err", err)
 	}
-
-	return &eks.CreateNodegroupOutput{Nodegroup: nodegroupRecordToAWS(rec)}, nil
 }
 
 // launchWorkers issues count customer-owned RunInstances calls (one per worker

--- a/spinifex/handlers/eks/nodegroup_test.go
+++ b/spinifex/handlers/eks/nodegroup_test.go
@@ -184,9 +184,17 @@ func TestCreateNodegroup_HappyPath(t *testing.T) {
 	out, err := f.svc.CreateNodegroup(createNGInput("c1", "ng1", 2), testAccountID)
 	require.NoError(t, err)
 	require.NotNil(t, out.Nodegroup)
-	assert.Equal(t, eks.NodegroupStatusActive, aws.StringValue(out.Nodegroup.Status))
+	// The create accepts the request as CREATING; worker launch runs async.
+	assert.Equal(t, eks.NodegroupStatusCreating, aws.StringValue(out.Nodegroup.Status))
 	assert.Equal(t, int64(2), aws.Int64Value(out.Nodegroup.ScalingConfig.DesiredSize))
 	assert.Contains(t, aws.StringValue(out.Nodegroup.NodegroupArn), ":nodegroup/c1/ng1/")
+
+	f.svc.WaitLaunches()
+
+	// The async launch transitions the record to ACTIVE once workers run.
+	active, err := GetNodegroupRecord(f.kv, "c1", "ng1")
+	require.NoError(t, err)
+	assert.Equal(t, eks.NodegroupStatusActive, active.Status)
 
 	// Two workers launched and tracked.
 	assert.Len(t, f.worker.runCalls, 2)
@@ -237,6 +245,7 @@ func TestDescribeAndListNodegroups(t *testing.T) {
 	seedActiveClusterWithToken(t, f, "c1")
 	_, err := f.svc.CreateNodegroup(createNGInput("c1", "ng1", 1), testAccountID)
 	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	desc, err := f.svc.DescribeNodegroup(&eks.DescribeNodegroupInput{
 		ClusterName: aws.String("c1"), NodegroupName: aws.String("ng1"),
@@ -260,6 +269,7 @@ func TestUpdateNodegroupConfig_ScaleUpAndDown(t *testing.T) {
 	seedActiveClusterWithToken(t, f, "c1")
 	_, err := f.svc.CreateNodegroup(createNGInput("c1", "ng1", 1), testAccountID)
 	require.NoError(t, err)
+	f.svc.WaitLaunches()
 	require.Len(t, f.worker.runCalls, 1)
 
 	// Scale up 1 → 3: two new workers launched.
@@ -294,6 +304,7 @@ func TestDeleteNodegroup_TerminatesAndIsIdempotent(t *testing.T) {
 	seedActiveClusterWithToken(t, f, "c1")
 	_, err := f.svc.CreateNodegroup(createNGInput("c1", "ng1", 2), testAccountID)
 	require.NoError(t, err)
+	f.svc.WaitLaunches()
 
 	_, err = f.svc.DeleteNodegroup(&eks.DeleteNodegroupInput{
 		ClusterName: aws.String("c1"), NodegroupName: aws.String("ng1"),

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -109,9 +109,20 @@ type EKSServiceImpl struct {
 	mu       sync.Mutex
 	bgCtx    context.Context
 	bgCancel context.CancelFunc
+
+	// launchWG tracks in-flight asynchronous create launches (control-plane and
+	// nodegroup VM provisioning kicked off after the fast CREATING response).
+	// Not part of request handling — exists so tests can deterministically await
+	// launch completion (WaitLaunches).
+	launchWG sync.WaitGroup
 }
 
 var _ EKSService = (*EKSServiceImpl)(nil)
+
+// WaitLaunches blocks until all asynchronous create launches started by this
+// service have finished. Intended for tests; production create handlers return
+// as soon as the CREATING record is claimed.
+func (s *EKSServiceImpl) WaitLaunches() { s.launchWG.Wait() }
 
 const defaultK8sVersion = "1.32"
 
@@ -368,10 +379,91 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 		return nil, err
 	}
 
+	// Respond with the cluster in CREATING immediately and run the launch
+	// (SGs, NLB, OIDC, control-plane VM boot, egress, target registration,
+	// bootstrap, reconciler) off the request goroutine. A multi-minute control-
+	// plane boot must not occupy the spinifex-workers subscription or the gateway
+	// times out and re-publishes the request, spawning a duplicate concurrent
+	// handler (267.4 — the same retry the 267.3 claim guards against). AWS itself
+	// returns the cluster in CREATING here; the client polls DescribeCluster to
+	// ACTIVE/FAILED.
+	// Snapshot the CREATING response before spawning the launch: the goroutine
+	// owns meta from here on (it mutates and re-persists it), so the request
+	// goroutine must not touch meta again.
+	out := &eks.CreateClusterOutput{Cluster: clusterMetaToAWS(meta)}
+	s.launchWG.Go(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.failClusterLaunch(acctKV, name, accountID, "launch panic", fmt.Errorf("%v", r))
+			}
+		}()
+		s.launchClusterInfra(clusterLaunchCtx{
+			accountID:          accountID,
+			callerPrincipalARN: callerPrincipalARN,
+			name:               name,
+			region:             region,
+			subnetIDs:          subnetIDs,
+			vpcID:              vpcID,
+			publicAccess:       publicAccess,
+			publicCidrs:        publicCidrs,
+			input:              input,
+			meta:               meta,
+			acctKV:             acctKV,
+		})
+	})
+	return out, nil
+}
+
+// clusterLaunchCtx carries the inputs the asynchronous control-plane launch
+// needs, captured at the end of CreateCluster's fast (claim) phase.
+type clusterLaunchCtx struct {
+	accountID          string
+	callerPrincipalARN string
+	name               string
+	region             string
+	subnetIDs          []string
+	vpcID              string
+	publicAccess       bool
+	publicCidrs        []string
+	input              *eks.CreateClusterInput
+	meta               *ClusterMeta
+	acctKV             nats.KeyValue
+}
+
+// failClusterLaunch records an asynchronous control-plane launch failure: it
+// marks the cluster FAILED (with reason, so DescribeCluster surfaces the cause
+// and the 267.3 reclaim path can recreate cleanly) and logs the stage. The
+// launch runs after the CREATING response was already sent, so a failure can
+// only surface as status, never as the CreateCluster return value.
+func (s *EKSServiceImpl) failClusterLaunch(kv nats.KeyValue, name, accountID, stage string, err error) {
+	_ = logCreateErr(name, accountID, stage, err)
+	if mErr := MarkClusterFailed(kv, name, stage+": "+err.Error()); mErr != nil && !errors.Is(mErr, ErrClusterNotFound) {
+		slog.Warn("launchClusterInfra: MarkClusterFailed failed", "cluster", name, "err", mErr)
+	}
+}
+
+// launchClusterInfra is CreateCluster's slow phase, run on a background
+// goroutine after the CREATING response is sent: security groups, the cluster
+// NLB, OIDC keypair, the control-plane VM(s), egress wiring, NLB target
+// registration, the creator-admin AccessEntry, and the bootstrap/reconciler
+// goroutines. Every failure path marks the cluster FAILED via failClusterLaunch.
+func (s *EKSServiceImpl) launchClusterInfra(lc clusterLaunchCtx) {
+	accountID := lc.accountID
+	callerPrincipalARN := lc.callerPrincipalARN
+	name := lc.name
+	region := lc.region
+	subnetIDs := lc.subnetIDs
+	vpcID := lc.vpcID
+	publicAccess := lc.publicAccess
+	publicCidrs := lc.publicCidrs
+	input := lc.input
+	meta := lc.meta
+	acctKV := lc.acctKV
+
 	cpSG, ngSG, err := EnsureClusterSGs(s.deps.VPCSG, accountID, name, vpcID)
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "ensure cluster SGs", err)
+		s.failClusterLaunch(acctKV, name, accountID, "ensure cluster SGs", err)
+		return
 	}
 	meta.ResourcesVpcConfig.SecurityGroupIds = []string{cpSG, ngSG}
 
@@ -380,27 +472,27 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 	// NLB target stays unhealthy and the endpoint never serves.
 	vpcCIDR, err := s.deps.VPCSubnet.GetVPCCIDR(accountID, vpcID)
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "resolve vpc cidr", err)
+		s.failClusterLaunch(acctKV, name, accountID, "resolve vpc cidr", err)
+		return
 	}
 	if err := EnsureControlPlaneIngress(s.deps.VPCSG, accountID, cpSG, vpcCIDR); err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "ensure control-plane ingress", err)
+		s.failClusterLaunch(acctKV, name, accountID, "ensure control-plane ingress", err)
+		return
 	}
 	// HA control planes run servers 2..N as join servers whose embedded etcd must
 	// peer with the quorum; without these self-referencing CP-SG rules a join
 	// registers but its etcd never replicates, so the node never reports Ready.
 	if err := EnsureControlPlaneHAIngress(s.deps.VPCSG, accountID, cpSG); err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "ensure control-plane HA ingress", err)
+		s.failClusterLaunch(acctKV, name, accountID, "ensure control-plane HA ingress", err)
+		return
 	}
 
 	// Public access ⇒ internet-facing NLB (external-pool front-end IP, reachable
 	// on the LAN/edge network); private-only ⇒ internal NLB (VPC-only).
 	nlb, err := EnsureClusterNLB(s.deps.NLB, accountID, name, subnetIDs, publicAccess, publicCidrs)
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "ensure cluster NLB", err)
+		s.failClusterLaunch(acctKV, name, accountID, "ensure cluster NLB", err)
+		return
 	}
 	// Prefer the reachable front-end IP as the kubeconfig endpoint host so the
 	// apiserver serving cert (which SANs this IP) validates with TLS verification
@@ -420,26 +512,26 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 	// DeleteCluster (which keys teardown off the persisted ARNs) could not
 	// reclaim them.
 	if err := PutClusterMeta(acctKV, meta); err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "persist NLB arns", err)
+		s.failClusterLaunch(acctKV, name, accountID, "persist NLB arns", err)
+		return
 	}
 
 	oidcIssuer, err := ClusterOIDCIssuer(s.deps.GatewayBaseURL, region, accountID, name)
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "build OIDC issuer", err)
+		s.failClusterLaunch(acctKV, name, accountID, "build OIDC issuer", err)
+		return
 	}
 	meta.OIDCIssuer = oidcIssuer
 
 	privPEM, _, err := GenerateClusterOIDCKeypair(acctKV, name, s.deps.MasterKey)
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "generate OIDC keypair", err)
+		s.failClusterLaunch(acctKV, name, accountID, "generate OIDC keypair", err)
+		return
 	}
 	pubPEM, err := PublicKeyPEMFromPrivate(privPEM)
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "derive OIDC public key", err)
+		s.failClusterLaunch(acctKV, name, accountID, "derive OIDC public key", err)
+		return
 	}
 
 	// Shared cluster token seeded into every control-plane server so the HA
@@ -447,8 +539,8 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 	// register). Single-CP clusters carry it too — harmless, one code path.
 	joinToken, err := GenerateK3sClusterToken()
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "generate k3s cluster token", err)
+		s.failClusterLaunch(acctKV, name, accountID, "generate k3s cluster token", err)
+		return
 	}
 
 	cpNodes, spreadGroup, err := s.placeControlPlane(accountID, name, K3sServerInput{
@@ -470,15 +562,12 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 		JoinToken:         joinToken,
 	})
 	if err != nil {
-		s.markFailed(acctKV, name)
 		if errors.Is(err, ErrEKSServerAMINotFound) {
-			slog.Error("CreateCluster: eks-server AMI not found; cannot launch control plane",
-				"cluster", name, "accountID", accountID, "err", err)
-			return nil, errors.New(awserrors.ErrorServiceUnavailable)
+			s.failClusterLaunch(acctKV, name, accountID, "eks-server AMI not found", err)
+			return
 		}
-		slog.Error("CreateCluster: K3s control-plane VM launch failed",
-			"cluster", name, "accountID", accountID, "err", err)
-		return nil, fmt.Errorf("launch K3s VM: %w", err)
+		s.failClusterLaunch(acctKV, name, accountID, "launch K3s VM", err)
+		return
 	}
 	// Mirror the primary ([0]) into the scalar fields the reconciler, egress
 	// wiring, and teardown read today. All CP nodes are NLB target-registered
@@ -497,8 +586,8 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 	// leaves them launched but unrecorded, so neither DeleteCluster nor the
 	// FAILED-cluster reclaim could reach them and the sys.medium VMs leak.
 	if err := PutClusterMeta(acctKV, meta); err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "persist control-plane ids", err)
+		s.failClusterLaunch(acctKV, name, accountID, "persist control-plane ids", err)
+		return
 	}
 
 	// Egress: the control-plane VM must pull container images. Allocate a
@@ -506,8 +595,8 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 	// the VM stays unreachable inbound; the NLB is its only front door).
 	egressIP, egressAllocID, err := s.allocateClusterEgressIP(accountID, name)
 	if err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "allocate cluster egress IP", err)
+		s.failClusterLaunch(acctKV, name, accountID, "allocate cluster egress IP", err)
+		return
 	}
 	meta.EgressEIPAllocationID = egressAllocID
 	meta.EgressEIPPublicIP = egressIP
@@ -521,8 +610,8 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 	// Record the egress allocation before registering the target so a failed
 	// register (or anything after) leaves it recoverable by DeleteCluster.
 	if err := PutClusterMeta(acctKV, meta); err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "persist egress allocation", err)
+		s.failClusterLaunch(acctKV, name, accountID, "persist egress allocation", err)
+		return
 	}
 
 	cpENIIPs := make([]string, 0, len(cpNodes))
@@ -530,13 +619,13 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 		cpENIIPs = append(cpENIIPs, n.ENIIP)
 	}
 	if err := RegisterClusterTargets(s.deps.NLB, accountID, nlb.TargetGroupArn, cpENIIPs); err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "register NLB targets", err)
+		s.failClusterLaunch(acctKV, name, accountID, "register NLB targets", err)
+		return
 	}
 
 	if err := PutClusterMeta(acctKV, meta); err != nil {
-		s.markFailed(acctKV, name)
-		return nil, logCreateErr(name, accountID, "persist final meta", err)
+		s.failClusterLaunch(acctKV, name, accountID, "persist final meta", err)
+		return
 	}
 
 	// bootstrapClusterCreatorAdminPermissions (default true): grant the caller
@@ -547,8 +636,8 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 		rec := newAccessEntryRecord(region, accountID, name, callerPrincipalARN, "",
 			[]string{"system:masters"}, AccessEntryTypeStandard, nil, time.Now().UTC())
 		if err := PutAccessEntryRecord(acctKV, rec); err != nil {
-			s.markFailed(acctKV, name)
-			return nil, fmt.Errorf("seed cluster-creator admin access entry: %w", err)
+			s.failClusterLaunch(acctKV, name, accountID, "seed cluster-creator admin access entry", err)
+			return
 		}
 	} else if bootstrapCreatorAdmin(input) {
 		slog.Warn("CreateCluster: bootstrapClusterCreatorAdminPermissions set but caller principal ARN unknown; skipping creator-admin AccessEntry",
@@ -557,8 +646,6 @@ func (s *EKSServiceImpl) CreateCluster(input *eks.CreateClusterInput, accountID,
 
 	s.spawnBootstrap(accountID, name, acctKV, nil)
 	s.spawnReconciler(accountID, name, meta)
-
-	return &eks.CreateClusterOutput{Cluster: clusterMetaToAWS(meta)}, nil
 }
 
 // bootstrapCreatorAdmin reports whether the cluster-creator-admin AccessEntry

--- a/spinifex/handlers/elbv2/arn_test.go
+++ b/spinifex/handlers/elbv2/arn_test.go
@@ -137,6 +137,7 @@ func TestCreateLoadBalancer_DeliversCACert(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 
 	require.Len(t, mock.launchCalls, 1)
 	assert.Equal(t, "-----BEGIN CERTIFICATE-----\nMOCK\n-----END CERTIFICATE-----\n",
@@ -158,6 +159,7 @@ func TestCreateLoadBalancer_Microvm_LBAgentEnv(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	require.Len(t, mock.launchCalls, 1)
 
 	envBlob := mock.launchCalls[0].LBAgentEnv
@@ -185,6 +187,7 @@ func TestCreateLoadBalancer_Microvm_NICs(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	require.Len(t, mock.launchCalls, 1)
 
 	nics := mock.launchCalls[0].NICs

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -131,7 +131,17 @@ type ELBv2ServiceImpl struct {
 
 	recoveryLBIndexMu sync.Mutex
 	recoveryLBIndex   map[string]*LoadBalancerRecord
+
+	// launchWG tracks in-flight asynchronous LB-VM launches spawned by
+	// CreateLoadBalancer. Not awaited at shutdown (a multi-minute boot must not
+	// block Close); exposed via WaitLaunches purely so tests can join the
+	// background launch deterministically.
+	launchWG sync.WaitGroup
 }
+
+// WaitLaunches blocks until every in-flight asynchronous LB-VM launch started by
+// CreateLoadBalancer has finished. Test-only join point.
+func (s *ELBv2ServiceImpl) WaitLaunches() { s.launchWG.Wait() }
 
 // NewELBv2ServiceImplWithNATS creates an ELBv2 service backed by JetStream KV.
 func NewELBv2ServiceImplWithNATS(cfg *config.Config, nc *nats.Conn) (*ELBv2ServiceImpl, error) {
@@ -1251,30 +1261,24 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 		}
 	}
 
-	// Launch ALB VM with every ENI (when instance launcher is available).
-	// The first ENI is the primary NIC; any additional ENIs are passed as
-	// ExtraENIs so the daemon sets up a tap + QEMU NIC for each, giving the
-	// ALB VM data-plane presence in every subnet the LB spans.
-	launch := s.launchLBVM(lbID, scheme, eniIDs, subnets, accountID)
-	albInstanceID := launch.instanceID
-	albVPCIP := launch.vpcIP
-	hostPorts := launch.hostPorts
-	launchFailed := launch.failed
-	// Record public IP on the first AZ entry for internet-facing LBs.
-	if launch.publicIP != "" && len(availZones) > 0 {
-		availZones[0].PublicIP = launch.publicIP
-	}
-
-	// ALB starts in provisioning until the agent inside the VM connects and
-	// responds to a ping. If no VM was launched (no launcher/AMI or launch
-	// failed), set state to failed so the API reflects the broken data-plane.
+	// Determine the data-plane state synchronously. When a launcher is configured
+	// the LB is backed by a system VM whose boot is a multi-minute job: running it
+	// inline head-of-line blocks the shared gateway responder and the gateway
+	// times out and re-publishes the create (267.4). So the VM boot runs on a
+	// background goroutine and the create returns provisioning immediately, which
+	// matches AWS (CreateLoadBalancer returns the LB provisioning; the AZ/VpcId in
+	// the response come from the ENIs created synchronously above). Launcher-less
+	// deployments (no InstanceLauncher / no ENIs) have no data plane to boot and
+	// are active on the spot.
 	state := StateActive
-	if albInstanceID != "" {
+	willLaunch := s.InstanceLauncher != nil && len(eniIDs) > 0 && len(subnets) > 0
+	if willLaunch {
 		state = StateProvisioning
 		// Internal LBs only leave provisioning once the lb-agent heartbeats,
 		// which needs the mgmt return route. If it can't be resolved the LB
-		// hangs in provisioning forever — fail loud instead so the broken
-		// return path is visible immediately rather than as a generic timeout.
+		// hangs in provisioning forever — record the failed state up front so the
+		// broken return path is visible immediately. The VM still boots (matching
+		// the synchronous path) so the data plane exists for diagnosis.
 		if scheme == SchemeInternal {
 			if gw, tgt := s.resolveMgmtRoute(scheme); gw == "" || tgt == "" {
 				slog.Error("CreateLoadBalancer: internal LB has no mgmt return route; marking failed (lb-agent cannot heartbeat AWSGW)",
@@ -1284,13 +1288,13 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 				state = StateFailed
 			}
 		}
-	} else if launchFailed {
-		state = StateFailed
 	}
 
 	// Attributes are intentionally left nil — DescribeLoadBalancerAttributes
 	// derives per-type defaults from lb.Type via DefaultLoadBalancerAttributes.
 	// Callers that want a non-default value must call ModifyLoadBalancerAttributes.
+	// InstanceID/VPCIP/HostPorts and the per-AZ PublicIP are filled in by the
+	// asynchronous launch below once the VM boots.
 	record := &LoadBalancerRecord{
 		LoadBalancerArn: lbArn,
 		LoadBalancerID:  lbID,
@@ -1305,9 +1309,6 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 		Subnets:         subnets,
 		AvailZones:      availZones,
 		ENIs:            eniIDs,
-		InstanceID:      albInstanceID,
-		VPCIP:           albVPCIP,
-		HostPorts:       hostPorts,
 		IPAddressType:   IPAddressTypeIPv4,
 		NodeID:          s.nodeID,
 		Tags:            tags,
@@ -1321,13 +1322,84 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
+	if willLaunch {
+		// Snapshot the launch inputs; the goroutine must not read the record the
+		// caller is about to return.
+		lc := lbLaunchCtx{lbID: lbID, lbArn: lbArn, scheme: scheme, eniIDs: eniIDs, subnets: subnets, accountID: accountID}
+		s.launchWG.Go(func() {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("CreateLoadBalancer: async launch panic", "lbId", lc.lbID, "panic", r)
+					s.markLBFailed(lc.lbArn)
+				}
+			}()
+			s.launchLBVMAsync(lc)
+		})
+	}
+
 	// Agent heartbeat will transition provisioning → active on first contact.
 
-	slog.Info("CreateLoadBalancer completed", "name", name, "lbArn", lbArn, "enis", len(eniIDs), "state", state, "accountID", accountID)
+	slog.Info("CreateLoadBalancer accepted", "name", name, "lbArn", lbArn, "enis", len(eniIDs), "state", state, "accountID", accountID)
 
 	return &elbv2.CreateLoadBalancerOutput{
 		LoadBalancers: []*elbv2.LoadBalancer{s.lbRecordToSDK(record)},
 	}, nil
+}
+
+// lbLaunchCtx carries the immutable inputs for an asynchronous LB-VM launch.
+type lbLaunchCtx struct {
+	lbID      string
+	lbArn     string
+	scheme    string
+	eniIDs    []string
+	subnets   []string
+	accountID string
+}
+
+// launchLBVMAsync boots the LB-VM on a background goroutine and folds the result
+// back into the persisted record: on success the instance/VPC-IP/host-ports (and
+// the per-AZ public IP) are recorded and the LB stays provisioning until the
+// lb-agent heartbeats; on failure the record is marked failed so the API
+// reflects the broken data plane. Runs after CreateLoadBalancer has returned.
+func (s *ELBv2ServiceImpl) launchLBVMAsync(lc lbLaunchCtx) {
+	launch := s.launchLBVM(lc.lbID, lc.scheme, lc.eniIDs, lc.subnets, lc.accountID)
+
+	record, err := s.store.GetLoadBalancerByArn(lc.lbArn)
+	if err != nil || record == nil {
+		slog.Error("CreateLoadBalancer: async launch cannot reload record", "lbArn", lc.lbArn, "err", err)
+		return
+	}
+
+	if launch.failed {
+		record.State = StateFailed
+		if putErr := s.store.PutLoadBalancer(record); putErr != nil {
+			slog.Error("CreateLoadBalancer: async launch failed to persist failed state", "lbArn", lc.lbArn, "err", putErr)
+		}
+		return
+	}
+
+	record.InstanceID = launch.instanceID
+	record.VPCIP = launch.vpcIP
+	record.HostPorts = launch.hostPorts
+	if launch.publicIP != "" && len(record.AvailZones) > 0 {
+		record.AvailZones[0].PublicIP = launch.publicIP
+	}
+	if putErr := s.store.PutLoadBalancer(record); putErr != nil {
+		slog.Error("CreateLoadBalancer: async launch failed to persist launch result", "lbArn", lc.lbArn, "err", putErr)
+	}
+}
+
+// markLBFailed reloads the LB record and flips it to the failed state, used by
+// the async launch panic recovery.
+func (s *ELBv2ServiceImpl) markLBFailed(lbArn string) {
+	record, err := s.store.GetLoadBalancerByArn(lbArn)
+	if err != nil || record == nil {
+		return
+	}
+	record.State = StateFailed
+	if putErr := s.store.PutLoadBalancer(record); putErr != nil {
+		slog.Error("CreateLoadBalancer: failed to persist failed state", "lbArn", lbArn, "err", putErr)
+	}
 }
 
 func (s *ELBv2ServiceImpl) DeleteLoadBalancer(input *elbv2.DeleteLoadBalancerInput, accountID string) (*elbv2.DeleteLoadBalancerOutput, error) {

--- a/spinifex/handlers/elbv2/service_impl_lb_network_test.go
+++ b/spinifex/handlers/elbv2/service_impl_lb_network_test.go
@@ -185,6 +185,7 @@ func TestSetSubnets_AddSubnet(t *testing.T) {
 		Subnets: []*string{aws.String(sub1)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	arn := *out.LoadBalancers[0].LoadBalancerArn
 	require.Equal(t, 1, countManagedENIs(t, vpcSvc))
 	require.Len(t, mock.launchCalls, 1)
@@ -217,6 +218,7 @@ func TestSetSubnets_RemoveSubnet(t *testing.T) {
 		Subnets: []*string{aws.String(sub1), aws.String(sub2)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	arn := *out.LoadBalancers[0].LoadBalancerArn
 	require.Equal(t, 2, countManagedENIs(t, vpcSvc))
 
@@ -245,6 +247,7 @@ func TestSetSubnets_Replace(t *testing.T) {
 		Subnets: []*string{aws.String(sub1)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	arn := *out.LoadBalancers[0].LoadBalancerArn
 
 	_, err = svc.SetSubnets(&elbv2.SetSubnetsInput{
@@ -270,6 +273,7 @@ func TestSetSubnets_TerminateFailureRollsBackNewENIs(t *testing.T) {
 		Subnets: []*string{aws.String(sub1)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	arn := *out.LoadBalancers[0].LoadBalancerArn
 	require.Equal(t, 1, countManagedENIs(t, vpcSvc))
 
@@ -300,6 +304,7 @@ func TestSetSubnets_Idempotent(t *testing.T) {
 		Subnets: []*string{aws.String(sub1)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	arn := *out.LoadBalancers[0].LoadBalancerArn
 
 	_, err = svc.SetSubnets(&elbv2.SetSubnetsInput{
@@ -325,6 +330,7 @@ func TestSetSubnets_SubnetMappings(t *testing.T) {
 		Subnets: []*string{aws.String(sub1)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	arn := *out.LoadBalancers[0].LoadBalancerArn
 
 	_, err = svc.SetSubnets(&elbv2.SetSubnetsInput{

--- a/spinifex/handlers/elbv2/service_impl_vpc_test.go
+++ b/spinifex/handlers/elbv2/service_impl_vpc_test.go
@@ -170,6 +170,7 @@ func TestCreateLoadBalancer_MultiSubnet_AllENIsPassedToLauncher(t *testing.T) {
 		Subnets: []*string{aws.String(sub1), aws.String(sub2), aws.String(sub3)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 
 	require.Len(t, mock.launchCalls, 1)
 	launchInput := mock.launchCalls[0]
@@ -290,13 +291,23 @@ func TestCreateLoadBalancer_InternetFacing_AllocatesPublicIP(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	assert.Equal(t, "internet-facing", *out.LoadBalancers[0].Scheme)
 
-	lb := out.LoadBalancers[0]
-	assert.Equal(t, "internet-facing", *lb.Scheme)
+	svc.WaitLaunches()
 
 	// Verify launcher was called with internet-facing scheme
 	require.Len(t, mock.launchCalls, 1)
 	assert.Equal(t, SchemeInternetFacing, mock.launchCalls[0].Scheme)
+
+	// The public IP is attached by the asynchronous launch, so it surfaces on a
+	// describe after the boot completes rather than on the create response (which
+	// returns while the LB is still provisioning — AWS parity).
+	desc, err := svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: []*string{out.LoadBalancers[0].LoadBalancerArn},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, desc.LoadBalancers, 1)
+	lb := desc.LoadBalancers[0]
 
 	// Internet-facing ALB: AZ includes both the public IP and the ENI's private IP.
 	require.Len(t, lb.AvailabilityZones, 1)
@@ -350,6 +361,7 @@ func TestCreateLoadBalancer_Internal_NoPublicIP(t *testing.T) {
 	assert.NotEmpty(t, aws.StringValue(lb.AvailabilityZones[0].LoadBalancerAddresses[0].PrivateIPv4Address))
 
 	// Verify launcher was called with internal scheme
+	svc.WaitLaunches()
 	require.Len(t, mock.launchCalls, 1)
 	assert.Equal(t, SchemeInternal, mock.launchCalls[0].Scheme)
 }
@@ -388,6 +400,7 @@ func TestCreateLoadBalancer_NLB_Internal_NoPublicIP(t *testing.T) {
 	assert.Contains(t, *lb.LoadBalancerArn, "loadbalancer/net/nlb-internal")
 
 	// Verify launcher was called with internal scheme
+	svc.WaitLaunches()
 	require.Len(t, mock.launchCalls, 1)
 	assert.Equal(t, SchemeInternal, mock.launchCalls[0].Scheme)
 
@@ -426,6 +439,7 @@ func TestDeleteLoadBalancer_TerminatesVM_WithPublicIP(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 
 	// Verify ENI exists before delete
 	eniDesc, _ := vpcSvc.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{}, testAccountID)
@@ -490,6 +504,7 @@ func TestDeleteLoadBalancer_ReapsFloatingIPNAT(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 
 	_, err = svc.DeleteLoadBalancer(&elbv2.DeleteLoadBalancerInput{
 		LoadBalancerArn: lbOut.LoadBalancers[0].LoadBalancerArn,
@@ -530,6 +545,7 @@ func TestDescribeLoadBalancers_InternetFacing_IncludesPublicIP(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 
 	// Describe and verify public IP is in the response
 	desc, err := svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
@@ -580,6 +596,7 @@ func TestDescribeLoadBalancers_Internal_NoPublicIP(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 
 	desc, err := svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
 		Names: []*string{aws.String("desc-int-alb")},
@@ -617,9 +634,17 @@ func TestCreateLoadBalancer_LaunchFailure_SetsStateFailed(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	// The create returns provisioning; the launch failure lands on the record
+	// once the background boot attempt fails.
+	assert.Equal(t, StateProvisioning, *out.LoadBalancers[0].State.Code)
 
-	lb := out.LoadBalancers[0]
-	assert.Equal(t, StateFailed, *lb.State.Code)
+	svc.WaitLaunches()
+	desc, err := svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: []*string{out.LoadBalancers[0].LoadBalancerArn},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, desc.LoadBalancers, 1)
+	assert.Equal(t, StateFailed, *desc.LoadBalancers[0].State.Code)
 }
 
 func TestCreateLoadBalancer_MissingCredentials_SetsStateFailed(t *testing.T) {
@@ -643,10 +668,16 @@ func TestCreateLoadBalancer_MissingCredentials_SetsStateFailed(t *testing.T) {
 		Subnets: []*string{aws.String(subnetID)},
 	}, testAccountID)
 	require.NoError(t, err)
+	assert.Equal(t, StateProvisioning, *out.LoadBalancers[0].State.Code)
 
-	lb := out.LoadBalancers[0]
-	assert.Equal(t, StateFailed, *lb.State.Code)
-	// Verify launcher was never called
+	svc.WaitLaunches()
+	desc, err := svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: []*string{out.LoadBalancers[0].LoadBalancerArn},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, desc.LoadBalancers, 1)
+	assert.Equal(t, StateFailed, *desc.LoadBalancers[0].State.Code)
+	// Verify launcher was never called (missing creds short-circuit the boot)
 	assert.Empty(t, mock.launchCalls)
 }
 
@@ -803,6 +834,7 @@ func TestRebuildSystemInstanceInput_HappyPath(t *testing.T) {
 		Scheme:  aws.String("internal"),
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	require.Len(t, mock.launchCalls, 1)
 	originalInput := mock.launchCalls[0]
 
@@ -879,6 +911,7 @@ func TestRebuildSystemInstanceInput_MultiENI(t *testing.T) {
 		Subnets: []*string{aws.String(sub1), aws.String(sub2)},
 	}, testAccountID)
 	require.NoError(t, err)
+	svc.WaitLaunches()
 	require.Len(t, mock.launchCalls, 1)
 	originalInput := mock.launchCalls[0]
 


### PR DESCRIPTION
## Problem

EKS `CreateCluster`/`CreateNodegroup` and ELBv2 `CreateLoadBalancer` ran their full VM/control-plane launch **synchronously** inside the NATS subscription callback on the shared `spinifex-workers` queue. A multi-minute create head-of-line blocked the worker, so `system.LaunchInstance`/`TerminateInstance` found no responder within the gateway timeout and failed with `nats: no responders available` even though the daemon was up. Observed live 2026-06-10 (casuarina failed the 3rd CP leg). Sibling of #340/267.3 — the synchronous block is also what triggered the gateway re-publish that provoked the duplicate-handler race.

## Fix

**Two halves:**

1. **Async create handlers.** Each create runs validation + the 267.3 atomic name-claim synchronously, snapshots the `CREATING`/`provisioning` output, then spawns the slow launch on a per-impl `launchWG` and returns immediately. Launch failures mark the record `FAILED`/`CREATE_FAILED` so 267.3 reclaim makes a retry idempotent.

2. **Per-request responder dispatch.** `handleSystemLaunchInstance`/`handleSystemTerminateInstance` now dispatch each request on its own goroutine (`systemDispatchWg`) — these must respond *after* the boot completes (the caller needs the InstanceID/IPs), so they can't use pure respond-then-launch.

The `EKSService`/`ELBv2Service` interfaces are shared by the gateway NATS clients **and** the daemon impls, so a `launch func()` closure can't cross the client boundary. The async split therefore lives **inside the impl method**, leaving the interface, `handleNATSRequest`, and every daemon handler unchanged.

ELBv2 keeps ENI creation synchronous (cheap VPC calls that yield the AZ/VpcId the create response needs per AWS parity); only the LB-VM boot goes async, folding InstanceID/IPs back into the record for a later `Describe`.

## AWS parity

EKS create is async in AWS (`CREATING` → poll Describe → `ACTIVE`/`FAILED`); ELBv2 returns `provisioning`. All input validation stays synchronous so genuine 400s still return as API errors, not async `FAILED`.

## Testing

- 267.3 race/concurrency tests keep their shape: one owner, one `ResourceInUse`/`DuplicateLoadBalancer`, exactly one launch after `WaitLaunches()`. Under `-race`.
- New `daemon_system_dispatch_test.go`: per-request panic-recovery + concurrent dispatch drain.
- eks / elbv2 / daemon-dispatch packages green under `go test -race`; lint/vet clean.
- One `-race`-only `TestHandleEC2DescribeInstanceTypes` failure is a **pre-existing** host-capacity flake (reproduces on base with these changes stashed; host schedules only 2 vCPU so parallel `-race` runs contend) — unrelated.

Closes mulga-siv-267.4.