### PR TITLE
fix(network): restore centralised EIP gateway-port neigh prime (regressed by #328)

### DIFF
--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -171,7 +171,7 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 			"router", router, "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP)
 		// Skip row churn but still re-prime: stop->start re-attaches the same EIP
 		// and the host neigh stays dark until ARP times out without a fresh prime.
-		m.primeReachability(eip, distributed)
+		m.primeReachability(ctx, eip, distributed)
 		return nil
 	}
 
@@ -188,20 +188,40 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 	if err := m.barrier(); err != nil {
 		slog.Warn("policy: AddEIP flows barrier failed", "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP, "err", err)
 	}
-	m.primeReachability(eip, distributed)
+	m.primeReachability(ctx, eip, distributed)
 	return nil
 }
 
-// primeReachability re-announces an EIP: distributed mode programs the ARP entry
-// directly; centralised mode (no MAC) flushes and re-arms ARP. Best-effort.
-func (m *natManager) primeReachability(eip EIPSpec, distributed bool) {
-	if distributed {
-		if err := m.neighPrime(eip); err != nil {
+// primeReachability programs the host neigh entry to the MAC owning the EIP on
+// the WAN segment — external_mac (distributed) or gateway router-port MAC
+// (centralised) — falling back to an ARP flush when no MAC resolves.
+func (m *natManager) primeReachability(ctx context.Context, eip EIPSpec, distributed bool) {
+	primeMAC := eip.MAC
+	if !distributed {
+		primeMAC = m.gatewayPortMAC(ctx, eip.VPCID)
+	}
+	if primeMAC != "" {
+		primed := eip
+		primed.MAC = primeMAC
+		if err := m.neighPrime(primed); err != nil {
 			slog.Warn("policy: AddEIP neighbour prime failed", "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP, "err", err)
 		}
-	} else if err := m.neigh(eip.ExternalIP); err != nil {
+		return
+	}
+	if err := m.neigh(eip.ExternalIP); err != nil {
 		slog.Warn("policy: AddEIP neighbour flush failed", "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP, "err", err)
 	}
+}
+
+// gatewayPortMAC returns the MAC of the VPC gateway router's external port, the
+// L2 owner of a centralised EIP on the WAN segment. Empty on lookup miss so the
+// caller falls back to an ARP flush.
+func (m *natManager) gatewayPortMAC(ctx context.Context, vpcID string) string {
+	lrp, err := m.ovn.GetLogicalRouterPort(ctx, topology.GatewayRouterPort(vpcID))
+	if err != nil || lrp == nil {
+		return ""
+	}
+	return lrp.MAC
 }
 
 func (m *natManager) DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error {

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 )
 
+func seedGatewayPort(t *testing.T, m *mock.Client, vpcID, mac string) {
+	t.Helper()
+	require.NoError(t, m.CreateLogicalRouterPort(context.Background(),
+		topology.VPCRouter(vpcID),
+		&nbdb.LogicalRouterPort{Name: topology.GatewayRouterPort(vpcID), MAC: mac}))
+}
+
 func seedRouter(t *testing.T, m *mock.Client, vpcID string) string {
 	t.Helper()
 	name := topology.VPCRouter(vpcID)
@@ -142,10 +149,11 @@ func TestNATManager_NeighPrime_OnDistributedAttach_FlushOnDetach(t *testing.T) {
 		"detach must still flush the released external IP")
 }
 
-func TestNATManager_NeighFlush_OnCentralizedAttach(t *testing.T) {
+func TestNATManager_NeighPrime_OnCentralizedAttach(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()
 	seedRouter(t, m, "vpc-1")
+	seedGatewayPort(t, m, "vpc-1", "02:gw:00:00:00:01")
 	var primed []EIPSpec
 	var flushed []string
 	nm, err := NewNATManager(m, NATModeCentralized,
@@ -162,9 +170,36 @@ func TestNATManager_NeighFlush_OnCentralizedAttach(t *testing.T) {
 	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
 		VPCID: "vpc-1", ExternalIP: "1.2.3.4", LogicalIP: "10.0.0.5",
 	}))
-	assert.Empty(t, primed, "centralized attach has no external_mac to prime")
+	require.Len(t, primed, 1,
+		"centralized attach must prime the host neighbour with the gateway port MAC")
+	assert.Equal(t, "02:gw:00:00:00:01", primed[0].MAC,
+		"centralized prime must use the VPC gateway router-port MAC")
+	assert.Empty(t, flushed, "a successful prime must not also flush")
+}
+
+func TestNATManager_NeighFlush_CentralizedNoGatewayMAC(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1") // no gateway port seeded → MAC unresolvable
+	var primed []EIPSpec
+	var flushed []string
+	nm, err := NewNATManager(m, NATModeCentralized,
+		WithNeighPrimer(func(eip EIPSpec) error {
+			primed = append(primed, eip)
+			return nil
+		}),
+		WithNeighFlusher(func(externalIP string) error {
+			flushed = append(flushed, externalIP)
+			return nil
+		}))
+	require.NoError(t, err)
+
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-1", ExternalIP: "1.2.3.4", LogicalIP: "10.0.0.5",
+	}))
+	assert.Empty(t, primed, "no gateway MAC to prime")
 	assert.Equal(t, []string{"1.2.3.4"}, flushed,
-		"centralized attach must fall back to a neighbour flush")
+		"centralized attach must fall back to a neighbour flush when no MAC resolves")
 }
 
 func TestNATManager_NeighHooks_FailureNonFatal(t *testing.T) {


### PR DESCRIPTION
## Summary

Restores centralised-mode EIP host-neighbour priming, which was accidentally reverted. Fixes the intermittent `TestMultinodeGuestSSH` failure in the multinode e2e suite.

## Symptom

E2E run [27389102143](https://github.com/mulgadc/spinifex/actions/runs/27389102143) failed only in `TestMultinodeGuestSSH`:

```
ssh 192.168.0.244:22: kex_exchange_identification: read: Connection reset by peer
```

The guest was fully booted (sshd listening, cloud-init final done ~2s before the probe) — this is L2/L3 EIP reachability, not the guest. Post-test neigh state: node1/node2 `192.168.0.244 ... STALE` (resolved), **node3
`192.168.0.244 dev br-wan FAILED`** (never resolved). The probe originated on the node that never resolved → reset at kex until the kernel ARP entry times out (60-300s), longer than the 2m test budget. The pass/fail split is that ARP race, which is why the test "sometimes passes".

## Root cause

In centralised/veth NAT, every EIP in a VPC is fronted on `br-wan` by the VPC **gateway router port**. Verified from the run artifacts: OVS flows rewrite traffic for all EIPs `.241`–`.244` to a single MAC `mod_dl_dst:02:01:cd:70:d0:2c`, which is the gateway router port of the VPC owning the EIP.

`primeReachability` took the **flush-only** branch in centralised mode, so after a cross-node stop/start the originating node had to passively re-ARP that gateway-port MAC across the WAN underlay — racy, and intermittently
never completes inside the SSH window.

## Why it regressed

This fix already shipped as `f7446c69` *"prime host neigh with gateway port MAC on centralised EIP attach"* (Jun 8). PR #328 (`06a583cb`) was branched from before `f7446c69`'s `nat.go` change and **clobbered it on merge**,
reverting `primeReachability` to flush-only. The `GetLogicalRouterPort` client method + mock survived; only the `gatewayPortMAC` helper and its use were lost. This PR restores `f7446c69` on top of #328's extracted primeReachability`.

## Change

- `primeReachability`: centralised mode resolves the gateway router-port MAC via `GetLogicalRouterPort(GatewayRouterPort(vpcID))` and programs it through the existing neigh primer (`host.ReplaceNeigh`); falls back to a flush only when no MAC resolves. `ctx` threaded through for the lookup.
- Distributed mode unchanged (programs the ENI `external_mac`).
- Tests: centralised prime asserts the gateway-port MAC; new no-gateway-MAC case asserts the flush fallback.