### PR TITLE
fix: roll back ELBv2 partial create-load-balancer/listener infra (mulga-siv-267.5)

### DIFF
--- a/spinifex/handlers/eks/nodegroup_test.go
+++ b/spinifex/handlers/eks/nodegroup_test.go
@@ -230,6 +230,8 @@ func TestCreateNodegroup_DiskSizePropagatesToBlockDeviceMapping(t *testing.T) {
 	_, err := f.svc.CreateNodegroup(in, testAccountID)
 	require.NoError(t, err)
 
+	f.svc.WaitLaunches()
+
 	require.Len(t, f.worker.runCalls, 1)
 	bdm := f.worker.runCalls[0].BlockDeviceMappings
 	require.Len(t, bdm, 1)
@@ -243,6 +245,8 @@ func TestCreateNodegroup_NoDiskSizeOmitsBlockDeviceMapping(t *testing.T) {
 
 	_, err := f.svc.CreateNodegroup(createNGInput("c1", "ng1", 1), testAccountID)
 	require.NoError(t, err)
+
+	f.svc.WaitLaunches()
 
 	require.Len(t, f.worker.runCalls, 1)
 	// No DiskSize requested → leave the launch path on its default sizing.

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -1230,16 +1230,9 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 			}
 			eniOut, eniErr := s.VPCService.CreateNetworkInterface(eniIn, accountID)
 			if eniErr != nil {
-				// Rollback: delete any ENIs already created
-				for _, rollbackENI := range eniIDs {
-					if _, delErr := s.VPCService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-						NetworkInterfaceId: aws.String(rollbackENI),
-					}, accountID); delErr != nil {
-						slog.Error("CreateLoadBalancer: rollback failed to delete ENI", "eni", rollbackENI, "err", delErr)
-					}
-				}
-				s.deleteNLBManagedSG(nlbManagedSGID, accountID)
-				s.releaseLBNameClaim(name, accountID)
+				// All-or-nothing: tear down the ENIs/SG already created so a
+				// failed create leaks nothing and frees the name claim.
+				s.rollbackLBInfra(eniIDs, nlbManagedSGID, name, accountID)
 				slog.Error("CreateLoadBalancer: failed to create ENI", "subnet", subnetID, "err", eniErr)
 				return nil, errors.New(awserrors.ErrorELBv2SubnetNotFound)
 			}
@@ -1318,7 +1311,9 @@ func (s *ELBv2ServiceImpl) CreateLoadBalancer(input *elbv2.CreateLoadBalancerInp
 
 	if err := s.store.PutLoadBalancer(record); err != nil {
 		slog.Error("CreateLoadBalancer: failed to persist record", "lbId", lbID, "err", err)
-		s.releaseLBNameClaim(name, accountID)
+		// The ENIs and managed SG exist but no record was persisted to own them —
+		// roll them back so they are not orphaned.
+		s.rollbackLBInfra(eniIDs, nlbManagedSGID, name, accountID)
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
@@ -1387,6 +1382,26 @@ func (s *ELBv2ServiceImpl) launchLBVMAsync(lc lbLaunchCtx) {
 	if putErr := s.store.PutLoadBalancer(record); putErr != nil {
 		slog.Error("CreateLoadBalancer: async launch failed to persist launch result", "lbArn", lc.lbArn, "err", putErr)
 	}
+}
+
+// rollbackLBInfra tears down the infrastructure a partial CreateLoadBalancer
+// created before it could persist an owning record: every ENI minted so far, the
+// NLB managed front-end SG (if any), and the name claim. Without this an
+// ENI/SG-create-then-persist-fail path orphans those resources with no record
+// for DeleteLoadBalancer or any reclaim to reach. Each step is best-effort and
+// idempotent — a NotFound is success.
+func (s *ELBv2ServiceImpl) rollbackLBInfra(eniIDs []string, nlbManagedSGID, name, accountID string) {
+	if s.VPCService != nil {
+		for _, eniID := range eniIDs {
+			if _, delErr := s.VPCService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+				NetworkInterfaceId: aws.String(eniID),
+			}, accountID); delErr != nil {
+				slog.Error("CreateLoadBalancer: rollback failed to delete ENI", "eni", eniID, "err", delErr)
+			}
+		}
+	}
+	s.deleteNLBManagedSG(nlbManagedSGID, accountID)
+	s.releaseLBNameClaim(name, accountID)
 }
 
 // markLBFailed reloads the LB record and flips it to the failed state, used by
@@ -2302,21 +2317,26 @@ func (s *ELBv2ServiceImpl) CreateListener(input *elbv2.CreateListenerInput, acco
 	// Open the listener port on the NLB's managed front-end SG so inbound
 	// traffic from the configured client CIDRs is admitted by the OVN ACL
 	// (NLB ENIs would otherwise sit in the intra-SG-only default SG).
+	var authorizedCIDRs []string
 	if lb.Type == LoadBalancerTypeNetwork && lb.NLBManagedSGID != "" && s.VPCService != nil {
 		cidrs, cidrErr := s.resolveNLBIngressCIDRs(lb)
 		if cidrErr != nil {
 			slog.Error("CreateListener: resolve ingress CIDRs failed", "lbArn", lb.LoadBalancerArn, "err", cidrErr)
+			s.rollbackListener(record, lb, protocol, port, nil, accountID)
 			return nil, errors.New(awserrors.ErrorServerInternal)
 		}
 		if authErr := s.authorizeNLBListenerPort(lb, protocol, port, cidrs, accountID); authErr != nil {
 			slog.Error("CreateListener: authorize listener port failed", "lbArn", lb.LoadBalancerArn, "port", port, "err", authErr)
+			s.rollbackListener(record, lb, protocol, port, nil, accountID)
 			return nil, errors.New(awserrors.ErrorServerInternal)
 		}
+		authorizedCIDRs = cidrs
 	}
 
 	// Start or reload HAProxy now that a listener exists
 	if err := s.updateStoredConfig(lb); err != nil {
 		slog.Error("CreateListener: failed to update config", "listenerId", listenerID, "err", err)
+		s.rollbackListener(record, lb, protocol, port, authorizedCIDRs, accountID)
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
@@ -2325,6 +2345,22 @@ func (s *ELBv2ServiceImpl) CreateListener(input *elbv2.CreateListenerInput, acco
 	return &elbv2.CreateListenerOutput{
 		Listeners: []*elbv2.Listener{s.listenerRecordToSDK(record)},
 	}, nil
+}
+
+// rollbackListener removes a just-persisted listener whose post-persist
+// data-plane wiring failed, so a failed CreateListener leaves no orphan record
+// and no dangling SG authorization. authorizedCIDRs is non-empty only when the
+// NLB front-end port was already opened (config-update failure path), in which
+// case the port is revoked first. Best-effort: cleanup errors are logged.
+func (s *ELBv2ServiceImpl) rollbackListener(record *ListenerRecord, lb *LoadBalancerRecord, protocol string, port int64, authorizedCIDRs []string, accountID string) {
+	if len(authorizedCIDRs) > 0 {
+		if err := s.revokeNLBListenerPort(lb, protocol, port, authorizedCIDRs, accountID); err != nil {
+			slog.Error("CreateListener: rollback failed to revoke listener port", "lbArn", lb.LoadBalancerArn, "port", port, "err", err)
+		}
+	}
+	if err := s.deleteListenerCascade(record); err != nil {
+		slog.Error("CreateListener: rollback failed to delete listener", "listenerArn", record.ListenerArn, "err", err)
+	}
 }
 
 // deleteListenerCascade removes a listener and all of its rules. Shared by

--- a/spinifex/handlers/elbv2/service_impl_rollback_test.go
+++ b/spinifex/handlers/elbv2/service_impl_rollback_test.go
@@ -1,0 +1,125 @@
+package handlers_elbv2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// managedENIIDs returns every requester-managed ENI in the account.
+func managedENIIDs(t *testing.T, vpcSvc *handlers_ec2_vpc.VPCServiceImpl) []string {
+	t.Helper()
+	out, err := vpcSvc.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{}, testAccountID)
+	require.NoError(t, err)
+	var ids []string
+	for _, eni := range out.NetworkInterfaces {
+		if eni.RequesterManaged != nil && *eni.RequesterManaged {
+			ids = append(ids, *eni.NetworkInterfaceId)
+		}
+	}
+	return ids
+}
+
+// TestRollbackLBInfra_RemovesAllInfra verifies the rollback the
+// PutLoadBalancer-failure path runs leaves no orphan: ENIs deleted, managed SG
+// deleted, name claim released (so the name is immediately reclaimable).
+func TestRollbackLBInfra_RemovesAllInfra(t *testing.T) {
+	svc, vpcSvc := setupTestServiceWithVPC(t)
+	subnetID, _ := firstSubnet(t, vpcSvc)
+
+	lb := createNLB(t, svc, "nlb-rollback", "internal", subnetID)
+	rec, err := svc.store.GetLoadBalancerByArn(*lb.LoadBalancerArn)
+	require.NoError(t, err)
+	sgID := rec.NLBManagedSGID
+	require.NotEmpty(t, sgID)
+
+	eniIDs := managedENIIDs(t, vpcSvc)
+	require.NotEmpty(t, eniIDs, "NLB create must mint at least one managed ENI")
+
+	// Roll back exactly as the PutLoadBalancer-failure path does.
+	svc.rollbackLBInfra(eniIDs, sgID, "nlb-rollback", testAccountID)
+
+	// ENIs gone.
+	for _, id := range managedENIIDs(t, vpcSvc) {
+		assert.NotContains(t, eniIDs, id, "rolled-back ENI must be deleted")
+	}
+
+	// Managed SG gone (empty result or not-found are both acceptable).
+	sgOut, err := vpcSvc.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		GroupIds: aws.StringSlice([]string{sgID}),
+	}, testAccountID)
+	if err == nil {
+		assert.Empty(t, sgOut.SecurityGroups, "rolled-back managed SG must be deleted")
+	}
+
+	// Name claim released → reclaimable by a fresh owner.
+	ok, dup, err := svc.store.ClaimLBName("nlb-rollback", testAccountID, "lb-fresh")
+	require.NoError(t, err)
+	assert.True(t, ok, "rollback must release the name claim")
+	assert.False(t, dup)
+}
+
+// TestRollbackListener_RevokesPortAndDeletesRecord covers the
+// updateStoredConfig-failure path: the listener port was already authorized, so
+// rollback must revoke it AND remove the persisted listener record.
+func TestRollbackListener_RevokesPortAndDeletesRecord(t *testing.T) {
+	svc, vpcSvc := setupTestServiceWithVPC(t)
+	subnetID, _ := firstSubnet(t, vpcSvc)
+
+	lb := createNLB(t, svc, "nlb-lst-rb", "internet-facing", subnetID)
+	createTCPListener(t, svc, lb.LoadBalancerArn, 443)
+
+	rec, err := svc.store.GetLoadBalancerByArn(*lb.LoadBalancerArn)
+	require.NoError(t, err)
+	require.True(t, sgHasRule(describeSG(t, vpcSvc, rec.NLBManagedSGID), "tcp", 443, "0.0.0.0/0"))
+
+	lst, err := svc.DescribeListeners(&elbv2.DescribeListenersInput{LoadBalancerArn: lb.LoadBalancerArn}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, lst.Listeners, 1)
+	listenerRec, err := svc.store.GetListenerByArn(*lst.Listeners[0].ListenerArn)
+	require.NoError(t, err)
+
+	// authorizedCIDRs non-empty ⇒ the config-failure path that already opened the port.
+	svc.rollbackListener(listenerRec, rec, "tcp", 443, []string{"0.0.0.0/0"}, testAccountID)
+
+	lst, err = svc.DescribeListeners(&elbv2.DescribeListenersInput{LoadBalancerArn: lb.LoadBalancerArn}, testAccountID)
+	require.NoError(t, err)
+	assert.Empty(t, lst.Listeners, "rolled-back listener record must be deleted")
+
+	assert.False(t, sgHasRule(describeSG(t, vpcSvc, rec.NLBManagedSGID), "tcp", 443, "0.0.0.0/0"),
+		"config-failure rollback must revoke the authorized port")
+}
+
+// TestRollbackListener_NilCIDRsSkipsRevoke covers the authorize-failure path:
+// the port was never successfully opened, so rollback deletes the listener
+// record but must not touch SG authorizations (authorizedCIDRs is nil).
+func TestRollbackListener_NilCIDRsSkipsRevoke(t *testing.T) {
+	svc, vpcSvc := setupTestServiceWithVPC(t)
+	subnetID, _ := firstSubnet(t, vpcSvc)
+
+	lb := createNLB(t, svc, "nlb-lst-nil", "internet-facing", subnetID)
+	createTCPListener(t, svc, lb.LoadBalancerArn, 443)
+
+	rec, err := svc.store.GetLoadBalancerByArn(*lb.LoadBalancerArn)
+	require.NoError(t, err)
+
+	lst, err := svc.DescribeListeners(&elbv2.DescribeListenersInput{LoadBalancerArn: lb.LoadBalancerArn}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, lst.Listeners, 1)
+	listenerRec, err := svc.store.GetListenerByArn(*lst.Listeners[0].ListenerArn)
+	require.NoError(t, err)
+
+	svc.rollbackListener(listenerRec, rec, "tcp", 443, nil, testAccountID)
+
+	lst, err = svc.DescribeListeners(&elbv2.DescribeListenersInput{LoadBalancerArn: lb.LoadBalancerArn}, testAccountID)
+	require.NoError(t, err)
+	assert.Empty(t, lst.Listeners, "rolled-back listener record must be deleted")
+
+	assert.True(t, sgHasRule(describeSG(t, vpcSvc, rec.NLBManagedSGID), "tcp", 443, "0.0.0.0/0"),
+		"nil authorizedCIDRs must skip the SG revoke")
+}


### PR DESCRIPTION
## Summary

Failure-mode A (partial-create leak), ELBv2 edition. `CreateLoadBalancer`/`CreateListener` provision infra then persist a KV record; a failure *after* the infra exists returned an error but orphaned the infra with no owning record, unreachable by `DeleteLoadBalancer`/`DeleteListener` or any reclaim. 267.4 already fixed the async LB-VM half (record-before-launch); this closes the two remaining synchronous gaps.

## Changes

- **`rollbackLBInfra` helper** — extracts the existing ENI-create-failure teardown (delete ENIs + `deleteNLBManagedSG` + `releaseLBNameClaim`). Now also called from the **`PutLoadBalancer`-failure** path, which previously only released the name claim and orphaned the ENIs + managed SG.
- **`rollbackListener` helper** — on `resolveNLBIngressCIDRs`/`authorizeNLBListenerPort`/`updateStoredConfig` failure, cascade-deletes the just-persisted listener record; when the port was already authorized (config-update failure path) it revokes it first. A failed `CreateListener` now leaves no orphan record and no dangling SG authorization.
- Customer-facing error codes unchanged; only cleanup-on-failure behaviour changes.
- **Test fix:** the two `CreateNodegroup` disk-size tests now `WaitLaunches()` before asserting `runCalls`, matching the record-before-launch async contract 267.4 introduced (they regressed on dev).

## Testing

- New `service_impl_rollback_test.go`: `rollbackLBInfra` deletes ENIs + managed SG + releases the name claim (reclaimable); `rollbackListener` revokes the port and deletes the record on the config-failure path, and skips the revoke (nil CIDRs) on the authorize-failure path.
- Existing CreateLoadBalancer/CreateListener/NLB-SG suites stay green.
- `make preflight` green.

Closes mulga-siv-267.5.