### PR TITLE
feat(gateway): enforce assumed-role session policies

### DIFF
--- a/spinifex/gateway/auth.go
+++ b/spinifex/gateway/auth.go
@@ -145,6 +145,9 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 			if principal.assumedRoleID != "" {
 				ctx = context.WithValue(ctx, ctxAssumedRoleID, principal.assumedRoleID)
 			}
+			if principal.underlyingRoleARN != "" {
+				ctx = context.WithValue(ctx, ctxUnderlyingRoleARN, principal.underlyingRoleARN)
+			}
 
 			// Parse once; dispatchers reuse via ctxQueryArgs. On error, the
 			// dispatcher re-parses and returns MalformedQueryString.
@@ -168,11 +171,12 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 // principalContext is the identity envelope set on the request context after
 // SigV4 verification succeeds.
 type principalContext struct {
-	identity       string
-	accountID      string
-	principalType  string
-	assumedRoleARN string
-	assumedRoleID  string
+	identity          string
+	accountID         string
+	principalType     string
+	assumedRoleARN    string
+	assumedRoleID     string
+	underlyingRoleARN string
 }
 
 // resolveLongLivedAKID handles the AKIA path: IAMService lookup, status check,
@@ -278,11 +282,12 @@ func (gw *GatewayConfig) resolveSessionAKID(r *http.Request, accessKeyID, client
 	// PrincipalType existed, so an absent value keeps the original role-session
 	// behaviour (see SessionCredential.PrincipalType backward-compat note).
 	return secret, principalContext{
-		identity:       cred.SessionName,
-		accountID:      cred.AccountID,
-		principalType:  principalTypeAssumedRole,
-		assumedRoleARN: cred.AssumedRoleARN,
-		assumedRoleID:  cred.AssumedRoleID,
+		identity:          cred.SessionName,
+		accountID:         cred.AccountID,
+		principalType:     principalTypeAssumedRole,
+		assumedRoleARN:    cred.AssumedRoleARN,
+		assumedRoleID:     cred.AssumedRoleID,
+		underlyingRoleARN: cred.UnderlyingRoleARN,
 	}, ""
 }
 

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -2178,8 +2178,8 @@ func TestCheckPolicy_AssumedRole_ExplicitDeny(t *testing.T) {
 }
 
 // TestCheckPolicy_AssumedRole_ZeroPolicyRole_DenyAll: a role that resolves but
-// has no attached policies can do nothing (decision 5a — assumability does not
-// imply permissions).
+// has no attached policies can do nothing — assumability does not imply
+// permissions.
 func TestCheckPolicy_AssumedRole_ZeroPolicyRole_DenyAll(t *testing.T) {
 	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/app-role", "123456789012")
 	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
@@ -2215,7 +2215,7 @@ func TestCheckPolicy_AssumedRole_SessionNamedRoot_NoBypass(t *testing.T) {
 
 // TestCheckPolicy_AssumedRole_EdgeARNs_Denied: a missing/legacy, cross-account,
 // or malformed underlying-role ARN fails closed with AccessDenied (403, not a
-// 500), and never reaches the role resolver (decision 6).
+// 500), and never reaches the role resolver.
 func TestCheckPolicy_AssumedRole_EdgeARNs_Denied(t *testing.T) {
 	cases := []struct {
 		name              string
@@ -2274,8 +2274,8 @@ func TestCheckPolicy_AssumedRole_TransientNATS_RetriesThenFails(t *testing.T) {
 }
 
 // TestCheckPolicy_AssumedRole_PassRole_ScopedToTargetARN_Allowed locks the
-// iam:PassRole resource match (decision 8): the role's policy scopes PassRole to
-// the exact target role ARN, so passing that role is allowed.
+// iam:PassRole resource match: the role's policy scopes PassRole to the exact
+// target role ARN, so passing that role is allowed.
 func TestCheckPolicy_AssumedRole_PassRole_ScopedToTargetARN_Allowed(t *testing.T) {
 	const targetRoleARN = "arn:aws:iam::123456789012:role/instance-role"
 	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/launcher-role", "123456789012")
@@ -2303,4 +2303,20 @@ func TestCheckPolicy_AssumedRole_PassRole_ScopedToOtherARN_Denied(t *testing.T) 
 	body, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	assert.Contains(t, string(body), "AccessDenied")
+}
+
+// TestCheckPolicy_AssumedRole_PassRole_WildcardResource_Allowed: a policy
+// granting iam:PassRole on "*" authorises passing any role ARN — the classic
+// wildcard PassRole grant. Locks the wildcard branch of the resource match.
+func TestCheckPolicy_AssumedRole_PassRole_WildcardResource_Allowed(t *testing.T) {
+	const targetRoleARN = "arn:aws:iam::123456789012:role/instance-role"
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/launcher-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return allowPolicyResource("iam:PassRole", "*"), nil
+	})
+
+	handler := setupPolicyResourceTestHandler(gw, "iam", "PassRole", targetRoleARN)
+	resp := doSessionPolicyRequest(t, handler, cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "body: %s", string(body))
 }

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -103,6 +103,9 @@ func (m *mockIAMService) ListAttachedUserPolicies(_ string, _ *iam.ListAttachedU
 func (m *mockIAMService) GetUserPolicies(_, _ string) ([]handlers_iam.PolicyDocument, error) {
 	return nil, nil
 }
+func (m *mockIAMService) GetRolePolicies(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+	return nil, nil
+}
 func (m *mockIAMService) DecryptSecret(ciphertext string) (string, error) {
 	return handlers_iam.DecryptSecret(ciphertext, m.masterKey)
 }
@@ -1061,16 +1064,26 @@ func TestSigV4Auth_QueryStringEdgeCases(t *testing.T) {
 
 // --- Policy Enforcement Tests (checkPolicy) ---
 
-// policyMockIAMService extends mockIAMService with configurable GetUserPolicies.
+// policyMockIAMService extends mockIAMService with configurable GetUserPolicies
+// and GetRolePolicies resolvers, so checkPolicy tests can drive both the user
+// and assumed-role enforcement branches.
 type policyMockIAMService struct {
 	mockIAMService
 
 	getUserPoliciesFn func(accountID, userName string) ([]handlers_iam.PolicyDocument, error)
+	getRolePoliciesFn func(accountID, roleName string) ([]handlers_iam.PolicyDocument, error)
 }
 
 func (m *policyMockIAMService) GetUserPolicies(accountID, userName string) ([]handlers_iam.PolicyDocument, error) {
 	if m.getUserPoliciesFn != nil {
 		return m.getUserPoliciesFn(accountID, userName)
+	}
+	return nil, nil
+}
+
+func (m *policyMockIAMService) GetRolePolicies(accountID, roleName string) ([]handlers_iam.PolicyDocument, error) {
+	if m.getRolePoliciesFn != nil {
+		return m.getRolePoliciesFn(accountID, roleName)
 	}
 	return nil, nil
 }
@@ -1941,17 +1954,22 @@ func TestSigV4Auth_Session_STSServiceNil(t *testing.T) {
 	assert.Contains(t, string(body), "InternalError")
 }
 
-// TestCheckPolicy_SessionNameCollision is the privilege-escalation regression
-// the ctxPrincipalType gate exists to prevent: an IAM user named "alice" has
-// a permissive Allow policy; a session is minted with SessionName="alice". A
-// missing gate would silently pass the session's identity through
-// GetUserPolicies("alice") and inherit alice's permissions. With the gate,
-// the assumed-role principal must fail closed regardless of name collisions.
+// TestCheckPolicy_SessionNameCollision is the load-bearing privilege-escalation
+// regression: an IAM user named "alice" has a permissive Allow policy; a session
+// is minted with SessionName="alice" but an underlying role "some-role" that
+// grants nothing. Evaluating the session against the colliding user name would
+// inherit alice's ec2:* permissions. The enforcement path must instead resolve
+// the session's UNDERLYING role — never the SessionName — so the request is
+// denied and GetUserPolicies is never consulted.
 func TestCheckPolicy_SessionNameCollision(t *testing.T) {
 	encryptedSecret, err := handlers_iam.EncryptSecret(testSecretKey, testMasterKey)
 	require.NoError(t, err)
 
-	// Real IAM user "alice" with permissive policy.
+	var userPoliciesCalled bool
+	var resolvedRoleName string
+
+	// IAM user "alice" carries a permissive policy. If the SessionName ("alice")
+	// were ever used as the policy-lookup key, the request would inherit ec2:*.
 	iamMock := &policyMockIAMService{
 		mockIAMService: mockIAMService{
 			masterKey: testMasterKey,
@@ -1965,30 +1983,24 @@ func TestCheckPolicy_SessionNameCollision(t *testing.T) {
 				},
 			},
 		},
-		getUserPoliciesFn: func(_, userName string) ([]handlers_iam.PolicyDocument, error) {
-			if userName == "alice" {
-				return []handlers_iam.PolicyDocument{
-					{
-						Version: "2012-10-17",
-						Statement: []handlers_iam.Statement{
-							{
-								Effect:   "Allow",
-								Action:   handlers_iam.StringOrArr{"ec2:*"},
-								Resource: handlers_iam.StringOrArr{"*"},
-							},
-						},
-					},
-				}, nil
-			}
+		getUserPoliciesFn: func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+			userPoliciesCalled = true
+			return allowPolicy("ec2:*"), nil
+		},
+		// The underlying role "some-role" grants nothing → implicit deny.
+		getRolePoliciesFn: func(_, roleName string) ([]handlers_iam.PolicyDocument, error) {
+			resolvedRoleName = roleName
 			return nil, nil
 		},
 	}
 
-	// Session whose SessionName == "alice" — colliding with the IAM user.
+	// Session whose SessionName == "alice" (colliding with the IAM user) but
+	// whose underlying role is "some-role".
 	cred := &handlers_sts.SessionCredential{
 		AccessKeyID:       testSessionAKID,
 		SecretEncrypted:   encryptedSecret,
 		AccountID:         "123456789012",
+		PrincipalType:     principalTypeAssumedRole,
 		AssumedRoleARN:    "arn:aws:sts::123456789012:assumed-role/some-role/alice",
 		UnderlyingRoleARN: "arn:aws:iam::123456789012:role/some-role",
 		SessionName:       "alice",
@@ -2016,8 +2028,279 @@ func TestCheckPolicy_SessionNameCollision(t *testing.T) {
 	resp := doRequest(handler, req)
 	body, _ := io.ReadAll(resp.Body)
 
-	// The collision must NOT escalate to alice's permissions — the gate
-	// rejects the session before it can even consult user policies.
+	// The session is evaluated against its ROLE, which grants nothing → deny.
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, string(body), "AccessDenied")
+	// The role — not the colliding user name — drove the lookup...
+	assert.Equal(t, "some-role", resolvedRoleName)
+	// ...and the user-policy resolver was never consulted.
+	assert.False(t, userPoliciesCalled, "priv-esc: assumed-role session must not consult GetUserPolicies")
+}
+
+// allowPolicy returns a single-statement Allow policy granting action on "*".
+func allowPolicy(action string) []handlers_iam.PolicyDocument {
+	return allowPolicyResource(action, "*")
+}
+
+// allowPolicyResource returns a single-statement Allow policy granting action
+// on a specific resource ARN.
+func allowPolicyResource(action, resource string) []handlers_iam.PolicyDocument {
+	return []handlers_iam.PolicyDocument{{
+		Version: "2012-10-17",
+		Statement: []handlers_iam.Statement{{
+			Effect:   "Allow",
+			Action:   handlers_iam.StringOrArr{action},
+			Resource: handlers_iam.StringOrArr{resource},
+		}},
+	}}
+}
+
+// assumedRoleSessionCred builds an assumed-role SessionCredential for the
+// enforcement tests. SecretEncrypted is filled in by the gateway builder.
+func assumedRoleSessionCred(sessionName, underlyingRoleARN, accountID string) *handlers_sts.SessionCredential {
+	return &handlers_sts.SessionCredential{
+		AccessKeyID:       testSessionAKID,
+		AccountID:         accountID,
+		PrincipalType:     principalTypeAssumedRole,
+		AssumedRoleARN:    "arn:aws:sts::" + accountID + ":assumed-role/role/" + sessionName,
+		UnderlyingRoleARN: underlyingRoleARN,
+		SessionName:       sessionName,
+		ExpiresAt:         time.Now().UTC().Add(time.Hour),
+		CreatedAt:         time.Now().UTC().Add(-time.Minute),
+	}
+}
+
+// newAssumedRoleEnforcementGateway wires a gateway whose checkPolicy path
+// evaluates an assumed-role session: an STS mock seeded with cred and an IAM
+// mock whose role resolver is getRoleFn. The user resolver fails the test if
+// consulted — an assumed-role principal must never be evaluated as a user.
+func newAssumedRoleEnforcementGateway(t *testing.T, cred *handlers_sts.SessionCredential,
+	getRoleFn func(accountID, roleName string) ([]handlers_iam.PolicyDocument, error),
+) *GatewayConfig {
+	t.Helper()
+	encryptedSecret, err := handlers_iam.EncryptSecret(testSecretKey, testMasterKey)
+	require.NoError(t, err)
+	cred.SecretEncrypted = encryptedSecret
+
+	iamMock := &policyMockIAMService{
+		mockIAMService: mockIAMService{masterKey: testMasterKey},
+		getUserPoliciesFn: func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+			t.Errorf("priv-esc: assumed-role principal must not consult GetUserPolicies")
+			return nil, nil
+		},
+		getRolePoliciesFn: getRoleFn,
+	}
+	stsMock := &mockSTSService{
+		sessions: map[string]*handlers_sts.SessionCredential{cred.AccessKeyID: cred},
+		tokens:   map[string]string{cred.AccessKeyID: testSessionToken},
+	}
+	return &GatewayConfig{
+		DisableLogging: true,
+		Region:         testRegion,
+		IAMService:     iamMock,
+		STSService:     stsMock,
+	}
+}
+
+// setupPolicyResourceTestHandler is setupPolicyTestHandler for a caller-chosen
+// service/action/resource, used to drive resource-scoped checks (e.g.
+// iam:PassRole on a specific role ARN).
+func setupPolicyResourceTestHandler(gw *GatewayConfig, service, action, resource string) http.Handler {
+	r := chi.NewRouter()
+	r.Use(gw.SigV4AuthMiddleware())
+	r.HandleFunc("/*", func(w http.ResponseWriter, req *http.Request) {
+		if err := gw.checkPolicyResource(req, service, action, resource); err != nil {
+			gw.ErrorHandler(w, req, err)
+			return
+		}
+		_, _ = w.Write([]byte("OK"))
+	})
+	return r
+}
+
+// doSessionPolicyRequest signs and runs a session-credential request through
+// handler, returning the response.
+func doSessionPolicyRequest(t *testing.T, handler http.Handler, akid string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:9999"
+	signSessionRequest(t, req, nil, akid, testSecretKey, testSessionToken)
+	return doRequest(handler, req)
+}
+
+// TestCheckPolicy_AssumedRole_AllowedByRolePolicy: the underlying role's managed
+// policy grants the action, so the session is allowed — the symmetric twin of
+// predastore's assumed-role S3 enforcement.
+func TestCheckPolicy_AssumedRole_AllowedByRolePolicy(t *testing.T) {
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/app-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, roleName string) ([]handlers_iam.PolicyDocument, error) {
+		require.Equal(t, "app-role", roleName)
+		return allowPolicy("ec2:RunInstances"), nil
+	})
+
+	resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "body: %s", string(body))
+}
+
+// TestCheckPolicy_AssumedRole_ImplicitDeny: the role policy matches neither the
+// action nor an explicit Deny, so the default deny applies.
+func TestCheckPolicy_AssumedRole_ImplicitDeny(t *testing.T) {
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/app-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return allowPolicy("ec2:DescribeInstances"), nil // does not cover RunInstances
+	})
+
+	resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, string(body), "AccessDenied")
+}
+
+// TestCheckPolicy_AssumedRole_ExplicitDeny: an explicit Deny in the role policy
+// overrides any Allow.
+func TestCheckPolicy_AssumedRole_ExplicitDeny(t *testing.T) {
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/app-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return []handlers_iam.PolicyDocument{{
+			Version: "2012-10-17",
+			Statement: []handlers_iam.Statement{
+				{Effect: "Allow", Action: handlers_iam.StringOrArr{"ec2:*"}, Resource: handlers_iam.StringOrArr{"*"}},
+				{Effect: "Deny", Action: handlers_iam.StringOrArr{"ec2:RunInstances"}, Resource: handlers_iam.StringOrArr{"*"}},
+			},
+		}}, nil
+	})
+
+	resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, string(body), "AccessDenied")
+}
+
+// TestCheckPolicy_AssumedRole_ZeroPolicyRole_DenyAll: a role that resolves but
+// has no attached policies can do nothing (decision 5a — assumability does not
+// imply permissions).
+func TestCheckPolicy_AssumedRole_ZeroPolicyRole_DenyAll(t *testing.T) {
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/app-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return nil, nil // role exists, zero attached policies
+	})
+
+	resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, string(body), "AccessDenied")
+}
+
+// TestCheckPolicy_AssumedRole_SessionNamedRoot_NoBypass: a session whose
+// attacker-chosen SessionName is "root" in the global account must NOT hit the
+// user-branch root short-circuit; it is evaluated against its role like any
+// other session.
+func TestCheckPolicy_AssumedRole_SessionNamedRoot_NoBypass(t *testing.T) {
+	cred := assumedRoleSessionCred("root",
+		"arn:aws:iam::"+utils.GlobalAccountID+":role/sneaky-role", utils.GlobalAccountID)
+	var roleResolved bool
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, roleName string) ([]handlers_iam.PolicyDocument, error) {
+		roleResolved = true
+		require.Equal(t, "sneaky-role", roleName)
+		return nil, nil // role grants nothing
+	})
+
+	resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, string(body), "AccessDenied")
+	assert.True(t, roleResolved, "root-named session must be evaluated against its role, not bypassed")
+}
+
+// TestCheckPolicy_AssumedRole_EdgeARNs_Denied: a missing/legacy, cross-account,
+// or malformed underlying-role ARN fails closed with AccessDenied (403, not a
+// 500), and never reaches the role resolver (decision 6).
+func TestCheckPolicy_AssumedRole_EdgeARNs_Denied(t *testing.T) {
+	cases := []struct {
+		name              string
+		underlyingRoleARN string
+	}{
+		{"empty/legacy", ""},
+		{"cross-account", "arn:aws:iam::999999999999:role/other"},
+		{"malformed", "not-an-arn"},
+		{"non-role-resource", "arn:aws:iam::123456789012:user/alice"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cred := assumedRoleSessionCred("app", tc.underlyingRoleARN, "123456789012")
+			gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+				t.Errorf("role resolver must not be consulted for an edge-case ARN (%s)", tc.name)
+				return nil, nil
+			})
+
+			resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode, "must deny, not 500")
+			assert.Contains(t, string(body), "AccessDenied")
+		})
+	}
+}
+
+// TestCheckPolicy_AssumedRole_ResolveError_InternalError: a non-transient role
+// resolve error fails closed — never an allow-on-error.
+func TestCheckPolicy_AssumedRole_ResolveError_InternalError(t *testing.T) {
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/app-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return nil, errors.New(awserrors.ErrorIAMNoSuchEntity) // role deleted after mint
+	})
+
+	resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(t, string(body), "InternalError")
+}
+
+// TestCheckPolicy_AssumedRole_TransientNATS_RetriesThenFails: a transient NATS
+// error is retried 3× then fails closed (no allow-on-error).
+func TestCheckPolicy_AssumedRole_TransientNATS_RetriesThenFails(t *testing.T) {
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/app-role", "123456789012")
+	var calls int
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		calls++
+		return nil, nats.ErrNoResponders
+	})
+
+	resp := doSessionPolicyRequest(t, setupPolicyTestHandler(gw), cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(t, string(body), "InternalError")
+	assert.Equal(t, 3, calls, "transient NATS error should retry 3×")
+}
+
+// TestCheckPolicy_AssumedRole_PassRole_ScopedToTargetARN_Allowed locks the
+// iam:PassRole resource match (decision 8): the role's policy scopes PassRole to
+// the exact target role ARN, so passing that role is allowed.
+func TestCheckPolicy_AssumedRole_PassRole_ScopedToTargetARN_Allowed(t *testing.T) {
+	const targetRoleARN = "arn:aws:iam::123456789012:role/instance-role"
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/launcher-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return allowPolicyResource("iam:PassRole", targetRoleARN), nil
+	})
+
+	handler := setupPolicyResourceTestHandler(gw, "iam", "PassRole", targetRoleARN)
+	resp := doSessionPolicyRequest(t, handler, cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "body: %s", string(body))
+}
+
+// TestCheckPolicy_AssumedRole_PassRole_ScopedToOtherARN_Denied: PassRole scoped
+// to a different role ARN must not authorise passing the target role.
+func TestCheckPolicy_AssumedRole_PassRole_ScopedToOtherARN_Denied(t *testing.T) {
+	const targetRoleARN = "arn:aws:iam::123456789012:role/instance-role"
+	cred := assumedRoleSessionCred("app", "arn:aws:iam::123456789012:role/launcher-role", "123456789012")
+	gw := newAssumedRoleEnforcementGateway(t, cred, func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return allowPolicyResource("iam:PassRole", "arn:aws:iam::123456789012:role/some-other-role"), nil
+	})
+
+	handler := setupPolicyResourceTestHandler(gw, "iam", "PassRole", targetRoleARN)
+	resp := doSessionPolicyRequest(t, handler, cred.AccessKeyID)
+	body, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	assert.Contains(t, string(body), "AccessDenied")
 }

--- a/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
+++ b/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
@@ -148,6 +148,9 @@ func (f *fakeIAMService) RemoveRoleFromInstanceProfile(string, *iam.RemoveRoleFr
 func (f *fakeIAMService) GetUserPolicies(string, string) ([]handlers_iam.PolicyDocument, error) {
 	return nil, nil
 }
+func (f *fakeIAMService) GetRolePolicies(string, string) ([]handlers_iam.PolicyDocument, error) {
+	return nil, nil
+}
 func (f *fakeIAMService) LookupAccessKey(string) (*handlers_iam.AccessKey, error) { return nil, nil }
 func (f *fakeIAMService) DecryptSecret(string) (string, error)                    { return "", nil }
 func (f *fakeIAMService) SeedBootstrap(*handlers_iam.BootstrapData) error         { return nil }

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/mulgadc/predastore/auth"
 	"github.com/mulgadc/predastore/ratelimit"
 	"github.com/mulgadc/spinifex/spinifex/awsec2query"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
@@ -40,6 +41,11 @@ const (
 	ctxPrincipalType  contextKey = "sigv4.principalType"
 	ctxAssumedRoleARN contextKey = "sigv4.assumedRoleARN"
 	ctxAssumedRoleID  contextKey = "sigv4.assumedRoleID"
+	// ctxUnderlyingRoleARN carries the IAM role ARN backing an assumed-role
+	// session (arn:aws:iam::A:role/Name). Policy enforcement resolves the role
+	// name from this, never from ctxIdentity (= attacker-influenced
+	// RoleSessionName).
+	ctxUnderlyingRoleARN contextKey = "sigv4.underlyingRoleARN"
 )
 
 // Values stored under ctxPrincipalType. The SigV4 middleware sets exactly one
@@ -402,52 +408,77 @@ func (gw *GatewayConfig) checkPolicyResource(r *http.Request, service, action, r
 		return errors.New(awserrors.ErrorInternalError)
 	}
 
-	// Classify the principal type BEFORE any identity-string-based bypass.
-	// An assumed-role session whose SessionName is "root" must not slip
-	// through the same-account root short-circuit; the identity string is
-	// attacker-influenced via RoleSessionName.
+	// Resolve the IAM action string (e.g. "ec2:RunInstances")
+	iamAction := policy.IAMAction(service, action)
+
+	// Select the policy resolver and log identity from the branch matching the
+	// principal type. Every identity-string-sensitive decision — the root
+	// bypass and the resolver choice — happens INSIDE its branch arm so an
+	// assumed-role session whose attacker-chosen SessionName is "root" can never
+	// reach the user root short-circuit. The shared tail below never reads the
+	// raw identity string.
+	var resolve func() ([]handlers_iam.PolicyDocument, error)
+	var logIdentity string
+
 	principalType, _ := r.Context().Value(ctxPrincipalType).(string)
 	switch principalType {
 	case principalTypeUser:
-		// fall through to identity-based checks and user-policy evaluation
+		if identity == "" || (identity == "root" && accountID == utils.GlobalAccountID) {
+			// root / pre-IAM bypass — USER BRANCH ONLY.
+			return nil
+		}
+		resolve = func() ([]handlers_iam.PolicyDocument, error) {
+			return gw.IAMService.GetUserPolicies(accountID, identity)
+		}
+		logIdentity = identity
 	case principalTypeAssumedRole:
-		slog.Warn("checkPolicy: assumed-role principal denied",
-			"sessionARN", r.Context().Value(ctxAssumedRoleARN),
-			"action", policy.IAMAction(service, action))
-		return errors.New(awserrors.ErrorAccessDenied)
+		// Resolve by the session's UNDERLYING role name — never by SessionName
+		// (= attacker-influenced ctxIdentity). A missing/legacy, cross-account,
+		// or malformed ARN fails closed with AccessDenied: these sessions were
+		// blanket-denied before this change, so denying them now is no
+		// regression, and a 403 (not 500) leaks no internal state.
+		underlyingRoleARN, _ := r.Context().Value(ctxUnderlyingRoleARN).(string)
+		roleAcct, roleName, perr := auth.ParseRoleARN(underlyingRoleARN)
+		if perr != nil || roleAcct != accountID {
+			slog.Warn("checkPolicy: unresolvable or cross-account assumed-role principal denied",
+				"underlyingRoleARN", underlyingRoleARN,
+				"accountID", accountID,
+				"action", iamAction,
+				"err", perr)
+			return errors.New(awserrors.ErrorAccessDenied)
+		}
+		resolve = func() ([]handlers_iam.PolicyDocument, error) {
+			return gw.IAMService.GetRolePolicies(accountID, roleName)
+		}
+		logIdentity, _ = r.Context().Value(ctxAssumedRoleARN).(string)
 	default:
 		slog.Error("checkPolicy: unknown principal type", "principalType", principalType)
 		return errors.New(awserrors.ErrorInternalError)
 	}
 
-	if identity == "" || (identity == "root" && accountID == utils.GlobalAccountID) {
-		return nil
-	}
-
-	// Resolve the IAM action string (e.g. "ec2:RunInstances")
-	iamAction := policy.IAMAction(service, action)
-
-	// Retry on transient NATS errors (e.g. during node failure / leader election).
+	// Shared tail: resolve policies (retrying transient NATS errors during node
+	// failure / leader election), then evaluate. Fail-closed on any non-transient
+	// resolve error; never reads the raw identity string.
 	var policies []handlers_iam.PolicyDocument
 	var err error
 	for attempt := range 3 {
-		policies, err = gw.IAMService.GetUserPolicies(accountID, identity)
+		policies, err = resolve()
 		if err == nil || !isNATSTransient(err) {
 			break
 		}
 		if attempt < 2 {
 			slog.Debug("checkPolicy: transient NATS error, retrying",
-				"user", identity, "attempt", attempt+1, "err", err)
+				"identity", logIdentity, "attempt", attempt+1, "err", err)
 			time.Sleep(time.Duration(attempt+1) * 200 * time.Millisecond)
 		}
 	}
 	if err != nil {
-		slog.Error("checkPolicy: failed to get user policies", "user", identity, "err", err)
+		slog.Error("checkPolicy: failed to resolve policies", "identity", logIdentity, "err", err)
 		return errors.New(awserrors.ErrorInternalError)
 	}
 
-	if policy.EvaluateAccess(identity, iamAction, resource, policies) == policy.Deny {
-		slog.Info("checkPolicy: access denied", "user", identity, "action", iamAction, "resource", resource)
+	if policy.EvaluateAccess(logIdentity, iamAction, resource, policies) == policy.Deny {
+		slog.Info("checkPolicy: access denied", "identity", logIdentity, "action", iamAction, "resource", resource)
 		return errors.New(awserrors.ErrorAccessDenied)
 	}
 

--- a/spinifex/gateway/iam/handler_test.go
+++ b/spinifex/gateway/iam/handler_test.go
@@ -90,6 +90,10 @@ func (s *stubIAMService) GetUserPolicies(_, _ string) ([]handlers_iam.PolicyDocu
 	return nil, nil
 }
 
+func (s *stubIAMService) GetRolePolicies(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+	return nil, nil
+}
+
 func (s *stubIAMService) LookupAccessKey(_ string) (*handlers_iam.AccessKey, error) {
 	return nil, nil
 }

--- a/spinifex/gateway/iam_request_test.go
+++ b/spinifex/gateway/iam_request_test.go
@@ -124,6 +124,10 @@ func (m *flexMockIAMService) GetUserPolicies(_, _ string) ([]handlers_iam.Policy
 	return nil, nil
 }
 
+func (m *flexMockIAMService) GetRolePolicies(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+	return nil, nil
+}
+
 func (m *flexMockIAMService) LookupAccessKey(_ string) (*handlers_iam.AccessKey, error) {
 	return nil, errors.New("not implemented")
 }

--- a/spinifex/gateway/sts/handler_test.go
+++ b/spinifex/gateway/sts/handler_test.go
@@ -196,6 +196,9 @@ func (s *stubIAMService) ResolveInstanceProfile(string, string) (*handlers_iam.I
 func (s *stubIAMService) GetUserPolicies(string, string) ([]handlers_iam.PolicyDocument, error) {
 	panic("unexpected GetUserPolicies call")
 }
+func (s *stubIAMService) GetRolePolicies(string, string) ([]handlers_iam.PolicyDocument, error) {
+	panic("unexpected GetRolePolicies call")
+}
 func (s *stubIAMService) LookupAccessKey(string) (*handlers_iam.AccessKey, error) {
 	panic("unexpected LookupAccessKey call")
 }

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -331,6 +331,42 @@ func (s *IAMServiceImpl) ListAttachedRolePolicies(accountID string, input *iam.L
 	}, nil
 }
 
+// GetRolePolicies resolves the managed policy documents attached to a role,
+// the symmetric twin of GetUserPolicies. The gateway uses it to evaluate an
+// assumed-role session's permissions. Inline role policies do not exist yet,
+// so this resolves attached managed policies only.
+//
+// Fails closed: a missing role (NoSuchEntity) or any unresolvable attached
+// policy returns an error so the caller denies access rather than evaluating
+// against a partial policy set. A role with no attached policies returns no
+// documents, which the evaluator treats as an implicit deny — AWS parity, as
+// assumability does not imply permissions.
+func (s *IAMServiceImpl) GetRolePolicies(accountID, roleName string) ([]PolicyDocument, error) {
+	role, err := s.getRole(accountID, roleName)
+	if err != nil {
+		return nil, err
+	}
+
+	var docs []PolicyDocument
+	for _, arn := range role.AttachedPolicies {
+		policy, err := s.getPolicyByARN(accountID, arn)
+		if err != nil {
+			// Fail closed: if we can't resolve a policy, we can't make a safe
+			// access decision. Return an error so the caller denies access.
+			return nil, fmt.Errorf("resolve policy %s: %w", arn, err)
+		}
+
+		// policy already validated at creation, so we skip validating again
+		var doc PolicyDocument
+		if err := json.Unmarshal([]byte(policy.PolicyDocument), &doc); err != nil {
+			return nil, fmt.Errorf("parse policy %s: %w", policy.PolicyName, err)
+		}
+		docs = append(docs, doc)
+	}
+
+	return docs, nil
+}
+
 func (s *IAMServiceImpl) getRole(accountID, roleName string) (*Role, error) {
 	entry, err := s.rolesBucket.Get(accountID + "." + roleName)
 	if err != nil {

--- a/spinifex/handlers/iam/roles_test.go
+++ b/spinifex/handlers/iam/roles_test.go
@@ -589,9 +589,13 @@ func TestGetRolePolicies(t *testing.T) {
 
 	docs, err := svc.GetRolePolicies(testAccountID, "eval-role")
 	require.NoError(t, err)
-	assert.Len(t, docs, 2)
-	assert.Equal(t, "2012-10-17", docs[0].Version)
-	assert.Equal(t, "2012-10-17", docs[1].Version)
+	require.Len(t, docs, 2)
+	for _, doc := range docs {
+		assert.Equal(t, "2012-10-17", doc.Version)
+		require.Len(t, doc.Statement, 1)
+		assert.Equal(t, "Allow", doc.Statement[0].Effect)
+		assert.Contains(t, doc.Statement[0].Action, "ec2:DescribeInstances")
+	}
 }
 
 func TestGetRolePolicies_NoPolicies(t *testing.T) {

--- a/spinifex/handlers/iam/roles_test.go
+++ b/spinifex/handlers/iam/roles_test.go
@@ -1,6 +1,7 @@
 package handlers_iam
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -563,6 +564,73 @@ func TestListAttachedRolePolicies_Empty(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Len(t, out.AttachedPolicies, 0)
+}
+
+// ============================================================================
+// GetRolePolicies (gateway enforcement resolver)
+// ============================================================================
+
+func TestGetRolePolicies(t *testing.T) {
+	svc := setupTestIAMService(t)
+	role := createTestRole(t, svc, "eval-role")
+	p1 := createTestPolicy(t, svc, "RolePolicy1")
+	p2 := createTestPolicy(t, svc, "RolePolicy2")
+
+	_, err := svc.AttachRolePolicy(testAccountID, &iam.AttachRolePolicyInput{
+		RoleName:  role.RoleName,
+		PolicyArn: p1.Arn,
+	})
+	require.NoError(t, err)
+	_, err = svc.AttachRolePolicy(testAccountID, &iam.AttachRolePolicyInput{
+		RoleName:  role.RoleName,
+		PolicyArn: p2.Arn,
+	})
+	require.NoError(t, err)
+
+	docs, err := svc.GetRolePolicies(testAccountID, "eval-role")
+	require.NoError(t, err)
+	assert.Len(t, docs, 2)
+	assert.Equal(t, "2012-10-17", docs[0].Version)
+	assert.Equal(t, "2012-10-17", docs[1].Version)
+}
+
+func TestGetRolePolicies_NoPolicies(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "bare-role")
+
+	docs, err := svc.GetRolePolicies(testAccountID, "bare-role")
+	require.NoError(t, err)
+	assert.Len(t, docs, 0)
+}
+
+func TestGetRolePolicies_NonexistentRole(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.GetRolePolicies(testAccountID, "ghost-role")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+// TestGetRolePolicies_UnresolvablePolicy locks the fail-closed contract: a role
+// referencing an attached policy ARN that can no longer be resolved must return
+// an error so the gateway denies rather than evaluating a partial policy set.
+func TestGetRolePolicies_UnresolvablePolicy(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "dangling-role")
+
+	// Overwrite the role record with an attachment to a policy that does not
+	// exist, simulating a managed policy deleted out from under a live
+	// attachment.
+	role, err := svc.getRole(testAccountID, "dangling-role")
+	require.NoError(t, err)
+	role.AttachedPolicies = []string{"arn:aws:iam::" + testAccountID + ":policy/Ghost"}
+	data, err := json.Marshal(role)
+	require.NoError(t, err)
+	_, err = svc.rolesBucket.Put(testAccountID+".dangling-role", data)
+	require.NoError(t, err)
+
+	_, err = svc.GetRolePolicies(testAccountID, "dangling-role")
+	assert.Error(t, err)
 }
 
 // ============================================================================

--- a/spinifex/handlers/iam/service.go
+++ b/spinifex/handlers/iam/service.go
@@ -71,6 +71,9 @@ type IAMService interface {
 
 	// Policy evaluation (internal — used by gateway enforcement)
 	GetUserPolicies(accountID, userName string) ([]PolicyDocument, error)
+	// GetRolePolicies resolves an assumed-role session's permission policies for
+	// gateway enforcement. Managed policies only in v1.
+	GetRolePolicies(accountID, roleName string) ([]PolicyDocument, error)
 
 	// Auth (internal — used by SigV4 middleware and bootstrap, not exposed via gateway)
 	LookupAccessKey(accessKeyID string) (*AccessKey, error)

--- a/spinifex/handlers/iam/service.go
+++ b/spinifex/handlers/iam/service.go
@@ -72,7 +72,8 @@ type IAMService interface {
 	// Policy evaluation (internal — used by gateway enforcement)
 	GetUserPolicies(accountID, userName string) ([]PolicyDocument, error)
 	// GetRolePolicies resolves an assumed-role session's permission policies for
-	// gateway enforcement. Managed policies only in v1.
+	// gateway enforcement. Managed policies only; inline policies are not yet
+	// supported.
 	GetRolePolicies(accountID, roleName string) ([]PolicyDocument, error)
 
 	// Auth (internal — used by SigV4 middleware and bootstrap, not exposed via gateway)

--- a/tests/e2e/single/assumed_role_enforcement_test.go
+++ b/tests/e2e/single/assumed_role_enforcement_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+
+package single
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// Identifiers for the assumed-role control-plane enforcement suite. The are-
+// prefix keeps them clear of the STS suite (sts-e2e-) and the IAM-roles suite
+// (app-role / other-role).
+const (
+	areRoleName    = "are-e2e-role"
+	arePolicyName  = "are-e2e-ec2-describe-regions"
+	areSessionName = "are-e2e-session"
+
+	// A single-action grant, so the positive case proves a specific managed
+	// policy was resolved and evaluated — not a blanket allow.
+	arePolicyDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ec2:DescribeRegions","Resource":"*"}]}`
+)
+
+// runAssumedRoleControlPlaneEnforcement proves the gateway evaluates an
+// assumed-role session's managed policies against the control plane — the
+// symmetric twin of predastore's assumed-role S3 enforcement. It exercises the
+// full SigV4-session → resolve-role-policies → evaluate path through the real
+// gateway:
+//
+//   - a zero-policy role is denied (assumability does not imply permissions);
+//   - after attaching a policy granting ec2:DescribeRegions, the SAME live
+//     session is permitted — the gateway resolves the role's current managed
+//     policies at request time, so already-minted credentials pick up the grant.
+//
+// Owns its own role + policy, so it is safe alongside the other IAM/STS suites,
+// but registered sequential so its grant doesn't race a parallel evaluation.
+func runAssumedRoleControlPlaneEnforcement(t *testing.T, fix *Fixture) {
+	harness.Phase(t, "Single — Assumed-role control-plane enforcement")
+	adminAccount := iamEnsureAdminAccountID(t, fix)
+	roleARN := iamRoleARN(adminAccount, areRoleName)
+	policyARN := iamPolicyARN(adminAccount, arePolicyName)
+
+	// Defensive pre-sweep + teardown — a previous failed run may have left
+	// fragments. iamDeleteRoleAndProfilesBestEffort detaches the policy before
+	// deleting the role; the explicit DeletePolicy then removes the managed
+	// policy itself.
+	sweep := func() {
+		iamDeleteRoleAndProfilesBestEffort(fix, areRoleName, nil, policyARN)
+		_, _ = fix.AWS.IAM.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: aws.String(policyARN)})
+	}
+	sweep()
+	fix.Harness.RegisterCleanup(sweep)
+
+	// Role assumable by anyone in-account (wildcard trust), with NO permission
+	// policy yet.
+	harness.Step(t, "create-role %q (no permission policy)", areRoleName)
+	_, err := fix.AWS.IAM.CreateRole(&iam.CreateRoleInput{
+		RoleName:                 aws.String(areRoleName),
+		AssumeRolePolicyDocument: aws.String(stsTrustPolicyAllowAny),
+		Description:              aws.String("E2E assumed-role control-plane enforcement"),
+	})
+	require.NoError(t, err, "create-role")
+
+	// Mint assumed-role (ASIA) credentials.
+	harness.Step(t, "assume-role %q session=%q", roleARN, areSessionName)
+	aOut, err := fix.AWS.STS.AssumeRole(&sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String(areSessionName),
+	})
+	require.NoError(t, err, "assume-role")
+	creds := aOut.Credentials
+	require.NotNil(t, creds, "AssumeRole returned nil Credentials")
+	sessionCli := harness.NewAWSClientWithSessionCreds(t, fix.Env,
+		aws.StringValue(creds.AccessKeyId),
+		aws.StringValue(creds.SecretAccessKey),
+		aws.StringValue(creds.SessionToken))
+
+	// Zero-policy role → implicit deny. The session authenticates (SigV4 ASIA
+	// path) but the resolved role grants nothing.
+	harness.Step(t, "describe-regions with zero-policy role (expect AccessDenied)")
+	harness.ExpectError(t, "AccessDenied", func() error {
+		_, e := sessionCli.EC2.DescribeRegions(&ec2.DescribeRegionsInput{})
+		return e
+	})
+
+	// Attach a managed policy granting ec2:DescribeRegions to the role.
+	harness.Step(t, "create+attach policy %q (grants ec2:DescribeRegions)", arePolicyName)
+	_, err = fix.AWS.IAM.CreatePolicy(&iam.CreatePolicyInput{
+		PolicyName:     aws.String(arePolicyName),
+		PolicyDocument: aws.String(arePolicyDoc),
+	})
+	require.NoError(t, err, "create-policy")
+	_, err = fix.AWS.IAM.AttachRolePolicy(&iam.AttachRolePolicyInput{
+		RoleName:  aws.String(areRoleName),
+		PolicyArn: aws.String(policyARN),
+	})
+	require.NoError(t, err, "attach-role-policy")
+
+	// The SAME live session is now permitted: the gateway resolves the role's
+	// current managed policies per request, so an already-minted session picks
+	// up the new grant.
+	harness.Step(t, "describe-regions after grant (expect success)")
+	_, err = sessionCli.EC2.DescribeRegions(&ec2.DescribeRegionsInput{})
+	require.NoError(t, err, "describe-regions must be allowed once the role grants it")
+}

--- a/tests/e2e/single/sts_test.go
+++ b/tests/e2e/single/sts_test.go
@@ -227,12 +227,13 @@ func runSTS(t *testing.T, fix *Fixture) {
 		"UserId for assumed-role must equal AssumedRoleId")
 
 	// Cross-service ASIA SigV4: drive a non-STS endpoint with the assumed
-	// creds. gateway.checkPolicy hard-denies any assumed-role principal
-	// (gateway.go switch on principalTypeAssumedRole) — locking that in
-	// here catches a future refactor that relaxes the gate before the role-
-	// policy evaluator exists. The wire path also proves ctxPrincipalType
-	// propagates beyond the STS service into the EC2 dispatcher; a unit
-	// test of checkPolicy cannot exercise that propagation.
+	// creds. The role here carries no permission policy, so gateway.checkPolicy
+	// resolves its (empty) managed policies and the action falls to an implicit
+	// deny — assumability does not imply permissions. The wire path also proves
+	// ctxPrincipalType + the underlying-role ARN propagate beyond the STS
+	// service into the EC2 dispatcher's policy gate; a unit test of checkPolicy
+	// cannot exercise that propagation. The granted-policy positive case lives
+	// in TestAssumedRoleControlPlaneEnforcement.
 	harness.Step(t, "ec2 describe-regions with assumed-role creds (expect AccessDenied)")
 	harness.ExpectError(t, "AccessDenied", func() error {
 		_, e := sessionCli.EC2.DescribeRegions(&ec2.DescribeRegionsInput{})

--- a/tests/e2e/single/tests_test.go
+++ b/tests/e2e/single/tests_test.go
@@ -241,6 +241,15 @@ func TestSTSAssumeRoleAndGetCallerIdentity(t *testing.T) {
 	runSTS(t, requireSingleNodeFixture(t))
 }
 
+// TestAssumedRoleControlPlaneEnforcement verifies the gateway evaluates an
+// assumed-role session's managed policies against the control plane: a
+// zero-policy role is denied, and the same live session is permitted once a
+// granting policy is attached. Owns its own role + policy, but sequential so
+// the mid-test grant doesn't race a parallel evaluation.
+func TestAssumedRoleControlPlaneEnforcement(t *testing.T) {
+	runAssumedRoleControlPlaneEnforcement(t, requireSingleNodeFixture(t))
+}
+
 // TestIMDS exercises the host-served IMDSv2 surface end-to-end: token
 // issuance, the v2-only stance, the metadata surface, the
 // instance-role credential path + wire round-trip, the per-subnet L2 localport


### PR DESCRIPTION
Resolve an assumed-role session's attached managed policies and evaluate them through the existing policy engine instead of blanket-denying every assumed-role principal. Mirrors predastore's assumed-role S3 enforcement, closing the asymmetry where the same role works against S3 but was denied against the EC2/IAM control plane.