### PR TITLE
Resilient resource lifecycle (ADR-0001..0006): EKS multi-node teardown, idempotent deletes, GC backstops

### DIFF
--- a/spinifex/awserrors/awserrors.go
+++ b/spinifex/awserrors/awserrors.go
@@ -497,6 +497,15 @@ func IsErrorCode(err error, code string) bool {
 	return err != nil && strings.Contains(err.Error(), code)
 }
 
+// IsNotFound reports whether err carries an AWS "*.NotFound" error code — the
+// canonical "resource absent" signal. Destroy orchestration (teardown / GC /
+// reaper) uses this to treat an already-gone resource as success, so the API
+// handlers stay AWS-faithful (idempotency lives at the call site, not the
+// handler). Substring match mirrors IsErrorCode for %w-wrapped errors.
+func IsNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), ".NotFound")
+}
+
 var ErrorLookup = map[string]ErrorMessage{
 	ErrorAccountDisabled: {HTTPCode: 400, Message: "The functionality you have requested has been administratively disabled for this account."},
 	ErrorActiveVpcPeeringConnectionPerVpcLimitExceeded:         {HTTPCode: 400, Message: "You've reached the limit on the number of active VPC peering connections you can have for the specified VPC."},

--- a/spinifex/awserrors/awserrors_test.go
+++ b/spinifex/awserrors/awserrors_test.go
@@ -1,6 +1,10 @@
 package awserrors
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
 
 // TestErrorLookup_Structure asserts ErrorLookup invariants: minimum size, valid HTTP codes, non-empty messages.
 // Avoids a 1:1 mirror that would need updating with every new error code.
@@ -61,6 +65,39 @@ func TestValidErrorCode(t *testing.T) {
 			got := ValidErrorCode(tt.code)
 			if got != tt.want {
 				t.Errorf("ValidErrorCode(%q) = %q, want %q", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsNotFound covers the destroy-orchestration tolerance helper: it matches
+// any AWS canonical InvalidX.NotFound (so teardown converges on already-gone
+// resources) and only those — a nil error or a non-NotFound failure is not
+// swallowed.
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"vpc not found", errors.New(ErrorInvalidVpcIDNotFound), true},
+		{"subnet not found", errors.New(ErrorInvalidSubnetIDNotFound), true},
+		{"igw not found", errors.New(ErrorInvalidInternetGatewayIDNotFound), true},
+		{"natgw not found", errors.New(ErrorInvalidNatGatewayIDNotFound), true},
+		{"route table not found", errors.New(ErrorInvalidRouteTableIDNotFound), true},
+		{"eni not found", errors.New(ErrorInvalidNetworkInterfaceIDNotFound), true},
+		{"sg not found", errors.New(ErrorInvalidGroupNotFound), true},
+		{"volume not found", errors.New(ErrorInvalidVolumeNotFound), true},
+		{"wrapped not found", fmt.Errorf("delete cp vpc: %w", errors.New(ErrorInvalidVpcIDNotFound)), true},
+		{"dependency violation is not NotFound", errors.New(ErrorDependencyViolation), false},
+		{"in use is not NotFound", errors.New(ErrorInvalidNetworkInterfaceInUse), false},
+		{"server internal is not NotFound", errors.New(ErrorServerInternal), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFound(tt.err); got != tt.want {
+				t.Errorf("IsNotFound(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1395,6 +1395,13 @@ func (d *Daemon) startCluster() error {
 	d.startHeartbeat()
 	d.vmMgr.StartPendingWatchdog(d.ctx)
 
+	// Reality→desired GC backstop (ADR-0003 §3): finish teardown interrupted by
+	// a node-down mid-cascade and purge completed terminated records.
+	if d.jsManager != nil {
+		gc := vm.NewGarbageCollector(d.jsManager.KVHealthy, d.vmMgr.NewTerminatedTeardownReaper())
+		gc.Start(d.ctx)
+	}
+
 	d.ready.Store(true)
 	slog.Info("Daemon fully initialized", "node", d.node, "startupTime", time.Since(d.startTime).Round(time.Second))
 

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1396,9 +1396,15 @@ func (d *Daemon) startCluster() error {
 	d.vmMgr.StartPendingWatchdog(d.ctx)
 
 	// Reality→desired GC backstop (ADR-0003 §3): finish teardown interrupted by
-	// a node-down mid-cascade and purge completed terminated records.
+	// a node-down mid-cascade and purge completed terminated records. The volume
+	// data-safety reaper (ADR-0005 §3) rides the same backstop but only marks +
+	// alarms — it never deletes volume data.
 	if d.jsManager != nil {
-		gc := vm.NewGarbageCollector(d.jsManager.KVHealthy, d.vmMgr.NewTerminatedTeardownReaper())
+		reapers := []vm.Reaper{d.vmMgr.NewTerminatedTeardownReaper()}
+		if d.volumeService != nil {
+			reapers = append(reapers, d.volumeService.NewVolumeLeakReaper(d.leakedVolumeInstances))
+		}
+		gc := vm.NewGarbageCollector(d.jsManager.KVHealthy, reapers...)
 		gc.Start(d.ctx)
 	}
 
@@ -1410,6 +1416,25 @@ func (d *Daemon) startCluster() error {
 	d.awaitShutdown()
 
 	return nil
+}
+
+// leakedVolumeInstances returns the set of instance IDs this node owns whose
+// teardown leaked a volume — terminated here with a failed volumes-teardown.
+// The volume data-safety reaper marks (never deletes) volumes still attached to
+// these definitively-gone instances. Keying on this node's terminated set keeps
+// the shared-store scan from false-marking another node's live-instance volume.
+func (d *Daemon) leakedVolumeInstances() (map[string]bool, error) {
+	terminated, err := d.jsManager.ListTerminatedInstances()
+	if err != nil {
+		return nil, err
+	}
+	leaked := make(map[string]bool)
+	for _, v := range terminated {
+		if v.LastNode == d.node && v.Teardown[vm.TeardownVolumes] == string(vm.TeardownFailed) {
+			leaked[v.ID] = true
+		}
+	}
+	return leaked, nil
 }
 
 // connectNATS connects to NATS with infinite retry (cap 60s backoff). Tests

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1406,6 +1406,7 @@ func (d *Daemon) startCluster() error {
 		}
 		if d.eksService != nil {
 			reapers = append(reapers, d.eksService.NewBillableReaper(d.nodeRunningVMs))
+			reapers = append(reapers, d.eksService.NewDeletingReaper())
 		}
 		gc := vm.NewGarbageCollector(d.jsManager.KVHealthy, reapers...)
 		gc.Start(d.ctx)

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1404,6 +1404,9 @@ func (d *Daemon) startCluster() error {
 		if d.volumeService != nil {
 			reapers = append(reapers, d.volumeService.NewVolumeLeakReaper(d.leakedVolumeInstances))
 		}
+		if d.eksService != nil {
+			reapers = append(reapers, d.eksService.NewBillableReaper(d.nodeRunningVMs))
+		}
 		gc := vm.NewGarbageCollector(d.jsManager.KVHealthy, reapers...)
 		gc.Start(d.ctx)
 	}
@@ -1435,6 +1438,23 @@ func (d *Daemon) leakedVolumeInstances() (map[string]bool, error) {
 		}
 	}
 	return leaked, nil
+}
+
+// nodeRunningVMs returns this node's running VMs for the EKS billable reaper to
+// scan. A nil stateStore (early init / test) yields an empty set.
+func (d *Daemon) nodeRunningVMs() ([]*vm.VM, error) {
+	if d.stateStore == nil {
+		return nil, nil
+	}
+	running, err := d.stateStore.LoadRunningState(d.node)
+	if err != nil {
+		return nil, err
+	}
+	vms := make([]*vm.VM, 0, len(running))
+	for _, v := range running {
+		vms = append(vms, v)
+	}
+	return vms, nil
 }
 
 // connectNATS connects to NATS with infinite retry (cap 60s backoff). Tests

--- a/spinifex/daemon/daemon_handlers_instance_test.go
+++ b/spinifex/daemon/daemon_handlers_instance_test.go
@@ -140,6 +140,13 @@ func (f *fakeStateStore) ListTerminatedInstances() ([]*vm.VM, error) {
 	return out, nil
 }
 
+func (f *fakeStateStore) DeleteTerminatedInstance(id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.terminated, id)
+	return nil
+}
+
 var _ vm.StateStore = (*fakeStateStore)(nil)
 
 // daemonWithFakeStateStore returns a daemon wired with an in-memory NATS

--- a/spinifex/daemon/daemon_handlers_test.go
+++ b/spinifex/daemon/daemon_handlers_test.go
@@ -1972,11 +1972,11 @@ func TestDelegateHandlers_RoundTrip(t *testing.T) {
 			input:   &ec2.DescribeVolumeStatusInput{},
 		},
 		{
-			name:       "DeleteVolume",
-			topic:      "ec2.test.DeleteVolume",
-			handler:    daemon.handleEC2DeleteVolume,
-			input:      &ec2.DeleteVolumeInput{VolumeId: aws.String("vol-nonexistent")},
-			allowEmpty: true, // RLC1: idempotent delete, absent volume → success
+			name:         "DeleteVolume",
+			topic:        "ec2.test.DeleteVolume",
+			handler:      daemon.handleEC2DeleteVolume,
+			input:        &ec2.DeleteVolumeInput{VolumeId: aws.String("vol-nonexistent")},
+			expectedCode: awserrors.ErrorInvalidVolumeNotFound,
 		},
 		{
 			name:         "CreateSnapshot",
@@ -2310,11 +2310,11 @@ func TestDelegateHandlers_VPC(t *testing.T) {
 			input:   &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")},
 		},
 		{
-			name:       "DeleteVpc",
-			topic:      "ec2.test.DeleteVpc",
-			handler:    daemon.handleEC2DeleteVpc,
-			input:      &ec2.DeleteVpcInput{VpcId: aws.String("vpc-nonexistent")},
-			allowEmpty: true, // RLC1: idempotent delete, absent VPC → success
+			name:         "DeleteVpc",
+			topic:        "ec2.test.DeleteVpc",
+			handler:      daemon.handleEC2DeleteVpc,
+			input:        &ec2.DeleteVpcInput{VpcId: aws.String("vpc-nonexistent")},
+			expectedCode: awserrors.ErrorInvalidVpcIDNotFound,
 		},
 		{
 			name:    "DescribeVpcs",
@@ -2333,11 +2333,11 @@ func TestDelegateHandlers_VPC(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidVpcIDNotFound,
 		},
 		{
-			name:       "DeleteSubnet",
-			topic:      "ec2.test.DeleteSubnet",
-			handler:    daemon.handleEC2DeleteSubnet,
-			input:      &ec2.DeleteSubnetInput{SubnetId: aws.String("subnet-nonexistent")},
-			allowEmpty: true, // RLC1: idempotent delete, absent subnet → success
+			name:         "DeleteSubnet",
+			topic:        "ec2.test.DeleteSubnet",
+			handler:      daemon.handleEC2DeleteSubnet,
+			input:        &ec2.DeleteSubnetInput{SubnetId: aws.String("subnet-nonexistent")},
+			expectedCode: awserrors.ErrorInvalidSubnetIDNotFound,
 		},
 		{
 			name:    "DescribeSubnets",
@@ -2353,11 +2353,11 @@ func TestDelegateHandlers_VPC(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidSubnetIDNotFound,
 		},
 		{
-			name:       "DeleteNetworkInterface",
-			topic:      "ec2.test.DeleteNetworkInterface",
-			handler:    daemon.handleEC2DeleteNetworkInterface,
-			input:      &ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String("eni-nonexistent")},
-			allowEmpty: true, // RLC1: idempotent delete, absent ENI → success
+			name:         "DeleteNetworkInterface",
+			topic:        "ec2.test.DeleteNetworkInterface",
+			handler:      daemon.handleEC2DeleteNetworkInterface,
+			input:        &ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String("eni-nonexistent")},
+			expectedCode: awserrors.ErrorInvalidNetworkInterfaceIDNotFound,
 		},
 		{
 			name:    "DescribeNetworkInterfaces",
@@ -2403,11 +2403,11 @@ func TestDelegateHandlers_IGW(t *testing.T) {
 			input:   &ec2.CreateInternetGatewayInput{},
 		},
 		{
-			name:       "DeleteInternetGateway",
-			topic:      "ec2.test.DeleteInternetGateway",
-			handler:    daemon.handleEC2DeleteInternetGateway,
-			input:      &ec2.DeleteInternetGatewayInput{InternetGatewayId: aws.String("igw-nonexistent")},
-			allowEmpty: true, // RLC1: idempotent delete, absent IGW → success
+			name:         "DeleteInternetGateway",
+			topic:        "ec2.test.DeleteInternetGateway",
+			handler:      daemon.handleEC2DeleteInternetGateway,
+			input:        &ec2.DeleteInternetGatewayInput{InternetGatewayId: aws.String("igw-nonexistent")},
+			expectedCode: awserrors.ErrorInvalidInternetGatewayIDNotFound,
 		},
 		{
 			name:    "DescribeInternetGateways",
@@ -3693,11 +3693,11 @@ func TestDelegateHandlers_SecurityGroup(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidGroupNotFound,
 		},
 		{
-			name:       "DeleteSecurityGroup",
-			topic:      "ec2.test.DeleteSecurityGroup",
-			handler:    daemon.handleEC2DeleteSecurityGroup,
-			input:      &ec2.DeleteSecurityGroupInput{GroupId: aws.String("sg-nonexistent")},
-			allowEmpty: true, // RLC1: idempotent delete, absent SG → success
+			name:         "DeleteSecurityGroup",
+			topic:        "ec2.test.DeleteSecurityGroup",
+			handler:      daemon.handleEC2DeleteSecurityGroup,
+			input:        &ec2.DeleteSecurityGroupInput{GroupId: aws.String("sg-nonexistent")},
+			expectedCode: awserrors.ErrorInvalidGroupNotFound,
 		},
 	}
 
@@ -3762,11 +3762,11 @@ func TestDelegateHandlers_RouteTable(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidVpcIDNotFound,
 		},
 		{
-			name:       "DeleteRouteTable",
-			topic:      "ec2.test.DeleteRouteTable",
-			handler:    daemon.handleEC2DeleteRouteTable,
-			input:      &ec2.DeleteRouteTableInput{RouteTableId: aws.String("rtb-nonexistent")},
-			allowEmpty: true, // RLC1: idempotent delete, absent route table → success
+			name:         "DeleteRouteTable",
+			topic:        "ec2.test.DeleteRouteTable",
+			handler:      daemon.handleEC2DeleteRouteTable,
+			input:        &ec2.DeleteRouteTableInput{RouteTableId: aws.String("rtb-nonexistent")},
+			expectedCode: awserrors.ErrorInvalidRouteTableIDNotFound,
 		},
 		{
 			name:    "DescribeRouteTables",

--- a/spinifex/daemon/daemon_handlers_test.go
+++ b/spinifex/daemon/daemon_handlers_test.go
@@ -1972,11 +1972,11 @@ func TestDelegateHandlers_RoundTrip(t *testing.T) {
 			input:   &ec2.DescribeVolumeStatusInput{},
 		},
 		{
-			name:         "DeleteVolume",
-			topic:        "ec2.test.DeleteVolume",
-			handler:      daemon.handleEC2DeleteVolume,
-			input:        &ec2.DeleteVolumeInput{VolumeId: aws.String("vol-nonexistent")},
-			expectedCode: awserrors.ErrorInvalidVolumeNotFound,
+			name:       "DeleteVolume",
+			topic:      "ec2.test.DeleteVolume",
+			handler:    daemon.handleEC2DeleteVolume,
+			input:      &ec2.DeleteVolumeInput{VolumeId: aws.String("vol-nonexistent")},
+			allowEmpty: true, // RLC1: idempotent delete, absent volume → success
 		},
 		{
 			name:         "CreateSnapshot",
@@ -2310,11 +2310,11 @@ func TestDelegateHandlers_VPC(t *testing.T) {
 			input:   &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")},
 		},
 		{
-			name:         "DeleteVpc",
-			topic:        "ec2.test.DeleteVpc",
-			handler:      daemon.handleEC2DeleteVpc,
-			input:        &ec2.DeleteVpcInput{VpcId: aws.String("vpc-nonexistent")},
-			expectedCode: awserrors.ErrorInvalidVpcIDNotFound,
+			name:       "DeleteVpc",
+			topic:      "ec2.test.DeleteVpc",
+			handler:    daemon.handleEC2DeleteVpc,
+			input:      &ec2.DeleteVpcInput{VpcId: aws.String("vpc-nonexistent")},
+			allowEmpty: true, // RLC1: idempotent delete, absent VPC → success
 		},
 		{
 			name:    "DescribeVpcs",
@@ -2333,11 +2333,11 @@ func TestDelegateHandlers_VPC(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidVpcIDNotFound,
 		},
 		{
-			name:         "DeleteSubnet",
-			topic:        "ec2.test.DeleteSubnet",
-			handler:      daemon.handleEC2DeleteSubnet,
-			input:        &ec2.DeleteSubnetInput{SubnetId: aws.String("subnet-nonexistent")},
-			expectedCode: awserrors.ErrorInvalidSubnetIDNotFound,
+			name:       "DeleteSubnet",
+			topic:      "ec2.test.DeleteSubnet",
+			handler:    daemon.handleEC2DeleteSubnet,
+			input:      &ec2.DeleteSubnetInput{SubnetId: aws.String("subnet-nonexistent")},
+			allowEmpty: true, // RLC1: idempotent delete, absent subnet → success
 		},
 		{
 			name:    "DescribeSubnets",
@@ -2353,11 +2353,11 @@ func TestDelegateHandlers_VPC(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidSubnetIDNotFound,
 		},
 		{
-			name:         "DeleteNetworkInterface",
-			topic:        "ec2.test.DeleteNetworkInterface",
-			handler:      daemon.handleEC2DeleteNetworkInterface,
-			input:        &ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String("eni-nonexistent")},
-			expectedCode: awserrors.ErrorInvalidNetworkInterfaceIDNotFound,
+			name:       "DeleteNetworkInterface",
+			topic:      "ec2.test.DeleteNetworkInterface",
+			handler:    daemon.handleEC2DeleteNetworkInterface,
+			input:      &ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String("eni-nonexistent")},
+			allowEmpty: true, // RLC1: idempotent delete, absent ENI → success
 		},
 		{
 			name:    "DescribeNetworkInterfaces",
@@ -2403,11 +2403,11 @@ func TestDelegateHandlers_IGW(t *testing.T) {
 			input:   &ec2.CreateInternetGatewayInput{},
 		},
 		{
-			name:         "DeleteInternetGateway",
-			topic:        "ec2.test.DeleteInternetGateway",
-			handler:      daemon.handleEC2DeleteInternetGateway,
-			input:        &ec2.DeleteInternetGatewayInput{InternetGatewayId: aws.String("igw-nonexistent")},
-			expectedCode: awserrors.ErrorInvalidInternetGatewayIDNotFound,
+			name:       "DeleteInternetGateway",
+			topic:      "ec2.test.DeleteInternetGateway",
+			handler:    daemon.handleEC2DeleteInternetGateway,
+			input:      &ec2.DeleteInternetGatewayInput{InternetGatewayId: aws.String("igw-nonexistent")},
+			allowEmpty: true, // RLC1: idempotent delete, absent IGW → success
 		},
 		{
 			name:    "DescribeInternetGateways",
@@ -3693,11 +3693,11 @@ func TestDelegateHandlers_SecurityGroup(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidGroupNotFound,
 		},
 		{
-			name:         "DeleteSecurityGroup",
-			topic:        "ec2.test.DeleteSecurityGroup",
-			handler:      daemon.handleEC2DeleteSecurityGroup,
-			input:        &ec2.DeleteSecurityGroupInput{GroupId: aws.String("sg-nonexistent")},
-			expectedCode: awserrors.ErrorInvalidGroupNotFound,
+			name:       "DeleteSecurityGroup",
+			topic:      "ec2.test.DeleteSecurityGroup",
+			handler:    daemon.handleEC2DeleteSecurityGroup,
+			input:      &ec2.DeleteSecurityGroupInput{GroupId: aws.String("sg-nonexistent")},
+			allowEmpty: true, // RLC1: idempotent delete, absent SG → success
 		},
 	}
 
@@ -3762,11 +3762,11 @@ func TestDelegateHandlers_RouteTable(t *testing.T) {
 			expectedCode: awserrors.ErrorInvalidVpcIDNotFound,
 		},
 		{
-			name:         "DeleteRouteTable",
-			topic:        "ec2.test.DeleteRouteTable",
-			handler:      daemon.handleEC2DeleteRouteTable,
-			input:        &ec2.DeleteRouteTableInput{RouteTableId: aws.String("rtb-nonexistent")},
-			expectedCode: awserrors.ErrorInvalidRouteTableIDNotFound,
+			name:       "DeleteRouteTable",
+			topic:      "ec2.test.DeleteRouteTable",
+			handler:    daemon.handleEC2DeleteRouteTable,
+			input:      &ec2.DeleteRouteTableInput{RouteTableId: aws.String("rtb-nonexistent")},
+			allowEmpty: true, // RLC1: idempotent delete, absent route table → success
 		},
 		{
 			name:    "DescribeRouteTables",

--- a/spinifex/daemon/daemon_system_dispatch.go
+++ b/spinifex/daemon/daemon_system_dispatch.go
@@ -2,12 +2,15 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
+	"github.com/mulgadc/spinifex/spinifex/handlers/sysinstance"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 )
@@ -113,6 +116,42 @@ func (d *Daemon) LaunchSystemInstanceOnNode(nodeID string, input *handlers_elbv2
 	return env.Output, nil
 }
 
+// systemTerminateRemoteTimeout caps a routed system.TerminateInstance round
+// trip. Sized for qemu stop + volume teardown + ENI cascade on a remote host.
+const systemTerminateRemoteTimeout = 90 * time.Second
+
+// terminateSystemInstanceRemote routes a terminate to the owning daemon over
+// system.TerminateInstance.{id} (only the owner subscribes). A no-responder
+// reply means no node owns the VM, so it is genuinely gone — reported as
+// ErrSystemInstanceNotFound, which callers treat as idempotent success.
+func (d *Daemon) terminateSystemInstanceRemote(instanceID string) error {
+	if d.natsConn == nil {
+		return fmt.Errorf("%w: %s", sysinstance.ErrSystemInstanceNotFound, instanceID)
+	}
+	subject := fmt.Sprintf("system.TerminateInstance.%s", instanceID)
+	reply, err := d.natsConn.Request(subject, nil, systemTerminateRemoteTimeout)
+	if err != nil {
+		if errors.Is(err, nats.ErrNoResponders) {
+			slog.Debug("terminateSystemInstanceRemote: no owner subscribed; VM already gone",
+				"instanceId", instanceID)
+			return fmt.Errorf("%w: %s", sysinstance.ErrSystemInstanceNotFound, instanceID)
+		}
+		return fmt.Errorf("route terminate %s: %w", instanceID, err)
+	}
+	var env systemInstanceTerminateEnvelope
+	if err := json.Unmarshal(reply.Data, &env); err != nil {
+		return fmt.Errorf("decode routed terminate reply %s: %w", instanceID, err)
+	}
+	if env.Error != "" {
+		if strings.Contains(env.Error, sysinstance.ErrSystemInstanceNotFound.Error()) {
+			return fmt.Errorf("%w: %s", sysinstance.ErrSystemInstanceNotFound, instanceID)
+		}
+		return fmt.Errorf("routed terminate %s: %s", instanceID, env.Error)
+	}
+	slog.Info("terminateSystemInstanceRemote: owner terminated VM", "instanceId", instanceID)
+	return nil
+}
+
 // subscribeSystemTerminate registers an owning-node subscription for
 // system.TerminateInstance.{instanceID}. Idempotent — calling for an
 // already-bound subscription is a no-op.
@@ -170,7 +209,10 @@ func (d *Daemon) serveSystemTerminateInstance(msg *nats.Msg) {
 		return
 	}
 
-	if err := d.TerminateSystemInstance(parts); err != nil {
+	// The local body, not the routing wrapper: only the owning node subscribes,
+	// so the VM is local here. Routing from the handler could loop back to this
+	// same subscription if the VM raced to gone.
+	if err := d.terminateSystemInstanceLocal(parts); err != nil {
 		slog.Error("system.TerminateInstance: failed",
 			"instanceId", parts, "err", err)
 		respondWithSystemTerminateError(msg, err.Error())

--- a/spinifex/daemon/daemon_system_dispatch_test.go
+++ b/spinifex/daemon/daemon_system_dispatch_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
+	"github.com/mulgadc/spinifex/spinifex/handlers/sysinstance"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -353,6 +354,109 @@ func TestLaunchSystemInstanceOnNode_RemoteWithoutConn(t *testing.T) {
 	d := &Daemon{node: "node-a"}
 	_, err := d.LaunchSystemInstanceOnNode("node-b", &handlers_elbv2.SystemInstanceInput{InstanceType: "sys.medium"})
 	require.Error(t, err, "remote placement requires a NATS connection")
+}
+
+// TestTerminateSystemInstanceRemote_RoundTrip locks mulga-siv-295.10: terminating
+// a CP VM this node does not own routes over system.TerminateInstance.{id} to the
+// owning daemon, which stops qemu and cascade-deletes the ENI before replying —
+// so the cluster-wide teardown actually frees the remote ENI instead of deleting
+// it while still attached (InvalidNetworkInterface.InUse).
+func TestTerminateSystemInstanceRemote_RoundTrip(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	d := &Daemon{natsConn: nc, node: "node-a", natsSubscriptions: make(map[string]*nats.Subscription)}
+
+	gotCh := make(chan struct{}, 1)
+	sub, err := nc.Subscribe("system.TerminateInstance.i-remote", func(msg *nats.Msg) {
+		gotCh <- struct{}{}
+		payload, _ := json.Marshal(systemInstanceTerminateEnvelope{})
+		_ = msg.Respond(payload)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	require.NoError(t, d.terminateSystemInstanceRemote("i-remote"))
+
+	select {
+	case <-gotCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("owning node never received the routed terminate")
+	}
+}
+
+// TestTerminateSystemInstanceRemote_NoResponders: no node owns the VM, so the
+// request gets no responders. That means the VM is genuinely gone, reported as
+// ErrSystemInstanceNotFound — which TerminateK3sServerVM treats as idempotent.
+func TestTerminateSystemInstanceRemote_NoResponders(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	d := &Daemon{natsConn: nc, node: "node-a", natsSubscriptions: make(map[string]*nats.Subscription)}
+
+	err = d.terminateSystemInstanceRemote("i-orphan")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sysinstance.ErrSystemInstanceNotFound,
+		"no owner means the VM is gone — caller must see idempotent NotFound, not a hang")
+}
+
+// TestTerminateSystemInstanceRemote_NotFoundPropagated: the owner replies with a
+// NotFound (it raced to gone); the routing layer normalizes it back to a typed
+// ErrSystemInstanceNotFound so the teardown still treats it as idempotent.
+func TestTerminateSystemInstanceRemote_NotFoundPropagated(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	d := &Daemon{natsConn: nc, node: "node-a", natsSubscriptions: make(map[string]*nats.Subscription)}
+
+	sub, err := nc.Subscribe("system.TerminateInstance.i-gone", func(msg *nats.Msg) {
+		payload, _ := json.Marshal(systemInstanceTerminateEnvelope{
+			Error: sysinstance.ErrSystemInstanceNotFound.Error() + ": i-gone",
+		})
+		_ = msg.Respond(payload)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	err = d.terminateSystemInstanceRemote("i-gone")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sysinstance.ErrSystemInstanceNotFound)
+}
+
+// TestTerminateSystemInstanceRemote_ErrorPropagated: a real teardown failure on
+// the owner surfaces to the caller (not swallowed), so the cluster delete fails
+// loudly and the backstop reaper re-drives it rather than stranding billable infra.
+func TestTerminateSystemInstanceRemote_ErrorPropagated(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+
+	d := &Daemon{natsConn: nc, node: "node-a", natsSubscriptions: make(map[string]*nats.Subscription)}
+
+	sub, err := nc.Subscribe("system.TerminateInstance.i-stuck", func(msg *nats.Msg) {
+		payload, _ := json.Marshal(systemInstanceTerminateEnvelope{Error: "volume detach timed out"})
+		_ = msg.Respond(payload)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	err = d.terminateSystemInstanceRemote("i-stuck")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volume detach timed out")
+	assert.NotErrorIs(t, err, sysinstance.ErrSystemInstanceNotFound,
+		"a real failure must not be misreported as idempotent NotFound")
+}
+
+// TestTerminateSystemInstanceRemote_WithoutConn: with no NATS connection there is
+// no way to reach an owner, so the VM is unreachable — reported as NotFound.
+func TestTerminateSystemInstanceRemote_WithoutConn(t *testing.T) {
+	d := &Daemon{node: "node-a"}
+	err := d.terminateSystemInstanceRemote("i-x")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sysinstance.ErrSystemInstanceNotFound)
 }
 
 // TestHandleSystemLaunchInstance_PanicRecovered drives a valid launch against a

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -244,7 +244,7 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 					slog.Warn("LaunchSystemInstance: failed to clear ENI public IP during NAT-failure rollback",
 						"eniId", instance.ENIId, "publicIp", publicIP, "err", clearErr)
 				}
-				if relErr := d.externalIPAM.ReleaseIP(poolName, publicIP); relErr != nil {
+				if relErr := d.externalIPAM.ReleaseIP(poolName, publicIP, instance.ENIId); relErr != nil {
 					slog.Warn("LaunchSystemInstance: failed to release public IP during NAT-failure rollback",
 						"publicIp", publicIP, "pool", poolName, "err", relErr)
 				}

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -489,8 +489,21 @@ func (d *Daemon) attachSystemMgmtNIC(inst *vm.VM) error {
 	return nil
 }
 
-// TerminateSystemInstance stops and cleans up a system-managed VM.
+// TerminateSystemInstance stops and cleans up a system-managed VM. When this
+// node does not own the VM, the terminate is routed over NATS to the owning
+// daemon: an HA-spread EKS control plane places CP VMs on remote hosts, so a
+// cluster-wide teardown invoked on any node must reach the owner to actually
+// stop qemu and free the ENI — otherwise the local-only path returns NotFound
+// and the teardown deletes a still-attached ENI (InvalidNetworkInterface.InUse).
 func (d *Daemon) TerminateSystemInstance(instanceID string) error {
+	if _, exists := d.vmMgr.Get(instanceID); exists {
+		return d.terminateSystemInstanceLocal(instanceID)
+	}
+	return d.terminateSystemInstanceRemote(instanceID)
+}
+
+// terminateSystemInstanceLocal stops a VM owned by this node.
+func (d *Daemon) terminateSystemInstanceLocal(instanceID string) error {
 	instance, exists := d.vmMgr.Get(instanceID)
 	if !exists {
 		return fmt.Errorf("%w: %s", sysinstance.ErrSystemInstanceNotFound, instanceID)

--- a/spinifex/daemon/jetstream.go
+++ b/spinifex/daemon/jetstream.go
@@ -61,6 +61,17 @@ func (m *JetStreamManager) SetSyncObserver(obs KVSyncObserver) {
 	m.obs = obs
 }
 
+// KVHealthy reports whether JetStream is reachable and quorate via a cheap
+// AccountInfo round-trip. The GC backstop gates every sweep on this so it never
+// reaps against a desired-state it cannot trust (ADR-0003 §3).
+func (m *JetStreamManager) KVHealthy() bool {
+	if m.js == nil {
+		return false
+	}
+	_, err := m.js.AccountInfo()
+	return err == nil
+}
+
 // NewJetStreamManager creates a new JetStreamManager from a NATS connection.
 // replicas specifies the number of replicas for the KV bucket (typically matches cluster node count).
 func NewJetStreamManager(nc *nats.Conn, replicas int) (*JetStreamManager, error) {

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -623,7 +623,7 @@ func (a *instanceCleanerAdapter) ReleasePublicIP(instance *vm.VM) error {
 	}
 	utils.PublishNATEvent(a.d.natsConn, "vpc.delete-nat", vpcId, instance.PublicIP, logicalIP, portName, "")
 
-	if err := a.d.externalIPAM.ReleaseIP(instance.PublicIPPool, instance.PublicIP); err != nil {
+	if err := a.d.externalIPAM.ReleaseIP(instance.PublicIPPool, instance.PublicIP, instance.ENIId); err != nil {
 		slog.Warn("Failed to release public IP on termination",
 			"ip", instance.PublicIP, "pool", instance.PublicIPPool, "err", err)
 		return err

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 	"github.com/mulgadc/spinifex/spinifex/tags"
@@ -523,10 +523,11 @@ func newInstanceCleanerAdapter(d *Daemon) *instanceCleanerAdapter {
 // DeleteVolumes deletes EFI / cloud-init internal volumes via ebs.delete
 // and user volumes flagged DeleteOnTermination via the volume service.
 // Errors are logged per volume; partial failure is tolerated.
-func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) {
+func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) error {
 	instance.EBSRequests.Mu.Lock()
 	defer instance.EBSRequests.Mu.Unlock()
 
+	var firstErr error
 	for _, ebsRequest := range instance.EBSRequests.Requests {
 		// Internal volumes (EFI, cloud-init) always go through ebs.delete to
 		// stop their viperblockd processes. S3 data is cleaned up via the
@@ -537,12 +538,14 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) {
 			if err != nil {
 				slog.Error("Failed to marshal ebs.delete request for internal volume",
 					"name", ebsRequest.Name, "err", err)
+				firstErr = cmp.Or(firstErr, err)
 				continue
 			}
 			deleteMsg, err := a.d.natsConn.Request("ebs.delete", ebsDeleteData, 30*time.Second)
 			if err != nil {
 				slog.Warn("Failed to send ebs.delete for internal volume",
 					"name", ebsRequest.Name, "id", instance.ID, "err", err)
+				firstErr = cmp.Or(firstErr, err)
 			} else {
 				slog.Info("Sent ebs.delete for internal volume",
 					"name", ebsRequest.Name, "id", instance.ID, "data", string(deleteMsg.Data))
@@ -569,11 +572,13 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) {
 		}, instance.AccountID); err != nil {
 			slog.Error("Failed to delete volume on termination",
 				"name", ebsRequest.Name, "id", instance.ID, "err", err)
+			firstErr = cmp.Or(firstErr, err)
 		} else {
 			slog.Info("Deleted volume on termination",
 				"name", ebsRequest.Name, "id", instance.ID)
 		}
 	}
+	return firstErr
 }
 
 // CleanupMgmtNetwork tears down the management TAP device (derived from
@@ -593,9 +598,9 @@ func (a *instanceCleanerAdapter) CleanupMgmtNetwork(instance *vm.VM) {
 // ReleasePublicIP publishes vpc.delete-nat for the OVN dnat_and_snat rule
 // and releases the public IP back to the external IPAM pool. No-op when
 // the instance has no public IP.
-func (a *instanceCleanerAdapter) ReleasePublicIP(instance *vm.VM) {
+func (a *instanceCleanerAdapter) ReleasePublicIP(instance *vm.VM) error {
 	if instance.PublicIP == "" || instance.PublicIPPool == "" || a.d.externalIPAM == nil {
-		return
+		return nil
 	}
 
 	portName := topology.Port(instance.ENIId)
@@ -614,45 +619,44 @@ func (a *instanceCleanerAdapter) ReleasePublicIP(instance *vm.VM) {
 	if err := a.d.externalIPAM.ReleaseIP(instance.PublicIPPool, instance.PublicIP); err != nil {
 		slog.Warn("Failed to release public IP on termination",
 			"ip", instance.PublicIP, "pool", instance.PublicIPPool, "err", err)
-	} else {
-		slog.Info("Released public IP on termination",
-			"ip", instance.PublicIP, "instanceId", instance.ID)
+		return err
 	}
+	slog.Info("Released public IP on termination",
+		"ip", instance.PublicIP, "instanceId", instance.ID)
+	return nil
 }
 
 // DetachAndDeleteENI detaches the auto-created ENI from the instance and
 // deletes it via the VPC service. NotFound is tolerated. Extra ENIs are
 // cleaned up by the load-balancer service via its own teardown loop and
 // are not touched here.
-func (a *instanceCleanerAdapter) DetachAndDeleteENI(instance *vm.VM) {
+func (a *instanceCleanerAdapter) DetachAndDeleteENI(instance *vm.VM) error {
 	if instance.ENIId == "" || a.d.vpcService == nil {
-		return
+		return nil
 	}
+	// Best-effort detach; a failure here must not block deletion — the force
+	// delete below bypasses the in-use guard for the owning instance, breaking
+	// the un-terminable-ENI deadlock (ADR-0003 §2).
 	if detachErr := a.d.vpcService.DetachENI(instance.AccountID, instance.ENIId); detachErr != nil {
 		slog.Warn("Failed to detach ENI on termination",
 			"eni", instance.ENIId, "instanceId", instance.ID, "err", detachErr)
 	}
-	if _, eniErr := a.d.vpcService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-		NetworkInterfaceId: &instance.ENIId,
-	}, instance.AccountID); eniErr != nil {
-		if awserrors.IsErrorCode(eniErr, awserrors.ErrorInvalidNetworkInterfaceIDNotFound) {
-			slog.Debug("ENI already cleaned up on termination", "eni", instance.ENIId)
-		} else {
-			slog.Error("Failed to delete ENI on termination",
-				"eni", instance.ENIId, "instanceId", instance.ID, "err", eniErr)
-		}
-	} else {
-		slog.Info("Deleted ENI on termination",
-			"eni", instance.ENIId, "instanceId", instance.ID)
+	if err := a.d.vpcService.ForceDeleteInstanceENI(instance.AccountID, instance.ENIId); err != nil {
+		slog.Error("Failed to delete ENI on termination",
+			"eni", instance.ENIId, "instanceId", instance.ID, "err", err)
+		return err
 	}
+	slog.Info("Deleted ENI on termination",
+		"eni", instance.ENIId, "instanceId", instance.ID)
+	return nil
 }
 
 // RemoveFromPlacementGroup unbinds the instance from its placement group
 // if one is set. No-op for ungrouped instances and when the placement
 // group service is not configured.
-func (a *instanceCleanerAdapter) RemoveFromPlacementGroup(instance *vm.VM) {
+func (a *instanceCleanerAdapter) RemoveFromPlacementGroup(instance *vm.VM) error {
 	if instance.PlacementGroupName == "" || a.d.placementGroupService == nil {
-		return
+		return nil
 	}
 	if _, err := a.d.placementGroupService.RemoveInstance(&handlers_ec2_placementgroup.RemoveInstanceInput{
 		GroupName:  instance.PlacementGroupName,
@@ -661,20 +665,23 @@ func (a *instanceCleanerAdapter) RemoveFromPlacementGroup(instance *vm.VM) {
 	}, instance.AccountID); err != nil {
 		slog.Error("Failed to remove instance from placement group",
 			"instanceId", instance.ID, "groupName", instance.PlacementGroupName, "err", err)
+		return err
 	}
+	return nil
 }
 
 // ReleaseGPU unbinds the instance's GPU from vfio-pci and rebinds to its
 // original host driver. No-op for instances without a GPU allocation or
 // when GPU passthrough is disabled.
-func (a *instanceCleanerAdapter) ReleaseGPU(instance *vm.VM) {
+func (a *instanceCleanerAdapter) ReleaseGPU(instance *vm.VM) error {
 	if a.d.gpuManager == nil || len(instance.GPUAttachments) == 0 {
-		return
+		return nil
 	}
 	if err := a.d.gpuManager.Release(instance.ID); err != nil {
 		slog.Error("Failed to release GPU on stop, device may need manual rebind",
 			"gpus", instance.GPUAttachments, "instanceId", instance.ID, "err", err)
-		return
+		return err
 	}
 	slog.Info("GPU released", "gpus", instance.GPUAttachments, "instanceId", instance.ID)
+	return nil
 }

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -373,13 +373,15 @@ func (d *Daemon) onInstanceUpHook() func(*vm.VM) error {
 		}
 		d.natsSubscriptions[consoleSubKey] = consoleSub
 
-		// Re-arm the per-instance terminate subscription for system-managed VMs
-		// (ELBv2 load balancers). The launch handler binds it at first launch,
-		// but it is lost across a daemon restart; OnInstanceUp fires on both the
-		// relaunch and the reconnect-to-surviving-QEMU recovery paths, so without
-		// this system.TerminateInstance.{id} has no responder and the VM can
-		// never be torn down (SetSubnets relaunch, DeleteLoadBalancer).
-		if instance.ManagedBy == tags.ManagedByELBv2 {
+		// Bind the per-instance terminate subscription for any system-managed VM
+		// (ELBv2 load balancers, EKS K3s control-plane VMs). OnInstanceUp is the
+		// one funnel every launch path crosses — local placement on the
+		// coordinator node, the remote-launch handler, and the
+		// reconnect-to-surviving-QEMU recovery after a daemon restart. Without it
+		// system.TerminateInstance.{id} has no responder, so a cluster-wide
+		// teardown invoked on another node cannot stop this VM and deletes its
+		// still-attached ENI (InvalidNetworkInterface.InUse).
+		if tags.IsSystemManaged(instance.ManagedBy) {
 			if subErr := d.subscribeSystemTerminateLocked(instance.ID); subErr != nil {
 				slog.Error("OnInstanceUp: failed to re-arm system terminate subscription",
 					"instanceId", instance.ID, "err", subErr)

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -62,6 +62,10 @@ func (a *stateStoreAdapter) ListTerminatedInstances() ([]*vm.VM, error) {
 	return a.js.ListTerminatedInstances()
 }
 
+func (a *stateStoreAdapter) DeleteTerminatedInstance(id string) error {
+	return a.js.DeleteTerminatedInstance(id)
+}
+
 // volumeMounterAdapter satisfies vm.VolumeMounter by routing ebs.mount /
 // ebs.unmount NATS requests. Unmount also updates volume state via VolumeStateUpdater.
 type volumeMounterAdapter struct {

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 	"github.com/mulgadc/spinifex/spinifex/tags"
@@ -575,7 +576,7 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) error {
 		}
 		if _, err := a.d.volumeService.DeleteVolume(&ec2.DeleteVolumeInput{
 			VolumeId: &ebsRequest.Name,
-		}, instance.AccountID); err != nil {
+		}, instance.AccountID); err != nil && !awserrors.IsNotFound(err) {
 			slog.Error("Failed to delete volume on termination",
 				"name", ebsRequest.Name, "id", instance.ID, "err", err)
 			firstErr = cmp.Or(firstErr, err)

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -60,6 +60,22 @@ func TestOnInstanceUpHook_ReArmsSystemTerminateForELBv2(t *testing.T) {
 	assert.Equal(t, "system.TerminateInstance.i-up-sys", sub.Subject)
 }
 
+// TestOnInstanceUpHook_ReArmsSystemTerminateForEKS locks mulga-siv-295.10: an EKS
+// K3s control-plane VM placed on the coordinator's own node (local launch, no
+// remote-launch handler) must still bind system.TerminateInstance.{id} via the
+// OnInstanceUp funnel — otherwise a cluster-wide teardown invoked on another node
+// finds no responder, treats the VM as gone, and deletes its still-attached ENI.
+func TestOnInstanceUpHook_ReArmsSystemTerminateForEKS(t *testing.T) {
+	d, _ := newHookTestDaemon(t)
+	instance := &vm.VM{ID: "i-up-eks", ManagedBy: tags.ManagedByEKS}
+
+	require.NoError(t, d.onInstanceUpHook()(instance))
+
+	sub, ok := d.natsSubscriptions["system.TerminateInstance.i-up-eks"]
+	require.True(t, ok, "system terminate subscription must be bound for EKS control-plane VMs")
+	assert.Equal(t, "system.TerminateInstance.i-up-eks", sub.Subject)
+}
+
 func TestOnInstanceUpHook_NoSystemTerminateForRegularInstance(t *testing.T) {
 	d, _ := newHookTestDaemon(t)
 	instance := &vm.VM{ID: "i-up-regular"}

--- a/spinifex/gateway/ec2/instance/TerminateInstances.go
+++ b/spinifex/gateway/ec2/instance/TerminateInstances.go
@@ -98,12 +98,25 @@ func TerminateInstances(input *ec2.TerminateInstancesInput, natsConn *nats.Conn,
 					}
 				}
 
-				// Check if instance is already terminated (idempotent, matches AWS behavior)
-				if isAlreadyTerminated(natsConn, instanceID, accountID) {
+				// Idempotent terminate (rule #1): no daemon owns the instance and it
+				// is not a stopped instance. If the terminated-bucket query succeeds
+				// (KV reachable) the instance is already gone — return success so
+				// tofu destroy retries converge. KV-health gated: a failed query does
+				// NOT fabricate success (never trust an empty desired-state we cannot
+				// read — ADR-0003 §3).
+				found, queryOK := lookupTerminated(natsConn, instanceID, accountID)
+				if found {
 					slog.Info("TerminateInstances: Instance already terminated", "instance_id", instanceID)
 					stateChanges = append(stateChanges, newStateChange(instanceID, 48, "terminated", 48, "terminated"))
 					continue
 				}
+				if queryOK {
+					slog.Info("TerminateInstances: Instance absent, terminate is idempotent", "instance_id", instanceID)
+					stateChanges = append(stateChanges, newStateChange(instanceID, 48, "terminated", 48, "terminated"))
+					continue
+				}
+				slog.Error("TerminateInstances: terminated-bucket query failed, cannot confirm absence",
+					"instance_id", instanceID)
 			}
 
 			slog.Error("TerminateInstances: Failed to send command", "instance_id", instanceID, "err", err)
@@ -128,35 +141,38 @@ func TerminateInstances(input *ec2.TerminateInstancesInput, natsConn *nats.Conn,
 	return output, nil
 }
 
-// isAlreadyTerminated checks if an instance exists in the terminated KV bucket.
-func isAlreadyTerminated(natsConn *nats.Conn, instanceID, accountID string) bool {
+// lookupTerminated reports whether an instance exists in the terminated KV
+// bucket. queryOK is false when the lookup itself failed (KV unreachable /
+// malformed reply), so callers can KV-health gate any idempotent-absence
+// decision rather than treating a failed query as "not found".
+func lookupTerminated(natsConn *nats.Conn, instanceID, accountID string) (found, queryOK bool) {
 	describeInput := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{&instanceID},
 	}
 	reqData, err := json.Marshal(describeInput)
 	if err != nil {
-		slog.Warn("isAlreadyTerminated: failed to marshal request", "instanceId", instanceID, "err", err)
-		return false
+		slog.Warn("lookupTerminated: failed to marshal request", "instanceId", instanceID, "err", err)
+		return false, false
 	}
 	reqMsg := nats.NewMsg("ec2.DescribeTerminatedInstances")
 	reqMsg.Data = reqData
 	reqMsg.Header.Set(utils.AccountIDHeader, accountID)
 	msg, err := natsConn.RequestMsg(reqMsg, 3*time.Second)
 	if err != nil {
-		slog.Warn("isAlreadyTerminated: failed to query terminated instances", "instanceId", instanceID, "err", err)
-		return false
+		slog.Warn("lookupTerminated: failed to query terminated instances", "instanceId", instanceID, "err", err)
+		return false, false
 	}
 	var output ec2.DescribeInstancesOutput
 	if unmarshalErr := json.Unmarshal(msg.Data, &output); unmarshalErr != nil {
-		slog.Warn("isAlreadyTerminated: failed to unmarshal response", "instanceId", instanceID, "err", unmarshalErr)
-		return false
+		slog.Warn("lookupTerminated: failed to unmarshal response", "instanceId", instanceID, "err", unmarshalErr)
+		return false, false
 	}
 	for _, res := range output.Reservations {
 		for _, inst := range res.Instances {
 			if inst.InstanceId != nil && *inst.InstanceId == instanceID {
-				return true
+				return true, true
 			}
 		}
 	}
-	return false
+	return false, true
 }

--- a/spinifex/handlers/ec2/eip/service_impl.go
+++ b/spinifex/handlers/ec2/eip/service_impl.go
@@ -141,8 +141,9 @@ func (s *EIPServiceImpl) ReleaseAddress(input *ec2.ReleaseAddressInput, accountI
 		return nil, errors.New(awserrors.ErrorInvalidAddressLocked)
 	}
 
-	// Release IP back to IPAM pool.
-	if err := s.externalIPAM.ReleaseIP(record.PoolName, record.PublicIp); err != nil {
+	// Release IP back to IPAM pool. User-driven release of an already-detached
+	// EIP — unconditional (no owner ENI to scope to).
+	if err := s.externalIPAM.ReleaseIP(record.PoolName, record.PublicIp, ""); err != nil {
 		slog.Warn("Failed to release IP back to IPAM pool", "allocationId", allocID, "ip", record.PublicIp, "pool", record.PoolName, "err", err)
 	}
 

--- a/spinifex/handlers/ec2/igw/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/igw/lifecycle_invariants_test.go
@@ -1,0 +1,24 @@
+package handlers_ec2_igw
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLC1_IGWDeleteIdempotentOnAbsent enforces the Common Resource Lifecycle
+// Contract rule #1 (idempotent delete): deleting an absent internet gateway is
+// success, not NotFound, so tofu destroy retries converge.
+func TestRLC1_IGWDeleteIdempotentOnAbsent(t *testing.T) {
+	svc, _ := setupTestIGWService(t)
+
+	out, err := svc.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+		InternetGatewayId: aws.String("igw-absent00000000"),
+	}, testAccountID)
+
+	require.NoErrorf(t, err, "DeleteInternetGateway on an absent IGW must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output on nats.ErrKeyNotFound")
+	assert.NotNil(t, out, "DeleteInternetGateway must return a non-nil output on absent (RLC rule #1)")
+}

--- a/spinifex/handlers/ec2/igw/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/igw/lifecycle_invariants_test.go
@@ -5,20 +5,23 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestRLC1_IGWDeleteIdempotentOnAbsent enforces the Common Resource Lifecycle
-// Contract rule #1 (idempotent delete): deleting an absent internet gateway is
-// success, not NotFound, so tofu destroy retries converge.
-func TestRLC1_IGWDeleteIdempotentOnAbsent(t *testing.T) {
+// TestRLC1_IGWDeleteNotFoundOnAbsent enforces the Common Resource Lifecycle
+// Contract rule #1 (AWS-faithful delete, per-service): the EC2 DeleteInternetGateway
+// API returns InvalidInternetGatewayID.NotFound for an absent IGW, not success.
+// Idempotent convergence belongs to destroy orchestration, which tolerates
+// NotFound via awserrors.IsNotFound; the public API stays AWS compatible.
+func TestRLC1_IGWDeleteNotFoundOnAbsent(t *testing.T) {
 	svc, _ := setupTestIGWService(t)
 
-	out, err := svc.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+	_, err := svc.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
 		InternetGatewayId: aws.String("igw-absent00000000"),
 	}, testAccountID)
 
-	require.NoErrorf(t, err, "DeleteInternetGateway on an absent IGW must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output on nats.ErrKeyNotFound")
-	assert.NotNil(t, out, "DeleteInternetGateway must return a non-nil output on absent (RLC rule #1)")
+	require.Errorf(t, err, "DeleteInternetGateway on an absent IGW must return %s, not success (RLC rule #1 AWS-faithful delete): destroy orchestration tolerates NotFound, the API must not", awserrors.ErrorInvalidInternetGatewayIDNotFound)
+	assert.ErrorContains(t, err, awserrors.ErrorInvalidInternetGatewayIDNotFound, "DeleteInternetGateway on an absent IGW must return the canonical InvalidInternetGatewayID.NotFound (RLC rule #1)")
 }

--- a/spinifex/handlers/ec2/igw/service_impl.go
+++ b/spinifex/handlers/ec2/igw/service_impl.go
@@ -136,7 +136,12 @@ func (s *IGWServiceImpl) DeleteInternetGateway(input *ec2.DeleteInternetGatewayI
 
 	entry, err := s.igwKV.Get(key)
 	if err != nil {
-		return nil, errors.New(awserrors.ErrorInvalidInternetGatewayIDNotFound)
+		// Idempotent delete: an absent internet gateway is success so destroy
+		// retries converge; a transient read error stays a server error.
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return &ec2.DeleteInternetGatewayOutput{}, nil
+		}
+		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
 	var record IGWRecord

--- a/spinifex/handlers/ec2/igw/service_impl.go
+++ b/spinifex/handlers/ec2/igw/service_impl.go
@@ -136,10 +136,11 @@ func (s *IGWServiceImpl) DeleteInternetGateway(input *ec2.DeleteInternetGatewayI
 
 	entry, err := s.igwKV.Get(key)
 	if err != nil {
-		// Idempotent delete: an absent internet gateway is success so destroy
-		// retries converge; a transient read error stays a server error.
+		// AWS-faithful: an absent internet gateway is NotFound (provider
+		// tolerates it on destroy); destroy orchestration tolerates it too.
+		// A transient read error stays a server error.
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			return &ec2.DeleteInternetGatewayOutput{}, nil
+			return nil, errors.New(awserrors.ErrorInvalidInternetGatewayIDNotFound)
 		}
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}

--- a/spinifex/handlers/ec2/igw/service_impl_test.go
+++ b/spinifex/handlers/ec2/igw/service_impl_test.go
@@ -133,14 +133,6 @@ func TestDeleteInternetGateway(t *testing.T) {
 	assert.ErrorContains(t, err, "InvalidInternetGatewayID.NotFound")
 }
 
-func TestDeleteInternetGateway_NotFound(t *testing.T) {
-	svc, _ := setupTestIGWService(t)
-	_, err := svc.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
-		InternetGatewayId: aws.String("igw-nonexistent"),
-	}, testAccountID)
-	assert.ErrorContains(t, err, "InvalidInternetGatewayID.NotFound")
-}
-
 func TestDeleteInternetGateway_MissingID(t *testing.T) {
 	svc, _ := setupTestIGWService(t)
 	_, err := svc.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{}, testAccountID)

--- a/spinifex/handlers/ec2/instance/service.go
+++ b/spinifex/handlers/ec2/instance/service.go
@@ -94,9 +94,10 @@ type ENIDeleter interface {
 }
 
 // PublicIPReleaser releases a previously allocated public IP back to a pool.
-// Implemented by handlers/ec2/vpc.ExternalIPAM.
+// Implemented by handlers/ec2/vpc.ExternalIPAM. ownerENIID scopes the release
+// to the ENI that owns the lease so a stale teardown for a recycled IP no-ops.
 type PublicIPReleaser interface {
-	ReleaseIP(pool, ip string) error
+	ReleaseIP(pool, ip, ownerENIID string) error
 }
 
 // AMIMetaLoader resolves an AMI ID to its metadata for ownership/validation

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -1071,6 +1071,13 @@ func (s *InstanceServiceImpl) StopOrTerminateInstance(instance *vm.VM, command s
 		}
 	})
 	if !ok {
+		if isTerminate {
+			// Idempotent terminate (rule #1): the instance was reclaimed/torn down
+			// between resolve and lock, so it is already gone.
+			slog.Info("StopOrTerminateInstance: instance already gone, terminate is idempotent",
+				"instanceId", instance.ID)
+			return nil
+		}
 		slog.Warn("StopOrTerminateInstance: instance no longer in running map",
 			"instanceId", instance.ID)
 		return errors.New(awserrors.ErrorInvalidInstanceIDNotFound)

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -2636,7 +2636,7 @@ func (s *InstanceServiceImpl) rollbackAutoAssignedPublicIP(accountID, instanceID
 		}
 	}
 	if s.ipReleaser != nil {
-		if err := s.ipReleaser.ReleaseIP(poolName, publicIP); err != nil {
+		if err := s.ipReleaser.ReleaseIP(poolName, publicIP, eniID); err != nil {
 			slog.Warn("PrepareRunInstances: failed to release public IP during NAT-failure rollback",
 				"publicIp", publicIP, "pool", poolName, "err", err)
 		}
@@ -2674,7 +2674,7 @@ func (s *InstanceServiceImpl) releaseInstancePublicIP(instance *vm.VM, instanceI
 	}
 	utils.PublishNATEvent(s.natsConn, "vpc.delete-nat", vpcID, instance.PublicIP, logicalIP, portName, "")
 
-	if err := s.ipReleaser.ReleaseIP(instance.PublicIPPool, instance.PublicIP); err != nil {
+	if err := s.ipReleaser.ReleaseIP(instance.PublicIPPool, instance.PublicIP, instance.ENIId); err != nil {
 		slog.Warn("TerminateStoppedInstance: failed to release public IP", "ip", instance.PublicIP, "pool", instance.PublicIPPool, "err", err)
 	} else {
 		slog.Info("TerminateStoppedInstance: released public IP", "ip", instance.PublicIP, "instanceId", instanceID)

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -1798,14 +1798,16 @@ func (f *fakeENIDeleter) DeleteNetworkInterface(input *ec2.DeleteNetworkInterfac
 }
 
 type fakePublicIPReleaser struct {
-	pool string
-	ip   string
-	err  error
+	pool     string
+	ip       string
+	ownerENI string
+	err      error
 }
 
-func (f *fakePublicIPReleaser) ReleaseIP(pool, ip string) error {
+func (f *fakePublicIPReleaser) ReleaseIP(pool, ip, ownerENIID string) error {
 	f.pool = pool
 	f.ip = ip
+	f.ownerENI = ownerENIID
 	return f.err
 }
 

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -976,6 +976,7 @@ func (f *fakeStoppedStore) DeleteStoppedInstance(id string) error {
 	f.deletedStopped = append(f.deletedStopped, id)
 	return nil
 }
+func (f *fakeStoppedStore) DeleteTerminatedInstance(string) error { return nil }
 
 func TestDescribeInstanceTypes_NilResourceMgr(t *testing.T) {
 	svc := &InstanceServiceImpl{}

--- a/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
@@ -15,18 +15,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRLC1_NatGatewayDeleteIdempotentOnAbsent enforces the Common Resource
-// Lifecycle Contract rule #1 (idempotent delete): deleting an absent NAT
-// gateway is success, not NotFound, so tofu destroy retries converge.
-func TestRLC1_NatGatewayDeleteIdempotentOnAbsent(t *testing.T) {
+// TestRLC1_NatGatewayDeleteNotFoundOnAbsent enforces the Common Resource
+// Lifecycle Contract rule #1 (AWS-faithful delete, per-service): the EC2
+// DeleteNatGateway API returns InvalidNatGatewayID.NotFound for an absent NAT
+// gateway, not success. Idempotent convergence belongs to destroy orchestration, which
+// tolerates NotFound via awserrors.IsNotFound; the public API stays AWS compatible.
+func TestRLC1_NatGatewayDeleteNotFoundOnAbsent(t *testing.T) {
 	svc := setupTestService(t)
 
-	out, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+	_, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
 		NatGatewayId: aws.String("nat-absent00000000"),
 	}, testAccountID)
 
-	require.NoErrorf(t, err, "DeleteNatGateway on an absent NAT gateway must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output on nats.ErrKeyNotFound")
-	assert.NotNil(t, out, "DeleteNatGateway must return a non-nil output on absent (RLC rule #1)")
+	require.Errorf(t, err, "DeleteNatGateway on an absent NAT gateway must return %s, not success (RLC rule #1 AWS-faithful delete): destroy orchestration tolerates NotFound, the API must not", awserrors.ErrorInvalidNatGatewayIDNotFound)
+	assert.ErrorContains(t, err, awserrors.ErrorInvalidNatGatewayIDNotFound, "DeleteNatGateway on an absent NAT gateway must return the canonical NotFound (RLC rule #1)")
 }
 
 // TestRLC3_NatGatewayBlocksWhileRouted enforces the Common Resource Lifecycle

--- a/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
@@ -31,15 +31,11 @@ func TestRLC1_NatGatewayDeleteNotFoundOnAbsent(t *testing.T) {
 	assert.ErrorContains(t, err, awserrors.ErrorInvalidNatGatewayIDNotFound, "DeleteNatGateway on an absent NAT gateway must return the canonical NotFound (RLC rule #1)")
 }
 
-// kvBucketRouteTables is the route-table KV bucket, seeded here to prove a live
-// route forwarding to a NAT gateway does not block its deletion.
-const kvBucketRouteTables = "spinifex-vpc-route-tables"
-
 // TestRLC3_NatGatewayDeletesWhileRouted enforces ADR-0004 §2: a NAT gateway is
 // exempt from rule #3 route-reference guards. AWS deletes a NAT gateway even
-// while a route table forwards to it (the route blackholes); the reconciler
-// drops the SNAT once the record leaves the active bucket. Delete must succeed
-// whether or not a live route still targets it.
+// while a route table forwards to it (the route blackholes); delete tears down
+// the SNAT for each routed subnet so egress stops. Delete must succeed whether
+// or not a live route still targets it.
 func TestRLC3_NatGatewayDeletesWhileRouted(t *testing.T) {
 	t.Run("succeeds while a route forwards to it", func(t *testing.T) {
 		svc, js := setupTestServiceJS(t)

--- a/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
@@ -1,0 +1,24 @@
+package handlers_ec2_natgw
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLC1_NatGatewayDeleteIdempotentOnAbsent enforces the Common Resource
+// Lifecycle Contract rule #1 (idempotent delete): deleting an absent NAT
+// gateway is success, not NotFound, so tofu destroy retries converge.
+func TestRLC1_NatGatewayDeleteIdempotentOnAbsent(t *testing.T) {
+	svc := setupTestService(t)
+
+	out, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+		NatGatewayId: aws.String("nat-absent00000000"),
+	}, testAccountID)
+
+	require.NoErrorf(t, err, "DeleteNatGateway on an absent NAT gateway must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output on nats.ErrKeyNotFound")
+	assert.NotNil(t, out, "DeleteNatGateway must return a non-nil output on absent (RLC rule #1)")
+}

--- a/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
@@ -31,12 +31,17 @@ func TestRLC1_NatGatewayDeleteNotFoundOnAbsent(t *testing.T) {
 	assert.ErrorContains(t, err, awserrors.ErrorInvalidNatGatewayIDNotFound, "DeleteNatGateway on an absent NAT gateway must return the canonical NotFound (RLC rule #1)")
 }
 
-// TestRLC3_NatGatewayBlocksWhileRouted enforces the Common Resource Lifecycle
-// Contract rule #3 (live-only dependency guards): a NAT gateway a live route
-// table still forwards to must not delete (DependencyViolation), so tofu
-// destroy ordering is driven; once nothing routes to it, delete succeeds.
-func TestRLC3_NatGatewayBlocksWhileRouted(t *testing.T) {
-	t.Run("blocked while a route forwards to it", func(t *testing.T) {
+// kvBucketRouteTables is the route-table KV bucket, seeded here to prove a live
+// route forwarding to a NAT gateway does not block its deletion.
+const kvBucketRouteTables = "spinifex-vpc-route-tables"
+
+// TestRLC3_NatGatewayDeletesWhileRouted enforces ADR-0004 §2: a NAT gateway is
+// exempt from rule #3 route-reference guards. AWS deletes a NAT gateway even
+// while a route table forwards to it (the route blackholes); the reconciler
+// drops the SNAT once the record leaves the active bucket. Delete must succeed
+// whether or not a live route still targets it.
+func TestRLC3_NatGatewayDeletesWhileRouted(t *testing.T) {
+	t.Run("succeeds while a route forwards to it", func(t *testing.T) {
 		svc, js := setupTestServiceJS(t)
 		natgwID := createTestNatGateway(t, svc)
 
@@ -46,11 +51,11 @@ func TestRLC3_NatGatewayBlocksWhileRouted(t *testing.T) {
 		})
 
 		_, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(natgwID)}, testAccountID)
-		assert.ErrorContainsf(t, err, awserrors.ErrorDependencyViolation,
-			"ADR-0004 §2: DeleteNatGateway must return DependencyViolation while a live route table forwards to it (rule #3)")
+		require.NoErrorf(t, err,
+			"ADR-0004 §2: DeleteNatGateway must succeed even while a live route table forwards to it (the route blackholes, AWS-faithful)")
 	})
 
-	t.Run("allowed once nothing routes to it", func(t *testing.T) {
+	t.Run("succeeds with no routes", func(t *testing.T) {
 		svc := setupTestService(t)
 		natgwID := createTestNatGateway(t, svc)
 

--- a/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/natgw/lifecycle_invariants_test.go
@@ -1,10 +1,16 @@
 package handlers_ec2_natgw
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ec2_eip "github.com/mulgadc/spinifex/spinifex/handlers/ec2/eip"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,4 +27,72 @@ func TestRLC1_NatGatewayDeleteIdempotentOnAbsent(t *testing.T) {
 
 	require.NoErrorf(t, err, "DeleteNatGateway on an absent NAT gateway must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output on nats.ErrKeyNotFound")
 	assert.NotNil(t, out, "DeleteNatGateway must return a non-nil output on absent (RLC rule #1)")
+}
+
+// TestRLC3_NatGatewayBlocksWhileRouted enforces the Common Resource Lifecycle
+// Contract rule #3 (live-only dependency guards): a NAT gateway a live route
+// table still forwards to must not delete (DependencyViolation), so tofu
+// destroy ordering is driven; once nothing routes to it, delete succeeds.
+func TestRLC3_NatGatewayBlocksWhileRouted(t *testing.T) {
+	t.Run("blocked while a route forwards to it", func(t *testing.T) {
+		svc, js := setupTestServiceJS(t)
+		natgwID := createTestNatGateway(t, svc)
+
+		testutil.SeedKV(t, js, kvBucketRouteTables, map[string][]byte{
+			utils.AccountKey(testAccountID, "rtb-routed"): fmt.Appendf(nil,
+				`{"route_table_id":"rtb-routed","vpc_id":"vpc-test1","routes":[{"destination_cidr_block":"0.0.0.0/0","nat_gateway_id":%q}]}`, natgwID),
+		})
+
+		_, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(natgwID)}, testAccountID)
+		assert.ErrorContainsf(t, err, awserrors.ErrorDependencyViolation,
+			"ADR-0004 §2: DeleteNatGateway must return DependencyViolation while a live route table forwards to it (rule #3)")
+	})
+
+	t.Run("allowed once nothing routes to it", func(t *testing.T) {
+		svc := setupTestService(t)
+		natgwID := createTestNatGateway(t, svc)
+
+		_, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(natgwID)}, testAccountID)
+		require.NoErrorf(t, err,
+			"ADR-0004 §2: with no route forwarding to it, DeleteNatGateway must succeed")
+	})
+}
+
+// TestRLC3_NatGatewayDeleteDisassociatesEIPKeepingAllocated enforces ADR-0004
+// §2: deleting a NAT gateway releases its EIP association but keeps the
+// allocation (AWS parity), never orphaning the EIP as permanently associated.
+func TestRLC3_NatGatewayDeleteDisassociatesEIPKeepingAllocated(t *testing.T) {
+	svc := setupTestService(t)
+	natgwID := createTestNatGateway(t, svc)
+
+	// Creating the NAT GW must have marked its EIP associated.
+	assoc := readEIP(t, svc, "eipalloc-test1")
+	require.Equal(t, "associated", assoc.State, "CreateNatGateway must mark the EIP associated so a second NAT GW cannot reuse it")
+	require.NotEmpty(t, assoc.AssociationId)
+
+	_, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(natgwID)}, testAccountID)
+	require.NoError(t, err)
+
+	eip := readEIP(t, svc, "eipalloc-test1")
+	assert.Equal(t, "allocated", eip.State, "ADR-0004 §2: the EIP must stay allocated after NAT GW delete (AWS parity)")
+	assert.Empty(t, eip.AssociationId, "ADR-0004 §2: the EIP must be disassociated, not left orphaned as associated")
+}
+
+func createTestNatGateway(t *testing.T, svc *NatGatewayServiceImpl) string {
+	t.Helper()
+	out, err := svc.CreateNatGateway(&ec2.CreateNatGatewayInput{
+		SubnetId:     aws.String("subnet-pub1"),
+		AllocationId: aws.String("eipalloc-test1"),
+	}, testAccountID)
+	require.NoError(t, err)
+	return *out.NatGateway.NatGatewayId
+}
+
+func readEIP(t *testing.T, svc *NatGatewayServiceImpl, allocID string) handlers_ec2_eip.EIPRecord {
+	t.Helper()
+	entry, err := svc.eipKV.Get(utils.AccountKey(testAccountID, allocID))
+	require.NoError(t, err)
+	var eip handlers_ec2_eip.EIPRecord
+	require.NoError(t, json.Unmarshal(entry.Value(), &eip))
+	return eip
 }

--- a/spinifex/handlers/ec2/natgw/service_impl.go
+++ b/spinifex/handlers/ec2/natgw/service_impl.go
@@ -202,9 +202,10 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
-	// AWS-faithful: a NAT gateway deletes even while routes still forward to it;
-	// the route entry blackholes. The reconciler drops the SNAT once the record
-	// leaves the active bucket, so no route-reference dependency guard is needed.
+	// AWS-faithful: a NAT gateway deletes even while routes still forward to it
+	// (the route blackholes), so there is no route-reference dependency guard.
+	// Tear down the SNAT for each subnet routed through it so egress stops.
+	s.publishDeleteEventsForNatGateway(&record, accountID)
 
 	// Move to deleted bucket (auto-expires via TTL) so DescribeNatGateways can
 	// return state=deleted while Terraform polls after deletion.
@@ -232,6 +233,85 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 	return &ec2.DeleteNatGatewayOutput{
 		NatGatewayId: aws.String(natgwID),
 	}, nil
+}
+
+// kvBucketRouteTables is the route-table KV bucket. Duplicated as a literal
+// (not imported from the routetable package) because routetable imports this
+// package for PublishAddEvent — importing it back would be a cycle.
+const kvBucketRouteTables = "spinifex-vpc-route-tables"
+
+// publishDeleteEventsForNatGateway tears down the SNAT for every private subnet
+// routed through this NAT gateway, by scanning route tables for routes that
+// target it and publishing vpc.delete-nat-gateway per associated subnet. Called
+// on delete so egress stops even though the route entry survives (blackhole).
+// Best-effort: a scan error only delays SNAT teardown until the route is deleted.
+func (s *NatGatewayServiceImpl) publishDeleteEventsForNatGateway(record *NatGatewayRecord, accountID string) {
+	if s.natsConn == nil {
+		return
+	}
+	rtbKV, err := utils.GetOrCreateKVBucket(mustJS(s.natsConn), kvBucketRouteTables, 10)
+	if err != nil {
+		slog.Warn("DeleteNatGateway: route-table scan failed, SNAT teardown deferred to route delete", "natGatewayId", record.NatGatewayId, "err", err)
+		return
+	}
+	keys, err := rtbKV.Keys()
+	if err != nil {
+		return
+	}
+	prefix := accountID + "."
+	for _, key := range keys {
+		if key == utils.VersionKey || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		entry, err := rtbKV.Get(key)
+		if err != nil {
+			continue
+		}
+		var rtbData struct {
+			VpcId  string `json:"vpc_id"`
+			Routes []struct {
+				NatGatewayId string `json:"nat_gateway_id"`
+			} `json:"routes"`
+			Associations []struct {
+				SubnetId string `json:"subnet_id"`
+			} `json:"associations"`
+		}
+		if err := json.Unmarshal(entry.Value(), &rtbData); err != nil {
+			continue
+		}
+		if rtbData.VpcId != record.VpcId {
+			continue
+		}
+		hasNatRoute := false
+		for _, r := range rtbData.Routes {
+			if r.NatGatewayId == record.NatGatewayId {
+				hasNatRoute = true
+				break
+			}
+		}
+		if !hasNatRoute {
+			continue
+		}
+		for _, assoc := range rtbData.Associations {
+			if assoc.SubnetId == "" {
+				continue
+			}
+			subnetEntry, err := s.subnetKV.Get(utils.AccountKey(accountID, assoc.SubnetId))
+			if err != nil {
+				continue
+			}
+			var subnet handlers_ec2_vpc.SubnetRecord
+			if err := json.Unmarshal(subnetEntry.Value(), &subnet); err != nil {
+				continue
+			}
+			s.PublishDeleteEvent(record.VpcId, record.NatGatewayId, record.PublicIp, subnet.CidrBlock)
+		}
+	}
+}
+
+func mustJS(nc *nats.Conn) nats.JetStreamContext {
+	js, _ := nc.JetStream()
+	return js
 }
 
 // disassociateEIP clears the EIP's association to this NAT gateway, keeping the

--- a/spinifex/handlers/ec2/natgw/service_impl.go
+++ b/spinifex/handlers/ec2/natgw/service_impl.go
@@ -143,7 +143,7 @@ func (s *NatGatewayServiceImpl) CreateNatGateway(input *ec2.CreateNatGatewayInpu
 		PublicIp:     eipRecord.PublicIp,
 		State:        "available",
 		AccountID:    accountID,
-		Tags:         make(map[string]string),
+		Tags:         utils.ExtractTags(input.TagSpecifications, ec2.ResourceTypeNatgateway),
 		CreatedAt:    time.Now(),
 	}
 

--- a/spinifex/handlers/ec2/natgw/service_impl.go
+++ b/spinifex/handlers/ec2/natgw/service_impl.go
@@ -156,6 +156,19 @@ func (s *NatGatewayServiceImpl) CreateNatGateway(input *ec2.CreateNatGatewayInpu
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
+	// Mark the EIP associated to this NAT gateway (AWS parity + stops a second
+	// NAT GW reusing the same allocation). Linkage is the shared AllocationId;
+	// DeleteNatGateway clears it back to allocated. Non-fatal: the NAT GW is
+	// already stored, so a failed mark only weakens the reuse guard until then.
+	eipRecord.AssociationId = utils.GenerateResourceID("eipassoc")
+	eipRecord.VpcId = subnetRecord.VpcId
+	eipRecord.State = "associated"
+	if eipData, err := json.Marshal(eipRecord); err == nil {
+		if _, err := s.eipKV.Update(utils.AccountKey(accountID, allocID), eipData, eipEntry.Revision()); err != nil {
+			slog.Warn("CreateNatGateway: failed to mark EIP associated", "natGatewayId", natgwID, "allocationId", allocID, "err", err)
+		}
+	}
+
 	slog.Info("CreateNatGateway completed", "natGatewayId", natgwID, "subnetId", subnetID,
 		"allocationId", allocID, "publicIp", eipRecord.PublicIp, "vpcId", subnetRecord.VpcId, "accountID", accountID)
 
@@ -189,9 +202,12 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
-	// Find all private subnets whose route tables have 0.0.0.0/0 → this NAT GW
-	// and publish delete events for their SNAT rules
-	s.publishDeleteEventsForNatGateway(&record, accountID)
+	// Block while any live route table forwards to this NAT GW (rule #3). The
+	// route-delete path tears down the SNAT rule, so a NAT GW only deletes once
+	// nothing routes to it.
+	if err := s.checkNatGatewayRouteRefs(&record, accountID); err != nil {
+		return nil, err
+	}
 
 	// Move to deleted bucket (auto-expires via TTL) so DescribeNatGateways can
 	// return state=deleted while Terraform polls after deletion.
@@ -211,6 +227,9 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
+	// Disassociate the EIP, keeping the allocation (AWS parity).
+	s.disassociateEIP(&record, accountID)
+
 	slog.Info("DeleteNatGateway completed", "natGatewayId", natgwID, "accountID", accountID)
 
 	return &ec2.DeleteNatGatewayOutput{
@@ -218,25 +237,31 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 	}, nil
 }
 
-// publishDeleteEventsForNatGateway finds all SNAT rules associated with this NAT GW
-// by scanning route tables for routes targeting it, and publishes delete events.
-func (s *NatGatewayServiceImpl) publishDeleteEventsForNatGateway(record *NatGatewayRecord, accountID string) {
+// kvBucketRouteTables is the route-table KV bucket. Duplicated as a literal
+// (not imported from the routetable package) because routetable imports this
+// package for PublishAddEvent — importing it back would be a cycle.
+const kvBucketRouteTables = "spinifex-vpc-route-tables"
+
+// checkNatGatewayRouteRefs returns DependencyViolation if any route table in
+// the NAT gateway's VPC has a live route forwarding to it (rule #3).
+// Fail-closed on a route-table read error so a transient fault never lets a
+// delete blackhole live routes.
+func (s *NatGatewayServiceImpl) checkNatGatewayRouteRefs(record *NatGatewayRecord, accountID string) error {
 	if s.natsConn == nil {
-		return
+		return nil
 	}
-
-	// Scan route tables in this VPC for routes targeting this NAT GW
-	rtbKV, err := utils.GetOrCreateKVBucket(mustJS(s.natsConn), "spinifex-vpc-route-tables", 10)
+	rtbKV, err := utils.GetOrCreateKVBucket(mustJS(s.natsConn), kvBucketRouteTables, 10)
 	if err != nil {
-		slog.Warn("Cannot scan route tables for NAT GW cleanup", "err", err)
-		return
+		slog.Error("DeleteNatGateway: route-table scan failed, blocking delete", "natGatewayId", record.NatGatewayId, "err", err)
+		return errors.New(awserrors.ErrorServerInternal)
 	}
-
 	keys, err := rtbKV.Keys()
 	if err != nil {
-		return
+		if errors.Is(err, nats.ErrNoKeysFound) {
+			return nil
+		}
+		return errors.New(awserrors.ErrorServerInternal)
 	}
-
 	prefix := accountID + "."
 	for _, key := range keys {
 		if key == utils.VersionKey || !strings.HasPrefix(key, prefix) {
@@ -244,18 +269,16 @@ func (s *NatGatewayServiceImpl) publishDeleteEventsForNatGateway(record *NatGate
 		}
 		entry, err := rtbKV.Get(key)
 		if err != nil {
-			continue
+			if errors.Is(err, nats.ErrKeyNotFound) {
+				continue
+			}
+			return errors.New(awserrors.ErrorServerInternal)
 		}
-
-		// Minimal route table parse — just need routes and associations
 		var rtbData struct {
 			VpcId  string `json:"vpc_id"`
 			Routes []struct {
 				NatGatewayId string `json:"nat_gateway_id"`
 			} `json:"routes"`
-			Associations []struct {
-				SubnetId string `json:"subnet_id"`
-			} `json:"associations"`
 		}
 		if err := json.Unmarshal(entry.Value(), &rtbData); err != nil {
 			continue
@@ -263,40 +286,50 @@ func (s *NatGatewayServiceImpl) publishDeleteEventsForNatGateway(record *NatGate
 		if rtbData.VpcId != record.VpcId {
 			continue
 		}
-
-		// Check if any route targets this NAT GW
-		hasNatRoute := false
 		for _, r := range rtbData.Routes {
 			if r.NatGatewayId == record.NatGatewayId {
-				hasNatRoute = true
-				break
+				return errors.New(awserrors.ErrorDependencyViolation)
 			}
 		}
-		if !hasNatRoute {
-			continue
-		}
+	}
+	return nil
+}
 
-		// Publish delete events for each associated subnet's CIDR
-		for _, assoc := range rtbData.Associations {
-			if assoc.SubnetId == "" {
-				continue
-			}
-			subnetEntry, err := s.subnetKV.Get(utils.AccountKey(accountID, assoc.SubnetId))
-			if err != nil {
-				continue
-			}
-			var subnet handlers_ec2_vpc.SubnetRecord
-			if err := json.Unmarshal(subnetEntry.Value(), &subnet); err != nil {
-				continue
-			}
-
-			utils.PublishEvent(s.natsConn, "vpc.delete-nat-gateway", natGatewayEvent{
-				VpcId:        record.VpcId,
-				NatGatewayId: record.NatGatewayId,
-				PublicIp:     record.PublicIp,
-				SubnetCidr:   subnet.CidrBlock,
-			})
+// disassociateEIP clears the EIP's association to this NAT gateway, keeping the
+// allocation (AWS parity). Idempotent and non-fatal: the NAT gateway is already
+// gone, so a stale association only delays the EIP's reuse.
+func (s *NatGatewayServiceImpl) disassociateEIP(record *NatGatewayRecord, accountID string) {
+	if record.AllocationId == "" {
+		return
+	}
+	key := utils.AccountKey(accountID, record.AllocationId)
+	entry, err := s.eipKV.Get(key)
+	if err != nil {
+		if !errors.Is(err, nats.ErrKeyNotFound) {
+			slog.Warn("DeleteNatGateway: EIP read failed during disassociate", "allocationId", record.AllocationId, "err", err)
 		}
+		return
+	}
+	var eip handlers_ec2_eip.EIPRecord
+	if err := json.Unmarshal(entry.Value(), &eip); err != nil {
+		return
+	}
+	if eip.AssociationId == "" && eip.State == "allocated" {
+		return
+	}
+	eip.AssociationId = ""
+	eip.ENIId = ""
+	eip.InstanceId = ""
+	eip.PrivateIp = ""
+	eip.MacAddress = ""
+	eip.VpcId = ""
+	eip.State = "allocated"
+	data, err := json.Marshal(eip)
+	if err != nil {
+		return
+	}
+	if _, err := s.eipKV.Update(key, data, entry.Revision()); err != nil {
+		slog.Warn("DeleteNatGateway: failed to disassociate EIP", "allocationId", record.AllocationId, "err", err)
 	}
 }
 

--- a/spinifex/handlers/ec2/natgw/service_impl.go
+++ b/spinifex/handlers/ec2/natgw/service_impl.go
@@ -176,7 +176,9 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 	entry, err := s.natgwKV.Get(key)
 	if err != nil {
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			return nil, errors.New(awserrors.ErrorInvalidNatGatewayIDNotFound)
+			// Idempotent delete: an absent NAT gateway is success so destroy
+			// retries converge.
+			return &ec2.DeleteNatGatewayOutput{NatGatewayId: aws.String(natgwID)}, nil
 		}
 		slog.Error("Failed to read NAT Gateway", "natGatewayId", natgwID, "err", err)
 		return nil, errors.New(awserrors.ErrorServerInternal)

--- a/spinifex/handlers/ec2/natgw/service_impl.go
+++ b/spinifex/handlers/ec2/natgw/service_impl.go
@@ -202,12 +202,9 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
-	// Block while any live route table forwards to this NAT GW (rule #3). The
-	// route-delete path tears down the SNAT rule, so a NAT GW only deletes once
-	// nothing routes to it.
-	if err := s.checkNatGatewayRouteRefs(&record, accountID); err != nil {
-		return nil, err
-	}
+	// AWS-faithful: a NAT gateway deletes even while routes still forward to it;
+	// the route entry blackholes. The reconciler drops the SNAT once the record
+	// leaves the active bucket, so no route-reference dependency guard is needed.
 
 	// Move to deleted bucket (auto-expires via TTL) so DescribeNatGateways can
 	// return state=deleted while Terraform polls after deletion.
@@ -235,64 +232,6 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 	return &ec2.DeleteNatGatewayOutput{
 		NatGatewayId: aws.String(natgwID),
 	}, nil
-}
-
-// kvBucketRouteTables is the route-table KV bucket. Duplicated as a literal
-// (not imported from the routetable package) because routetable imports this
-// package for PublishAddEvent — importing it back would be a cycle.
-const kvBucketRouteTables = "spinifex-vpc-route-tables"
-
-// checkNatGatewayRouteRefs returns DependencyViolation if any route table in
-// the NAT gateway's VPC has a live route forwarding to it (rule #3).
-// Fail-closed on a route-table read error so a transient fault never lets a
-// delete blackhole live routes.
-func (s *NatGatewayServiceImpl) checkNatGatewayRouteRefs(record *NatGatewayRecord, accountID string) error {
-	if s.natsConn == nil {
-		return nil
-	}
-	rtbKV, err := utils.GetOrCreateKVBucket(mustJS(s.natsConn), kvBucketRouteTables, 10)
-	if err != nil {
-		slog.Error("DeleteNatGateway: route-table scan failed, blocking delete", "natGatewayId", record.NatGatewayId, "err", err)
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-	keys, err := rtbKV.Keys()
-	if err != nil {
-		if errors.Is(err, nats.ErrNoKeysFound) {
-			return nil
-		}
-		return errors.New(awserrors.ErrorServerInternal)
-	}
-	prefix := accountID + "."
-	for _, key := range keys {
-		if key == utils.VersionKey || !strings.HasPrefix(key, prefix) {
-			continue
-		}
-		entry, err := rtbKV.Get(key)
-		if err != nil {
-			if errors.Is(err, nats.ErrKeyNotFound) {
-				continue
-			}
-			return errors.New(awserrors.ErrorServerInternal)
-		}
-		var rtbData struct {
-			VpcId  string `json:"vpc_id"`
-			Routes []struct {
-				NatGatewayId string `json:"nat_gateway_id"`
-			} `json:"routes"`
-		}
-		if err := json.Unmarshal(entry.Value(), &rtbData); err != nil {
-			continue
-		}
-		if rtbData.VpcId != record.VpcId {
-			continue
-		}
-		for _, r := range rtbData.Routes {
-			if r.NatGatewayId == record.NatGatewayId {
-				return errors.New(awserrors.ErrorDependencyViolation)
-			}
-		}
-	}
-	return nil
 }
 
 // disassociateEIP clears the EIP's association to this NAT gateway, keeping the
@@ -331,11 +270,6 @@ func (s *NatGatewayServiceImpl) disassociateEIP(record *NatGatewayRecord, accoun
 	if _, err := s.eipKV.Update(key, data, entry.Revision()); err != nil {
 		slog.Warn("DeleteNatGateway: failed to disassociate EIP", "allocationId", record.AllocationId, "err", err)
 	}
-}
-
-func mustJS(nc *nats.Conn) nats.JetStreamContext {
-	js, _ := nc.JetStream()
-	return js
 }
 
 var describeNatGatewaysValidFilters = map[string]bool{

--- a/spinifex/handlers/ec2/natgw/service_impl.go
+++ b/spinifex/handlers/ec2/natgw/service_impl.go
@@ -189,9 +189,9 @@ func (s *NatGatewayServiceImpl) DeleteNatGateway(input *ec2.DeleteNatGatewayInpu
 	entry, err := s.natgwKV.Get(key)
 	if err != nil {
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			// Idempotent delete: an absent NAT gateway is success so destroy
-			// retries converge.
-			return &ec2.DeleteNatGatewayOutput{NatGatewayId: aws.String(natgwID)}, nil
+			// AWS-faithful: an absent NAT gateway is NotFound (provider
+			// tolerates it on destroy); destroy orchestration tolerates it too.
+			return nil, errors.New(awserrors.ErrorInvalidNatGatewayIDNotFound)
 		}
 		slog.Error("Failed to read NAT Gateway", "natGatewayId", natgwID, "err", err)
 		return nil, errors.New(awserrors.ErrorServerInternal)

--- a/spinifex/handlers/ec2/natgw/service_impl_test.go
+++ b/spinifex/handlers/ec2/natgw/service_impl_test.go
@@ -105,14 +105,6 @@ func TestDeleteNatGateway(t *testing.T) {
 	assert.EqualError(t, err, awserrors.ErrorInvalidNatGatewayIDNotFound)
 }
 
-func TestDeleteNatGateway_NotFound(t *testing.T) {
-	svc := setupTestService(t)
-	_, err := svc.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
-		NatGatewayId: aws.String("nat-nope"),
-	}, testAccountID)
-	assert.EqualError(t, err, awserrors.ErrorInvalidNatGatewayIDNotFound)
-}
-
 func TestDescribeNatGateways(t *testing.T) {
 	svc := setupTestService(t)
 	createOut, err := svc.CreateNatGateway(&ec2.CreateNatGatewayInput{

--- a/spinifex/handlers/ec2/natgw/service_impl_test.go
+++ b/spinifex/handlers/ec2/natgw/service_impl_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/filterutil"
 	handlers_ec2_eip "github.com/mulgadc/spinifex/spinifex/handlers/ec2/eip"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
@@ -62,6 +63,38 @@ func TestCreateNatGateway(t *testing.T) {
 	assert.Equal(t, "available", *ngw.State)
 	require.Len(t, ngw.NatGatewayAddresses, 1)
 	assert.Equal(t, "203.0.113.50", *ngw.NatGatewayAddresses[0].PublicIp)
+}
+
+// TestCreateNatGateway_PersistsTagsForTagFilterDiscovery locks the mulga-siv-303
+// fix: CreateNatGateway must persist TagSpecifications so DeleteClusterCPVPC can
+// find the cluster NAT gateway by tag filter and release its EIP. A dropped tag
+// makes the tag-filtered describe return empty, leaking the NAT-GW EIP.
+func TestCreateNatGateway_PersistsTagsForTagFilterDiscovery(t *testing.T) {
+	svc := setupTestService(t)
+	_, err := svc.CreateNatGateway(&ec2.CreateNatGatewayInput{
+		SubnetId:     aws.String("subnet-pub1"),
+		AllocationId: aws.String("eipalloc-test1"),
+		TagSpecifications: []*ec2.TagSpecification{{
+			ResourceType: aws.String(ec2.ResourceTypeNatgateway),
+			Tags: []*ec2.Tag{
+				{Key: aws.String("spinifex:eks-cluster"), Value: aws.String("alpha")},
+				{Key: aws.String("spinifex:eks-role"), Value: aws.String("cp-natgw")},
+			},
+		}},
+	}, testAccountID)
+	require.NoError(t, err)
+
+	out, err := svc.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
+		Filter: []*ec2.Filter{
+			{Name: aws.String("tag:spinifex:eks-cluster"), Values: aws.StringSlice([]string{"alpha"})},
+			{Name: aws.String("tag:spinifex:eks-role"), Values: aws.StringSlice([]string{"cp-natgw"})},
+		},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.NatGateways, 1, "tagged NAT GW must be discoverable by tag filter (mulga-siv-303)")
+	tags := filterutil.EC2TagsToMap(out.NatGateways[0].Tags)
+	assert.Equal(t, "alpha", tags["spinifex:eks-cluster"])
+	assert.Equal(t, "cp-natgw", tags["spinifex:eks-role"])
 }
 
 func TestCreateNatGateway_SubnetNotFound(t *testing.T) {

--- a/spinifex/handlers/ec2/natgw/service_impl_test.go
+++ b/spinifex/handlers/ec2/natgw/service_impl_test.go
@@ -10,6 +10,7 @@ import (
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +18,11 @@ import (
 const testAccountID = "123456789012"
 
 func setupTestService(t *testing.T) *NatGatewayServiceImpl {
+	svc, _ := setupTestServiceJS(t)
+	return svc
+}
+
+func setupTestServiceJS(t *testing.T) (*NatGatewayServiceImpl, nats.JetStreamContext) {
 	t.Helper()
 	_, nc, js := testutil.StartTestJetStream(t)
 
@@ -38,7 +44,7 @@ func setupTestService(t *testing.T) *NatGatewayServiceImpl {
 
 	svc, err := NewNatGatewayServiceImplWithNATS(nc)
 	require.NoError(t, err)
-	return svc
+	return svc, js
 }
 
 func TestCreateNatGateway(t *testing.T) {

--- a/spinifex/handlers/ec2/routetable/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/routetable/lifecycle_invariants_test.go
@@ -5,20 +5,23 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestRLC1_RouteTableDeleteIdempotentOnAbsent enforces the Common Resource
-// Lifecycle Contract rule #1 (idempotent delete): deleting an absent route
-// table is success, not NotFound, so tofu destroy retries converge.
-func TestRLC1_RouteTableDeleteIdempotentOnAbsent(t *testing.T) {
+// TestRLC1_RouteTableDeleteNotFoundOnAbsent enforces the Common Resource
+// Lifecycle Contract rule #1 (AWS-faithful delete, per-service): the EC2
+// DeleteRouteTable API returns InvalidRouteTableID.NotFound for an absent route
+// table, not success. Idempotent convergence belongs to destroy orchestration,
+// which tolerates NotFound via awserrors.IsNotFound; the public API stays AWS compatible.
+func TestRLC1_RouteTableDeleteNotFoundOnAbsent(t *testing.T) {
 	svc := setupTestService(t)
 
-	out, err := svc.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+	_, err := svc.DeleteRouteTable(&ec2.DeleteRouteTableInput{
 		RouteTableId: aws.String("rtb-absent00000000"),
 	}, testAccountID)
 
-	require.NoErrorf(t, err, "DeleteRouteTable on an absent route table must return success, not NotFound (RLC rule #1 idempotent delete): pre-check by key and return an empty output on nats.ErrKeyNotFound")
-	assert.NotNil(t, out, "DeleteRouteTable must return a non-nil output on absent (RLC rule #1)")
+	require.Errorf(t, err, "DeleteRouteTable on an absent route table must return %s, not success (RLC rule #1 AWS-faithful delete): destroy orchestration tolerates NotFound, the API must not", awserrors.ErrorInvalidRouteTableIDNotFound)
+	assert.ErrorContains(t, err, awserrors.ErrorInvalidRouteTableIDNotFound, "DeleteRouteTable on an absent route table must return the canonical InvalidRouteTableID.NotFound (RLC rule #1)")
 }

--- a/spinifex/handlers/ec2/routetable/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/routetable/lifecycle_invariants_test.go
@@ -1,0 +1,24 @@
+package handlers_ec2_routetable
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLC1_RouteTableDeleteIdempotentOnAbsent enforces the Common Resource
+// Lifecycle Contract rule #1 (idempotent delete): deleting an absent route
+// table is success, not NotFound, so tofu destroy retries converge.
+func TestRLC1_RouteTableDeleteIdempotentOnAbsent(t *testing.T) {
+	svc := setupTestService(t)
+
+	out, err := svc.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+		RouteTableId: aws.String("rtb-absent00000000"),
+	}, testAccountID)
+
+	require.NoErrorf(t, err, "DeleteRouteTable on an absent route table must return success, not NotFound (RLC rule #1 idempotent delete): pre-check by key and return an empty output on nats.ErrKeyNotFound")
+	assert.NotNil(t, out, "DeleteRouteTable must return a non-nil output on absent (RLC rule #1)")
+}

--- a/spinifex/handlers/ec2/routetable/service_impl.go
+++ b/spinifex/handlers/ec2/routetable/service_impl.go
@@ -486,6 +486,16 @@ func (s *RouteTableServiceImpl) CreateRouteTable(input *ec2.CreateRouteTableInpu
 		return nil, err
 	}
 
+	// Persist tags from the create spec so tag-filtered describes (and the
+	// tag-driven CP-VPC teardown that reclaims the NAT-GW EIP) can find this
+	// route table.
+	if tags := utils.ExtractTags(input.TagSpecifications, ec2.ResourceTypeRouteTable); len(tags) > 0 {
+		record.Tags = tags
+		if err := s.putRouteTable(accountID, record); err != nil {
+			return nil, err
+		}
+	}
+
 	return &ec2.CreateRouteTableOutput{
 		RouteTable: recordToEC2(record),
 	}, nil

--- a/spinifex/handlers/ec2/routetable/service_impl.go
+++ b/spinifex/handlers/ec2/routetable/service_impl.go
@@ -508,11 +508,8 @@ func (s *RouteTableServiceImpl) DeleteRouteTable(input *ec2.DeleteRouteTableInpu
 	}
 
 	rtbID := *input.RouteTableId
-	// Idempotent delete: an absent route table is success so destroy retries
-	// converge. Pre-check by key since getRouteTable maps absence to NotFound.
-	if _, err := s.rtbKV.Get(utils.AccountKey(accountID, rtbID)); errors.Is(err, nats.ErrKeyNotFound) {
-		return &ec2.DeleteRouteTableOutput{}, nil
-	}
+	// AWS-faithful: getRouteTable maps an absent route table to NotFound (the
+	// provider tolerates it on destroy); destroy orchestration tolerates it too.
 	record, err := s.getRouteTable(accountID, rtbID)
 	if err != nil {
 		return nil, err

--- a/spinifex/handlers/ec2/routetable/service_impl.go
+++ b/spinifex/handlers/ec2/routetable/service_impl.go
@@ -498,6 +498,11 @@ func (s *RouteTableServiceImpl) DeleteRouteTable(input *ec2.DeleteRouteTableInpu
 	}
 
 	rtbID := *input.RouteTableId
+	// Idempotent delete: an absent route table is success so destroy retries
+	// converge. Pre-check by key since getRouteTable maps absence to NotFound.
+	if _, err := s.rtbKV.Get(utils.AccountKey(accountID, rtbID)); errors.Is(err, nats.ErrKeyNotFound) {
+		return &ec2.DeleteRouteTableOutput{}, nil
+	}
 	record, err := s.getRouteTable(accountID, rtbID)
 	if err != nil {
 		return nil, err

--- a/spinifex/handlers/ec2/routetable/service_impl_test.go
+++ b/spinifex/handlers/ec2/routetable/service_impl_test.go
@@ -78,6 +78,41 @@ func TestCreateRouteTable(t *testing.T) {
 	assert.Equal(t, "active", *rtb.Routes[0].State)
 }
 
+// TestCreateRouteTable_PersistsTagsForTagFilterDiscovery locks mulga-siv-303:
+// CreateRouteTable must persist TagSpecifications so the tag-driven CP-VPC
+// teardown can find the private route table, clear its NAT-GW route, and let
+// the NAT gateway (and its billable EIP) be reclaimed.
+func TestCreateRouteTable_PersistsTagsForTagFilterDiscovery(t *testing.T) {
+	svc := setupTestService(t)
+	_, err := svc.CreateRouteTable(&ec2.CreateRouteTableInput{
+		VpcId: aws.String("vpc-test1"),
+		TagSpecifications: []*ec2.TagSpecification{{
+			ResourceType: aws.String(ec2.ResourceTypeRouteTable),
+			Tags: []*ec2.Tag{
+				{Key: aws.String("spinifex:eks-cluster"), Value: aws.String("alpha")},
+				{Key: aws.String("spinifex:eks-role"), Value: aws.String("cp-private-rt")},
+			},
+		}},
+	}, testAccountID)
+	require.NoError(t, err)
+
+	out, err := svc.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{
+			{Name: aws.String("tag:spinifex:eks-cluster"), Values: aws.StringSlice([]string{"alpha"})},
+			{Name: aws.String("tag:spinifex:eks-role"), Values: aws.StringSlice([]string{"cp-private-rt"})},
+		},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.RouteTables, 1, "tagged route table must be discoverable by tag filter (mulga-siv-303)")
+
+	tags := map[string]string{}
+	for _, tg := range out.RouteTables[0].Tags {
+		tags[aws.StringValue(tg.Key)] = aws.StringValue(tg.Value)
+	}
+	assert.Equal(t, "alpha", tags["spinifex:eks-cluster"])
+	assert.Equal(t, "cp-private-rt", tags["spinifex:eks-role"])
+}
+
 func TestCreateRouteTable_VpcNotFound(t *testing.T) {
 	svc := setupTestService(t)
 	_, err := svc.CreateRouteTable(&ec2.CreateRouteTableInput{

--- a/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
@@ -1,0 +1,26 @@
+package handlers_ec2_volume
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLC1_VolumeDeleteIdempotentOnAbsent enforces the Common Resource
+// Lifecycle Contract rule #1 (idempotent delete): deleting an absent volume is
+// success, not NotFound, so tofu destroy retries converge. The attached /
+// has-snapshots live-reference guards are unaffected — only true absence is
+// idempotent.
+func TestRLC1_VolumeDeleteIdempotentOnAbsent(t *testing.T) {
+	svc := newTestVolumeService("ap-southeast-2a")
+
+	out, err := svc.DeleteVolume(&ec2.DeleteVolumeInput{
+		VolumeId: aws.String("vol-absent00000000"),
+	}, "123456789012")
+
+	require.NoErrorf(t, err, "DeleteVolume on an absent volume must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output when GetVolumeConfig reports InvalidVolume.NotFound")
+	assert.NotNil(t, out, "DeleteVolume must return a non-nil output on absent (RLC rule #1)")
+}

--- a/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
@@ -33,20 +33,21 @@ func seedVolume(t *testing.T, svc *VolumeServiceImpl, volID, state, attachedInst
 	require.NoError(t, svc.putVolumeConfig(volID, cfg))
 }
 
-// TestRLC1_VolumeDeleteIdempotentOnAbsent enforces the Common Resource
-// Lifecycle Contract rule #1 (idempotent delete): deleting an absent volume is
-// success, not NotFound, so tofu destroy retries converge. The attached /
-// has-snapshots live-reference guards are unaffected — only true absence is
-// idempotent.
-func TestRLC1_VolumeDeleteIdempotentOnAbsent(t *testing.T) {
+// TestRLC1_VolumeDeleteNotFoundOnAbsent enforces the Common Resource Lifecycle
+// Contract rule #1 (AWS-faithful delete, per-service): the EC2 DeleteVolume API
+// returns InvalidVolume.NotFound for an absent volume, not success. Idempotent
+// convergence belongs to destroy orchestration, which tolerates NotFound via
+// awserrors.IsNotFound; the public API stays AWS compatible. The attached /
+// has-snapshots live-reference guards are unaffected.
+func TestRLC1_VolumeDeleteNotFoundOnAbsent(t *testing.T) {
 	svc := newTestVolumeService("ap-southeast-2a")
 
-	out, err := svc.DeleteVolume(&ec2.DeleteVolumeInput{
+	_, err := svc.DeleteVolume(&ec2.DeleteVolumeInput{
 		VolumeId: aws.String("vol-absent00000000"),
 	}, "123456789012")
 
-	require.NoErrorf(t, err, "DeleteVolume on an absent volume must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output when GetVolumeConfig reports InvalidVolume.NotFound")
-	assert.NotNil(t, out, "DeleteVolume must return a non-nil output on absent (RLC rule #1)")
+	require.Errorf(t, err, "DeleteVolume on an absent volume must return %s, not success (RLC rule #1 AWS-faithful delete): destroy orchestration tolerates NotFound, the API must not", awserrors.ErrorInvalidVolumeNotFound)
+	assert.ErrorContains(t, err, awserrors.ErrorInvalidVolumeNotFound, "DeleteVolume on an absent volume must return the canonical InvalidVolume.NotFound (RLC rule #1)")
 }
 
 // TestRLC3_VolumeDeleteRequiresDetach enforces the Common Resource Lifecycle

--- a/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
@@ -1,13 +1,37 @@
 package handlers_ec2_volume
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/objectstore"
+	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testVolAccountID = "123456789012"
+
+// seedVolume writes a volume config.json into the store so listAllVolumeIDs /
+// GetVolumeConfig see it. CreateVolume cannot be used in unit tests — it needs a
+// live viperblock S3 backend.
+func seedVolume(t *testing.T, svc *VolumeServiceImpl, volID, state, attachedInstance string) {
+	t.Helper()
+	cfg := &viperblock.VolumeConfig{
+		VolumeMetadata: viperblock.VolumeMetadata{
+			VolumeID:         volID,
+			TenantID:         testVolAccountID,
+			SizeGiB:          8,
+			State:            state,
+			AttachedInstance: attachedInstance,
+			AvailabilityZone: "ap-southeast-2a",
+		},
+	}
+	require.NoError(t, svc.putVolumeConfig(volID, cfg))
+}
 
 // TestRLC1_VolumeDeleteIdempotentOnAbsent enforces the Common Resource
 // Lifecycle Contract rule #1 (idempotent delete): deleting an absent volume is
@@ -23,4 +47,57 @@ func TestRLC1_VolumeDeleteIdempotentOnAbsent(t *testing.T) {
 
 	require.NoErrorf(t, err, "DeleteVolume on an absent volume must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output when GetVolumeConfig reports InvalidVolume.NotFound")
 	assert.NotNil(t, out, "DeleteVolume must return a non-nil output on absent (RLC rule #1)")
+}
+
+// TestRLC3_VolumeDeleteRequiresDetach enforces the Common Resource Lifecycle
+// Contract rule #3 (live-reference guard): an attached volume is a live
+// reference and must not be deleted out from under its instance — DeleteVolume
+// returns VolumeInUse until it is detached.
+func TestRLC3_VolumeDeleteRequiresDetach(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	seedVolume(t, svc, "vol-attached00000", "in-use", "i-live0000000000")
+
+	_, err := svc.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: aws.String("vol-attached00000")}, testVolAccountID)
+	assert.ErrorContainsf(t, err, awserrors.ErrorVolumeInUse,
+		"ADR-0005 §2: deleting an attached volume must return VolumeInUse (detach-before-delete, rule #3)")
+}
+
+// TestRLC5_VolumeGCMarksLeakedVolumeNeverDeletes enforces ADR-0005 §3 — the one
+// principled exception to the GC backstop's reap-actual−desired default. A
+// volume left attached to a definitively-gone instance is data: the GC must
+// MARK it orphaned + alarm and NEVER delete it. A future maintainer must not be
+// able to "fix" this into destroying volume data.
+func TestRLC5_VolumeGCMarksLeakedVolumeNeverDeletes(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	seedVolume(t, svc, "vol-leaked0000000", "in-use", "i-gone0000000000")
+	seedVolume(t, svc, "vol-live000000000", "in-use", "i-running00000000")
+
+	reaper := svc.NewVolumeLeakReaper(func() (map[string]bool, error) {
+		return map[string]bool{"i-gone0000000000": true}, nil
+	})
+
+	marked, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, marked, "ADR-0005 §3: the GC must surface exactly the leaked volume")
+
+	leaked, err := svc.GetVolumeConfig("vol-leaked0000000")
+	require.NoErrorf(t, err, "ADR-0005 §3: the GC must NOT delete the leaked volume — it carries data; it may only mark + alarm")
+	assert.NotEmpty(t, leaked.VolumeMetadata.Tags[orphanTagKey],
+		"ADR-0005 §3: a leaked volume must be marked orphaned")
+
+	// A volume attached to an instance NOT in the leaked set must be untouched —
+	// node-local detection never false-marks another node's live-instance volume.
+	live, err := svc.GetVolumeConfig("vol-live000000000")
+	require.NoError(t, err)
+	assert.Empty(t, live.VolumeMetadata.Tags[orphanTagKey],
+		"a volume on a live instance must never be marked orphaned")
+
+	// Idempotent: a second sweep re-marks nothing and still deletes nothing.
+	marked, err = reaper.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, marked, "an already-marked orphan must not be re-marked")
+	_, err = svc.GetVolumeConfig("vol-leaked0000000")
+	require.NoError(t, err, "ADR-0005 §3: the volume must still exist after repeated sweeps")
 }

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -1292,14 +1292,11 @@ func (s *VolumeServiceImpl) DeleteVolume(input *ec2.DeleteVolumeInput, accountID
 	volumeID := *input.VolumeId
 	slog.Info("DeleteVolume request", "volumeId", volumeID)
 
-	// Fetch volume config to validate state
+	// Fetch volume config to validate state. AWS-faithful: an absent volume
+	// returns InvalidVolume.NotFound (the provider tolerates it on destroy);
+	// destroy orchestration tolerates it too.
 	cfg, err := s.GetVolumeConfig(volumeID)
 	if err != nil {
-		// Idempotent delete: an absent volume is success so destroy retries
-		// converge.
-		if err.Error() == awserrors.ErrorInvalidVolumeNotFound {
-			return &ec2.DeleteVolumeOutput{}, nil
-		}
 		slog.Error("DeleteVolume failed to get volume config", "volumeId", volumeID, "err", err)
 		return nil, err
 	}

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -1295,6 +1295,11 @@ func (s *VolumeServiceImpl) DeleteVolume(input *ec2.DeleteVolumeInput, accountID
 	// Fetch volume config to validate state
 	cfg, err := s.GetVolumeConfig(volumeID)
 	if err != nil {
+		// Idempotent delete: an absent volume is success so destroy retries
+		// converge.
+		if err.Error() == awserrors.ErrorInvalidVolumeNotFound {
+			return &ec2.DeleteVolumeOutput{}, nil
+		}
 		slog.Error("DeleteVolume failed to get volume config", "volumeId", volumeID, "err", err)
 		return nil, err
 	}

--- a/spinifex/handlers/ec2/volume/volume_leak_reaper.go
+++ b/spinifex/handlers/ec2/volume/volume_leak_reaper.go
@@ -1,0 +1,104 @@
+package handlers_ec2_volume
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/mulgadc/viperblock/viperblock"
+)
+
+// orphanTagKey marks a volume the GC has surfaced as orphaned. It is a
+// non-destructive tag, never a delete: volumes carry customer data.
+const (
+	orphanTagKey         = "spinifex:orphaned"
+	orphanInstanceTagKey = "spinifex:orphaned-instance"
+)
+
+// VolumeLeakReaper is ADR-0005's data-safety GC override. The shared GC backstop
+// reaps actual−desired for every other resource class; for volumes that default
+// is forbidden. This reaper finds a volume left attached to an instance that is
+// definitively gone and MARKS it orphaned + ALARMS — it never issues a delete.
+// A wrongful reap of an OVN port reboots a VM; a wrongful reap of a volume loses
+// customer data, so reclamation is always an explicit operator action.
+type VolumeLeakReaper struct {
+	svc *VolumeServiceImpl
+	// leaked returns the set of instance IDs this node owns whose teardown
+	// leaked a volume (terminated here with a failed volumes-teardown). Keying
+	// on this node's definitively-gone instances keeps the shared-store scan
+	// from ever false-marking a volume attached to another node's live instance.
+	leaked func() (map[string]bool, error)
+}
+
+var _ vm.Reaper = (*VolumeLeakReaper)(nil)
+
+// NewVolumeLeakReaper builds the data-safety reaper. leaked supplies the
+// node-owned instance IDs whose volume teardown failed.
+func (s *VolumeServiceImpl) NewVolumeLeakReaper(leaked func() (map[string]bool, error)) *VolumeLeakReaper {
+	return &VolumeLeakReaper{svc: s, leaked: leaked}
+}
+
+func (r *VolumeLeakReaper) Class() string         { return "volume-leak" }
+func (r *VolumeLeakReaper) Scope() vm.ReaperScope { return vm.ScopeNodeLocal }
+
+// Sweep marks every volume attached to a leaked instance as orphaned and alarms.
+// It never deletes — that is the deliberate data-safety exception to the GC's
+// reap-actual−desired default (ADR-0005 §3).
+func (r *VolumeLeakReaper) Sweep(ctx context.Context) (int, error) {
+	leaked, err := r.leaked()
+	if err != nil {
+		return 0, err
+	}
+	if len(leaked) == 0 {
+		return 0, nil
+	}
+
+	ids, err := r.svc.listAllVolumeIDs()
+	if err != nil {
+		return 0, err
+	}
+
+	marked := 0
+	for _, id := range ids {
+		select {
+		case <-ctx.Done():
+			return marked, ctx.Err()
+		default:
+		}
+
+		cfg, err := r.svc.GetVolumeConfig(id)
+		if err != nil {
+			continue
+		}
+		md := &cfg.VolumeMetadata
+		if md.AttachedInstance == "" || !leaked[md.AttachedInstance] {
+			continue
+		}
+		if md.Tags[orphanTagKey] != "" {
+			continue // already surfaced; idempotent
+		}
+
+		if err := r.svc.markVolumeOrphaned(id, cfg); err != nil {
+			slog.Error("volume-leak: failed to mark orphaned volume", "volumeId", id, "err", err)
+			continue
+		}
+		// ALARM — surface the retained orphan to the operator. NEVER delete:
+		// reclamation is the explicit --purge / operator path (ADR-0005 §3).
+		slog.Warn("DATA-SAFETY ALARM: orphaned volume retained, not deleted",
+			"volumeId", id, "attachedInstance", md.AttachedInstance, "sizeGiB", md.SizeGiB)
+		marked++
+	}
+	return marked, nil
+}
+
+// markVolumeOrphaned tags the volume as orphaned and persists it. Tag-only: the
+// volume's data and state are untouched so reclamation stays an explicit choice.
+func (s *VolumeServiceImpl) markVolumeOrphaned(volumeID string, cfg *viperblock.VolumeConfig) error {
+	if cfg.VolumeMetadata.Tags == nil {
+		cfg.VolumeMetadata.Tags = make(map[string]string)
+	}
+	cfg.VolumeMetadata.Tags[orphanTagKey] = time.Now().UTC().Format(time.RFC3339)
+	cfg.VolumeMetadata.Tags[orphanInstanceTagKey] = cfg.VolumeMetadata.AttachedInstance
+	return s.putVolumeConfig(volumeID, cfg)
+}

--- a/spinifex/handlers/ec2/vpc/eni.go
+++ b/spinifex/handlers/ec2/vpc/eni.go
@@ -246,7 +246,7 @@ func (s *VPCServiceImpl) deleteNetworkInterface(eniId, accountID string, force b
 		} else {
 			portName := topology.Port(eniId)
 			s.publishNATEvent("vpc.delete-nat", record.VpcId, record.PublicIpAddress, record.PrivateIpAddress, portName, record.MacAddress)
-			if err := s.externalIPAM.ReleaseIP(record.PublicIpPool, record.PublicIpAddress); err != nil {
+			if err := s.externalIPAM.ReleaseIP(record.PublicIpPool, record.PublicIpAddress, eniId); err != nil {
 				slog.Warn("Failed to release public IP during ENI delete", "eni", eniId, "ip", record.PublicIpAddress, "pool", record.PublicIpPool, "err", err)
 			} else {
 				slog.Info("Released auto-assigned public IP during ENI delete", "eniId", eniId, "publicIp", record.PublicIpAddress, "pool", record.PublicIpPool)

--- a/spinifex/handlers/ec2/vpc/eni.go
+++ b/spinifex/handlers/ec2/vpc/eni.go
@@ -62,6 +62,16 @@ type ENIRecord struct {
 	DetachForce bool `json:"detach_force,omitempty"`
 }
 
+// eniIsLiveAttachment reports whether the ENI record is a live attachment to
+// an instance — the rule #3 live reference that pins its subnet undeletable
+// and blocks a plain ENI delete. Checks every structured attachment field so a
+// single-field drift (e.g. Status cleared but AttachmentId retained) still
+// counts. A detached/available ENI is not a live ref: it is itself deletable
+// and reaped by the GC backstop, so it never pins its subnet.
+func eniIsLiveAttachment(r *ENIRecord) bool {
+	return r.Status == "in-use" || r.InstanceId != "" || r.AttachmentId != ""
+}
+
 // CreateNetworkInterface creates a new ENI in the specified subnet
 func (s *VPCServiceImpl) CreateNetworkInterface(input *ec2.CreateNetworkInterfaceInput, accountID string) (*ec2.CreateNetworkInterfaceOutput, error) {
 	if input.SubnetId == nil || *input.SubnetId == "" {
@@ -209,8 +219,10 @@ func (s *VPCServiceImpl) deleteNetworkInterface(eniId, accountID string, force b
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
-	// Cannot delete an in-use ENI unless the owning instance forces teardown.
-	if !force && record.Status == "in-use" {
+	// Cannot delete an ENI that is a live attachment unless the owning
+	// instance forces teardown. An ENI whose instance is gone is detached by
+	// terminate (0003 §2) and falls through as deletable.
+	if !force && eniIsLiveAttachment(&record) {
 		return nil, errors.New(awserrors.ErrorInvalidNetworkInterfaceInUse)
 	}
 

--- a/spinifex/handlers/ec2/vpc/eni.go
+++ b/spinifex/handlers/ec2/vpc/eni.go
@@ -206,10 +206,14 @@ func (s *VPCServiceImpl) deleteNetworkInterface(eniId, accountID string, force b
 	// Get the ENI record
 	entry, err := s.eniKV.Get(key)
 	if err != nil {
-		// Idempotent delete: an absent ENI is success so destroy retries
-		// converge; a transient read error stays a server error.
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			return &ec2.DeleteNetworkInterfaceOutput{}, nil
+			// Internal teardown (force) tolerates an already-gone ENI so
+			// instance terminate converges (ADR-0003 §2); the public API is
+			// AWS-faithful and returns NotFound.
+			if force {
+				return &ec2.DeleteNetworkInterfaceOutput{}, nil
+			}
+			return nil, errors.New(awserrors.ErrorInvalidNetworkInterfaceIDNotFound)
 		}
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}

--- a/spinifex/handlers/ec2/vpc/eni.go
+++ b/spinifex/handlers/ec2/vpc/eni.go
@@ -181,7 +181,12 @@ func (s *VPCServiceImpl) DeleteNetworkInterface(input *ec2.DeleteNetworkInterfac
 	// Get the ENI record
 	entry, err := s.eniKV.Get(key)
 	if err != nil {
-		return nil, errors.New(awserrors.ErrorInvalidNetworkInterfaceIDNotFound)
+		// Idempotent delete: an absent ENI is success so destroy retries
+		// converge; a transient read error stays a server error.
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return &ec2.DeleteNetworkInterfaceOutput{}, nil
+		}
+		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
 	var record ENIRecord

--- a/spinifex/handlers/ec2/vpc/eni.go
+++ b/spinifex/handlers/ec2/vpc/eni.go
@@ -169,13 +169,28 @@ func (s *VPCServiceImpl) CreateNetworkInterface(input *ec2.CreateNetworkInterfac
 	}, nil
 }
 
-// DeleteNetworkInterface deletes an ENI
+// DeleteNetworkInterface deletes an ENI. An in-use ENI is rejected; instance
+// teardown of its own ENI uses ForceDeleteInstanceENI instead.
 func (s *VPCServiceImpl) DeleteNetworkInterface(input *ec2.DeleteNetworkInterfaceInput, accountID string) (*ec2.DeleteNetworkInterfaceOutput, error) {
 	if input.NetworkInterfaceId == nil || *input.NetworkInterfaceId == "" {
 		return nil, errors.New(awserrors.ErrorMissingParameter)
 	}
+	return s.deleteNetworkInterface(*input.NetworkInterfaceId, accountID, false)
+}
 
-	eniId := *input.NetworkInterfaceId
+// ForceDeleteInstanceENI deletes an instance's own ENI, bypassing the in-use
+// guard. The guard protects against deleting an ENI a *different* live instance
+// holds; an instance tearing down its own ENI is always permitted (ADR-0003 §2),
+// which breaks the un-terminable-ENI deadlock. Absent is success (idempotent).
+func (s *VPCServiceImpl) ForceDeleteInstanceENI(accountID, eniId string) error {
+	if eniId == "" {
+		return errors.New(awserrors.ErrorMissingParameter)
+	}
+	_, err := s.deleteNetworkInterface(eniId, accountID, true)
+	return err
+}
+
+func (s *VPCServiceImpl) deleteNetworkInterface(eniId, accountID string, force bool) (*ec2.DeleteNetworkInterfaceOutput, error) {
 	key := utils.AccountKey(accountID, eniId)
 
 	// Get the ENI record
@@ -194,8 +209,8 @@ func (s *VPCServiceImpl) DeleteNetworkInterface(input *ec2.DeleteNetworkInterfac
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
-	// Cannot delete an in-use ENI
-	if record.Status == "in-use" {
+	// Cannot delete an in-use ENI unless the owning instance forces teardown.
+	if !force && record.Status == "in-use" {
 		return nil, errors.New(awserrors.ErrorInvalidNetworkInterfaceInUse)
 	}
 

--- a/spinifex/handlers/ec2/vpc/eni_test.go
+++ b/spinifex/handlers/ec2/vpc/eni_test.go
@@ -118,14 +118,6 @@ func TestDeleteNetworkInterface(t *testing.T) {
 	assert.ErrorContains(t, err, "InvalidNetworkInterfaceID.NotFound")
 }
 
-func TestDeleteNetworkInterface_NotFound(t *testing.T) {
-	svc := setupTestVPCService(t)
-	_, err := svc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-		NetworkInterfaceId: aws.String("eni-nonexistent"),
-	}, testAccountID)
-	assert.ErrorContains(t, err, "InvalidNetworkInterfaceID.NotFound")
-}
-
 func TestDeleteNetworkInterface_InUse(t *testing.T) {
 	svc := setupTestVPCService(t)
 	vpcId := createTestVPC(t, svc, "10.0.0.0/16")

--- a/spinifex/handlers/ec2/vpc/external_ipam.go
+++ b/spinifex/handlers/ec2/vpc/external_ipam.go
@@ -134,7 +134,9 @@ func (m *ExternalIPAM) allocateFromPool(poolName, purpose, allocID, eniID, insta
 }
 
 // ReleaseIP releases a previously allocated external IP back to its pool.
-func (m *ExternalIPAM) ReleaseIP(poolName, ip string) error {
+// ownerENIID, when non-empty, scopes the release to the ENI that currently owns
+// the lease so a stale or duplicated teardown for a recycled IP is a no-op.
+func (m *ExternalIPAM) ReleaseIP(poolName, ip, ownerENIID string) error {
 	addr, err := netip.ParseAddr(ip)
 	if err != nil {
 		return fmt.Errorf("parse release IP %q: %w", ip, err)
@@ -143,7 +145,7 @@ func (m *ExternalIPAM) ReleaseIP(poolName, ip string) error {
 	if err != nil {
 		return err
 	}
-	return alloc.Release(context.Background(), poolName, addr)
+	return alloc.Release(context.Background(), poolName, addr, ownerENIID)
 }
 
 // GetPoolRecord returns the current IPAM record for a pool. DHCP-sourced

--- a/spinifex/handlers/ec2/vpc/external_ipam_test.go
+++ b/spinifex/handlers/ec2/vpc/external_ipam_test.go
@@ -60,7 +60,7 @@ func TestExternalIPAM_GatewayIPReserved(t *testing.T) {
 	assert.Equal(t, PurposeIGWLRP, alloc.Purpose)
 
 	// Cannot release gateway IP
-	err = ipam.ReleaseIP("wan", "192.168.1.150")
+	err = ipam.ReleaseIP("wan", "192.168.1.150", "")
 	assert.ErrorContains(t, err, "cannot release gateway IP")
 }
 
@@ -97,7 +97,7 @@ func TestExternalIPAM_Release(t *testing.T) {
 	assert.Equal(t, "192.168.1.152", ip2)
 
 	// Release first
-	err = ipam.ReleaseIP("wan", "192.168.1.151")
+	err = ipam.ReleaseIP("wan", "192.168.1.151", "")
 	require.NoError(t, err)
 
 	// Round-robin: a released IP is NOT reused immediately. Allocation resumes
@@ -360,7 +360,7 @@ func TestExternalIPAM_ReleaseNotAllocated(t *testing.T) {
 	pool := testPool()
 	ipam := setupTestExternalIPAM(t, []ExternalPoolConfig{pool})
 
-	err := ipam.ReleaseIP("wan", "192.168.1.200")
+	err := ipam.ReleaseIP("wan", "192.168.1.200", "")
 	assert.ErrorContains(t, err, "not allocated")
 }
 

--- a/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,4 +81,62 @@ func TestRLC_ENINonDeadlock(t *testing.T) {
 	// Idempotent: forcing teardown of an already-gone ENI is success.
 	require.NoErrorf(t, svc.ForceDeleteInstanceENI(testAccountID, eniId),
 		"ADR-0003 §2 / RLC rule #1: ForceDeleteInstanceENI on an absent ENI must be idempotent success")
+}
+
+// TestRLC3_VPCFamilyDeleteGuardsLiveDependents enforces the Common Resource
+// Lifecycle Contract rule #3 (live-only dependency guards): a VPC-family delete
+// must return DependencyViolation while a *live* dependent remains, but a
+// detached/available (orphan) child must never pin its parent undeletable —
+// otherwise tofu destroy deadlocks on a child the GC backstop already reaps.
+func TestRLC3_VPCFamilyDeleteGuardsLiveDependents(t *testing.T) {
+	t.Run("DeleteSubnet blocked by an attached ENI", func(t *testing.T) {
+		svc := setupTestVPCService(t)
+		vpcId := createTestVPC(t, svc, "10.0.0.0/16")
+		subnetId := createTestSubnet(t, svc, vpcId, "10.0.1.0/24")
+		eniId := createTestENI(t, svc, subnetId)
+		_, err := svc.AttachENI(testAccountID, eniId, "i-resident000000", 0)
+		require.NoError(t, err)
+
+		_, err = svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(subnetId)}, testAccountID)
+		assert.ErrorContainsf(t, err, awserrors.ErrorDependencyViolation,
+			"ADR-0004 §2: DeleteSubnet must return DependencyViolation while a live ENI attachment (a resident instance) remains (rule #3)")
+	})
+
+	t.Run("DeleteSubnet allowed with only an available ENI", func(t *testing.T) {
+		svc := setupTestVPCService(t)
+		vpcId := createTestVPC(t, svc, "10.0.0.0/16")
+		subnetId := createTestSubnet(t, svc, vpcId, "10.0.1.0/24")
+		_ = createTestENI(t, svc, subnetId) // available, never attached
+
+		_, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(subnetId)}, testAccountID)
+		require.NoErrorf(t, err,
+			"ADR-0004 §2/rule #3: an available (orphan) ENI must not pin its subnet — it is itself deletable and GC-reaped")
+	})
+
+	t.Run("DeleteNetworkInterface blocked while attached", func(t *testing.T) {
+		svc := setupTestVPCService(t)
+		vpcId := createTestVPC(t, svc, "10.0.0.0/16")
+		subnetId := createTestSubnet(t, svc, vpcId, "10.0.1.0/24")
+		eniId := createTestENI(t, svc, subnetId)
+		_, err := svc.AttachENI(testAccountID, eniId, "i-live0000000000", 0)
+		require.NoError(t, err)
+
+		_, err = svc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String(eniId)}, testAccountID)
+		assert.ErrorContainsf(t, err, awserrors.ErrorInvalidNetworkInterfaceInUse,
+			"ADR-0004 §2: a plain DeleteNetworkInterface must reject an ENI attached to a live instance")
+	})
+
+	t.Run("DeleteNetworkInterface allowed once detached", func(t *testing.T) {
+		svc := setupTestVPCService(t)
+		vpcId := createTestVPC(t, svc, "10.0.0.0/16")
+		subnetId := createTestSubnet(t, svc, vpcId, "10.0.1.0/24")
+		eniId := createTestENI(t, svc, subnetId)
+		_, err := svc.AttachENI(testAccountID, eniId, "i-gone0000000000", 0)
+		require.NoError(t, err)
+		require.NoError(t, svc.DetachENI(testAccountID, eniId))
+
+		_, err = svc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String(eniId)}, testAccountID)
+		require.NoErrorf(t, err,
+			"ADR-0004 §2/rule #3: an ENI whose instance is gone (detached) must be deletable")
+	})
 }

--- a/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
@@ -42,3 +42,42 @@ func TestRLC1_VPCDeleteIdempotentOnAbsent(t *testing.T) {
 		})
 	}
 }
+
+// TestRLC_ENINonDeadlock enforces ADR-0003 §2 (break the un-terminable-ENI
+// deadlock). The public DeleteNetworkInterface guard must keep rejecting an
+// in-use ENI — that protects an ENI a *different* live instance holds — while
+// ForceDeleteInstanceENI must delete the owning instance's in-use ENI anyway.
+// Without the force path a failed DetachENI CAS leaves the ENI stuck "in-use"
+// and the in-use guard then blocks delete forever, so the instance can never
+// finish terminating.
+func TestRLC_ENINonDeadlock(t *testing.T) {
+	svc := setupTestVPCService(t)
+	vpcId := createTestVPC(t, svc, "10.0.0.0/16")
+	subnetId := createTestSubnet(t, svc, vpcId, "10.0.1.0/24")
+	eniId := createTestENI(t, svc, subnetId)
+
+	// Simulate the deadlock precondition: the ENI is "in-use" because a prior
+	// DetachENI never flipped it back to "available".
+	_, err := svc.AttachENI(testAccountID, eniId, "i-deadlock", 0)
+	require.NoError(t, err)
+
+	// The guard stays intact: a plain delete of an in-use ENI is still rejected.
+	_, err = svc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniId),
+	}, testAccountID)
+	assert.ErrorContainsf(t, err, "InvalidNetworkInterface.InUse",
+		"ADR-0003 §2: the in-use guard must still protect an ENI held by a different live instance")
+
+	// The owning instance's force teardown must break the deadlock.
+	require.NoErrorf(t, svc.ForceDeleteInstanceENI(testAccountID, eniId),
+		"ADR-0003 §2: ForceDeleteInstanceENI must delete the owning instance's in-use ENI to break the un-terminable-ENI deadlock")
+
+	_, err = svc.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []*string{aws.String(eniId)},
+	}, testAccountID)
+	assert.ErrorContains(t, err, "InvalidNetworkInterfaceID.NotFound")
+
+	// Idempotent: forcing teardown of an already-gone ENI is success.
+	require.NoErrorf(t, svc.ForceDeleteInstanceENI(testAccountID, eniId),
+		"ADR-0003 §2 / RLC rule #1: ForceDeleteInstanceENI on an absent ENI must be idempotent success")
+}

--- a/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
@@ -1,0 +1,44 @@
+package handlers_ec2_vpc
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLC1_VPCDeleteIdempotentOnAbsent enforces the Common Resource Lifecycle
+// Contract rule #1 (idempotent delete): deleting an absent VPC-family resource
+// is success, not NotFound, so tofu destroy retries and double-targeted graph
+// nodes converge. Every VPC-family delete endpoint must have a case here — a
+// missing case is an idempotency gap.
+func TestRLC1_VPCDeleteIdempotentOnAbsent(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(svc *VPCServiceImpl) (any, error)
+	}{
+		{"DeleteVpc", func(svc *VPCServiceImpl) (any, error) {
+			return svc.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String("vpc-absent00000000")}, testAccountID)
+		}},
+		{"DeleteSubnet", func(svc *VPCServiceImpl) (any, error) {
+			return svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String("subnet-absent0000")}, testAccountID)
+		}},
+		{"DeleteSecurityGroup", func(svc *VPCServiceImpl) (any, error) {
+			return svc.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: aws.String("sg-absent000000000")}, testAccountID)
+		}},
+		{"DeleteNetworkInterface", func(svc *VPCServiceImpl) (any, error) {
+			return svc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String("eni-absent00000000")}, testAccountID)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, _ := setupTestVPCServiceWithNC(t)
+			out, err := tc.call(svc)
+			require.NoErrorf(t, err, "%s on an absent resource must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output on nats.ErrKeyNotFound", tc.name)
+			assert.NotNilf(t, out, "%s must return a non-nil output on absent (RLC rule #1)", tc.name)
+		})
+	}
+}

--- a/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/vpc/lifecycle_invariants_test.go
@@ -10,26 +10,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRLC1_VPCDeleteIdempotentOnAbsent enforces the Common Resource Lifecycle
-// Contract rule #1 (idempotent delete): deleting an absent VPC-family resource
-// is success, not NotFound, so tofu destroy retries and double-targeted graph
-// nodes converge. Every VPC-family delete endpoint must have a case here — a
-// missing case is an idempotency gap.
-func TestRLC1_VPCDeleteIdempotentOnAbsent(t *testing.T) {
+// TestRLC1_VPCDeleteNotFoundOnAbsent enforces the Common Resource Lifecycle
+// Contract rule #1 (AWS-faithful delete, per-service): the EC2/VPC delete API
+// returns the service's canonical InvalidX.NotFound for an absent resource —
+// not success. Idempotent convergence belongs to destroy orchestration, which
+// tolerates NotFound via awserrors.IsNotFound; the public API must stay AWS
+// compatible so SDK callers and account-scoping checks see the real error.
+// Every VPC-family delete endpoint must have a case here.
+func TestRLC1_VPCDeleteNotFoundOnAbsent(t *testing.T) {
 	cases := []struct {
-		name string
-		call func(svc *VPCServiceImpl) (any, error)
+		name    string
+		wantErr string
+		call    func(svc *VPCServiceImpl) (any, error)
 	}{
-		{"DeleteVpc", func(svc *VPCServiceImpl) (any, error) {
+		{"DeleteVpc", awserrors.ErrorInvalidVpcIDNotFound, func(svc *VPCServiceImpl) (any, error) {
 			return svc.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String("vpc-absent00000000")}, testAccountID)
 		}},
-		{"DeleteSubnet", func(svc *VPCServiceImpl) (any, error) {
+		{"DeleteSubnet", awserrors.ErrorInvalidSubnetIDNotFound, func(svc *VPCServiceImpl) (any, error) {
 			return svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String("subnet-absent0000")}, testAccountID)
 		}},
-		{"DeleteSecurityGroup", func(svc *VPCServiceImpl) (any, error) {
+		{"DeleteSecurityGroup", awserrors.ErrorInvalidGroupNotFound, func(svc *VPCServiceImpl) (any, error) {
 			return svc.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: aws.String("sg-absent000000000")}, testAccountID)
 		}},
-		{"DeleteNetworkInterface", func(svc *VPCServiceImpl) (any, error) {
+		{"DeleteNetworkInterface", awserrors.ErrorInvalidNetworkInterfaceIDNotFound, func(svc *VPCServiceImpl) (any, error) {
 			return svc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: aws.String("eni-absent00000000")}, testAccountID)
 		}},
 	}
@@ -37,9 +40,9 @@ func TestRLC1_VPCDeleteIdempotentOnAbsent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			svc, _ := setupTestVPCServiceWithNC(t)
-			out, err := tc.call(svc)
-			require.NoErrorf(t, err, "%s on an absent resource must return success, not NotFound (RLC rule #1 idempotent delete): return an empty output on nats.ErrKeyNotFound", tc.name)
-			assert.NotNilf(t, out, "%s must return a non-nil output on absent (RLC rule #1)", tc.name)
+			_, err := tc.call(svc)
+			require.Errorf(t, err, "%s on an absent resource must return %s, not success (RLC rule #1 AWS-faithful delete): destroy orchestration tolerates NotFound, the API must not", tc.name, tc.wantErr)
+			assert.ErrorContainsf(t, err, tc.wantErr, "%s on an absent resource must return the canonical %s (RLC rule #1)", tc.name, tc.wantErr)
 		})
 	}
 }

--- a/spinifex/handlers/ec2/vpc/security_group.go
+++ b/spinifex/handlers/ec2/vpc/security_group.go
@@ -223,7 +223,12 @@ func (s *VPCServiceImpl) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput
 
 	entry, err := s.sgKV.Get(key)
 	if err != nil {
-		return nil, errors.New(awserrors.ErrorInvalidGroupNotFound)
+		// Idempotent delete: an absent security group is success so destroy
+		// retries converge; a transient read error stays a server error.
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		}
+		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
 	var record SecurityGroupRecord

--- a/spinifex/handlers/ec2/vpc/security_group.go
+++ b/spinifex/handlers/ec2/vpc/security_group.go
@@ -223,10 +223,11 @@ func (s *VPCServiceImpl) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput
 
 	entry, err := s.sgKV.Get(key)
 	if err != nil {
-		// Idempotent delete: an absent security group is success so destroy
-		// retries converge; a transient read error stays a server error.
+		// AWS-faithful: an absent security group is InvalidGroup.NotFound, not
+		// success. Destroy orchestration tolerates it via awserrors.IsNotFound;
+		// a transient read error stays a server error.
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			return &ec2.DeleteSecurityGroupOutput{}, nil
+			return nil, errors.New(awserrors.ErrorInvalidGroupNotFound)
 		}
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}

--- a/spinifex/handlers/ec2/vpc/security_group_test.go
+++ b/spinifex/handlers/ec2/vpc/security_group_test.go
@@ -107,16 +107,6 @@ func TestDeleteSecurityGroup_Success(t *testing.T) {
 	}
 }
 
-func TestDeleteSecurityGroup_NotFound(t *testing.T) {
-	svc := setupTestVPCService(t)
-
-	_, err := svc.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
-		GroupId: aws.String("sg-nonexistent"),
-	}, testAccountID)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "InvalidGroup.NotFound")
-}
-
 func TestDeleteSecurityGroup_MissingGroupId(t *testing.T) {
 	svc := setupTestVPCService(t)
 

--- a/spinifex/handlers/ec2/vpc/service_impl.go
+++ b/spinifex/handlers/ec2/vpc/service_impl.go
@@ -313,10 +313,11 @@ func (s *VPCServiceImpl) DeleteVpc(input *ec2.DeleteVpcInput, accountID string) 
 	key := utils.AccountKey(accountID, vpcID)
 
 	if _, err := s.vpcKV.Get(key); err != nil {
-		// Idempotent delete: an absent VPC is success so destroy retries
-		// converge; a transient read error stays a server error.
+		// AWS-faithful: an absent VPC is NotFound (the tofu/SDK provider
+		// tolerates it on destroy); destroy orchestration tolerates it too.
+		// A transient read error stays a server error.
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			return &ec2.DeleteVpcOutput{}, nil
+			return nil, errors.New(awserrors.ErrorInvalidVpcIDNotFound)
 		}
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
@@ -631,10 +632,11 @@ func (s *VPCServiceImpl) DeleteSubnet(input *ec2.DeleteSubnetInput, accountID st
 	// Read subnet record before deletion (needed for vpcd event)
 	subnetEntry, err := s.subnetKV.Get(key)
 	if err != nil {
-		// Idempotent delete: an absent subnet is success so destroy retries
-		// converge; a transient read error stays a server error.
+		// AWS-faithful: an absent subnet is NotFound (provider tolerates it on
+		// destroy); destroy orchestration tolerates it too. A transient read
+		// error stays a server error.
 		if errors.Is(err, nats.ErrKeyNotFound) {
-			return &ec2.DeleteSubnetOutput{}, nil
+			return nil, errors.New(awserrors.ErrorInvalidSubnetIDNotFound)
 		}
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}

--- a/spinifex/handlers/ec2/vpc/service_impl.go
+++ b/spinifex/handlers/ec2/vpc/service_impl.go
@@ -313,7 +313,12 @@ func (s *VPCServiceImpl) DeleteVpc(input *ec2.DeleteVpcInput, accountID string) 
 	key := utils.AccountKey(accountID, vpcID)
 
 	if _, err := s.vpcKV.Get(key); err != nil {
-		return nil, errors.New(awserrors.ErrorInvalidVpcIDNotFound)
+		// Idempotent delete: an absent VPC is success so destroy retries
+		// converge; a transient read error stays a server error.
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return &ec2.DeleteVpcOutput{}, nil
+		}
+		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
 	// Check for dependent subnets owned by this account
@@ -626,7 +631,12 @@ func (s *VPCServiceImpl) DeleteSubnet(input *ec2.DeleteSubnetInput, accountID st
 	// Read subnet record before deletion (needed for vpcd event)
 	subnetEntry, err := s.subnetKV.Get(key)
 	if err != nil {
-		return nil, errors.New(awserrors.ErrorInvalidSubnetIDNotFound)
+		// Idempotent delete: an absent subnet is success so destroy retries
+		// converge; a transient read error stays a server error.
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return &ec2.DeleteSubnetOutput{}, nil
+		}
+		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 	var subnetRecord SubnetRecord
 	_ = json.Unmarshal(subnetEntry.Value(), &subnetRecord)

--- a/spinifex/handlers/ec2/vpc/service_impl.go
+++ b/spinifex/handlers/ec2/vpc/service_impl.go
@@ -641,6 +641,13 @@ func (s *VPCServiceImpl) DeleteSubnet(input *ec2.DeleteSubnetInput, accountID st
 	var subnetRecord SubnetRecord
 	_ = json.Unmarshal(subnetEntry.Value(), &subnetRecord)
 
+	// Block while a live ENI attachment (hence a resident instance) remains in
+	// the subnet (rule #3). Orphan/available ENIs do not pin it: tofu deletes
+	// them first and the GC backstop reaps leftovers.
+	if err := s.checkSubnetResidents(accountID, subnetID); err != nil {
+		return nil, err
+	}
+
 	if err := s.subnetKV.Delete(key); err != nil {
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
@@ -651,6 +658,41 @@ func (s *VPCServiceImpl) DeleteSubnet(input *ec2.DeleteSubnetInput, accountID st
 	s.publishSubnetEvent("vpc.delete-subnet", subnetID, subnetRecord.VpcId, subnetRecord.CidrBlock)
 
 	return &ec2.DeleteSubnetOutput{}, nil
+}
+
+// checkSubnetResidents returns DependencyViolation if any ENI residing in the
+// subnet is a live attachment (rule #3). Fail-closed on a KV read error so a
+// transient fault never lets a delete orphan a port.
+func (s *VPCServiceImpl) checkSubnetResidents(accountID, subnetID string) error {
+	keys, err := s.eniKV.Keys()
+	if err != nil {
+		if errors.Is(err, nats.ErrNoKeysFound) {
+			return nil
+		}
+		slog.Error("DeleteSubnet: ENI scan failed, blocking delete to avoid orphaning ports", "subnetId", subnetID, "err", err)
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+	prefix := accountID + "."
+	for _, key := range keys {
+		if key == utils.VersionKey || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		entry, err := s.eniKV.Get(key)
+		if err != nil {
+			if errors.Is(err, nats.ErrKeyNotFound) {
+				continue
+			}
+			return errors.New(awserrors.ErrorServerInternal)
+		}
+		var record ENIRecord
+		if err := json.Unmarshal(entry.Value(), &record); err != nil {
+			continue
+		}
+		if record.SubnetId == subnetID && eniIsLiveAttachment(&record) {
+			return errors.New(awserrors.ErrorDependencyViolation)
+		}
+	}
+	return nil
 }
 
 // DescribeSubnets describes subnets

--- a/spinifex/handlers/ec2/vpc/service_impl_test.go
+++ b/spinifex/handlers/ec2/vpc/service_impl_test.go
@@ -189,14 +189,6 @@ func TestDeleteVpc(t *testing.T) {
 	assert.Nil(t, desc)
 }
 
-func TestDeleteVpc_NotFound(t *testing.T) {
-	svc := setupTestVPCService(t)
-	_, err := svc.DeleteVpc(&ec2.DeleteVpcInput{
-		VpcId: aws.String("vpc-nonexistent"),
-	}, testAccountID)
-	assert.ErrorContains(t, err, "InvalidVpcID.NotFound")
-}
-
 func TestDeleteVpc_MissingID(t *testing.T) {
 	svc := setupTestVPCService(t)
 	_, err := svc.DeleteVpc(&ec2.DeleteVpcInput{}, testAccountID)
@@ -381,14 +373,6 @@ func TestDeleteSubnet(t *testing.T) {
 	}, testAccountID)
 	assert.ErrorContains(t, err, "InvalidSubnetID.NotFound")
 	assert.Nil(t, desc)
-}
-
-func TestDeleteSubnet_NotFound(t *testing.T) {
-	svc := setupTestVPCService(t)
-	_, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{
-		SubnetId: aws.String("subnet-nonexistent"),
-	}, testAccountID)
-	assert.ErrorContains(t, err, "InvalidSubnetID.NotFound")
 }
 
 func TestDeleteSubnet_MissingID(t *testing.T) {

--- a/spinifex/handlers/eks/cluster_state.go
+++ b/spinifex/handlers/eks/cluster_state.go
@@ -73,6 +73,12 @@ type ClusterMeta struct {
 	NLBArn                string    `json:"nlbArn,omitempty"`
 	NLBTargetGroupArn     string    `json:"nlbTargetGroupArn,omitempty"`
 	CreatedAt             time.Time `json:"createdAt"`
+	// DeletingSince stamps when the cluster entered DELETING. The teardown
+	// backstop reaper waits out a healthy synchronous DeleteCluster (min-age)
+	// before re-driving purgeClusterInfra, so it only ever re-drives a wedged
+	// teardown, never one still in progress. No omitempty: encoding/json never
+	// treats a time.Time as empty.
+	DeletingSince time.Time `json:"deletingSince"`
 	// HealthIssue is the last health failure reason ("" = healthy).
 	// DescribeCluster surfaces it as a ClusterHealth issue.
 	HealthIssue string `json:"healthIssue,omitempty"`
@@ -210,6 +216,9 @@ func SetClusterStatus(kv nats.KeyValue, name string, status ClusterStatus) error
 			return false
 		}
 		m.Status = status
+		if status == ClusterStatusDeleting && m.DeletingSince.IsZero() {
+			m.DeletingSince = time.Now().UTC()
+		}
 		return true
 	})
 }

--- a/spinifex/handlers/eks/cp_vpc.go
+++ b/spinifex/handlers/eks/cp_vpc.go
@@ -426,32 +426,12 @@ func DeleteClusterCPVPC(deps CPVPCDeps, accountID, clusterName string) error {
 		return errors.New("eks: DeleteClusterCPVPC empty cluster name")
 	}
 
-	// 1. NAT gateway + its EIP. DeleteNatGateway publishes the SNAT removal.
-	if ngOut, err := deps.NGW.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
-		Filter: cpClusterRoleFilters(clusterName, clusterEKSRoleCPNatGW),
-	}, accountID); err != nil {
-		slog.Warn("DeleteClusterCPVPC: describe NAT gateways failed", "cluster", clusterName, "err", err)
-	} else if ngOut != nil {
-		for _, ng := range ngOut.NatGateways {
-			if state := aws.StringValue(ng.State); state == "deleted" || state == "deleting" {
-				continue
-			}
-			ngID := aws.StringValue(ng.NatGatewayId)
-			if _, err := deps.NGW.DeleteNatGateway(&ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(ngID)}, accountID); err != nil {
-				slog.Warn("DeleteClusterCPVPC: delete NAT gateway failed", "natgw", ngID, "err", err)
-			}
-			for _, addr := range ng.NatGatewayAddresses {
-				if alloc := aws.StringValue(addr.AllocationId); alloc != "" {
-					if _, err := deps.EIP.ReleaseAddress(&ec2.ReleaseAddressInput{AllocationId: aws.String(alloc)}, accountID); err != nil {
-						slog.Warn("DeleteClusterCPVPC: release NAT EIP failed", "alloc", alloc, "err", err)
-					}
-				}
-			}
-		}
-	}
-
-	// 2. Route tables: disassociate every subnet, then delete. Disassociation
-	// publishes the egress-reroute removal for each subnet.
+	// 1. Route tables: disassociate every subnet, then delete. Disassociation
+	// publishes the egress-reroute removal for each subnet. Route tables go first
+	// so the NAT gateway's live route refs are gone before its delete — the NAT
+	// GW delete is guarded against live route forwards (rule #3), so deleting it
+	// while the private RT still routes 0.0.0.0/0 to it would fail (and strand
+	// its billable EIP).
 	for _, role := range []string{clusterEKSRolePublicRT, clusterEKSRolePrivateRT} {
 		rtOut, err := deps.RT.DescribeRouteTables(&ec2.DescribeRouteTablesInput{Filters: cpClusterRoleFilters(clusterName, role)}, accountID)
 		if err != nil {
@@ -475,6 +455,31 @@ func DeleteClusterCPVPC(deps CPVPCDeps, accountID, clusterName string) error {
 			}
 			if _, err := deps.RT.DeleteRouteTable(&ec2.DeleteRouteTableInput{RouteTableId: aws.String(rtID)}, accountID); err != nil {
 				slog.Warn("DeleteClusterCPVPC: delete route table failed", "rt", rtID, "err", err)
+			}
+		}
+	}
+
+	// 2. NAT gateway + its EIP. DeleteNatGateway publishes the SNAT removal and
+	// disassociates the EIP; release follows so the billable address is reclaimed.
+	if ngOut, err := deps.NGW.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
+		Filter: cpClusterRoleFilters(clusterName, clusterEKSRoleCPNatGW),
+	}, accountID); err != nil {
+		slog.Warn("DeleteClusterCPVPC: describe NAT gateways failed", "cluster", clusterName, "err", err)
+	} else if ngOut != nil {
+		for _, ng := range ngOut.NatGateways {
+			if state := aws.StringValue(ng.State); state == "deleted" || state == "deleting" {
+				continue
+			}
+			ngID := aws.StringValue(ng.NatGatewayId)
+			if _, err := deps.NGW.DeleteNatGateway(&ec2.DeleteNatGatewayInput{NatGatewayId: aws.String(ngID)}, accountID); err != nil {
+				slog.Warn("DeleteClusterCPVPC: delete NAT gateway failed", "natgw", ngID, "err", err)
+			}
+			for _, addr := range ng.NatGatewayAddresses {
+				if alloc := aws.StringValue(addr.AllocationId); alloc != "" {
+					if _, err := deps.EIP.ReleaseAddress(&ec2.ReleaseAddressInput{AllocationId: aws.String(alloc)}, accountID); err != nil {
+						slog.Warn("DeleteClusterCPVPC: release NAT EIP failed", "alloc", alloc, "err", err)
+					}
+				}
 			}
 		}
 	}

--- a/spinifex/handlers/eks/cp_vpc.go
+++ b/spinifex/handlers/eks/cp_vpc.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 )
 
@@ -515,7 +516,7 @@ func DeleteClusterCPVPC(deps CPVPCDeps, accountID, clusterName string) error {
 	if err := DeleteClusterIGW(deps.IGW, accountID, vpcID, clusterName); err != nil {
 		slog.Warn("DeleteClusterCPVPC: delete IGW failed", "vpc", vpcID, "err", err)
 	}
-	if _, err := deps.VPC.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String(vpcID)}, accountID); err != nil {
+	if _, err := deps.VPC.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String(vpcID)}, accountID); err != nil && !awserrors.IsNotFound(err) {
 		return fmt.Errorf("eks: delete cp vpc %s: %w", vpcID, err)
 	}
 	slog.Info("DeleteClusterCPVPC: managed control-plane VPC removed", "cluster", clusterName, "vpc", vpcID)

--- a/spinifex/handlers/eks/cp_vpc_test.go
+++ b/spinifex/handlers/eks/cp_vpc_test.go
@@ -1,11 +1,13 @@
 package handlers_eks
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
 // Fakes for the managed control-plane VPC ("Set B") collaborators. They model
@@ -330,6 +332,11 @@ type fakeNatGatewayProvisioner struct {
 	deleteCalls []*ec2.DeleteNatGatewayInput
 
 	createErr error
+
+	// routeGuard, when set, models the live rule #3 guard: DeleteNatGateway is
+	// blocked (DependencyViolation) while any route table in routeGuard still
+	// exists — i.e. while a route table can forward to this NAT GW.
+	routeGuard *fakeRouteTableProvisioner
 }
 
 func newFakeNatGatewayProvisioner() *fakeNatGatewayProvisioner { return &fakeNatGatewayProvisioner{} }
@@ -374,6 +381,9 @@ func (f *fakeNatGatewayProvisioner) CreateNatGateway(input *ec2.CreateNatGateway
 
 func (f *fakeNatGatewayProvisioner) DeleteNatGateway(input *ec2.DeleteNatGatewayInput, _ string) (*ec2.DeleteNatGatewayOutput, error) {
 	f.deleteCalls = append(f.deleteCalls, input)
+	if f.routeGuard != nil && len(f.routeGuard.tables) > 0 {
+		return nil, errors.New(awserrors.ErrorDependencyViolation)
+	}
 	id := aws.StringValue(input.NatGatewayId)
 	for _, ng := range f.gws {
 		if ng.id == id {

--- a/spinifex/handlers/eks/cp_vpc_test.go
+++ b/spinifex/handlers/eks/cp_vpc_test.go
@@ -115,6 +115,7 @@ type fakeVPCProvisioner struct {
 
 	createVpcErr    error
 	createSubnetErr error
+	deleteVpcErr    error
 }
 
 func newFakeVPCProvisioner() *fakeVPCProvisioner { return &fakeVPCProvisioner{} }
@@ -148,6 +149,9 @@ func (f *fakeVPCProvisioner) CreateVpc(input *ec2.CreateVpcInput, accountID stri
 
 func (f *fakeVPCProvisioner) DeleteVpc(input *ec2.DeleteVpcInput, _ string) (*ec2.DeleteVpcOutput, error) {
 	f.deleteVpcCalls = append(f.deleteVpcCalls, input)
+	if f.deleteVpcErr != nil {
+		return nil, f.deleteVpcErr
+	}
 	id := aws.StringValue(input.VpcId)
 	kept := f.vpcs[:0]
 	for _, v := range f.vpcs {

--- a/spinifex/handlers/eks/delete_cluster_test.go
+++ b/spinifex/handlers/eks/delete_cluster_test.go
@@ -265,3 +265,42 @@ func TestDeleteCluster_EgressEIPReleaseRealErrorLeavesMeta(t *testing.T) {
 	assert.Equal(t, ClusterStatusDeleting, meta.Status)
 	assert.NotEmpty(t, meta.EgressEIPAllocationID, "alloc ID must remain for retry")
 }
+
+// TestDeleteClusterSingleFlightLoserSkipsTeardown locks mulga-siv-295.12: when a
+// concurrent handler already holds the per-cluster teardown lease (an SDK retry
+// fanned to another worker), DeleteCluster must return the cluster as DELETING
+// without running purgeClusterInfra — no duplicate ENI/NLB/EIP teardown — and
+// must leave the meta for the lease holder to sweep.
+func TestDeleteClusterSingleFlightLoserSkipsTeardown(t *testing.T) {
+	f := newDeleteClusterFixture(t, "alpha")
+
+	// Stand in for the winning handler: hold the teardown lease.
+	_, err := f.svc.leaderKV.Create(teardownLeaderKey(testAccountID, "alpha"), []byte("node-2"))
+	require.NoError(t, err)
+
+	out, err := f.svc.DeleteCluster(deleteInput("alpha"), testAccountID)
+	require.NoError(t, err)
+	require.NotNil(t, out.Cluster)
+	assert.Equal(t, string(ClusterStatusDeleting), aws.StringValue(out.Cluster.Status),
+		"the loser must report the cluster as DELETING (AWS-async delete semantics)")
+
+	assert.Empty(t, f.inst.terminateCalls, "the loser must not terminate the CP VM — the lease holder owns the teardown")
+	assert.Empty(t, f.eip.releaseCalls, "the loser must not release the billable EIP")
+
+	meta, getErr := GetClusterMeta(f.kv, "alpha")
+	require.NoError(t, getErr, "the loser must leave the meta for the lease holder to sweep")
+	assert.Equal(t, ClusterStatusCreating, meta.Status, "the loser must not mutate KV state; the winner owns the DELETING transition")
+}
+
+// TestDeleteClusterWinnerReleasesTeardownLease: a successful synchronous delete
+// must release the teardown lease so a later delete or the backstop reaper can
+// re-acquire it (a leaked lease would wedge every future teardown until TTL).
+func TestDeleteClusterWinnerReleasesTeardownLease(t *testing.T) {
+	f := newDeleteClusterFixture(t, "alpha")
+
+	_, err := f.svc.DeleteCluster(deleteInput("alpha"), testAccountID)
+	require.NoError(t, err)
+
+	_, getErr := f.svc.leaderKV.Get(teardownLeaderKey(testAccountID, "alpha"))
+	assert.ErrorIs(t, getErr, nats.ErrKeyNotFound, "the teardown lease must be released after a successful delete")
+}

--- a/spinifex/handlers/eks/delete_cluster_test.go
+++ b/spinifex/handlers/eks/delete_cluster_test.go
@@ -157,6 +157,39 @@ func TestRLC5_DeleteClusterCPVPCReleasesNATGWEIPAfterRoutes(t *testing.T) {
 	assert.Equal(t, "eipalloc-cp", aws.StringValue(f.eip.releaseCalls[0].AllocationId))
 }
 
+// TestRLC1_DeleteClusterCPVPCToleratesAbsentVPC enforces the destroy-side half
+// of the Common Resource Lifecycle Contract rule #1 (AWS-faithful delete): the
+// EC2 DeleteVpc API now returns InvalidVpcID.NotFound for an absent VPC, so the
+// teardown orchestrator must converge by tolerating that NotFound (a concurrent
+// GC or a retried delete-cluster already removed it) — while a real failure
+// still surfaces so the backstop retries.
+func TestRLC1_DeleteClusterCPVPCToleratesAbsentVPC(t *testing.T) {
+	cpVPC := []*fakeCPVPC{{
+		id:   "vpc-cp",
+		cidr: "10.0.0.0/16",
+		tags: map[string]string{clusterEKSClusterTagKey: "alpha", clusterEKSRoleTagKey: clusterEKSRoleCPVPC},
+	}}
+
+	t.Run("absent VPC (NotFound) converges to success", func(t *testing.T) {
+		f := newEKSServiceFixture(t)
+		f.vpcMgr.vpcs = cpVPC
+		f.vpcMgr.deleteVpcErr = errors.New(awserrors.ErrorInvalidVpcIDNotFound)
+
+		require.NoErrorf(t, DeleteClusterCPVPC(f.svc.cpVPCDeps(), testAccountID, "alpha"),
+			"RLC rule #1: teardown must tolerate DeleteVpc NotFound (resource already gone), not abort")
+	})
+
+	t.Run("a real DeleteVpc failure still surfaces", func(t *testing.T) {
+		f := newEKSServiceFixture(t)
+		f.vpcMgr.vpcs = cpVPC
+		f.vpcMgr.deleteVpcErr = errors.New(awserrors.ErrorDependencyViolation)
+
+		err := DeleteClusterCPVPC(f.svc.cpVPCDeps(), testAccountID, "alpha")
+		require.Error(t, err, "a non-NotFound DeleteVpc failure must surface so the teardown backstop retries")
+		assert.Contains(t, err.Error(), awserrors.ErrorDependencyViolation)
+	})
+}
+
 func TestDeleteCluster_AllTeardownSucceedsSweepsKV(t *testing.T) {
 	f := newDeleteClusterFixture(t, "alpha")
 

--- a/spinifex/handlers/eks/delete_cluster_test.go
+++ b/spinifex/handlers/eks/delete_cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
@@ -126,6 +127,34 @@ func newDeleteClusterFixture(t *testing.T, clusterName string) *deleteClusterFix
 	require.NoError(t, err)
 
 	return &deleteClusterFixture{svc: f.svc, kv: kv, nlb: f.nlb, inst: f.inst, vpc: f.vpc, eip: f.eip}
+}
+
+// TestRLC5_DeleteClusterCPVPCReleasesNATGWEIPAfterRoutes locks the mulga-siv-303
+// teardown order: route tables must be torn down before the NAT gateway, because
+// the NAT GW delete is guarded against live route forwards (rule #3). Deleting it
+// while the private route table still routes to it fails with DependencyViolation
+// and strands the billable NAT-GW EIP.
+func TestRLC5_DeleteClusterCPVPCReleasesNATGWEIPAfterRoutes(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	f.ngw.routeGuard = f.rt
+	f.ngw.gws = []*fakeCPNatGateway{{
+		id:    "nat-cp",
+		tags:  map[string]string{clusterEKSClusterTagKey: "alpha", clusterEKSRoleTagKey: clusterEKSRoleCPNatGW},
+		state: "available",
+		addrs: []*ec2.NatGatewayAddress{{AllocationId: aws.String("eipalloc-cp")}},
+	}}
+	f.rt.tables = []*fakeCPRouteTable{{
+		id:   "rtb-cp",
+		vpc:  "vpc-cp",
+		tags: map[string]string{clusterEKSClusterTagKey: "alpha", clusterEKSRoleTagKey: clusterEKSRolePrivateRT},
+	}}
+
+	require.NoError(t, DeleteClusterCPVPC(f.svc.cpVPCDeps(), testAccountID, "alpha"))
+
+	require.Len(t, f.ngw.gws, 1)
+	assert.Equal(t, "deleted", f.ngw.gws[0].state, "NAT GW must delete after routes are cleared (rule #3 guard not tripped)")
+	require.Len(t, f.eip.releaseCalls, 1, "the NAT-GW EIP must be released, not stranded (mulga-siv-303)")
+	assert.Equal(t, "eipalloc-cp", aws.StringValue(f.eip.releaseCalls[0].AllocationId))
 }
 
 func TestDeleteCluster_AllTeardownSucceedsSweepsKV(t *testing.T) {

--- a/spinifex/handlers/eks/eks_billable_reaper.go
+++ b/spinifex/handlers/eks/eks_billable_reaper.go
@@ -1,0 +1,115 @@
+package handlers_eks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/tags"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+)
+
+// EKSBillableReaper is ADR-0006 §5's meta-independent billable cleanup, built on
+// the 0003 reality→desired GC backstop. A normal DeleteCluster can leave a
+// running control-plane VM behind (terminate completes async; a daemon restart
+// re-launches it from saved running-state) after the cluster meta is already
+// swept — a billable orphan with no owner to drive a retry. This reaper finds a
+// running EKS control-plane VM whose cluster meta is DEFINITIVELY GONE and
+// terminates it. It is node-local: each node reaps the orphans it runs.
+type EKSBillableReaper struct {
+	svc *EKSServiceImpl
+	// running returns this node's running VMs. The reaper filters to the EKS
+	// control-plane VMs and checks each against its cluster meta.
+	running func() ([]*vm.VM, error)
+}
+
+var _ vm.Reaper = (*EKSBillableReaper)(nil)
+
+// NewBillableReaper builds the EKS billable-orphan reaper. running supplies this
+// node's running VMs (from the daemon's StateStore).
+func (s *EKSServiceImpl) NewBillableReaper(running func() ([]*vm.VM, error)) *EKSBillableReaper {
+	return &EKSBillableReaper{svc: s, running: running}
+}
+
+func (r *EKSBillableReaper) Class() string         { return "eks-billable" }
+func (r *EKSBillableReaper) Scope() vm.ReaperScope { return vm.ScopeNodeLocal }
+
+// Sweep terminates every running EKS control-plane VM whose cluster meta is
+// absent. A VM whose cluster still exists (CREATING or DELETING) is left to the
+// cluster's own teardown/retry; an ENI that is gone or untagged is skipped, so
+// the reaper never reaps on uncertainty.
+func (r *EKSBillableReaper) Sweep(ctx context.Context) (int, error) {
+	vms, err := r.running()
+	if err != nil {
+		return 0, fmt.Errorf("list running VMs: %w", err)
+	}
+
+	js, err := r.svc.deps.NATSConn.JetStream()
+	if err != nil {
+		return 0, fmt.Errorf("jetstream: %w", err)
+	}
+
+	reaped := 0
+	for _, v := range vms {
+		select {
+		case <-ctx.Done():
+			return reaped, ctx.Err()
+		default:
+		}
+		if v == nil || v.ManagedBy != tags.ManagedByEKS || v.ENIId == "" {
+			continue
+		}
+
+		clusterName, clusterAccount, ok := r.clusterRefFromENI(v)
+		if !ok {
+			continue // ENI gone or untagged: cannot confirm orphan-hood, never reap
+		}
+
+		acctKV, err := GetOrCreateAccountBucket(js, clusterAccount)
+		if err != nil {
+			slog.Warn("eks-billable: account bucket lookup failed", "account", clusterAccount, "err", err)
+			continue
+		}
+		if _, err := GetClusterMeta(acctKV, clusterName); !errors.Is(err, ErrClusterNotFound) {
+			// Meta present (live/CREATING/DELETING) or unreadable: not a definitive
+			// orphan — leave it to the cluster's own teardown/retry.
+			continue
+		}
+
+		// ALARM + reap: the cluster is gone but its control-plane VM still runs.
+		slog.Warn("DATA-SAFETY ALARM: orphaned EKS control-plane VM reaped (cluster meta gone)",
+			"instanceId", v.ID, "cluster", clusterName, "account", clusterAccount, "node", v.LastNode)
+		if err := TerminateK3sServerVM(r.svc.deps.VPCK3s, r.svc.deps.Instance, v.AccountID, v.ID, v.ENIId); err != nil {
+			slog.Warn("eks-billable: failed to terminate orphan CP VM", "instanceId", v.ID, "err", err)
+			continue
+		}
+		reaped++
+	}
+	return reaped, nil
+}
+
+// clusterRefFromENI reads the cluster name + customer account from the VM's
+// control-plane ENI tags. ok is false when the ENI is gone or missing either tag.
+func (r *EKSBillableReaper) clusterRefFromENI(v *vm.VM) (clusterName, clusterAccount string, ok bool) {
+	out, err := r.svc.deps.VPCK3s.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: aws.StringSlice([]string{v.ENIId}),
+	}, v.AccountID)
+	if err != nil || out == nil || len(out.NetworkInterfaces) == 0 {
+		return "", "", false
+	}
+	for _, tag := range out.NetworkInterfaces[0].TagSet {
+		switch aws.StringValue(tag.Key) {
+		case clusterEKSClusterTagKey:
+			clusterName = aws.StringValue(tag.Value)
+		case clusterEKSAccountTagKey:
+			clusterAccount = aws.StringValue(tag.Value)
+		}
+	}
+	if clusterName == "" || clusterAccount == "" {
+		return "", "", false
+	}
+	return clusterName, clusterAccount, true
+}

--- a/spinifex/handlers/eks/eks_billable_reaper.go
+++ b/spinifex/handlers/eks/eks_billable_reaper.go
@@ -87,8 +87,25 @@ func (r *EKSBillableReaper) Sweep(ctx context.Context) (int, error) {
 			continue
 		}
 		reaped++
+		r.reclaimOrphanInfra(v.AccountID, clusterName)
 	}
 	return reaped, nil
+}
+
+// reclaimOrphanInfra tears down the billable infra a reaped orphan's swept meta
+// no longer anchors: the NLB front-end NAT and the managed CP VPC's NAT-GW EIP.
+// Both are keyed by cluster name and idempotent, so a clean prior delete is a
+// no-op. Best-effort — the costliest resource (the VM) is already gone, and
+// DeleteClusterCPVPC releases the NAT-GW EIP before the VPC delete, so the
+// billable address is reclaimed even if the now-empty VPC delete trails. account
+// is the infra account (system account for the managed CP VPC topology).
+func (r *EKSBillableReaper) reclaimOrphanInfra(account, clusterName string) {
+	if err := DeleteClusterNLB(r.svc.deps.NLB, account, clusterName); err != nil {
+		slog.Warn("eks-billable: reclaim orphan NLB failed", "cluster", clusterName, "err", err)
+	}
+	if err := DeleteClusterCPVPC(r.svc.cpVPCDeps(), account, clusterName); err != nil {
+		slog.Warn("eks-billable: reclaim orphan CP VPC (NAT-GW EIP) failed", "cluster", clusterName, "err", err)
+	}
 }
 
 // clusterRefFromENI reads the cluster name + customer account from the VM's

--- a/spinifex/handlers/eks/eks_billable_reaper_test.go
+++ b/spinifex/handlers/eks/eks_billable_reaper_test.go
@@ -1,0 +1,89 @@
+package handlers_eks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/tags"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reaperSysAccount = "000000000000"
+
+// cpENI builds a control-plane ENI record carrying the cluster + account tags
+// the billable reaper reads to map a running VM back to its cluster meta.
+func cpENI(eniID, cluster, account string) *ec2.NetworkInterface {
+	return &ec2.NetworkInterface{
+		NetworkInterfaceId: aws.String(eniID),
+		TagSet: []*ec2.Tag{
+			{Key: aws.String(tags.ManagedByKey), Value: aws.String(tags.ManagedByEKS)},
+			{Key: aws.String(clusterEKSClusterTagKey), Value: aws.String(cluster)},
+			{Key: aws.String(clusterEKSAccountTagKey), Value: aws.String(account)},
+			{Key: aws.String(clusterEKSRoleTagKey), Value: aws.String(clusterEKSRoleControlPlane)},
+		},
+	}
+}
+
+func cpVM(id, eniID string) *vm.VM {
+	return &vm.VM{ID: id, ManagedBy: tags.ManagedByEKS, ENIId: eniID, AccountID: reaperSysAccount, LastNode: "node-1"}
+}
+
+// TestRLC5_EKSBillableReaperTerminatesOrphanCPVM enforces ADR-0006 §5
+// meta-independent billable cleanup: a running EKS control-plane VM whose
+// cluster meta is DEFINITIVELY GONE is a billable orphan and must be terminated
+// by the GC backstop — the real fix for mulga-siv-294 (orphan CP VM surviving a
+// daemon restart after DeleteCluster swept the meta).
+func TestRLC5_EKSBillableReaperTerminatesOrphanCPVM(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	f.vpc.describeByENI = map[string]*ec2.NetworkInterface{
+		"eni-orphan": cpENI("eni-orphan", "gone-cluster", testAccountID),
+	}
+	orphan := cpVM("i-orphan", "eni-orphan")
+
+	reaper := f.svc.NewBillableReaper(func() ([]*vm.VM, error) { return []*vm.VM{orphan}, nil })
+
+	reaped, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped, "ADR-0006 §5: a CP VM whose cluster meta is gone must be reaped")
+	assert.Contains(t, f.inst.terminateCalls, "i-orphan", "the orphan CP VM must be terminated")
+	require.Len(t, f.vpc.deleteCalls, 1, "the orphan CP ENI must be deleted")
+	assert.Equal(t, "eni-orphan", aws.StringValue(f.vpc.deleteCalls[0].NetworkInterfaceId))
+
+	// Idempotent: a repeat sweep over the same (still meta-absent) VM is safe —
+	// the terminate path tolerates an already-gone instance/ENI.
+	_, err = reaper.Sweep(context.Background())
+	require.NoError(t, err)
+}
+
+// TestRLC5_EKSBillableReaperSpareLiveAndUncertain enforces the reaper's no-false-
+// reap guarantee: a CP VM whose cluster meta still exists (live / CREATING /
+// DELETING) is left to the cluster's own teardown, and a VM whose ENI is gone or
+// untagged is never reaped (orphan-hood cannot be confirmed).
+func TestRLC5_EKSBillableReaperSpareLiveAndUncertain(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	require.NoError(t, PutClusterMeta(f.kv, sampleClusterMeta("alive")))
+
+	f.vpc.describeByENI = map[string]*ec2.NetworkInterface{
+		"eni-live": cpENI("eni-live", "alive", testAccountID),
+		// eni-untagged present but missing the cluster/account tags.
+		"eni-untagged": {NetworkInterfaceId: aws.String("eni-untagged")},
+	}
+
+	live := cpVM("i-live", "eni-live")                    // meta present → spare
+	untagged := cpVM("i-untagged", "eni-untagged")        // tags missing → spare
+	gone := cpVM("i-gone", "eni-missing")                 // ENI absent from describe → spare
+	notEKS := &vm.VM{ID: "i-customer", ENIId: "eni-cust"} // not EKS-managed → ignored
+
+	reaper := f.svc.NewBillableReaper(func() ([]*vm.VM, error) {
+		return []*vm.VM{live, untagged, gone, notEKS}, nil
+	})
+
+	reaped, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, reaped, "ADR-0006 §5: the reaper must never reap on uncertainty or a live cluster")
+	assert.Empty(t, f.inst.terminateCalls, "no VM with a live/unknown cluster may be terminated")
+}

--- a/spinifex/handlers/eks/eks_billable_reaper_test.go
+++ b/spinifex/handlers/eks/eks_billable_reaper_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/stretchr/testify/assert"
@@ -44,6 +45,21 @@ func TestRLC5_EKSBillableReaperTerminatesOrphanCPVM(t *testing.T) {
 	}
 	orphan := cpVM("i-orphan", "eni-orphan")
 
+	// Seed the orphan cluster's name/tag-driven billable infra the swept meta no
+	// longer anchors: an NLB front-end and a tagged NAT gateway holding a billable
+	// EIP. The reaper's post-terminate reclaim must sweep both (mulga-siv-302).
+	nlbName := ClusterNLBName("gone-cluster")
+	f.nlb.lbByName[nlbName] = &elbv2.LoadBalancer{
+		LoadBalancerArn:  aws.String("arn:lb-orphan"),
+		LoadBalancerName: aws.String(nlbName),
+	}
+	f.ngw.gws = []*fakeCPNatGateway{{
+		id:    "nat-orphan",
+		tags:  map[string]string{clusterEKSClusterTagKey: "gone-cluster", clusterEKSRoleTagKey: clusterEKSRoleCPNatGW},
+		state: "available",
+		addrs: []*ec2.NatGatewayAddress{{AllocationId: aws.String("eipalloc-orphan")}},
+	}}
+
 	reaper := f.svc.NewBillableReaper(func() ([]*vm.VM, error) { return []*vm.VM{orphan}, nil })
 
 	reaped, err := reaper.Sweep(context.Background())
@@ -53,10 +69,16 @@ func TestRLC5_EKSBillableReaperTerminatesOrphanCPVM(t *testing.T) {
 	require.Len(t, f.vpc.deleteCalls, 1, "the orphan CP ENI must be deleted")
 	assert.Equal(t, "eni-orphan", aws.StringValue(f.vpc.deleteCalls[0].NetworkInterfaceId))
 
+	// mulga-siv-302: the orphan's billable NLB + NAT-GW EIP must also be reclaimed.
+	assert.NotContains(t, f.nlb.lbByName, nlbName, "the orphan NLB front-end must be reclaimed")
+	require.Len(t, f.eip.releaseCalls, 1, "the orphan NAT-GW EIP must be released")
+	assert.Equal(t, "eipalloc-orphan", aws.StringValue(f.eip.releaseCalls[0].AllocationId))
+
 	// Idempotent: a repeat sweep over the same (still meta-absent) VM is safe —
-	// the terminate path tolerates an already-gone instance/ENI.
+	// the terminate + reclaim paths tolerate already-gone infra (no second release).
 	_, err = reaper.Sweep(context.Background())
 	require.NoError(t, err)
+	assert.Len(t, f.eip.releaseCalls, 1, "reclaim must not double-release an already-freed EIP")
 }
 
 // TestRLC5_EKSBillableReaperSpareLiveAndUncertain enforces the reaper's no-false-
@@ -86,4 +108,5 @@ func TestRLC5_EKSBillableReaperSpareLiveAndUncertain(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, reaped, "ADR-0006 §5: the reaper must never reap on uncertainty or a live cluster")
 	assert.Empty(t, f.inst.terminateCalls, "no VM with a live/unknown cluster may be terminated")
+	assert.Empty(t, f.eip.releaseCalls, "no reclaim (no EIP release) may run without a reap")
 }

--- a/spinifex/handlers/eks/eks_deleting_reaper.go
+++ b/spinifex/handlers/eks/eks_deleting_reaper.go
@@ -97,9 +97,9 @@ func (r *EKSDeletingReaper) reapCluster(accountID string, acctKV nats.KeyValue, 
 		return 0, nil // still within the in-flight synchronous-delete window
 	}
 
-	release, ok := r.acquireClusterLease(accountID, cluster)
+	release, ok := r.svc.acquireTeardownLease(accountID, cluster)
 	if !ok {
-		return 0, nil // the active reconciler or another node owns this teardown
+		return 0, nil // a synchronous delete or another node's reaper owns this teardown
 	}
 	defer release()
 
@@ -110,23 +110,4 @@ func (r *EKSDeletingReaper) reapCluster(accountID string, acctKV nats.KeyValue, 
 	}
 	slog.Info("eks-deleting: teardown completed, meta swept", "cluster", cluster, "account", accountID)
 	return 1, nil
-}
-
-// acquireClusterLease takes the per-cluster reconciler leader lease so the
-// backstop never re-drives a teardown concurrently with the active reconciler or
-// another node's reaper. A nil leaderKV (single-node/test) skips gating. The
-// bucket TTL reaps the lease if release does not run.
-func (r *EKSDeletingReaper) acquireClusterLease(accountID, cluster string) (func(), bool) {
-	if r.svc.leaderKV == nil {
-		return func() {}, true
-	}
-	key := reconcilerLeaderKey(accountID, cluster)
-	if _, err := r.svc.leaderKV.Create(key, []byte(r.svc.deps.HolderID)); err != nil {
-		return nil, false
-	}
-	return func() {
-		if err := r.svc.leaderKV.Delete(key); err != nil {
-			slog.Warn("eks-deleting: lease release failed (TTL will reap)", "key", key, "err", err)
-		}
-	}, true
 }

--- a/spinifex/handlers/eks/eks_deleting_reaper.go
+++ b/spinifex/handlers/eks/eks_deleting_reaper.go
@@ -1,0 +1,132 @@
+package handlers_eks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go"
+)
+
+// deletingReapMinAge is how long a cluster must sit in DELETING before the
+// backstop reaper re-drives its teardown. It must exceed a healthy synchronous
+// DeleteCluster so the reaper never races an in-flight delete; only a wedged
+// teardown (failed first attempt with no client retry) is re-driven. Var for tests.
+var deletingReapMinAge = 90 * time.Second
+
+// EKSDeletingReaper is the ADR-0004 tracked-async-teardown backstop. A
+// DeleteCluster whose synchronous teardown fails leaves the cluster in DELETING
+// with its billable infra (NAT-GW EIP, NLB, CP VPC) still allocated and nothing
+// to re-drive it: the per-cluster reconciler exits on DELETING and the billable
+// reaper only acts once the cluster meta is GONE. This reaper finds clusters
+// stuck in DELETING past deletingReapMinAge and re-runs purgeClusterInfra to
+// completion, idempotently, under the per-cluster reconciler leader lease so only
+// one node drives each teardown.
+type EKSDeletingReaper struct {
+	svc    *EKSServiceImpl
+	minAge time.Duration
+}
+
+var _ vm.Reaper = (*EKSDeletingReaper)(nil)
+
+// NewDeletingReaper builds the EKS wedged-DELETING teardown backstop.
+func (s *EKSServiceImpl) NewDeletingReaper() *EKSDeletingReaper {
+	return &EKSDeletingReaper{svc: s, minAge: deletingReapMinAge}
+}
+
+func (r *EKSDeletingReaper) Class() string         { return "eks-deleting" }
+func (r *EKSDeletingReaper) Scope() vm.ReaperScope { return vm.ScopeNodeLocal }
+
+// Sweep re-drives every cluster stuck in DELETING past minAge. Idempotent:
+// purgeClusterInfra tolerates already-gone resources, so a clean prior delete is
+// a no-op and the meta is swept on success.
+func (r *EKSDeletingReaper) Sweep(ctx context.Context) (int, error) {
+	if !r.svc.depsReadyForOrchestration() {
+		return 0, nil
+	}
+	js, err := r.svc.deps.NATSConn.JetStream()
+	if err != nil {
+		return 0, fmt.Errorf("jetstream: %w", err)
+	}
+
+	reaped := 0
+	for name := range js.KeyValueStoreNames() {
+		if !strings.HasPrefix(name, KVBucketEKSAccountPrefix) {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return reaped, ctx.Err()
+		default:
+		}
+		accountID := strings.TrimPrefix(name, KVBucketEKSAccountPrefix)
+		acctKV, err := js.KeyValue(name)
+		if err != nil {
+			continue
+		}
+		clusters, err := listClusterNames(acctKV)
+		if err != nil {
+			continue
+		}
+		for _, cluster := range clusters {
+			n, err := r.reapCluster(accountID, acctKV, cluster)
+			if err != nil {
+				slog.Warn("eks-deleting: re-drive teardown failed", "cluster", cluster, "err", err)
+			}
+			reaped += n
+		}
+	}
+	return reaped, nil
+}
+
+// reapCluster re-drives one cluster's teardown if it is wedged in DELETING past
+// minAge and its leader lease can be acquired. Returns 1 when it completed a
+// teardown, 0 otherwise.
+func (r *EKSDeletingReaper) reapCluster(accountID string, acctKV nats.KeyValue, cluster string) (int, error) {
+	meta, err := GetClusterMeta(acctKV, cluster)
+	if err != nil {
+		return 0, nil // gone or unreadable: nothing to re-drive
+	}
+	if meta.Status != ClusterStatusDeleting {
+		return 0, nil
+	}
+	if !meta.DeletingSince.IsZero() && time.Since(meta.DeletingSince) < r.minAge {
+		return 0, nil // still within the in-flight synchronous-delete window
+	}
+
+	release, ok := r.acquireClusterLease(accountID, cluster)
+	if !ok {
+		return 0, nil // the active reconciler or another node owns this teardown
+	}
+	defer release()
+
+	slog.Warn("eks-deleting: re-driving wedged DELETING teardown",
+		"cluster", cluster, "account", accountID, "deletingSince", meta.DeletingSince)
+	if err := r.svc.purgeClusterInfra(accountID, cluster, meta, acctKV, true); err != nil {
+		return 0, err
+	}
+	slog.Info("eks-deleting: teardown completed, meta swept", "cluster", cluster, "account", accountID)
+	return 1, nil
+}
+
+// acquireClusterLease takes the per-cluster reconciler leader lease so the
+// backstop never re-drives a teardown concurrently with the active reconciler or
+// another node's reaper. A nil leaderKV (single-node/test) skips gating. The
+// bucket TTL reaps the lease if release does not run.
+func (r *EKSDeletingReaper) acquireClusterLease(accountID, cluster string) (func(), bool) {
+	if r.svc.leaderKV == nil {
+		return func() {}, true
+	}
+	key := reconcilerLeaderKey(accountID, cluster)
+	if _, err := r.svc.leaderKV.Create(key, []byte(r.svc.deps.HolderID)); err != nil {
+		return nil, false
+	}
+	return func() {
+		if err := r.svc.leaderKV.Delete(key); err != nil {
+			slog.Warn("eks-deleting: lease release failed (TTL will reap)", "key", key, "err", err)
+		}
+	}, true
+}

--- a/spinifex/handlers/eks/eks_deleting_reaper_test.go
+++ b/spinifex/handlers/eks/eks_deleting_reaper_test.go
@@ -1,0 +1,72 @@
+package handlers_eks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// markDeleting transitions a seeded cluster to DELETING and backdates
+// DeletingSince so the reaper treats it as wedged (past min-age).
+func markDeleting(t *testing.T, f *deleteClusterFixture, name string, age time.Duration) {
+	t.Helper()
+	require.NoError(t, SetClusterStatus(f.kv, name, ClusterStatusDeleting))
+	meta, err := GetClusterMeta(f.kv, name)
+	require.NoError(t, err)
+	meta.DeletingSince = time.Now().UTC().Add(-age)
+	require.NoError(t, PutClusterMeta(f.kv, meta))
+}
+
+// TestRLC4_DeletingReaperReDrivesWedgedTeardown locks mulga-siv-295.11: a cluster
+// stuck in DELETING past min-age (its synchronous DeleteCluster failed and no
+// client re-issued) must be re-driven to completion by the backstop reaper —
+// infra torn down and meta swept — so its billable EIP is never stranded.
+func TestRLC4_DeletingReaperReDrivesWedgedTeardown(t *testing.T) {
+	f := newDeleteClusterFixture(t, "alpha")
+	markDeleting(t, f, "alpha", 10*time.Minute)
+
+	reaper := f.svc.NewDeletingReaper()
+	n, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "the wedged DELETING cluster must be re-driven")
+
+	_, getErr := GetClusterMeta(f.kv, "alpha")
+	assert.ErrorIs(t, getErr, ErrClusterNotFound, "meta must be swept after the backstop completes teardown")
+	assert.GreaterOrEqual(t, len(f.inst.terminateCalls), 1, "CP VM must be terminated")
+	assert.Len(t, f.eip.releaseCalls, 1, "the billable egress EIP must be released, not stranded")
+}
+
+// TestDeletingReaperSkipsFreshDelete: a cluster that just entered DELETING is
+// within the in-flight synchronous-delete window; the reaper must not race it.
+func TestDeletingReaperSkipsFreshDelete(t *testing.T) {
+	f := newDeleteClusterFixture(t, "beta")
+	markDeleting(t, f, "beta", 1*time.Second) // younger than min-age
+
+	reaper := f.svc.NewDeletingReaper()
+	n, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "a freshly-DELETING cluster must be left to its in-flight delete")
+
+	meta, getErr := GetClusterMeta(f.kv, "beta")
+	require.NoError(t, getErr, "meta must survive — the reaper did not re-drive")
+	assert.Equal(t, ClusterStatusDeleting, meta.Status)
+	assert.Empty(t, f.inst.terminateCalls, "no teardown must run within the min-age window")
+}
+
+// TestDeletingReaperSkipsNonDeleting: a CREATING/ACTIVE cluster is never touched.
+func TestDeletingReaperSkipsNonDeleting(t *testing.T) {
+	f := newDeleteClusterFixture(t, "gamma") // stays CREATING
+
+	reaper := f.svc.NewDeletingReaper()
+	n, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	meta, getErr := GetClusterMeta(f.kv, "gamma")
+	require.NoError(t, getErr)
+	assert.Equal(t, ClusterStatusCreating, meta.Status)
+	assert.Empty(t, f.inst.terminateCalls)
+}

--- a/spinifex/handlers/eks/igw.go
+++ b/spinifex/handlers/eks/igw.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 )
 
@@ -101,7 +102,7 @@ func DeleteClusterIGW(igwp igwProvisioner, accountID, vpcID, clusterName string)
 	}
 	if _, err := igwp.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
 		InternetGatewayId: aws.String(igwID),
-	}, accountID); err != nil {
+	}, accountID); err != nil && !awserrors.IsNotFound(err) {
 		slog.Warn("DeleteClusterIGW: delete failed", "igw", igwID, "err", err)
 		return nil
 	}

--- a/spinifex/handlers/eks/k3s_ha_control_plane_test.go
+++ b/spinifex/handlers/eks/k3s_ha_control_plane_test.go
@@ -76,6 +76,10 @@ func (v *seqK3sVPC) DeleteNetworkInterface(in *ec2.DeleteNetworkInterfaceInput, 
 	return &ec2.DeleteNetworkInterfaceOutput{}, nil
 }
 
+func (v *seqK3sVPC) DescribeNetworkInterfaces(*ec2.DescribeNetworkInterfacesInput, string) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	return &ec2.DescribeNetworkInterfacesOutput{}, nil
+}
+
 // seqK3sInst returns instance ID "i-<nodeID>" so launches map deterministically
 // back to their target host. failNodes makes a node's launch return an error.
 type seqK3sInst struct {

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -338,7 +338,7 @@ func lookupEKSServerAMI(amiSvc k3sAMIResolver, accountID string) (string, error)
 func rollbackK3sENI(vpcSvc k3sVPCProvisioner, accountID, eniID string) {
 	if _, err := vpcSvc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
 		NetworkInterfaceId: aws.String(eniID),
-	}, accountID); err != nil {
+	}, accountID); err != nil && !awserrors.IsNotFound(err) {
 		slog.Warn("LaunchK3sServerVM: rollback ENI delete failed", "eniId", eniID, "err", err)
 	}
 }

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -28,6 +28,7 @@ var ErrEKSServerAMINotFound = errors.New("eks: eks-server AMI not found")
 type k3sVPCProvisioner interface {
 	CreateNetworkInterface(input *ec2.CreateNetworkInterfaceInput, accountID string) (*ec2.CreateNetworkInterfaceOutput, error)
 	DeleteNetworkInterface(input *ec2.DeleteNetworkInterfaceInput, accountID string) (*ec2.DeleteNetworkInterfaceOutput, error)
+	DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput, accountID string) (*ec2.DescribeNetworkInterfacesOutput, error)
 }
 
 // k3sInstanceLauncher is the system-instance launch surface for the K3s CP VM.
@@ -164,6 +165,7 @@ func LaunchK3sServerVM(
 			Tags: []*ec2.Tag{
 				{Key: aws.String(tags.ManagedByKey), Value: aws.String(tags.ManagedByEKS)},
 				{Key: aws.String(clusterEKSClusterTagKey), Value: aws.String(in.ClusterName)},
+				{Key: aws.String(clusterEKSAccountTagKey), Value: aws.String(in.ClusterAccountID)},
 				{Key: aws.String(clusterEKSRoleTagKey), Value: aws.String(clusterEKSRoleControlPlane)},
 			},
 		}},

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -243,24 +244,57 @@ func TerminateK3sServerVM(
 		}
 	}
 	if eniID != "" {
-		if _, err := vpcSvc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
-			NetworkInterfaceId: aws.String(eniID),
-		}, accountID); err != nil {
-			switch {
-			case awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceIDNotFound),
-				awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceNotFound):
-				// ENI already gone (instance-terminate cascade or prior retry); idempotent success.
-				slog.Debug("TerminateK3sServerVM: ENI already gone", "eniId", eniID)
-			default:
-				// InUse = VM still terminating async; surface error so the reconciler retries.
-				slog.Warn("TerminateK3sServerVM: ENI delete failed", "eniId", eniID, "err", err)
-				if firstErr == nil {
-					firstErr = fmt.Errorf("delete ENI %s: %w", eniID, err)
-				}
+		if err := deleteENIAwaitingTerminate(vpcSvc, accountID, eniID); err != nil {
+			slog.Warn("TerminateK3sServerVM: ENI delete failed", "eniId", eniID, "err", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("delete ENI %s: %w", eniID, err)
 			}
 		}
 	}
 	return firstErr
+}
+
+var (
+	// eniDeleteWaitBudget bounds how long deleteENIAwaitingTerminate retries a
+	// DeleteNetworkInterface that returns InvalidNetworkInterface.InUse while the
+	// async instance-terminate cascade force-deletes the same ENI. Vars (not
+	// consts) so tests can shrink them.
+	eniDeleteWaitBudget   = 45 * time.Second
+	eniDeleteWaitInterval = 1 * time.Second
+)
+
+// deleteENIAwaitingTerminate deletes the server VM's ENI, tolerating the
+// InvalidNetworkInterface.InUse window while the async instance-terminate
+// cascade (DetachAndDeleteENI → ForceDeleteInstanceENI) removes the same ENI
+// once qemu exits. On a multi-node cluster the teardown handler often runs on a
+// node that does not own the VM, so TerminateSystemInstance returns before the
+// cascade completes and the immediate delete loses the race. It retries until
+// the ENI is gone (NotFound = removed by the cascade or by us) or the budget
+// elapses; a persistent InUse past the budget is surfaced so the teardown
+// backstop retries rather than stranding the cluster's billable infra.
+func deleteENIAwaitingTerminate(vpcSvc k3sVPCProvisioner, accountID, eniID string) error {
+	deadline := time.Now().Add(eniDeleteWaitBudget)
+	for {
+		_, err := vpcSvc.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: aws.String(eniID),
+		}, accountID)
+		switch {
+		case err == nil:
+			return nil
+		case awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceIDNotFound),
+			awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceNotFound):
+			// ENI already gone (cascade or prior retry); idempotent success.
+			slog.Debug("TerminateK3sServerVM: ENI already gone", "eniId", eniID)
+			return nil
+		case awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceInUse):
+			if time.Now().After(deadline) {
+				return err
+			}
+			time.Sleep(eniDeleteWaitInterval)
+		default:
+			return err
+		}
+	}
 }
 
 // lookupEKSServerAMI resolves the EKS CP AMI by the spinifex:managed-by=eks tag

--- a/spinifex/handlers/eks/k3s_server_vm_test.go
+++ b/spinifex/handlers/eks/k3s_server_vm_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -22,6 +23,10 @@ type fakeK3sVPC struct {
 	createOut *ec2.CreateNetworkInterfaceOutput
 	createErr error
 	deleteErr error
+	// deleteInUseUntil models the async instance-terminate cascade: the first N
+	// DeleteNetworkInterface calls return InvalidNetworkInterface.InUse, then the
+	// cascade has force-deleted the ENI so the next call returns NotFound.
+	deleteInUseUntil int
 
 	// describeByENI maps an ENI ID to the record DescribeNetworkInterfaces
 	// returns; a missing ENI yields an empty result (gone). describeErr forces
@@ -51,6 +56,12 @@ func (f *fakeK3sVPC) CreateNetworkInterface(input *ec2.CreateNetworkInterfaceInp
 
 func (f *fakeK3sVPC) DeleteNetworkInterface(input *ec2.DeleteNetworkInterfaceInput, _ string) (*ec2.DeleteNetworkInterfaceOutput, error) {
 	f.deleteCalls = append(f.deleteCalls, input)
+	if f.deleteInUseUntil > 0 {
+		if len(f.deleteCalls) <= f.deleteInUseUntil {
+			return nil, errors.New(awserrors.ErrorInvalidNetworkInterfaceInUse)
+		}
+		return nil, errors.New(awserrors.ErrorInvalidNetworkInterfaceIDNotFound)
+	}
 	if f.deleteErr != nil {
 		return nil, f.deleteErr
 	}
@@ -561,15 +572,39 @@ func TestTerminateK3sServerVM_ENINotFoundIsIdempotent(t *testing.T) {
 	require.Len(t, vpc.deleteCalls, 1)
 }
 
-func TestTerminateK3sServerVM_ENIInUseIsRetryable(t *testing.T) {
-	// The VM is still terminating async and holds the ENI. InUse must surface
-	// as an error so the cluster stays DELETING and the reconciler retries.
+func TestTerminateK3sServerVM_ENIInUseThenCascadeDeletes(t *testing.T) {
+	// mulga-siv-295.10: the VM is still terminating async; its terminate cascade
+	// force-deletes the ENI a beat later. TerminateK3sServerVM must wait out the
+	// InUse window so the first DeleteCluster completes instead of wedging.
+	withFastENIWait(t)
+	vpc := &fakeK3sVPC{deleteInUseUntil: 3}
+	inst := &fakeK3sInst{}
+
+	err := TerminateK3sServerVM(vpc, inst, "111122223333", "i-aaa111", "eni-aaa111")
+	require.NoError(t, err, "InUse that resolves to NotFound (cascade) must be tolerated, not surfaced")
+	assert.Greater(t, len(vpc.deleteCalls), 3, "must retry past the InUse window until the ENI is gone")
+}
+
+func TestTerminateK3sServerVM_ENIInUsePastBudgetSurfaces(t *testing.T) {
+	// A persistent InUse (cascade never fires) must still surface after the
+	// bounded budget so the teardown backstop retries rather than blocking forever.
+	withFastENIWait(t)
 	vpc := &fakeK3sVPC{deleteErr: errors.New(awserrors.ErrorInvalidNetworkInterfaceInUse)}
 	inst := &fakeK3sInst{}
 
 	err := TerminateK3sServerVM(vpc, inst, "111122223333", "i-aaa111", "eni-aaa111")
-	require.Error(t, err, "ENI still in use must be retryable, not swallowed")
+	require.Error(t, err, "ENI in use past the budget must surface so the backstop retries")
 	assert.Contains(t, err.Error(), "delete ENI eni-aaa111")
+	assert.Greater(t, len(vpc.deleteCalls), 1, "must have retried before giving up")
+}
+
+// withFastENIWait shrinks the ENI-delete retry budget for tests so a bounded
+// retry loop runs in milliseconds, restoring the production defaults after.
+func withFastENIWait(t *testing.T) {
+	t.Helper()
+	budget, interval := eniDeleteWaitBudget, eniDeleteWaitInterval
+	eniDeleteWaitBudget, eniDeleteWaitInterval = 20*time.Millisecond, 1*time.Millisecond
+	t.Cleanup(func() { eniDeleteWaitBudget, eniDeleteWaitInterval = budget, interval })
 }
 
 func TestTerminateK3sServerVM_InstanceAlreadyGoneIsIdempotent(t *testing.T) {

--- a/spinifex/handlers/eks/k3s_server_vm_test.go
+++ b/spinifex/handlers/eks/k3s_server_vm_test.go
@@ -22,6 +22,12 @@ type fakeK3sVPC struct {
 	createOut *ec2.CreateNetworkInterfaceOutput
 	createErr error
 	deleteErr error
+
+	// describeByENI maps an ENI ID to the record DescribeNetworkInterfaces
+	// returns; a missing ENI yields an empty result (gone). describeErr forces
+	// a describe failure.
+	describeByENI map[string]*ec2.NetworkInterface
+	describeErr   error
 }
 
 var _ k3sVPCProvisioner = (*fakeK3sVPC)(nil)
@@ -49,6 +55,19 @@ func (f *fakeK3sVPC) DeleteNetworkInterface(input *ec2.DeleteNetworkInterfaceInp
 		return nil, f.deleteErr
 	}
 	return &ec2.DeleteNetworkInterfaceOutput{}, nil
+}
+
+func (f *fakeK3sVPC) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput, _ string) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	if f.describeErr != nil {
+		return nil, f.describeErr
+	}
+	out := &ec2.DescribeNetworkInterfacesOutput{}
+	for _, id := range input.NetworkInterfaceIds {
+		if eni, ok := f.describeByENI[aws.StringValue(id)]; ok {
+			out.NetworkInterfaces = append(out.NetworkInterfaces, eni)
+		}
+	}
+	return out, nil
 }
 
 type fakeK3sInst struct {

--- a/spinifex/handlers/eks/lifecycle_invariants_test.go
+++ b/spinifex/handlers/eks/lifecycle_invariants_test.go
@@ -1,0 +1,73 @@
+package handlers_eks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLC1_EKSDeleteClusterIdempotentOnAbsent enforces the Common Resource
+// Lifecycle Contract rule #1 (idempotent delete), ADR-0006 §1: DeleteCluster of
+// a cluster already swept from KV returns success, not ResourceNotFound, so a
+// tofu destroy retry / double-targeted graph node converges instead of failing
+// the run. The live-reference teardown is unaffected — only true absence is
+// idempotent.
+func TestRLC1_EKSDeleteClusterIdempotentOnAbsent(t *testing.T) {
+	f := newEKSServiceFixture(t)
+
+	out, err := f.svc.DeleteCluster(deleteInput("absent"), testAccountID)
+	require.NoErrorf(t, err, "ADR-0006 §1: DeleteCluster on an absent cluster must return success, not ResourceNotFound (RLC rule #1)")
+	require.NotNil(t, out, "ADR-0006 §1: DeleteCluster must return a non-nil output on absent")
+	assert.Empty(t, f.inst.terminateCalls, "an absent cluster must trigger no billable teardown")
+}
+
+// TestRLC2_EKSBillableTeardownBeforeKVSweep enforces ADR-0006 §6 billable-before-
+// sweep ordering: the KV sweep (DeleteClusterPrefix) must NOT run while any
+// billable teardown (OIDC / NLB / VM / EIP) returned an error. A failed VM
+// terminate must leave the cluster meta in DELETING — its resource ARNs/IDs
+// intact for a retry — never erased out from under a still-running billable VM.
+// Regression guard for the errors.Join-before-sweep ordering in purgeClusterInfra.
+func TestRLC2_EKSBillableTeardownBeforeKVSweep(t *testing.T) {
+	f := newDeleteClusterFixture(t, "alpha")
+	f.inst.terminateErr = errors.New("hypervisor unreachable")
+
+	_, err := f.svc.DeleteCluster(deleteInput("alpha"), testAccountID)
+	require.Error(t, err, "ADR-0006 §6: a failed billable teardown must surface, not be swallowed")
+
+	require.Len(t, f.inst.terminateCalls, 1, "the VM teardown must have been attempted")
+	meta, getErr := GetClusterMeta(f.kv, "alpha")
+	require.NoErrorf(t, getErr, "ADR-0006 §6 billable-before-sweep: the KV sweep must NOT run while a billable teardown is failing — the meta must survive for retry")
+	assert.Equal(t, ClusterStatusDeleting, meta.Status, "a cluster with failed teardown must stay DELETING")
+}
+
+// TestRLC3_EKSNLBNoOrphanTargetGroupAfterDelete enforces ADR-0006 §6 NLB
+// no-orphan (riding ADR-0002 / mulga-siv-172 cascade composition): after a
+// successful DeleteCluster, the eks-{cluster}-cp target group must be gone — an
+// orphaned EKS NLB target group would pin itself as ResourceInUse exactly as a
+// user target group does.
+func TestRLC3_EKSNLBNoOrphanTargetGroupAfterDelete(t *testing.T) {
+	f := newDeleteClusterFixture(t, "alpha")
+
+	lbName := ClusterNLBName("alpha")
+	tgName := ClusterTargetGroupName("alpha")
+	f.nlb.lbByName[lbName] = &elbv2.LoadBalancer{
+		LoadBalancerArn:  aws.String("arn:lb-alpha"),
+		LoadBalancerName: aws.String(lbName),
+	}
+	f.nlb.tgByName[tgName] = &elbv2.TargetGroup{
+		TargetGroupArn:  aws.String("arn:tg-alpha"),
+		TargetGroupName: aws.String(tgName),
+	}
+
+	_, err := f.svc.DeleteCluster(deleteInput("alpha"), testAccountID)
+	require.NoError(t, err)
+
+	_, getErr := GetClusterMeta(f.kv, "alpha")
+	require.ErrorIs(t, getErr, ErrClusterNotFound, "a fully torn-down cluster must be swept")
+	assert.NotContainsf(t, f.nlb.tgByName, tgName,
+		"ADR-0006 §6 NLB no-orphan: the eks-{cluster}-cp target group must not survive DeleteCluster (rides ADR-0002/172)")
+}

--- a/spinifex/handlers/eks/security_groups.go
+++ b/spinifex/handlers/eks/security_groups.go
@@ -25,6 +25,12 @@ const clusterEKSClusterTagKey = "spinifex:eks-cluster"
 // clusterEKSRoleTagKey distinguishes the control-plane SG from the nodegroup SG.
 const clusterEKSRoleTagKey = "spinifex:eks-role"
 
+// clusterEKSAccountTagKey records the customer account that owns the cluster
+// meta. The control-plane VM/ENI run under the system account, so this tag is
+// the only link from a running CP ENI back to the KV bucket holding its cluster
+// meta — the billable GC reaper needs it to decide orphan-hood.
+const clusterEKSAccountTagKey = "spinifex:eks-cluster-account"
+
 // clusterEKSNodegroupTagKey is stamped on worker instances to identify their nodegroup.
 const clusterEKSNodegroupTagKey = "spinifex:eks-nodegroup"
 

--- a/spinifex/handlers/eks/security_groups.go
+++ b/spinifex/handlers/eks/security_groups.go
@@ -101,7 +101,7 @@ func DeleteClusterSGs(sgp sgProvisioner, accountID, clusterName, vpcID string) e
 		if id == "" {
 			continue
 		}
-		if _, err := sgp.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: aws.String(id)}, accountID); err != nil {
+		if _, err := sgp.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: aws.String(id)}, accountID); err != nil && !awserrors.IsNotFound(err) {
 			slog.Warn("DeleteClusterSGs: SG delete failed", "sg", id, "name", name, "err", err)
 			if firstErr == nil {
 				firstErr = fmt.Errorf("delete SG %s: %w", id, err)

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -698,6 +698,19 @@ func (s *EKSServiceImpl) DeleteCluster(input *eks.DeleteClusterInput, accountID 
 		return nil, err
 	}
 
+	// Single-flight the teardown: SDK retries of the same DeleteCluster are fanned
+	// across nodes by the worker queue group, so without this gate multiple
+	// purgeClusterInfra runs race the same cluster (duplicate ENI/NLB teardown,
+	// risking a double-release on the billable NAT-GW EIP). The loser returns the
+	// cluster as DELETING — AWS-async delete semantics — and the winner (or the
+	// DELETING backstop reaper) drives the teardown to completion.
+	release, ok := s.acquireTeardownLease(accountID, name)
+	if !ok {
+		meta.Status = ClusterStatusDeleting
+		return &eks.DeleteClusterOutput{Cluster: clusterMetaToAWS(meta)}, nil
+	}
+	defer release()
+
 	if err := SetClusterStatus(acctKV, name, ClusterStatusDeleting); err != nil {
 		return nil, fmt.Errorf("set DELETING: %w", err)
 	}
@@ -710,6 +723,36 @@ func (s *EKSServiceImpl) DeleteCluster(input *eks.DeleteClusterInput, accountID 
 	}
 
 	return &eks.DeleteClusterOutput{Cluster: clusterMetaToAWS(meta)}, nil
+}
+
+// teardownLeaderKey is the per-cluster single-flight gate for a DELETING
+// teardown. It is distinct from reconcilerLeaderKey so a delete never contends
+// with the still-live reconciler, which holds the reconciler lease until it
+// observes DELETING and exits; only concurrent purgeClusterInfra runs meet here.
+func teardownLeaderKey(accountID, clusterName string) string {
+	return reconcilerLeaderKey(accountID, clusterName) + "/teardown"
+}
+
+// acquireTeardownLease takes the per-cluster teardown lease so only one
+// purgeClusterInfra runs at a time for a cluster — the gate against the
+// concurrent-handler herd from SDK-retried DeleteClusters fanned across nodes by
+// the worker queue group. Shared by the synchronous DeleteCluster path and the
+// DELETING backstop reaper. CAS Create fails when another holder owns it. A nil
+// leaderKV (single-node/test) skips gating; the bucket TTL reaps a lease whose
+// release never runs.
+func (s *EKSServiceImpl) acquireTeardownLease(accountID, clusterName string) (func(), bool) {
+	if s.leaderKV == nil {
+		return func() {}, true
+	}
+	key := teardownLeaderKey(accountID, clusterName)
+	if _, err := s.leaderKV.Create(key, []byte(s.deps.HolderID)); err != nil {
+		return nil, false
+	}
+	return func() {
+		if err := s.leaderKV.Delete(key); err != nil {
+			slog.Warn("eks: teardown lease release failed (TTL will reap)", "key", key, "err", err)
+		}
+	}, true
 }
 
 // claimClusterName atomically claims the cluster meta key before any launch work.

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -690,7 +690,10 @@ func (s *EKSServiceImpl) DeleteCluster(input *eks.DeleteClusterInput, accountID 
 	meta, err := GetClusterMeta(acctKV, name)
 	if err != nil {
 		if errors.Is(err, ErrClusterNotFound) {
-			return nil, errors.New(awserrors.ErrorEKSResourceNotFound)
+			// Idempotent: a cluster already swept from KV is "deleted". Returning
+			// success lets a tofu destroy retry / double-targeted delete converge
+			// instead of failing the run (Common Resource Lifecycle Contract #1).
+			return &eks.DeleteClusterOutput{}, nil
 		}
 		return nil, err
 	}

--- a/spinifex/handlers/eks/service_impl_test.go
+++ b/spinifex/handlers/eks/service_impl_test.go
@@ -105,12 +105,15 @@ func TestDescribeCluster_NotFoundWithFullDeps(t *testing.T) {
 
 // DeleteCluster on an absent cluster must reach the KV lookup with full deps
 // wired (the shim path short-circuits to ServiceUnavailable before the meta
-// read) and surface ResourceNotFoundException, not a teardown of nothing.
+// read) and return idempotent success (Common Resource Lifecycle Contract #1),
+// not a teardown of nothing — so a tofu destroy retry converges.
 func TestDeleteCluster_NotFoundWithFullDeps(t *testing.T) {
 	f := newEKSServiceFixture(t)
 
-	_, err := f.svc.DeleteCluster(deleteInput("ghost"), testAccountID)
-	require.EqualError(t, err, awserrors.ErrorEKSResourceNotFound)
+	out, err := f.svc.DeleteCluster(deleteInput("ghost"), testAccountID)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Empty(t, f.inst.terminateCalls, "absent cluster must trigger no teardown")
 }
 
 // Security guarantee: the OIDC signing key must be zeroized BEFORE infra

--- a/spinifex/handlers/elbv2/arn_test.go
+++ b/spinifex/handlers/elbv2/arn_test.go
@@ -48,8 +48,8 @@ func TestBuildLBAgentEnv(t *testing.T) {
 		SystemSecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		region:          "ap-southeast-2",
 	}
-	// A customer-account LB heartbeats over the WAN GatewayURL.
-	env := svc.buildLBAgentEnv("lb-abc123", "111122223333")
+	// With no mgmt bridge, the lb-agent falls back to the WAN GatewayURL.
+	env := svc.buildLBAgentEnv("lb-abc123")
 
 	lines := strings.Split(strings.TrimRight(env, "\n"), "\n")
 	kvs := make(map[string]string, len(lines))
@@ -66,10 +66,10 @@ func TestBuildLBAgentEnv(t *testing.T) {
 	assert.Equal(t, "ap-southeast-2", kvs["LB_REGION"])
 }
 
-// TestBuildLBAgentEnv_SystemAccountUsesMgmtGateway verifies a system-account LB
-// (e.g. the EKS cluster control-plane NLB) heartbeats over the mgmt-bridge URL,
-// not the WAN GatewayURL.
-func TestBuildLBAgentEnv_SystemAccountUsesMgmtGateway(t *testing.T) {
+// TestBuildLBAgentEnv_UsesMgmtGateway verifies every lb-agent (customer or
+// system) heartbeats over the on-link mgmt-bridge URL, not the WAN GatewayURL,
+// so the control-plane heartbeat survives a reboot that strands the data plane.
+func TestBuildLBAgentEnv_UsesMgmtGateway(t *testing.T) {
 	svc := &ELBv2ServiceImpl{
 		GatewayURL:      "https://10.0.0.1:9999",
 		MgmtBridgeIP:    "192.168.50.1",
@@ -77,12 +77,12 @@ func TestBuildLBAgentEnv_SystemAccountUsesMgmtGateway(t *testing.T) {
 		SystemSecretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		region:          "ap-southeast-2",
 	}
-	env := svc.buildLBAgentEnv("lb-eks01", "000000000000")
+	env := svc.buildLBAgentEnv("lb-abc123")
 	assert.Contains(t, env, "LB_GATEWAY_URL=https://192.168.50.1:9999\n")
 
-	// With no mgmt bridge, a system-account LB falls back to the WAN URL.
+	// With no mgmt bridge, the lb-agent falls back to the WAN URL.
 	svc.MgmtBridgeIP = ""
-	env = svc.buildLBAgentEnv("lb-eks01", "000000000000")
+	env = svc.buildLBAgentEnv("lb-abc123")
 	assert.Contains(t, env, "LB_GATEWAY_URL=https://10.0.0.1:9999\n")
 }
 

--- a/spinifex/handlers/elbv2/lifecycle_invariants_test.go
+++ b/spinifex/handlers/elbv2/lifecycle_invariants_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -174,4 +175,51 @@ func TestRLC4_ELBv2TGDeletableAfterLBTeardown(t *testing.T) {
 
 	_, err = svc.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: tgArn}, testAccountID)
 	require.NoErrorf(t, err, "ADR-0002 §5 TG deletability after LB teardown: target group must not stay pinned as ResourceInUse")
+}
+
+// TestRLC3_ELBv2TGInUseGuardGatesOnLiveRefsOnly enforces ADR-0002 §3 (live-only
+// dependency guard): DeleteTargetGroup may block on ResourceInUse ONLY when a
+// LIVE listener/rule (one whose owning LB still exists) forwards to the TG. A
+// rule orphaned by a vanished LB must NOT pin the TG — that is the permanent
+// trap mulga-siv-172 reported. Locks the liveLB/liveListener skip both ways so a
+// maintainer cannot regress the in-use scan back to a global rule sweep.
+func TestRLC3_ELBv2TGInUseGuardGatesOnLiveRefsOnly(t *testing.T) {
+	svc := setupTestService(t)
+
+	// Orphan-rule TG: forwarded to by a rule whose owning LB/listener is gone.
+	orphanTG, err := svc.CreateTargetGroup(&elbv2.CreateTargetGroupInput{Name: aws.String("rlc3-orphan-tg")}, testAccountID)
+	require.NoError(t, err)
+	orphanTGArn := *orphanTG.TargetGroups[0].TargetGroupArn
+
+	danglingListenerArn := "arn:aws:elasticloadbalancing:us-east-1:" + testAccountID +
+		":listener/app/gone/0000000000000000/1111111111111111"
+	require.NoError(t, svc.store.PutRule(&RuleRecord{
+		RuleArn:     "arn:aws:elasticloadbalancing:us-east-1:" + testAccountID + ":listener-rule/app/gone/0000000000000000/1111111111111111/2222222222222222",
+		RuleID:      "rule-orphan00000000",
+		ListenerArn: danglingListenerArn,
+		Actions:     []ListenerAction{{Type: "forward", TargetGroupArn: orphanTGArn}},
+		AccountID:   testAccountID,
+	}))
+
+	_, err = svc.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: aws.String(orphanTGArn)}, testAccountID)
+	require.NoErrorf(t, err, "ADR-0002 §3 live-only guard: a rule orphaned by a vanished LB must NOT pin the TG as ResourceInUse (mulga-siv-172 regression)")
+
+	// Live-rule TG: forwarded to by a listener whose LB still exists → ResourceInUse.
+	lbOut, err := svc.CreateLoadBalancer(&elbv2.CreateLoadBalancerInput{Name: aws.String("rlc3-lb")}, testAccountID)
+	require.NoError(t, err)
+	liveTG, err := svc.CreateTargetGroup(&elbv2.CreateTargetGroupInput{Name: aws.String("rlc3-live-tg")}, testAccountID)
+	require.NoError(t, err)
+	liveTGArn := liveTG.TargetGroups[0].TargetGroupArn
+
+	_, err = svc.CreateListener(&elbv2.CreateListenerInput{
+		LoadBalancerArn: lbOut.LoadBalancers[0].LoadBalancerArn,
+		Protocol:        aws.String("HTTP"),
+		Port:            aws.Int64(80),
+		DefaultActions:  []*elbv2.Action{{Type: aws.String("forward"), TargetGroupArn: liveTGArn}},
+	}, testAccountID)
+	require.NoError(t, err)
+
+	_, err = svc.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: liveTGArn}, testAccountID)
+	assert.ErrorContainsf(t, err, awserrors.ErrorELBv2TargetGroupInUse,
+		"ADR-0002 §3 live-only guard: a TG forwarded to by a LIVE listener must block on ResourceInUse")
 }

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
-	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	handlers_acm "github.com/mulgadc/spinifex/spinifex/handlers/acm"
@@ -247,24 +246,19 @@ func (s *ELBv2ServiceImpl) getSystemInstanceType() string {
 	return s.systemInstanceType
 }
 
-// buildLBAgentEnv returns the KEY=value blob written to /etc/conf.d/lb-agent
-// via fw_cfg on the direct-boot path. A system-account LB (e.g. the EKS
-// cluster control-plane NLB) is a hidden system instance whose only path to the
-// gateway is its on-link br-mgmt NIC, so it heartbeats over the mgmt-bridge URL
-// — the same path the EKS control-plane VM uses — rather than out the WAN and
-// back. A customer LB reaches the gateway via its VPC egress (the WAN URL).
-func (s *ELBv2ServiceImpl) buildLBAgentEnv(lbID, accountID string) string {
-	gatewayURL := s.GatewayURL
-	if accountID == admin.SystemAccountID() {
-		gatewayURL = s.mgmtGatewayURL()
-	}
+// buildLBAgentEnv returns the KEY=value blob written to /etc/conf.d/lb-agent via
+// fw_cfg on the direct-boot path. Every lb-agent heartbeats over its on-link
+// br-mgmt NIC (the mgmt-bridge URL): the heartbeat is control-plane and must
+// survive a host reboot that strands the OVN/EIP data plane, so it never rides
+// the WAN. mgmtGatewayURL falls back to the WAN URL when no mgmt bridge exists.
+func (s *ELBv2ServiceImpl) buildLBAgentEnv(lbID string) string {
 	return fmt.Sprintf("LB_LB_ID=%s\nLB_GATEWAY_URL=%s\nLB_ACCESS_KEY=%s\nLB_SECRET_KEY=%s\nLB_REGION=%s\n",
-		lbID, gatewayURL, s.SystemAccessKey, s.SystemSecretKey, s.region)
+		lbID, s.mgmtGatewayURL(), s.SystemAccessKey, s.SystemSecretKey, s.region)
 }
 
-// mgmtGatewayURL is the AWS gateway URL a system instance reaches over its
-// br-mgmt NIC (on-link to MgmtBridgeIP). The port is taken from the configured
-// WAN GatewayURL so both paths target the same AWSGW listener. Falls back to the
+// mgmtGatewayURL is the AWS gateway URL an lb-agent reaches over its on-link
+// br-mgmt NIC (MgmtBridgeIP). The port is taken from the configured WAN
+// GatewayURL so both paths target the same AWSGW listener. Falls back to the
 // WAN URL when no mgmt bridge exists (e.g. dev-shim networking).
 func (s *ELBv2ServiceImpl) mgmtGatewayURL() string {
 	if s.MgmtBridgeIP == "" {
@@ -458,7 +452,7 @@ func (s *ELBv2ServiceImpl) launchLBVM(lbID, scheme string, eniIDs, subnets []str
 		Scheme:       scheme,
 		AccountID:    accountID,
 		NICs:         nics,
-		LBAgentEnv:   s.buildLBAgentEnv(lbID, accountID),
+		LBAgentEnv:   s.buildLBAgentEnv(lbID),
 		CACert:       s.CACert,
 	}
 	// Dev-mode only: forward HTTP/HTTPS ports from host for local testing.
@@ -554,7 +548,7 @@ func (s *ELBv2ServiceImpl) RebuildSystemInstanceInput(ctx RecoveryContext) (*Sys
 		Scheme:       lb.Scheme,
 		AccountID:    lb.AccountID,
 		NICs:         nics,
-		LBAgentEnv:   s.buildLBAgentEnv(lb.LoadBalancerID, lb.AccountID),
+		LBAgentEnv:   s.buildLBAgentEnv(lb.LoadBalancerID),
 		CACert:       s.CACert,
 	}, nil
 }

--- a/spinifex/handlers/elbv2/service_impl_lb_network.go
+++ b/spinifex/handlers/elbv2/service_impl_lb_network.go
@@ -162,7 +162,7 @@ func (s *ELBv2ServiceImpl) SetSubnets(input *elbv2.SetSubnetsInput, accountID st
 		for _, created := range newENIBySubnet {
 			if _, delErr := s.VPCService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
 				NetworkInterfaceId: aws.String(created),
-			}, accountID); delErr != nil {
+			}, accountID); delErr != nil && !awserrors.IsNotFound(delErr) {
 				slog.Error("SetSubnets: rollback failed to delete ENI", "eni", created, "err", delErr)
 			}
 		}
@@ -209,7 +209,7 @@ func (s *ELBv2ServiceImpl) SetSubnets(input *elbv2.SetSubnetsInput, accountID st
 		eniID := current[sn]
 		if _, delErr := s.VPCService.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
 			NetworkInterfaceId: aws.String(eniID),
-		}, accountID); delErr != nil {
+		}, accountID); delErr != nil && !awserrors.IsNotFound(delErr) {
 			slog.Error("SetSubnets: failed to delete removed ENI", "subnet", sn, "eni", eniID, "err", delErr)
 		}
 	}

--- a/spinifex/handlers/elbv2/service_impl_nlb_sg.go
+++ b/spinifex/handlers/elbv2/service_impl_nlb_sg.go
@@ -72,7 +72,7 @@ func (s *ELBv2ServiceImpl) deleteNLBManagedSG(sgID, accountID string) {
 	}
 	if _, err := s.VPCService.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
 		GroupId: aws.String(sgID),
-	}, accountID); err != nil {
+	}, accountID); err != nil && !awserrors.IsNotFound(err) {
 		slog.Warn("deleteNLBManagedSG: delete failed", "sg", sgID, "err", err)
 	}
 }

--- a/spinifex/network/external/allocator.go
+++ b/spinifex/network/external/allocator.go
@@ -21,5 +21,11 @@ type AllocateRequest struct {
 // DHCPPoolAllocator (RFC 2131 DORA via vpcd, Q4).
 type Allocator interface {
 	Allocate(ctx context.Context, req AllocateRequest) (netip.Addr, error)
-	Release(ctx context.Context, poolName string, ip netip.Addr) error
+	// Release frees ip back to poolName. ownerENIID, when non-empty, scopes the
+	// release to the ENI that currently owns the lease: external IPs are recycled
+	// and teardown sweeps re-emit releases, so a release naming an owner that no
+	// longer matches the live allocation is a no-op (prevents double-freeing an
+	// IP already reassigned to another instance). Empty ownerENIID releases
+	// unconditionally.
+	Release(ctx context.Context, poolName string, ip netip.Addr, ownerENIID string) error
 }

--- a/spinifex/network/external/dhcp/pool_allocator.go
+++ b/spinifex/network/external/dhcp/pool_allocator.go
@@ -82,8 +82,10 @@ func (a *DHCPPoolAllocator) Allocate(ctx context.Context, req external.AllocateR
 }
 
 // Release issues vpc.dhcp.release for ip. Errors if poolName doesn't match
-// this allocator's pool to prevent cross-pool release.
-func (a *DHCPPoolAllocator) Release(ctx context.Context, poolName string, ip netip.Addr) error {
+// this allocator's pool to prevent cross-pool release. ownerENIID is unused:
+// DHCP leases are keyed by client-ID, not ENI, so ownership scoping does not
+// apply.
+func (a *DHCPPoolAllocator) Release(ctx context.Context, poolName string, ip netip.Addr, _ string) error {
 	if a == nil || a.client == nil {
 		return errors.New("dhcp pool allocator: nil client")
 	}

--- a/spinifex/network/external/dhcp/pool_allocator_test.go
+++ b/spinifex/network/external/dhcp/pool_allocator_test.go
@@ -48,7 +48,7 @@ func TestDHCPPoolAllocatorAllocateAndRelease(t *testing.T) {
 	assert.Equal(t, dhcp.PurposeEIP, entry.Purpose)
 	assert.Equal(t, "wan", entry.PoolName)
 
-	require.NoError(t, allocator.Release(context.Background(), "wan", addr))
+	require.NoError(t, allocator.Release(context.Background(), "wan", addr, ""))
 	_, err = store.Get("eipalloc-1")
 	assert.Error(t, err)
 	assert.Equal(t, 1, fake.ReleaseCount())
@@ -113,6 +113,6 @@ func TestDHCPPoolAllocatorReleaseUnknownIPIsNoop(t *testing.T) {
 	allocator, _ := newPoolAllocator(t, fake, pool)
 
 	addr := netip.MustParseAddr("198.51.100.99")
-	assert.NoError(t, allocator.Release(context.Background(), "wan", addr))
+	assert.NoError(t, allocator.Release(context.Background(), "wan", addr, ""))
 	assert.Equal(t, 0, fake.ReleaseCount())
 }

--- a/spinifex/network/external/eip.go
+++ b/spinifex/network/external/eip.go
@@ -12,7 +12,7 @@ import (
 // that adds the flows-barrier so callers see the EIP reachable on return.
 type EIPManager interface {
 	AttachEIP(ctx context.Context, eip policy.EIPSpec) error
-	DetachEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error
+	DetachEIP(ctx context.Context, vpcID, externalIP, logicalIP, portName string) error
 }
 
 type eipManager struct {
@@ -44,6 +44,6 @@ func (m *eipManager) AttachEIP(ctx context.Context, eip policy.EIPSpec) error {
 	return nil
 }
 
-func (m *eipManager) DetachEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error {
-	return m.nat.DeleteEIP(ctx, vpcID, externalIP, logicalIP)
+func (m *eipManager) DetachEIP(ctx context.Context, vpcID, externalIP, logicalIP, portName string) error {
+	return m.nat.DeleteEIP(ctx, vpcID, externalIP, logicalIP, portName)
 }

--- a/spinifex/network/external/eip_test.go
+++ b/spinifex/network/external/eip_test.go
@@ -41,7 +41,7 @@ func TestEIPManager_AttachAndDetach(t *testing.T) {
 	require.NotNil(t, found)
 	assert.Equal(t, 1, barrierCalls)
 
-	require.NoError(t, mgr.DetachEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5"))
+	require.NoError(t, mgr.DetachEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5", ""))
 	for _, n := range m.NATs {
 		assert.NotEqual(t, "10.0.0.5", n.LogicalIP)
 	}
@@ -59,5 +59,5 @@ func TestEIPManager_DetachIdempotent(t *testing.T) {
 	require.NoError(t, m.CreateLogicalRouter(ctx, &nbdb.LogicalRouter{Name: topology.VPCRouter("vpc-1")}))
 	nm, _ := policy.NewNATManager(m, policy.NATModeDistributed)
 	mgr, _ := NewEIPManager(nm, nil)
-	require.NoError(t, mgr.DetachEIP(ctx, "vpc-1", "9.9.9.9", "10.0.0.99"))
+	require.NoError(t, mgr.DetachEIP(ctx, "vpc-1", "9.9.9.9", "10.0.0.99", ""))
 }

--- a/spinifex/network/external/igw.go
+++ b/spinifex/network/external/igw.go
@@ -43,6 +43,13 @@ type IGWManager interface {
 	EnsureSystemInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP, externalIP string) error
 	// RemoveSystemInstanceEgress is the inverse. Idempotent.
 	RemoveSystemInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP, externalIP string) error
+	// EnsureEIPInstanceEgress installs a /32 reroute above the drop gate for an
+	// EIP-backed instance — reroute only, no SNAT. The EIP's dnat_and_snat already
+	// SNATs the instance, so the reroute alone lets the inbound connection's reply
+	// (and instance-initiated egress) bypass the subnet drop gate. Idempotent.
+	EnsureEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error
+	// RemoveEIPInstanceEgress is the inverse. Idempotent.
+	RemoveEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error
 }
 
 // IGWManagerConfig is the construction-time bag for igwManager.
@@ -400,6 +407,50 @@ func (m *igwManager) RemoveSystemInstanceEgress(ctx context.Context, vpcID, subn
 		firstErr = fmt.Errorf("delete system instance egress snat: %w", err)
 	}
 	return firstErr
+}
+
+// EnsureEIPInstanceEgress installs the /32 reroute above the drop gate for an EIP
+// instance, without the plain SNAT EnsureSystemInstanceEgress adds: the EIP's
+// dnat_and_snat already SNATs the instance, so the reroute alone is what lets the
+// inbound connection's reply bypass the subnet drop gate (lr_in_policy runs before
+// lr_out un-DNAT/SNAT, so the reply still carries its private source at the gate).
+// Idempotent.
+func (m *igwManager) EnsureEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error {
+	if vpcID == "" || subnetID == "" {
+		return errors.New("EnsureEIPInstanceEgress: vpcID and subnetID required")
+	}
+	srcIP, err := netip.ParseAddr(instanceIP)
+	if err != nil {
+		return fmt.Errorf("EnsureEIPInstanceEgress: parse instance IP %q: %w", instanceIP, err)
+	}
+	_, nexthop, _, err := m.resolveGatewayNetwork(ctx, vpcID)
+	if err != nil {
+		return fmt.Errorf("resolve gateway network for %s: %w", vpcID, err)
+	}
+	if nexthop == "" {
+		return fmt.Errorf("EnsureEIPInstanceEgress: no gateway nexthop for %s (IGW not attached?)", vpcID)
+	}
+	return m.routes.AddSystemInstanceEgress(ctx, vpcID, policy.SystemInstanceEgressSpec{
+		SubnetID:     subnetID,
+		SrcIP:        srcIP,
+		Prefix:       defaultRoutePrefix,
+		Nexthop:      nexthop,
+		OutputPort:   topology.GatewayRouterPort(vpcID),
+		ExcludeCIDRs: m.vpcExcludeCIDRs(ctx, vpcID),
+	})
+}
+
+// RemoveEIPInstanceEgress deletes the reroute installed by EnsureEIPInstanceEgress.
+// Idempotent.
+func (m *igwManager) RemoveEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error {
+	if vpcID == "" || subnetID == "" {
+		return errors.New("RemoveEIPInstanceEgress: vpcID and subnetID required")
+	}
+	srcIP, err := netip.ParseAddr(instanceIP)
+	if err != nil {
+		return fmt.Errorf("RemoveEIPInstanceEgress: parse instance IP %q: %w", instanceIP, err)
+	}
+	return m.routes.DeleteSystemInstanceEgress(ctx, vpcID, subnetID, srcIP, defaultRoutePrefix, m.vpcExcludeCIDRs(ctx, vpcID))
 }
 
 // linkLocalCIDR / multicastCIDR are appended to drop-policy excludes so link-local

--- a/spinifex/network/external/igw.go
+++ b/spinifex/network/external/igw.go
@@ -106,80 +106,60 @@ func NewIGWManager(cfg IGWManagerConfig) (IGWManager, error) {
 	}, nil
 }
 
-// AttachIGW wires external connectivity for spec.VPCID: external switch +
-// localnet + gateway LRP + default route + chassis + flows barrier.
-// Idempotent: returns nil if the external switch already exists.
+// AttachIGW wires external connectivity for spec.VPCID onto the shared external
+// switch: it ensures the singleton external switch + localnet, attaches the VPC
+// gateway LRP via its own router-type switch port, installs the default route,
+// binds gateway chassis, and waits on the flows barrier. Idempotent, and
+// migration-safe: a VPC still bound to a legacy per-VPC switch re-attaches to the
+// shared switch once the legacy switch is pruned.
 func (m *igwManager) AttachIGW(ctx context.Context, spec IGWSpec) error {
 	if spec.VPCID == "" {
 		return errors.New("AttachIGW: VPCID required")
 	}
 
-	extSwitchName := topology.ExternalSwitch(spec.VPCID)
-	extPortName := topology.ExternalLocalnetPort(spec.VPCID)
+	extSwitchName := topology.ExternalSwitchShared()
+	extPortName := topology.ExternalLocalnetPortShared()
 	gwPortName := topology.GatewayRouterPort(spec.VPCID)
 	switchGWPortName := topology.GatewaySwitchPort(spec.VPCID)
 	routerName := topology.VPCRouter(spec.VPCID)
 
-	extSwitch := &nbdb.LogicalSwitch{
-		Name: extSwitchName,
-		ExternalIDs: map[string]string{
-			"spinifex:vpc_id": spec.VPCID,
-			"spinifex:igw_id": spec.InternetGatewayID,
-			"spinifex:role":   "external",
-		},
-	}
-	existingSwitch, err := m.ovn.EnsureLogicalSwitch(ctx, extSwitch)
-	if err != nil {
-		return fmt.Errorf("ensure external switch %s: %w", extSwitchName, err)
-	}
-	if existingSwitch.UUID != extSwitch.UUID {
-		slog.Debug("external: IGW topology already exists, skipping",
-			"vpc_id", spec.VPCID, "ext_switch", extSwitchName)
-		return nil
+	if err := m.ensureSharedExternal(ctx, extSwitchName, extPortName); err != nil {
+		return err
 	}
 
-	localnetOpts := map[string]string{"network_name": "external"}
-	if m.natMode == policy.NATModeCentralized {
-		localnetOpts["nat-addresses"] = "router"
-	}
-	if err := m.ovn.CreateLogicalSwitchPort(ctx, extSwitchName, &nbdb.LogicalSwitchPort{
-		Name:      extPortName,
-		Type:      "localnet",
-		Addresses: []string{"unknown"},
-		Options:   localnetOpts,
-		ExternalIDs: map[string]string{
-			"spinifex:vpc_id": spec.VPCID,
-			"spinifex:igw_id": spec.InternetGatewayID,
-		},
-	}); err != nil {
-		_ = m.ovn.DeleteLogicalSwitch(ctx, extSwitchName)
-		return fmt.Errorf("create localnet port %s: %w", extPortName, err)
+	// The gateway switch port on the shared switch is the per-VPC attach marker.
+	if _, err := m.ovn.GetLogicalSwitchPort(ctx, switchGWPortName); err == nil {
+		slog.Debug("external: IGW already attached for VPC, skipping",
+			"vpc_id", spec.VPCID, "gw_port", switchGWPortName)
+		return nil
 	}
 
 	gwNetwork, wanNexthop, gwLrpIP, err := m.resolveGatewayNetwork(ctx, spec.VPCID)
 	if err != nil {
-		_ = m.ovn.DeleteLogicalSwitchPort(ctx, extSwitchName, extPortName)
-		_ = m.ovn.DeleteLogicalSwitch(ctx, extSwitchName)
 		return err
 	}
 
-	lrpExtIDs := map[string]string{
-		"spinifex:vpc_id": spec.VPCID,
-		"spinifex:igw_id": spec.InternetGatewayID,
-		"spinifex:role":   "gateway",
-	}
-	if gwLrpIP != "" {
-		lrpExtIDs[gatewayIPExtIDKey] = gwLrpIP
-	}
-	if err := m.ovn.CreateLogicalRouterPort(ctx, routerName, &nbdb.LogicalRouterPort{
-		Name:        gwPortName,
-		MAC:         utils.HashMAC(gwPortName),
-		Networks:    []string{gwNetwork},
-		ExternalIDs: lrpExtIDs,
-	}); err != nil {
-		_ = m.ovn.DeleteLogicalSwitchPort(ctx, extSwitchName, extPortName)
-		_ = m.ovn.DeleteLogicalSwitch(ctx, extSwitchName)
-		return fmt.Errorf("create gateway router port %s: %w", gwPortName, err)
+	// The gateway LRP may already exist (e.g. migrating off a legacy per-VPC
+	// switch); create it only when absent so its allocated IP is preserved.
+	createdLRP := false
+	if _, err := m.ovn.GetLogicalRouterPort(ctx, gwPortName); err != nil {
+		lrpExtIDs := map[string]string{
+			"spinifex:vpc_id": spec.VPCID,
+			"spinifex:igw_id": spec.InternetGatewayID,
+			"spinifex:role":   "gateway",
+		}
+		if gwLrpIP != "" {
+			lrpExtIDs[gatewayIPExtIDKey] = gwLrpIP
+		}
+		if err := m.ovn.CreateLogicalRouterPort(ctx, routerName, &nbdb.LogicalRouterPort{
+			Name:        gwPortName,
+			MAC:         utils.HashMAC(gwPortName),
+			Networks:    []string{gwNetwork},
+			ExternalIDs: lrpExtIDs,
+		}); err != nil {
+			return fmt.Errorf("create gateway router port %s: %w", gwPortName, err)
+		}
+		createdLRP = true
 	}
 
 	if err := m.ovn.CreateLogicalSwitchPort(ctx, extSwitchName, &nbdb.LogicalSwitchPort{
@@ -190,11 +170,12 @@ func (m *igwManager) AttachIGW(ctx context.Context, spec IGWSpec) error {
 		ExternalIDs: map[string]string{
 			"spinifex:vpc_id": spec.VPCID,
 			"spinifex:igw_id": spec.InternetGatewayID,
+			"spinifex:role":   "gateway",
 		},
 	}); err != nil {
-		_ = m.ovn.DeleteLogicalRouterPort(ctx, routerName, gwPortName)
-		_ = m.ovn.DeleteLogicalSwitchPort(ctx, extSwitchName, extPortName)
-		_ = m.ovn.DeleteLogicalSwitch(ctx, extSwitchName)
+		if createdLRP {
+			_ = m.ovn.DeleteLogicalRouterPort(ctx, routerName, gwPortName)
+		}
 		return fmt.Errorf("create switch gateway port %s: %w", switchGWPortName, err)
 	}
 
@@ -228,14 +209,45 @@ func (m *igwManager) AttachIGW(ctx context.Context, spec IGWSpec) error {
 	return nil
 }
 
-// DetachIGW reverses AttachIGW. Idempotent.
+// ensureSharedExternal idempotently creates the singleton shared external switch
+// and its single localnet port. The localnet advertises router NAT addresses in
+// centralized mode so gateways behind it are reachable from the uplink.
+func (m *igwManager) ensureSharedExternal(ctx context.Context, switchName, portName string) error {
+	extSwitch := &nbdb.LogicalSwitch{
+		Name:        switchName,
+		ExternalIDs: map[string]string{"spinifex:role": "external"},
+	}
+	if _, err := m.ovn.EnsureLogicalSwitch(ctx, extSwitch); err != nil {
+		return fmt.Errorf("ensure shared external switch %s: %w", switchName, err)
+	}
+	if _, err := m.ovn.GetLogicalSwitchPort(ctx, portName); err == nil {
+		return nil
+	}
+	localnetOpts := map[string]string{"network_name": "external"}
+	if m.natMode == policy.NATModeCentralized {
+		localnetOpts["nat-addresses"] = "router"
+	}
+	if err := m.ovn.CreateLogicalSwitchPort(ctx, switchName, &nbdb.LogicalSwitchPort{
+		Name:        portName,
+		Type:        "localnet",
+		Addresses:   []string{"unknown"},
+		Options:     localnetOpts,
+		ExternalIDs: map[string]string{"spinifex:role": "external-localnet"},
+	}); err != nil {
+		return fmt.Errorf("create shared localnet port %s: %w", portName, err)
+	}
+	return nil
+}
+
+// DetachIGW removes the VPC's gateway attachment — its switch port on the shared
+// external switch, gateway LRP, default route, and SNAT — while preserving the
+// shared external switch and localnet for other VPCs. Idempotent.
 func (m *igwManager) DetachIGW(ctx context.Context, vpcID string) error {
 	if vpcID == "" {
 		return errors.New("DetachIGW: vpcID required")
 	}
 
-	extSwitchName := topology.ExternalSwitch(vpcID)
-	extPortName := topology.ExternalLocalnetPort(vpcID)
+	extSwitchName := topology.ExternalSwitchShared()
 	gwPortName := topology.GatewayRouterPort(vpcID)
 	switchGWPortName := topology.GatewaySwitchPort(vpcID)
 	routerName := topology.VPCRouter(vpcID)
@@ -260,12 +272,6 @@ func (m *igwManager) DetachIGW(ctx context.Context, vpcID string) error {
 	}
 	if err := m.ovn.DeleteLogicalRouterPort(ctx, routerName, gwPortName); err != nil {
 		slog.Warn("external: delete gateway router port failed", "port", gwPortName, "err", err)
-	}
-	if err := m.ovn.DeleteLogicalSwitchPort(ctx, extSwitchName, extPortName); err != nil {
-		slog.Warn("external: delete localnet port failed", "port", extPortName, "err", err)
-	}
-	if err := m.ovn.DeleteLogicalSwitch(ctx, extSwitchName); err != nil {
-		return fmt.Errorf("delete external switch %s: %w", extSwitchName, err)
 	}
 
 	if err := m.allocator.Release(ctx, vpcID); err != nil {

--- a/spinifex/network/external/igw.go
+++ b/spinifex/network/external/igw.go
@@ -48,8 +48,6 @@ type IGWManager interface {
 	// SNATs the instance, so the reroute alone lets the inbound connection's reply
 	// (and instance-initiated egress) bypass the subnet drop gate. Idempotent.
 	EnsureEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error
-	// RemoveEIPInstanceEgress is the inverse. Idempotent.
-	RemoveEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error
 }
 
 // IGWManagerConfig is the construction-time bag for igwManager.
@@ -438,19 +436,6 @@ func (m *igwManager) EnsureEIPInstanceEgress(ctx context.Context, vpcID, subnetI
 		OutputPort:   topology.GatewayRouterPort(vpcID),
 		ExcludeCIDRs: m.vpcExcludeCIDRs(ctx, vpcID),
 	})
-}
-
-// RemoveEIPInstanceEgress deletes the reroute installed by EnsureEIPInstanceEgress.
-// Idempotent.
-func (m *igwManager) RemoveEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error {
-	if vpcID == "" || subnetID == "" {
-		return errors.New("RemoveEIPInstanceEgress: vpcID and subnetID required")
-	}
-	srcIP, err := netip.ParseAddr(instanceIP)
-	if err != nil {
-		return fmt.Errorf("RemoveEIPInstanceEgress: parse instance IP %q: %w", instanceIP, err)
-	}
-	return m.routes.DeleteSystemInstanceEgress(ctx, vpcID, subnetID, srcIP, defaultRoutePrefix, m.vpcExcludeCIDRs(ctx, vpcID))
 }
 
 // linkLocalCIDR / multicastCIDR are appended to drop-policy excludes so link-local

--- a/spinifex/network/external/igw_test.go
+++ b/spinifex/network/external/igw_test.go
@@ -70,10 +70,10 @@ func TestAttachIGW_Distributed_LinkLocalLRP(t *testing.T) {
 
 	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
 
-	// External switch + ports created.
-	_, err := m.GetLogicalSwitch(ctx, topology.ExternalSwitch("vpc-1"))
+	// Shared external switch + localnet created.
+	_, err := m.GetLogicalSwitch(ctx, topology.ExternalSwitchShared())
 	require.NoError(t, err)
-	localnet, err := m.GetLogicalSwitchPort(ctx, topology.ExternalLocalnetPort("vpc-1"))
+	localnet, err := m.GetLogicalSwitchPort(ctx, topology.ExternalLocalnetPortShared())
 	require.NoError(t, err)
 	assert.Equal(t, "external", localnet.Options["network_name"])
 	_, hasNat := localnet.Options["nat-addresses"]
@@ -125,7 +125,7 @@ func TestAttachIGW_Centralized_AllocatesGwLrpIP(t *testing.T) {
 
 	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
 
-	localnet, err := m.GetLogicalSwitchPort(ctx, topology.ExternalLocalnetPort("vpc-1"))
+	localnet, err := m.GetLogicalSwitchPort(ctx, topology.ExternalLocalnetPortShared())
 	require.NoError(t, err)
 	assert.Equal(t, "router", localnet.Options["nat-addresses"], "centralized mode must set nat-addresses=router")
 
@@ -180,7 +180,7 @@ func TestAttachIGW_NoPoolNoChassis_UsesLinkLocalFallbacks(t *testing.T) {
 	assert.Equal(t, 0, m.SetGatewayChassisCalls)
 }
 
-func TestDetachIGW_RemovesEverything(t *testing.T) {
+func TestDetachIGW_RemovesVPCAttachmentPreservesSharedSwitch(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()
 	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
@@ -190,13 +190,20 @@ func TestDetachIGW_RemovesEverything(t *testing.T) {
 	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
 	require.NoError(t, mgr.DetachIGW(ctx, "vpc-1"))
 
-	_, err := m.GetLogicalSwitch(ctx, topology.ExternalSwitch("vpc-1"))
+	// Per-VPC attachment (gateway switch port + LRP + default route) is gone.
+	_, err := m.GetLogicalSwitchPort(ctx, topology.GatewaySwitchPort("vpc-1"))
 	assert.Error(t, err)
 	_, err = m.GetLogicalRouterPort(ctx, topology.GatewayRouterPort("vpc-1"))
 	assert.Error(t, err)
 	route, err := m.FindStaticRoute(ctx, topology.VPCRouter("vpc-1"), "0.0.0.0/0")
 	require.NoError(t, err)
 	assert.Nil(t, route)
+
+	// The shared external switch + localnet survive for other VPCs.
+	_, err = m.GetLogicalSwitch(ctx, topology.ExternalSwitchShared())
+	assert.NoError(t, err, "shared external switch must persist after detach")
+	_, err = m.GetLogicalSwitchPort(ctx, topology.ExternalLocalnetPortShared())
+	assert.NoError(t, err, "shared localnet must persist after detach")
 }
 
 func TestDetachIGW_IdempotentOnAbsent(t *testing.T) {
@@ -205,8 +212,8 @@ func TestDetachIGW_IdempotentOnAbsent(t *testing.T) {
 	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
 	mgr, _ := newTestIGWManager(t, m, policy.NATModeDistributed, nil, LinkLocalAllocator{}, nil)
 
-	err := mgr.DetachIGW(ctx, "vpc-1")
-	require.Error(t, err) // external switch absent
+	// Detaching a VPC that was never attached is a no-op, not an error.
+	require.NoError(t, mgr.DetachIGW(ctx, "vpc-1"))
 }
 
 type failingAllocator struct{}
@@ -257,7 +264,7 @@ func TestAttachIGW_Centralized_AllocatorNexthopOverridesPool(t *testing.T) {
 	assert.Equal(t, "192.168.1.254", *policies[0].Nexthop, "allocator-supplied nexthop must override pool/link-local fallback")
 }
 
-func TestAttachIGW_AllocatorFailureUnwindsExtSwitch(t *testing.T) {
+func TestAttachIGW_AllocatorFailureLeavesNoGatewayPort(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()
 	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
@@ -266,8 +273,12 @@ func TestAttachIGW_AllocatorFailureUnwindsExtSwitch(t *testing.T) {
 
 	require.Error(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
 
-	_, err := m.GetLogicalSwitch(ctx, topology.ExternalSwitch("vpc-1"))
-	assert.Error(t, err, "external switch must be unwound on allocator failure")
+	// Allocation fails before any per-VPC object is created: no gateway LRP and
+	// no gateway switch port. The shared switch is not VPC-owned, so it may exist.
+	_, err := m.GetLogicalRouterPort(ctx, topology.GatewayRouterPort("vpc-1"))
+	assert.Error(t, err, "gateway LRP must not be created when allocation fails")
+	_, err = m.GetLogicalSwitchPort(ctx, topology.GatewaySwitchPort("vpc-1"))
+	assert.Error(t, err, "gateway switch port must not be created when allocation fails")
 }
 
 // TestEnsureNATGatewaySubnetEgress installs an LR policy at NATGW priority

--- a/spinifex/network/external/igw_test.go
+++ b/spinifex/network/external/igw_test.go
@@ -404,6 +404,44 @@ func TestEnsureSystemInstanceEgress(t *testing.T) {
 	assert.Nil(t, dnat, "egress-only: no inbound dnat_and_snat may be installed")
 }
 
+// TestEnsureEIPInstanceEgress installs the /32 reroute above the drop gate WITHOUT
+// any snat row: an EIP's dnat_and_snat already SNATs the instance, so a second plain
+// snat would be redundant. The reroute alone lets the EIP's inbound-connection reply
+// bypass the subnet drop gate.
+func TestEnsureEIPInstanceEgress(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
+	pool := &ExternalPoolConfig{Name: "p", Gateway: "192.168.1.1", PrefixLen: 24}
+	mgr, _ := newTestIGWManager(t, m, policy.NATModeDistributed, pool, LinkLocalAllocator{}, []string{"chassis-a"})
+
+	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
+	// Drop gate first (1100), then the EIP reroute above it (1200).
+	require.NoError(t, mgr.EnsureSubnetEgressDrop(ctx, "vpc-1", "subnet-pub", netip.MustParsePrefix("0.0.0.0/0")))
+	require.NoError(t, mgr.EnsureEIPInstanceEgress(ctx, "vpc-1", "subnet-pub", "10.0.4.10"))
+
+	policies, err := m.ListLogicalRouterPolicies(ctx, topology.VPCRouter("vpc-1"))
+	require.NoError(t, err)
+	var reroute, drop *nbdb.LogicalRouterPolicy
+	for i := range policies {
+		switch policies[i].Priority {
+		case policy.SystemInstanceEgressPriority:
+			reroute = &policies[i]
+		case policy.SubnetEgressPriorityDrop:
+			drop = &policies[i]
+		}
+	}
+	require.NotNil(t, reroute, "EIP /32 reroute must be installed")
+	require.NotNil(t, drop, "drop gate must remain — the reroute exempts the EIP, not the subnet")
+	assert.Equal(t, "reroute", reroute.Action)
+	assert.Contains(t, reroute.Match, "ip4.src == 10.0.4.10/32")
+	assert.Greater(t, reroute.Priority, drop.Priority, "EIP reroute must sit above the drop gate")
+
+	for _, n := range m.NATs {
+		assert.NotEqual(t, "snat", n.Type, "EIP egress is reroute-only: dnat_and_snat already SNATs, no plain snat")
+	}
+}
+
 // TestEnsureSystemInstanceEgress_IsIdempotent re-runs install; row counts stay 1.
 func TestEnsureSystemInstanceEgress_IsIdempotent(t *testing.T) {
 	ctx := context.Background()

--- a/spinifex/network/external/static_pool.go
+++ b/spinifex/network/external/static_pool.go
@@ -140,7 +140,7 @@ func (a *StaticPoolAllocator) Allocate(_ context.Context, req AllocateRequest) (
 }
 
 // Release implements Allocator.
-func (a *StaticPoolAllocator) Release(_ context.Context, poolName string, ip netip.Addr) error {
+func (a *StaticPoolAllocator) Release(_ context.Context, poolName string, ip netip.Addr, ownerENIID string) error {
 	target := ip.String()
 	for attempt := range staticPoolCASRetries {
 		record, revision, err := a.getRecord(poolName)
@@ -150,7 +150,21 @@ func (a *StaticPoolAllocator) Release(_ context.Context, poolName string, ip net
 
 		alloc, ok := record.Allocated[target]
 		if !ok {
+			// An owner-scoped release of an already-freed IP is an idempotent
+			// no-op (a duplicated or stale teardown), not an error.
+			if ownerENIID != "" {
+				return nil
+			}
 			return fmt.Errorf("IP %s not allocated in pool %s", target, poolName)
+		}
+		// Ownership guard: when a caller names an owner, only free the lease if
+		// it still belongs to that ENI. External IPs are recycled and GC/teardown
+		// sweeps re-emit releases, so a release for a prior owner must not free an
+		// IP since reassigned to a live instance (that would double-allocate).
+		if ownerENIID != "" && alloc.ENIId != "" && alloc.ENIId != ownerENIID {
+			slog.Info("external IPAM release skip — IP reassigned to a different ENI (stale release)",
+				"pool", poolName, "ip", target, "stale_owner_eni", ownerENIID, "current_owner_eni", alloc.ENIId)
+			return nil
 		}
 		if alloc.Purpose == purposeIGWLRP {
 			return fmt.Errorf("cannot release gateway IP %s in pool %s", target, poolName)

--- a/spinifex/network/external/static_pool_test.go
+++ b/spinifex/network/external/static_pool_test.go
@@ -58,7 +58,7 @@ func TestStaticPool_GatewayReserved(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, purposeIGWLRP, alloc.Purpose)
 
-	err = a.Release(context.Background(), "wan", mustAddr(t, "192.168.1.150"))
+	err = a.Release(context.Background(), "wan", mustAddr(t, "192.168.1.150"), "")
 	assert.ErrorContains(t, err, "cannot release gateway IP")
 }
 
@@ -76,7 +76,7 @@ func TestStaticPool_NoInstantReuseAfterRelease(t *testing.T) {
 	require.NoError(t, err)
 
 	// Release the first IP; the very next allocation must NOT reuse it.
-	require.NoError(t, a.Release(ctx, "wan", ip1))
+	require.NoError(t, a.Release(ctx, "wan", ip1, "eni-1"))
 	ip3, err := a.Allocate(ctx, AllocateRequest{PoolName: "wan", Purpose: "eni-public", ENIID: "eni-3"})
 	require.NoError(t, err)
 	assert.NotEqual(t, ip1, ip3, "released IP must not be reused immediately")
@@ -141,8 +141,37 @@ func TestStaticPool_CASConflict(t *testing.T) {
 
 func TestStaticPool_ReleaseUnknown(t *testing.T) {
 	a := newStaticAllocator(t, []ExternalPoolConfig{wanPool()})
-	err := a.Release(context.Background(), "wan", mustAddr(t, "192.168.1.200"))
+	err := a.Release(context.Background(), "wan", mustAddr(t, "192.168.1.200"), "")
 	assert.ErrorContains(t, err, "not allocated")
+}
+
+// TestStaticPool_Release_OwnershipScoped pins the recycle guard: an owner-scoped
+// release whose ENI no longer matches the live allocation is a no-op (the IP was
+// reassigned), while a release naming the current owner frees it.
+func TestStaticPool_Release_OwnershipScoped(t *testing.T) {
+	a := newStaticAllocator(t, []ExternalPoolConfig{wanPool()})
+	ctx := context.Background()
+
+	ip, err := a.Allocate(ctx, AllocateRequest{PoolName: "wan", Purpose: "eni-public", ENIID: "eni-live"})
+	require.NoError(t, err)
+
+	// Stale teardown of a prior owner must not free the live lease.
+	require.NoError(t, a.Release(ctx, "wan", ip, "eni-stale"))
+	rec, err := a.GetPoolRecord("wan")
+	require.NoError(t, err)
+	alloc, ok := rec.Allocated[ip.String()]
+	require.True(t, ok, "foreign-ENI release must not free the live lease")
+	assert.Equal(t, "eni-live", alloc.ENIId)
+
+	// The current owner releases it.
+	require.NoError(t, a.Release(ctx, "wan", ip, "eni-live"))
+	rec, err = a.GetPoolRecord("wan")
+	require.NoError(t, err)
+	_, ok = rec.Allocated[ip.String()]
+	assert.False(t, ok, "owner-scoped release must free the lease")
+
+	// Idempotent: a duplicate owner-scoped release of an already-freed IP no-ops.
+	require.NoError(t, a.Release(ctx, "wan", ip, "eni-live"))
 }
 
 // TestNextAvailableIP_SkipsGwLrpRange verifies the static allocator honors

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -41,25 +41,6 @@ func (p *GatewayClaimProber) GatewayPortClaimed(_ context.Context, crPortName st
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
-// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up —
-// bound to a chassis with logical flows installed. ovn-controller sets up=true
-// only once the port is realised on its hosting chassis, which is the southbound
-// signal that the cross-node geneve flow to that chassis exists; until then the
-// ingress EIP datapath blackholes after DNAT. Output() not CombinedOutput(): sudo
-// PAM noise on stderr would be misread as the column value.
-func (p *GatewayClaimProber) GuestPortUp(_ context.Context, lspName string) (bool, error) {
-	args := []string{"--no-leader-only"}
-	if p.sbAddr != "" {
-		args = append(args, "--db="+p.sbAddr)
-	}
-	args = append(args, "--bare", "--columns=up", "find", "Port_Binding", "logical_port="+lspName)
-	out, err := utils.SudoCommand("ovn-sbctl", args...).Output()
-	if err != nil {
-		return false, fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lspName, err)
-	}
-	return strings.TrimSpace(string(out)) == "true", nil
-}
-
 // NudgeRecompute asks the local ovn-controller to re-evaluate logical flows via
 // the incremental engine, forcing a re-claim of unbound Port_Bindings.
 func (p *GatewayClaimProber) NudgeRecompute(_ context.Context) error {

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -41,6 +41,25 @@ func (p *GatewayClaimProber) GatewayPortClaimed(_ context.Context, crPortName st
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
+// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up —
+// bound to a chassis with logical flows installed. ovn-controller sets up=true
+// only once the port is realised on its hosting chassis, which is the southbound
+// signal that the gatewayLRP->guest flow exists; until then the ingress EIP
+// datapath blackholes after DNAT. Output() not CombinedOutput(): sudo PAM noise on
+// stderr would be misread as the column value.
+func (p *GatewayClaimProber) GuestPortUp(_ context.Context, lspName string) (bool, error) {
+	args := []string{"--no-leader-only"}
+	if p.sbAddr != "" {
+		args = append(args, "--db="+p.sbAddr)
+	}
+	args = append(args, "--bare", "--columns=up", "find", "Port_Binding", "logical_port="+lspName)
+	out, err := utils.SudoCommand("ovn-sbctl", args...).Output()
+	if err != nil {
+		return false, fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lspName, err)
+	}
+	return strings.TrimSpace(string(out)) == "true", nil
+}
+
 // NudgeRecompute asks the local ovn-controller to re-evaluate logical flows via
 // the incremental engine, forcing a re-claim of unbound Port_Bindings.
 func (p *GatewayClaimProber) NudgeRecompute(_ context.Context) error {

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -41,6 +41,25 @@ func (p *GatewayClaimProber) GatewayPortClaimed(_ context.Context, crPortName st
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
+// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up —
+// bound to a chassis with logical flows installed. ovn-controller sets up=true
+// only once the port is realised on its hosting chassis, which is the southbound
+// signal that the cross-node geneve flow to that chassis exists; until then the
+// ingress EIP datapath blackholes after DNAT. Output() not CombinedOutput(): sudo
+// PAM noise on stderr would be misread as the column value.
+func (p *GatewayClaimProber) GuestPortUp(_ context.Context, lspName string) (bool, error) {
+	args := []string{"--no-leader-only"}
+	if p.sbAddr != "" {
+		args = append(args, "--db="+p.sbAddr)
+	}
+	args = append(args, "--bare", "--columns=up", "find", "Port_Binding", "logical_port="+lspName)
+	out, err := utils.SudoCommand("ovn-sbctl", args...).Output()
+	if err != nil {
+		return false, fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lspName, err)
+	}
+	return strings.TrimSpace(string(out)) == "true", nil
+}
+
 // NudgeRecompute asks the local ovn-controller to re-evaluate logical flows via
 // the incremental engine, forcing a re-claim of unbound Port_Bindings.
 func (p *GatewayClaimProber) NudgeRecompute(_ context.Context) error {

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -41,24 +41,23 @@ func (p *GatewayClaimProber) GatewayPortClaimed(_ context.Context, crPortName st
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
-// GuestPortBound reports whether the SB Port_Binding for a guest ENI LSP is claimed
-// by a chassis. The chassis reference is released the moment the local tap
-// disappears and reset only once ovn-controller re-claims the replumbed port, so it
-// is the reliable post-reboot signal that the gatewayLRP->guest leg is realisable —
-// unlike the up column, which ovn-controller leaves stale-true across a host reboot
-// until it re-evaluates. Output() not CombinedOutput(): sudo PAM noise on stderr
-// would be misread as the column value.
-func (p *GatewayClaimProber) GuestPortBound(_ context.Context, lspName string) (bool, error) {
+// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up —
+// bound to a chassis with logical flows installed. ovn-controller sets up=true
+// only once the port is realised on its hosting chassis, which is the southbound
+// signal that the gatewayLRP->guest flow exists; until then the ingress EIP
+// datapath blackholes after DNAT. Output() not CombinedOutput(): sudo PAM noise on
+// stderr would be misread as the column value.
+func (p *GatewayClaimProber) GuestPortUp(_ context.Context, lspName string) (bool, error) {
 	args := []string{"--no-leader-only"}
 	if p.sbAddr != "" {
 		args = append(args, "--db="+p.sbAddr)
 	}
-	args = append(args, "--bare", "--columns=chassis", "find", "Port_Binding", "logical_port="+lspName)
+	args = append(args, "--bare", "--columns=up", "find", "Port_Binding", "logical_port="+lspName)
 	out, err := utils.SudoCommand("ovn-sbctl", args...).Output()
 	if err != nil {
 		return false, fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lspName, err)
 	}
-	return strings.TrimSpace(string(out)) != "", nil
+	return strings.TrimSpace(string(out)) == "true", nil
 }
 
 // NudgeRecompute asks the local ovn-controller to re-evaluate logical flows via

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
 
@@ -48,6 +49,30 @@ func (p *GatewayClaimProber) NudgeRecompute(_ context.Context) error {
 		return fmt.Errorf("ovn-appctl recompute: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
+}
+
+// RepairDatapath re-asserts the WAN-glue veth admin state, then forces a recompute.
+// A post-reboot boot race (ovs-vswitchd/ovn-controller start after the passive
+// network.target, concurrently with systemd-networkd) can leave veth-wan-ovs
+// admin-down — br-wan loses carrier and the external datapath is dead, which a flow
+// recompute alone cannot revive. Bring both veth ends up (idempotent; skipped when
+// the device is absent, e.g. physical-uplink mode), then recompute to also clear any
+// stale gateway ofport flows. Best-effort: link errors are logged, not returned.
+func (p *GatewayClaimProber) RepairDatapath(ctx context.Context) error {
+	for _, dev := range []string{VethOVSEnd, VethLinuxEnd} {
+		if !linkExists(dev) {
+			continue
+		}
+		if out, err := utils.SudoCommand("ip", "link", "set", dev, "up").CombinedOutput(); err != nil {
+			slog.Warn("gateway claim: veth uplink admin-up failed", "dev", dev, "out", strings.TrimSpace(string(out)), "err", err)
+		}
+	}
+	return p.NudgeRecompute(ctx)
+}
+
+// linkExists reports whether a network device is present. Read-only, no sudo.
+func linkExists(dev string) bool {
+	return exec.Command("ip", "link", "show", dev).Run() == nil
 }
 
 // GatewayReachable pings the gateway LRP IP once to confirm the external datapath

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -41,23 +41,24 @@ func (p *GatewayClaimProber) GatewayPortClaimed(_ context.Context, crPortName st
 	return strings.TrimSpace(string(out)) != "", nil
 }
 
-// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up —
-// bound to a chassis with logical flows installed. ovn-controller sets up=true
-// only once the port is realised on its hosting chassis, which is the southbound
-// signal that the gatewayLRP->guest flow exists; until then the ingress EIP
-// datapath blackholes after DNAT. Output() not CombinedOutput(): sudo PAM noise on
-// stderr would be misread as the column value.
-func (p *GatewayClaimProber) GuestPortUp(_ context.Context, lspName string) (bool, error) {
+// GuestPortBound reports whether the SB Port_Binding for a guest ENI LSP is claimed
+// by a chassis. The chassis reference is released the moment the local tap
+// disappears and reset only once ovn-controller re-claims the replumbed port, so it
+// is the reliable post-reboot signal that the gatewayLRP->guest leg is realisable —
+// unlike the up column, which ovn-controller leaves stale-true across a host reboot
+// until it re-evaluates. Output() not CombinedOutput(): sudo PAM noise on stderr
+// would be misread as the column value.
+func (p *GatewayClaimProber) GuestPortBound(_ context.Context, lspName string) (bool, error) {
 	args := []string{"--no-leader-only"}
 	if p.sbAddr != "" {
 		args = append(args, "--db="+p.sbAddr)
 	}
-	args = append(args, "--bare", "--columns=up", "find", "Port_Binding", "logical_port="+lspName)
+	args = append(args, "--bare", "--columns=chassis", "find", "Port_Binding", "logical_port="+lspName)
 	out, err := utils.SudoCommand("ovn-sbctl", args...).Output()
 	if err != nil {
 		return false, fmt.Errorf("ovn-sbctl find Port_Binding %s: %w", lspName, err)
 	}
-	return strings.TrimSpace(string(out)) == "true", nil
+	return strings.TrimSpace(string(out)) != "", nil
 }
 
 // NudgeRecompute asks the local ovn-controller to re-evaluate logical flows via

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -80,6 +80,9 @@ func linkExists(dev string) bool {
 // so this probes host -> br-wan -> br-ext -> localnet -> OVN gateway router with no
 // guest or security-group dependency. A failed ping (non-zero exit) reports
 // unreachable, not an error; an error is reserved for the inability to run ping.
+//
+// Fallback only: the LRP IP is answered natively, so it stays reachable even when
+// the EIP NAT pipeline is stranded — prefer EIPReachable when the VPC has an EIP.
 func (p *GatewayClaimProber) GatewayReachable(ctx context.Context, gwIP string) (bool, error) {
 	if gwIP == "" {
 		return false, fmt.Errorf("GatewayReachable: gwIP required")
@@ -93,4 +96,59 @@ func (p *GatewayClaimProber) GatewayReachable(ctx context.Context, gwIP string) 
 		return false, fmt.Errorf("ping %s: %w", gwIP, err)
 	}
 	return true, nil
+}
+
+// EIPReachable reports whether the NAT external-IP datapath for eip is live by
+// forcing a fresh ARP resolution on the WAN segment. The gateway chassis answers
+// ARP for a dnat_and_snat external IP regardless of the guest behind it, so a
+// resolved MAC proves the WAN uplink forwards and the EIP NAT flows are installed —
+// unlike the gateway LRP IP, which OVN answers natively even while the EIP pipeline
+// is dead. Guest ICMP state is irrelevant; only L2 resolution is checked.
+//
+// The stale neighbour entry is dropped first (a STALE entry keeps its old MAC until
+// used, masking a dead datapath), then a single ping triggers re-resolution (the
+// echo DNATs to the guest, so its result is ignored — the preceding ARP is the
+// signal). A resolution miss reports unreachable, not an error.
+func (p *GatewayClaimProber) EIPReachable(ctx context.Context, eip string) (bool, error) {
+	if eip == "" {
+		return false, fmt.Errorf("EIPReachable: eip required")
+	}
+	dev, err := routeDev(ctx, eip)
+	if err != nil {
+		return false, err
+	}
+	_ = utils.SudoCommand("ip", "neigh", "del", eip, "dev", dev).Run()
+	_ = exec.CommandContext(ctx, "ping", "-c", "1", "-W", "1", eip).Run()
+	out, err := exec.CommandContext(ctx, "ip", "neigh", "show", eip, "dev", dev).Output()
+	if err != nil {
+		return false, fmt.Errorf("ip neigh show %s: %w", eip, err)
+	}
+	return neighResolved(string(out)), nil
+}
+
+// routeDev resolves the egress interface the kernel uses to reach addr.
+func routeDev(ctx context.Context, addr string) (string, error) {
+	out, err := exec.CommandContext(ctx, "ip", "route", "get", addr).Output()
+	if err != nil {
+		return "", fmt.Errorf("ip route get %s: %w", addr, err)
+	}
+	fields := strings.Fields(string(out))
+	for i, f := range fields {
+		if f == "dev" && i+1 < len(fields) {
+			return fields[i+1], nil
+		}
+	}
+	return "", fmt.Errorf("ip route get %s: no dev in %q", addr, strings.TrimSpace(string(out)))
+}
+
+// neighResolved reports whether an `ip neigh show` line carries a usable MAC.
+// Output is empty (no entry) for an unresolved address, or a line like
+// "<ip> dev br-wan lladdr 52:54:.. REACHABLE"; INCOMPLETE/FAILED entries carry no
+// usable MAC and mean the ARP went unanswered (a stranded datapath).
+func neighResolved(out string) bool {
+	out = strings.TrimSpace(out)
+	if out == "" || !strings.Contains(out, "lladdr") {
+		return false
+	}
+	return !strings.Contains(out, "FAILED") && !strings.Contains(out, "INCOMPLETE")
 }

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -2,7 +2,9 @@ package host
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -46,4 +48,24 @@ func (p *GatewayClaimProber) NudgeRecompute(_ context.Context) error {
 		return fmt.Errorf("ovn-appctl recompute: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
+}
+
+// GatewayReachable pings the gateway LRP IP once to confirm the external datapath
+// forwards. OVN logical routers answer ICMP echo to their own port IPs natively,
+// so this probes host -> br-wan -> br-ext -> localnet -> OVN gateway router with no
+// guest or security-group dependency. A failed ping (non-zero exit) reports
+// unreachable, not an error; an error is reserved for the inability to run ping.
+func (p *GatewayClaimProber) GatewayReachable(ctx context.Context, gwIP string) (bool, error) {
+	if gwIP == "" {
+		return false, fmt.Errorf("GatewayReachable: gwIP required")
+	}
+	cmd := exec.CommandContext(ctx, "ping", "-c", "1", "-W", "1", gwIP)
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, nil
+		}
+		return false, fmt.Errorf("ping %s: %w", gwIP, err)
+	}
+	return true, nil
 }

--- a/spinifex/network/host/gateway_claim_test.go
+++ b/spinifex/network/host/gateway_claim_test.go
@@ -1,0 +1,26 @@
+package host
+
+import "testing"
+
+func TestNeighResolved(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"no entry", "", false},
+		{"reachable", "192.168.0.211 dev br-wan lladdr 52:54:00:aa:bb:cc REACHABLE", true},
+		{"stale keeps a usable mac", "192.168.0.211 dev br-wan lladdr 52:54:00:aa:bb:cc STALE", true},
+		{"delay", "192.168.0.211 dev br-wan lladdr 52:54:00:aa:bb:cc DELAY", true},
+		{"incomplete has no mac", "192.168.0.211 dev br-wan  INCOMPLETE", false},
+		{"failed", "192.168.0.211 dev br-wan FAILED", false},
+		{"failed even with a stale mac", "192.168.0.211 dev br-wan lladdr 52:54:00:aa:bb:cc FAILED", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := neighResolved(tc.out); got != tc.want {
+				t.Errorf("neighResolved(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
+	}
+}

--- a/spinifex/network/ovn/client.go
+++ b/spinifex/network/ovn/client.go
@@ -53,6 +53,9 @@ type Client interface {
 	DeleteLogicalSwitchPort(ctx context.Context, switchName string, portName string) error
 	GetLogicalSwitchPort(ctx context.Context, name string) (*nbdb.LogicalSwitchPort, error)
 	UpdateLogicalSwitchPort(ctx context.Context, lsp *nbdb.LogicalSwitchPort) error
+	// ListLogicalSwitchPorts returns every LSP in OVN NB. The reconciler uses it
+	// to find orphan ENI ports (spinifex:eni_id with no matching intent).
+	ListLogicalSwitchPorts(ctx context.Context) ([]nbdb.LogicalSwitchPort, error)
 
 	// Logical Router (VPC router)
 	CreateLogicalRouter(ctx context.Context, lr *nbdb.LogicalRouter) error

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -359,6 +359,14 @@ func (c *LiveClient) GetLogicalSwitchPort(ctx context.Context, name string) (*nb
 	return &ports[0], nil
 }
 
+func (c *LiveClient) ListLogicalSwitchPorts(ctx context.Context) ([]nbdb.LogicalSwitchPort, error) {
+	var ports []nbdb.LogicalSwitchPort
+	if err := c.client.List(ctx, &ports); err != nil {
+		return nil, fmt.Errorf("list logical switch ports: %w", err)
+	}
+	return ports, nil
+}
+
 func (c *LiveClient) UpdateLogicalSwitchPort(ctx context.Context, lsp *nbdb.LogicalSwitchPort) error {
 	if lsp.UUID == "" {
 		existing, err := c.GetLogicalSwitchPort(ctx, lsp.Name)

--- a/spinifex/network/ovn/mock/mock.go
+++ b/spinifex/network/ovn/mock/mock.go
@@ -243,6 +243,16 @@ func (m *Client) GetLogicalSwitchPort(_ context.Context, name string) (*nbdb.Log
 	return &result, nil
 }
 
+func (m *Client) ListLogicalSwitchPorts(_ context.Context) ([]nbdb.LogicalSwitchPort, error) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	result := make([]nbdb.LogicalSwitchPort, 0, len(m.Ports))
+	for _, lsp := range m.Ports {
+		result = append(result, *lsp)
+	}
+	return result, nil
+}
+
 func (m *Client) UpdateLogicalSwitchPort(_ context.Context, lsp *nbdb.LogicalSwitchPort) error {
 	m.Mu.Lock()
 	defer m.Mu.Unlock()

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -38,9 +38,11 @@ type NATManager interface {
 
 	// DeleteEIP removes the (ExternalIP, LogicalIP) rule and flushes the host
 	// ARP entry for ExternalIP so a recycled IP is not shadowed by the stale
-	// MAC. Scoped to the pair so a stale delete for an IP since reassigned to a
-	// live owner is a no-op; idempotent.
-	DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error
+	// MAC. portName, when set, owner-scopes the delete: a row whose stamped
+	// logical port differs has been reassigned to a live ENI, so the stale
+	// delete is a no-op even when the (ExternalIP, LogicalIP) pair recycles
+	// identically. Idempotent.
+	DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP, portName string) error
 
 	// AddNATGateway installs the (snat, SubnetCIDR) rule; rejects overlap.
 	AddNATGateway(ctx context.Context, gw NATGWSpec) error
@@ -151,6 +153,12 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 			"spinifex:public_ip": eip.ExternalIP,
 		},
 	}
+	// Stamp the owning ENI port so DeleteEIP can owner-scope a stale delete.
+	// Centralised mode leaves the native LogicalPort unset, so the ExternalID
+	// is the portable discriminator across both NAT modes.
+	if eip.PortName != "" {
+		natRule.ExternalIDs["spinifex:logical_port"] = eip.PortName
+	}
 	distributed := m.mode == NATModeDistributed && eip.PortName != "" && eip.MAC != ""
 	if distributed {
 		mac := eip.MAC
@@ -225,30 +233,38 @@ func (m *natManager) gatewayPortMAC(ctx context.Context, vpcID string) string {
 	return lrp.MAC
 }
 
-func (m *natManager) DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error {
+func (m *natManager) DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP, portName string) error {
 	router := topology.VPCRouter(vpcID)
 	// An empty external IP means there is no EIP and therefore no dnat_and_snat
 	// row to remove.
 	if externalIP == "" {
 		return nil
 	}
-	// Scope the delete to the (external_ip, logical_ip) pair. External IPs are
-	// recycled from the pool as instances come and go, and vpc.delete-nat is
-	// fire-and-forget plus re-emitted by the GC teardown sweep, so a stale or
-	// duplicated delete can arrive after the IP has been reassigned to a live
-	// instance. Deleting by external IP alone would tear down the new owner's
-	// rule and ARP entry. When the current row maps to a different logical IP
-	// the delete is stale — skip it and the ARP flush so the live owner survives.
-	if logicalIP != "" {
+	// Scope the delete to the (external_ip, logical_ip) pair and, when known, the
+	// owning ENI port. External IPs are recycled from the pool as instances come
+	// and go, and vpc.delete-nat is fire-and-forget plus re-emitted by the GC
+	// teardown sweep, so a stale or duplicated delete can arrive after the IP —
+	// and even the identical private IP — has been reassigned to a live instance.
+	// Deleting on a pair that recycled identically would tear down the new owner's
+	// rule and ARP entry; the stamped logical port is the discriminator that
+	// survives identical-pair reuse.
+	if logicalIP != "" || portName != "" {
 		existing, err := m.ovn.FindNATByExternalIP(ctx, "dnat_and_snat", externalIP)
-		if err != nil {
+		switch {
+		case err != nil:
 			slog.Warn("policy: DeleteEIP ownership lookup failed, proceeding with delete",
 				"external_ip", externalIP, "logical_ip", logicalIP, "err", err)
-		} else if existing == nil {
+		case existing == nil:
 			return nil
-		} else if existing.LogicalIP != logicalIP {
+		case logicalIP != "" && existing.LogicalIP != logicalIP:
 			slog.Info("policy: DeleteEIP skip — external IP reassigned to a different logical IP (stale delete)",
 				"external_ip", externalIP, "stale_logical_ip", logicalIP, "current_logical_ip", existing.LogicalIP)
+			return nil
+		case portName != "" && existing.ExternalIDs["spinifex:logical_port"] != "" &&
+			existing.ExternalIDs["spinifex:logical_port"] != portName:
+			slog.Info("policy: DeleteEIP skip — external IP reassigned to a different ENI (stale delete)",
+				"external_ip", externalIP, "stale_port", portName,
+				"current_port", existing.ExternalIDs["spinifex:logical_port"])
 			return nil
 		}
 	}

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -226,16 +226,22 @@ func (m *natManager) gatewayPortMAC(ctx context.Context, vpcID string) string {
 
 func (m *natManager) DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error {
 	router := topology.VPCRouter(vpcID)
-	if err := m.ovn.DeleteNAT(ctx, router, "dnat_and_snat", logicalIP); err != nil {
+	// Delete the dnat_and_snat row by its external IP, not its logical IP. A row's
+	// identity on the gateway router is the EIP; private IPs are recycled as instances
+	// come and go, so a stale or retried delete keyed on logical IP clobbers whichever
+	// EIP currently holds that private IP (the next owner goes dark). An empty external
+	// IP means there is no EIP and therefore no dnat_and_snat row to remove.
+	if externalIP == "" {
+		return nil
+	}
+	if err := m.ovn.DeleteNATByExternalIP(ctx, router, "dnat_and_snat", externalIP); err != nil {
 		if !errors.Is(err, ovn.ErrNATNotFound) {
-			return fmt.Errorf("delete dnat_and_snat %s on %s: %w", logicalIP, router, err)
+			return fmt.Errorf("delete dnat_and_snat %s on %s: %w", externalIP, router, err)
 		}
 	}
 	// Flush host ARP for the released IP so the next owner isn't shadowed. Best-effort.
-	if externalIP != "" {
-		if err := m.neigh(externalIP); err != nil {
-			slog.Warn("policy: DeleteEIP neighbour flush failed", "external_ip", externalIP, "logical_ip", logicalIP, "err", err)
-		}
+	if err := m.neigh(externalIP); err != nil {
+		slog.Warn("policy: DeleteEIP neighbour flush failed", "external_ip", externalIP, "logical_ip", logicalIP, "err", err)
 	}
 	return nil
 }

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -36,9 +36,10 @@ type NATManager interface {
 	// same ExternalIP on any router first (pool reuse across VPCs).
 	AddEIP(ctx context.Context, eip EIPSpec) error
 
-	// DeleteEIP removes the rule by LogicalIP and flushes the host ARP entry
-	// for ExternalIP so a recycled IP is not shadowed by the stale MAC;
-	// idempotent.
+	// DeleteEIP removes the (ExternalIP, LogicalIP) rule and flushes the host
+	// ARP entry for ExternalIP so a recycled IP is not shadowed by the stale
+	// MAC. Scoped to the pair so a stale delete for an IP since reassigned to a
+	// live owner is a no-op; idempotent.
 	DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error
 
 	// AddNATGateway installs the (snat, SubnetCIDR) rule; rejects overlap.
@@ -226,13 +227,30 @@ func (m *natManager) gatewayPortMAC(ctx context.Context, vpcID string) string {
 
 func (m *natManager) DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP string) error {
 	router := topology.VPCRouter(vpcID)
-	// Delete the dnat_and_snat row by its external IP, not its logical IP. A row's
-	// identity on the gateway router is the EIP; private IPs are recycled as instances
-	// come and go, so a stale or retried delete keyed on logical IP clobbers whichever
-	// EIP currently holds that private IP (the next owner goes dark). An empty external
-	// IP means there is no EIP and therefore no dnat_and_snat row to remove.
+	// An empty external IP means there is no EIP and therefore no dnat_and_snat
+	// row to remove.
 	if externalIP == "" {
 		return nil
+	}
+	// Scope the delete to the (external_ip, logical_ip) pair. External IPs are
+	// recycled from the pool as instances come and go, and vpc.delete-nat is
+	// fire-and-forget plus re-emitted by the GC teardown sweep, so a stale or
+	// duplicated delete can arrive after the IP has been reassigned to a live
+	// instance. Deleting by external IP alone would tear down the new owner's
+	// rule and ARP entry. When the current row maps to a different logical IP
+	// the delete is stale — skip it and the ARP flush so the live owner survives.
+	if logicalIP != "" {
+		existing, err := m.ovn.FindNATByExternalIP(ctx, "dnat_and_snat", externalIP)
+		if err != nil {
+			slog.Warn("policy: DeleteEIP ownership lookup failed, proceeding with delete",
+				"external_ip", externalIP, "logical_ip", logicalIP, "err", err)
+		} else if existing == nil {
+			return nil
+		} else if existing.LogicalIP != logicalIP {
+			slog.Info("policy: DeleteEIP skip — external IP reassigned to a different logical IP (stale delete)",
+				"external_ip", externalIP, "stale_logical_ip", logicalIP, "current_logical_ip", existing.LogicalIP)
+			return nil
+		}
 	}
 	if err := m.ovn.DeleteNATByExternalIP(ctx, router, "dnat_and_snat", externalIP); err != nil {
 		if !errors.Is(err, ovn.ErrNATNotFound) {

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -141,7 +141,7 @@ func TestNATManager_NeighPrime_OnDistributedAttach_FlushOnDetach(t *testing.T) {
 		PortName: "port-eni-abc", MAC: "aa:bb:cc:dd:ee:ff",
 	}
 	require.NoError(t, nm.AddEIP(ctx, spec))
-	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5"))
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5", ""))
 
 	require.Equal(t, []EIPSpec{spec}, primed,
 		"distributed attach must prime the host neighbour with the external_mac, not flush")
@@ -215,7 +215,7 @@ func TestNATManager_NeighHooks_FailureNonFatal(t *testing.T) {
 		VPCID: "vpc-1", ExternalIP: "1.2.3.4", LogicalIP: "10.0.0.5",
 		PortName: "port-eni-abc", MAC: "aa:bb:cc:dd:ee:ff",
 	}), "neigh prime failure must not propagate from AddEIP")
-	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5"),
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5", ""),
 		"neigh flush failure must not propagate from DeleteEIP")
 }
 
@@ -316,7 +316,7 @@ func TestNATManager_DeleteEIP_IdempotentOnMissing(t *testing.T) {
 	nm, _ := NewNATManager(m, NATModeDistributed)
 
 	// No prior AddEIP — delete should still succeed.
-	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5"))
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "1.2.3.4", "10.0.0.5", ""))
 }
 
 func TestNATManager_AddNATGateway_FlowsBarrier_Fires(t *testing.T) {
@@ -415,7 +415,7 @@ func TestNATManager_DeleteEIP_CrossRouterIsolation(t *testing.T) {
 		PortName: "port-b", MAC: "bb:bb:bb:bb:bb:bb",
 	}))
 
-	require.NoError(t, nm.DeleteEIP(ctx, "vpc-a", "1.1.1.1", "10.0.0.5"))
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-a", "1.1.1.1", "10.0.0.5", ""))
 
 	var survived *nbdb.NAT
 	for _, n := range m.NATs {
@@ -444,7 +444,7 @@ func TestNATManager_DeleteEIP_RecycledLogicalIP_NoClobber(t *testing.T) {
 	}))
 
 	// Stale delete for an earlier EIP (.172) on the same recycled private IP.
-	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.0.172", "172.31.0.4"))
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.0.172", "172.31.0.4", ""))
 
 	got := findNAT(m, "dnat_and_snat", "172.31.0.4")
 	require.NotNil(t, got, "live EIP row must survive a stale delete for a recycled private IP")
@@ -475,12 +475,50 @@ func TestNATManager_DeleteEIP_RecycledExternalIP_NoClobber(t *testing.T) {
 	flushed = nil
 
 	// Stale GC teardown of the dead prior owner (172.31.0.4) of the same IP.
-	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.0.201", "172.31.0.4"))
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.0.201", "172.31.0.4", ""))
 
 	got := findNAT(m, "dnat_and_snat", "172.31.0.5")
 	require.NotNil(t, got, "live owner's row must survive a stale delete for the recycled external IP")
 	assert.Equal(t, "192.168.0.201", got.ExternalIP)
 	assert.Empty(t, flushed, "stale delete must not flush the live owner's host ARP")
+}
+
+// TestNATManager_DeleteEIP_RecycledIdenticalPair_OwnerScoped guards the residual
+// race left by the (external_ip, logical_ip) pair-key: a terminated instance and
+// a live one hold the IDENTICAL public+private pair in the same VPC, so the pair
+// matches and the logical-IP guard falls through. The stamped logical port is the
+// only discriminator — a stale delete carrying the dead instance's port must be a
+// no-op, while a delete for the live owner's own port still removes the row.
+func TestNATManager_DeleteEIP_RecycledIdenticalPair_OwnerScoped(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	var flushed []string
+	nm, err := NewNATManager(m, NATModeCentralized,
+		WithNeighFlusher(func(externalIP string) error {
+			flushed = append(flushed, externalIP)
+			return nil
+		}))
+	require.NoError(t, err)
+
+	// Live owner: 192.168.1.93 → 172.31.0.4 on the live ENI's port.
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-1", ExternalIP: "192.168.1.93", LogicalIP: "172.31.0.4",
+		PortName: "port-live",
+	}))
+	flushed = nil
+
+	// Stale GC teardown of the terminated owner: identical pair, dead ENI port.
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.1.93", "172.31.0.4", "port-dead"))
+	got := findNAT(m, "dnat_and_snat", "172.31.0.4")
+	require.NotNil(t, got, "live owner's row must survive a stale delete for the recycled identical pair")
+	assert.Equal(t, "192.168.1.93", got.ExternalIP)
+	assert.Empty(t, flushed, "stale identical-pair delete must not flush the live owner's host ARP")
+
+	// The live owner's own delete (matching port) still removes the row.
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.1.93", "172.31.0.4", "port-live"))
+	assert.Nil(t, findNAT(m, "dnat_and_snat", "172.31.0.4"),
+		"a delete carrying the owning port must remove the row")
 }
 
 func TestNATManager_AddSNAT_AndDelete(t *testing.T) {

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -427,6 +427,30 @@ func TestNATManager_DeleteEIP_CrossRouterIsolation(t *testing.T) {
 	assert.Equal(t, "2.2.2.2", survived.ExternalIP, "surviving row must belong to vpc-b")
 }
 
+// TestNATManager_DeleteEIP_RecycledLogicalIP_NoClobber guards the EIP-recycling
+// clobber: a dnat_and_snat row's identity is its external IP, not its logical IP.
+// Private IPs are reused as instances recycle, so a stale or retried delete keyed
+// on a freed EIP must not tear down whichever live EIP now holds the same private IP.
+func TestNATManager_DeleteEIP_RecycledLogicalIP_NoClobber(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	nm, err := NewNATManager(m, NATModeCentralized)
+	require.NoError(t, err)
+
+	// Live EIP .174 bound to recycled private IP 172.31.0.4.
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-1", ExternalIP: "192.168.0.174", LogicalIP: "172.31.0.4",
+	}))
+
+	// Stale delete for an earlier EIP (.172) on the same recycled private IP.
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.0.172", "172.31.0.4"))
+
+	got := findNAT(m, "dnat_and_snat", "172.31.0.4")
+	require.NotNil(t, got, "live EIP row must survive a stale delete for a recycled private IP")
+	assert.Equal(t, "192.168.0.174", got.ExternalIP, "the surviving row must be the live EIP")
+}
+
 func TestNATManager_AddSNAT_AndDelete(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -451,6 +451,38 @@ func TestNATManager_DeleteEIP_RecycledLogicalIP_NoClobber(t *testing.T) {
 	assert.Equal(t, "192.168.0.174", got.ExternalIP, "the surviving row must be the live EIP")
 }
 
+// TestNATManager_DeleteEIP_RecycledExternalIP_NoClobber guards the proven flake:
+// a public IP is recycled from a terminated instance to a live one, then the
+// dead instance's delayed GC teardown publishes vpc.delete-nat for that external
+// IP carrying the OLD logical IP. The delete must be a no-op — deleting by
+// external IP alone would tear down the live owner's NAT (and ARP).
+func TestNATManager_DeleteEIP_RecycledExternalIP_NoClobber(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	var flushed []string
+	nm, err := NewNATManager(m, NATModeCentralized,
+		WithNeighFlusher(func(externalIP string) error {
+			flushed = append(flushed, externalIP)
+			return nil
+		}))
+	require.NoError(t, err)
+
+	// Live instance now owns 192.168.0.201 → 172.31.0.5.
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-1", ExternalIP: "192.168.0.201", LogicalIP: "172.31.0.5",
+	}))
+	flushed = nil
+
+	// Stale GC teardown of the dead prior owner (172.31.0.4) of the same IP.
+	require.NoError(t, nm.DeleteEIP(ctx, "vpc-1", "192.168.0.201", "172.31.0.4"))
+
+	got := findNAT(m, "dnat_and_snat", "172.31.0.5")
+	require.NotNil(t, got, "live owner's row must survive a stale delete for the recycled external IP")
+	assert.Equal(t, "192.168.0.201", got.ExternalIP)
+	assert.Empty(t, flushed, "stale delete must not flush the live owner's host ARP")
+}
+
 func TestNATManager_AddSNAT_AndDelete(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()

--- a/spinifex/network/reconcile/actual.go
+++ b/spinifex/network/reconcile/actual.go
@@ -17,7 +17,7 @@ type ActualState struct {
 	Ports        map[string]struct{}
 	RouterPorts  map[string]struct{}
 	PortGroups   map[string]struct{}
-	ExternalSwch map[string]struct{} // vpcID → external switch present (spinifex:role=external)
+	ExternalSwch map[string]struct{} // vpcID → gateway attached to shared external switch (gw-port LSP, role=gateway)
 }
 
 func newActualState() ActualState {
@@ -50,11 +50,6 @@ func scanActual(ctx context.Context, client ovn.Client) (ActualState, error) {
 	}
 	for _, s := range switches {
 		actual.Switches[s.Name] = struct{}{}
-		if s.ExternalIDs["spinifex:role"] == "external" {
-			if vpcID := s.ExternalIDs["spinifex:vpc_id"]; vpcID != "" {
-				actual.ExternalSwch[vpcID] = struct{}{}
-			}
-		}
 		for _, port := range s.Ports {
 			actual.Ports[port] = struct{}{}
 		}
@@ -66,6 +61,13 @@ func scanActual(ctx context.Context, client ovn.Client) (ActualState, error) {
 	}
 	for _, rp := range routerPorts {
 		actual.RouterPorts[rp.Name] = struct{}{}
+		// The gateway LRP signals the VPC is attached to the shared external
+		// switch; the switch itself carries no vpc_id under the shared topology.
+		if rp.ExternalIDs["spinifex:role"] == "gateway" {
+			if vpcID := rp.ExternalIDs["spinifex:vpc_id"]; vpcID != "" {
+				actual.ExternalSwch[vpcID] = struct{}{}
+			}
+		}
 	}
 
 	portGroups, err := client.ListPortGroups(ctx)

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -24,12 +24,13 @@ var (
 	gatewayDatapathInterval = 2 * time.Second
 )
 
-// Bounds for the guest-port SB Port_Binding convergence wait. Long enough to span
-// a guest's post-reboot boot: the tap is replumbed several seconds after the host
-// reconcile starts, so the window must outlast that. Package vars so tests shorten.
+// Bounds for the post-reboot guest-port bind wait. Long enough to span the guest
+// VMs' restart + boot: the daemon re-launches them seconds after the startup
+// reconcile begins, so the window must outlast tap re-plumb. Package vars so tests
+// shorten.
 var (
-	guestPortDatapathTimeout  = 45 * time.Second
-	guestPortDatapathInterval = 5 * time.Second
+	guestPortDatapathTimeout  = 120 * time.Second
+	guestPortDatapathInterval = 3 * time.Second
 )
 
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
@@ -437,54 +438,51 @@ func (r *reconciler) ensureGatewayClaimed(ctx context.Context, crPortName string
 	}
 }
 
-// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent. After the
-// DNAT row is in place it gates on the guest ENI's SB Port_Binding: AddEIP only
-// proves the gateway-chassis flow exists, not the gatewayLRP->guest hop, so a guest
-// whose port has not converged (e.g. just after a host reboot) stays dark while
-// every other signal is green.
-func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ ActualState) {
+// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent. On the
+// startup (post-reboot) path it then forces the guest datapath to converge: the
+// centralised gateway DNAT flows are not reliably reinstalled by ovn-controller's
+// incremental engine on a cold start, so the public IP stays dark while every
+// control-plane signal is green until a recompute fires once the guest tap re-binds.
+func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ ActualState, startup bool) {
 	for _, spec := range intent.EIPs {
 		if err := r.nat.AddEIP(ctx, spec); err != nil {
 			slog.Error("reconcile/apply: AddEIP failed", "external_ip", spec.ExternalIP, "logical_ip", spec.LogicalIP, "err", err)
 		}
-		r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
+		if startup {
+			r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
+		}
 	}
 }
 
-// ensureGuestPortDatapath verifies the guest ENI behind an EIP is reachable on the
-// ingress path. AddEIP installs the DNAT and primes the host neigh, but until the
-// guest port's SB Port_Binding is up the gatewayLRP->guest flow is missing and the
-// DNAT-translated packet blackholes. Probe the binding; on a miss force an
-// ovn-controller recompute and re-probe until a deadline. Recompute on every miss,
-// not once: post-reboot the guest tap is replumbed seconds after this runs, so a
-// single early nudge fires before the port exists and never binds it. No-op when no
-// verifier is wired or the EIP carries no guest port.
+// ensureGuestPortDatapath forces the centralised gateway DNAT flows to install for a
+// guest behind an EIP after a host reboot. ovn-controller's incremental engine does
+// not reliably realise the gatewayLRP->guest leg on a cold start, leaving the public
+// IP dark while NAT/ARP/chassis are all green; a recompute fixes it, but only once
+// the guest tap is back — its SB Port_Binding chassis reclaimed. Poll that chassis
+// claim (reliable post-reboot, unlike the up column which stays stale-true), then
+// force a single recompute. Startup-only: drift must not recompute or it darkens
+// freshly attached EIPs. No-op without a verifier or guest port.
 func (r *reconciler) ensureGuestPortDatapath(ctx context.Context, vpcID, lspName string) {
 	if r.gwClaim == nil || lspName == "" {
 		return
 	}
 	deadline := time.Now().Add(guestPortDatapathTimeout)
-	nudged := false
 	for {
-		up, err := r.gwClaim.GuestPortUp(ctx, lspName)
+		bound, err := r.gwClaim.GuestPortBound(ctx, lspName)
 		if err != nil {
-			slog.Warn("reconcile/apply: guest port datapath probe failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+			slog.Warn("reconcile/apply: guest port bind probe failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
 			return
 		}
-		if up {
-			if nudged {
-				slog.Info("reconcile/apply: guest port datapath converged after recompute", "vpc_id", vpcID, "lsp", lspName)
+		if bound {
+			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
+				slog.Warn("reconcile/apply: post-reboot recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+				return
 			}
+			slog.Info("reconcile/apply: guest port bound; recomputed to realise EIP ingress", "vpc_id", vpcID, "lsp", lspName)
 			return
 		}
-		slog.Warn("reconcile/apply: guest port SB binding not up; nudging ovn-controller recompute",
-			"vpc_id", vpcID, "lsp", lspName)
-		if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
-			slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
-		}
-		nudged = true
 		if time.Now().After(deadline) {
-			slog.Error("reconcile/apply: guest port datapath did not converge; EIP ingress may be unreachable",
+			slog.Error("reconcile/apply: guest port did not bind; EIP ingress may stay unreachable",
 				"vpc_id", vpcID, "lsp", lspName, "timeout", guestPortDatapathTimeout)
 			return
 		}

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -175,7 +175,9 @@ func (r *reconciler) applySGs(ctx context.Context, intent IntentState, actual Ac
 
 // applyPorts ensures each intent ENI has an LSP with PG memberships matching its
 // SGIDs. Existing ports use diff-based UpdatePortGroupMemberships to avoid gaps.
-func (r *reconciler) applyPorts(ctx context.Context, intent IntentState, actual ActualState) {
+// When pruneOrphans is true, ENI LSPs with no matching intent ENI are torn down;
+// startup passes false so in-flight ports survive until subscribers converge.
+func (r *reconciler) applyPorts(ctx context.Context, intent IntentState, actual ActualState, pruneOrphans bool) {
 	for portID, spec := range intent.Ports {
 		portName := topology.Port(portID)
 		switchName := topology.SubnetSwitch(spec.SubnetID)
@@ -223,6 +225,38 @@ func (r *reconciler) applyPorts(ctx context.Context, intent IntentState, actual 
 		if err := r.ovn.UpdatePortGroupMemberships(ctx, portName, addPGs, removePGs); err != nil {
 			slog.Warn("reconcile/apply: update port group memberships failed", "port", portName, "err", err)
 		}
+	}
+
+	if !pruneOrphans {
+		return
+	}
+	r.pruneOrphanPorts(ctx, intent)
+}
+
+// pruneOrphanPorts deletes guest LSPs whose spinifex:eni_id has no matching
+// intent ENI, closing the create-only gap that leaks ports across instance
+// terminate and host reinstall. DeletePort clears PG memberships then removes
+// the LSP (composed cascade).
+func (r *reconciler) pruneOrphanPorts(ctx context.Context, intent IntentState) {
+	lsps, err := r.ovn.ListLogicalSwitchPorts(ctx)
+	if err != nil {
+		slog.Warn("reconcile/apply: list LSPs for orphan prune failed", "err", err)
+		return
+	}
+	for i := range lsps {
+		eniID := lsps[i].ExternalIDs["spinifex:eni_id"]
+		if eniID == "" {
+			continue
+		}
+		if _, ok := intent.Ports[eniID]; ok {
+			continue
+		}
+		spec := topology.PortSpec{PortID: eniID, SubnetID: lsps[i].ExternalIDs["spinifex:subnet_id"]}
+		if err := r.topology.DeletePort(ctx, spec); err != nil {
+			slog.Warn("reconcile/apply: orphan ENI DeletePort failed", "port", lsps[i].Name, "err", err)
+			continue
+		}
+		slog.Info("reconcile/apply: removed orphan ENI port", "port", lsps[i].Name, "eni_id", eniID)
 	}
 }
 

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -318,17 +318,17 @@ func gatewayLRPIP(lrp *nbdb.LogicalRouterPort) string {
 
 // ensureGatewayDatapath verifies the external datapath actually forwards after the
 // SB claim converges. A claimed chassisredirect binding is not proof the flows are
-// installed: post-reboot ovn-controller can claim the port yet leave stale
-// gateway/localnet flows, leaving every control-plane signal green while EIPs stay
+// installed: post-reboot a boot race can leave the WAN-glue veth admin-down or the
+// gateway flows stale, leaving every control-plane signal green while EIPs stay
 // unreachable. Probe the gateway LRP IP (OVN answers ICMP natively, no guest or
-// security-group dependency); on a miss force one recompute and re-probe until a
-// short deadline. No-op when no verifier is wired or no gateway IP resolved.
+// security-group dependency); on a miss repair the uplink + recompute, then re-probe
+// until a short deadline. No-op when no verifier is wired or no gateway IP resolved.
 func (r *reconciler) ensureGatewayDatapath(ctx context.Context, vpcID, gwIP string) {
 	if r.gwClaim == nil || gwIP == "" {
 		return
 	}
 	deadline := time.Now().Add(gatewayDatapathTimeout)
-	nudged := false
+	repaired := false
 	for {
 		reachable, err := r.gwClaim.GatewayReachable(ctx, gwIP)
 		if err != nil {
@@ -336,21 +336,21 @@ func (r *reconciler) ensureGatewayDatapath(ctx context.Context, vpcID, gwIP stri
 			return
 		}
 		if reachable {
-			if nudged {
-				slog.Info("reconcile/apply: gateway datapath recovered after recompute", "vpc_id", vpcID, "gw_ip", gwIP)
+			if repaired {
+				slog.Info("reconcile/apply: gateway datapath recovered after uplink repair", "vpc_id", vpcID, "gw_ip", gwIP)
 			}
 			return
 		}
-		if !nudged {
-			slog.Warn("reconcile/apply: gateway datapath unreachable despite SB claim; forcing ovn-controller recompute",
+		if !repaired {
+			slog.Warn("reconcile/apply: gateway datapath unreachable despite SB claim; repairing uplink + forcing recompute",
 				"vpc_id", vpcID, "gw_ip", gwIP)
-			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
-				slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "gw_ip", gwIP, "err", err)
+			if err := r.gwClaim.RepairDatapath(ctx); err != nil {
+				slog.Warn("reconcile/apply: gateway datapath repair failed", "vpc_id", vpcID, "gw_ip", gwIP, "err", err)
 			}
-			nudged = true
+			repaired = true
 		}
 		if time.Now().After(deadline) {
-			slog.Error("reconcile/apply: gateway datapath did not recover after recompute; external connectivity degraded",
+			slog.Error("reconcile/apply: gateway datapath did not recover after uplink repair; external connectivity degraded",
 				"vpc_id", vpcID, "gw_ip", gwIP, "timeout", gatewayDatapathTimeout)
 			return
 		}

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -24,6 +24,14 @@ var (
 	gatewayDatapathInterval = 2 * time.Second
 )
 
+// Bounds for the guest-port SB Port_Binding convergence wait. Shorter than the
+// gateway gate: a guest port binds quickly once its tap is plugged, and this runs
+// per EIP. Package vars so tests can shorten.
+var (
+	guestPortDatapathTimeout  = 20 * time.Second
+	guestPortDatapathInterval = 2 * time.Second
+)
+
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
 // routers are left alone.
 func (r *reconciler) applyVPCs(ctx context.Context, intent IntentState, actual ActualState) {
@@ -403,11 +411,62 @@ func (r *reconciler) ensureGatewayClaimed(ctx context.Context, crPortName string
 	}
 }
 
-// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent.
+// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent. After the
+// DNAT row + neigh prime are in place it gates on the guest ENI's SB Port_Binding:
+// AddEIP only proves the gateway-chassis flow exists, not the gatewayLRP->guest
+// geneve hop, so a fresh post-churn guest can stay dark (SSH to the public IP times
+// out) while every control-plane signal is green.
 func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ ActualState) {
 	for _, spec := range intent.EIPs {
 		if err := r.nat.AddEIP(ctx, spec); err != nil {
 			slog.Error("reconcile/apply: AddEIP failed", "external_ip", spec.ExternalIP, "logical_ip", spec.LogicalIP, "err", err)
+		}
+		r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
+	}
+}
+
+// ensureGuestPortDatapath verifies the guest ENI behind an EIP is actually
+// reachable on the ingress path. AddEIP installs the DNAT and primes the host
+// neigh, but the DNAT-translated packet still has to cross geneve to the guest's
+// chassis; until that port's SB Port_Binding is up the flow is missing and the EIP
+// blackholes. Probe the guest Port_Binding; on a miss force one ovn-controller
+// recompute (binds the port / installs the remote flow) and re-probe until a short
+// deadline. No-op when no verifier is wired or the EIP carries no guest port.
+func (r *reconciler) ensureGuestPortDatapath(ctx context.Context, vpcID, lspName string) {
+	if r.gwClaim == nil || lspName == "" {
+		return
+	}
+	deadline := time.Now().Add(guestPortDatapathTimeout)
+	nudged := false
+	for {
+		up, err := r.gwClaim.GuestPortUp(ctx, lspName)
+		if err != nil {
+			slog.Warn("reconcile/apply: guest port datapath probe failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+			return
+		}
+		if up {
+			if nudged {
+				slog.Info("reconcile/apply: guest port datapath converged after recompute", "vpc_id", vpcID, "lsp", lspName)
+			}
+			return
+		}
+		if !nudged {
+			slog.Warn("reconcile/apply: guest port SB binding not up; nudging ovn-controller recompute",
+				"vpc_id", vpcID, "lsp", lspName)
+			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
+				slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+			}
+			nudged = true
+		}
+		if time.Now().After(deadline) {
+			slog.Error("reconcile/apply: guest port datapath did not converge; EIP ingress may be unreachable",
+				"vpc_id", vpcID, "lsp", lspName, "timeout", guestPortDatapathTimeout)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(guestPortDatapathInterval):
 		}
 	}
 }

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
@@ -15,6 +16,12 @@ import (
 var (
 	gatewayClaimTimeout  = 30 * time.Second
 	gatewayClaimInterval = 2 * time.Second
+)
+
+// Bounds for the post-claim datapath-reachability wait. Package vars so tests can shorten.
+var (
+	gatewayDatapathTimeout  = 30 * time.Second
+	gatewayDatapathInterval = 2 * time.Second
 )
 
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
@@ -281,7 +288,8 @@ func (r *reconciler) rebindGatewayChassis(ctx context.Context, vpcID string) {
 		return
 	}
 	gwPortName := topology.GatewayRouterPort(vpcID)
-	if _, err := r.ovn.GetLogicalRouterPort(ctx, gwPortName); err != nil {
+	lrp, err := r.ovn.GetLogicalRouterPort(ctx, gwPortName)
+	if err != nil {
 		return
 	}
 	for i, chassis := range r.chassis {
@@ -291,6 +299,67 @@ func (r *reconciler) rebindGatewayChassis(ctx context.Context, vpcID string) {
 		}
 	}
 	r.ensureGatewayClaimed(ctx, topology.GatewayChassisRedirectPort(vpcID))
+	r.ensureGatewayDatapath(ctx, vpcID, gatewayLRPIP(lrp))
+}
+
+// gatewayLRPIP returns the bare IPv4 of the gateway router port, parsed from its
+// first CIDR network (e.g. "192.168.1.241/23" -> "192.168.1.241"). Empty when the
+// LRP is nil or carries no network, which makes the datapath gate a no-op.
+func gatewayLRPIP(lrp *nbdb.LogicalRouterPort) string {
+	if lrp == nil || len(lrp.Networks) == 0 {
+		return ""
+	}
+	ip, _, ok := strings.Cut(lrp.Networks[0], "/")
+	if !ok {
+		return ""
+	}
+	return ip
+}
+
+// ensureGatewayDatapath verifies the external datapath actually forwards after the
+// SB claim converges. A claimed chassisredirect binding is not proof the flows are
+// installed: post-reboot ovn-controller can claim the port yet leave stale
+// gateway/localnet flows, leaving every control-plane signal green while EIPs stay
+// unreachable. Probe the gateway LRP IP (OVN answers ICMP natively, no guest or
+// security-group dependency); on a miss force one recompute and re-probe until a
+// short deadline. No-op when no verifier is wired or no gateway IP resolved.
+func (r *reconciler) ensureGatewayDatapath(ctx context.Context, vpcID, gwIP string) {
+	if r.gwClaim == nil || gwIP == "" {
+		return
+	}
+	deadline := time.Now().Add(gatewayDatapathTimeout)
+	nudged := false
+	for {
+		reachable, err := r.gwClaim.GatewayReachable(ctx, gwIP)
+		if err != nil {
+			slog.Warn("reconcile/apply: gateway datapath probe failed", "vpc_id", vpcID, "gw_ip", gwIP, "err", err)
+			return
+		}
+		if reachable {
+			if nudged {
+				slog.Info("reconcile/apply: gateway datapath recovered after recompute", "vpc_id", vpcID, "gw_ip", gwIP)
+			}
+			return
+		}
+		if !nudged {
+			slog.Warn("reconcile/apply: gateway datapath unreachable despite SB claim; forcing ovn-controller recompute",
+				"vpc_id", vpcID, "gw_ip", gwIP)
+			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
+				slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "gw_ip", gwIP, "err", err)
+			}
+			nudged = true
+		}
+		if time.Now().After(deadline) {
+			slog.Error("reconcile/apply: gateway datapath did not recover after recompute; external connectivity degraded",
+				"vpc_id", vpcID, "gw_ip", gwIP, "timeout", gatewayDatapathTimeout)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(gatewayDatapathInterval):
+		}
+	}
 }
 
 // ensureGatewayClaimed polls the SB chassisredirect binding after SetGatewayChassis.

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -24,13 +24,12 @@ var (
 	gatewayDatapathInterval = 2 * time.Second
 )
 
-// Bounds for the post-reboot guest-port bind wait. Long enough to span the guest
-// VMs' restart + boot: the daemon re-launches them seconds after the startup
-// reconcile begins, so the window must outlast tap re-plumb. Package vars so tests
-// shorten.
+// Bounds for the guest-port SB Port_Binding convergence wait. Long enough to span
+// a guest's post-reboot boot: the tap is replumbed several seconds after the host
+// reconcile starts, so the window must outlast that. Package vars so tests shorten.
 var (
-	guestPortDatapathTimeout  = 120 * time.Second
-	guestPortDatapathInterval = 3 * time.Second
+	guestPortDatapathTimeout  = 45 * time.Second
+	guestPortDatapathInterval = 5 * time.Second
 )
 
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
@@ -438,51 +437,54 @@ func (r *reconciler) ensureGatewayClaimed(ctx context.Context, crPortName string
 	}
 }
 
-// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent. On the
-// startup (post-reboot) path it then forces the guest datapath to converge: the
-// centralised gateway DNAT flows are not reliably reinstalled by ovn-controller's
-// incremental engine on a cold start, so the public IP stays dark while every
-// control-plane signal is green until a recompute fires once the guest tap re-binds.
-func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ ActualState, startup bool) {
+// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent. After the
+// DNAT row is in place it gates on the guest ENI's SB Port_Binding: AddEIP only
+// proves the gateway-chassis flow exists, not the gatewayLRP->guest hop, so a guest
+// whose port has not converged (e.g. just after a host reboot) stays dark while
+// every other signal is green.
+func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ ActualState) {
 	for _, spec := range intent.EIPs {
 		if err := r.nat.AddEIP(ctx, spec); err != nil {
 			slog.Error("reconcile/apply: AddEIP failed", "external_ip", spec.ExternalIP, "logical_ip", spec.LogicalIP, "err", err)
 		}
-		if startup {
-			r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
-		}
+		r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
 	}
 }
 
-// ensureGuestPortDatapath forces the centralised gateway DNAT flows to install for a
-// guest behind an EIP after a host reboot. ovn-controller's incremental engine does
-// not reliably realise the gatewayLRP->guest leg on a cold start, leaving the public
-// IP dark while NAT/ARP/chassis are all green; a recompute fixes it, but only once
-// the guest tap is back — its SB Port_Binding chassis reclaimed. Poll that chassis
-// claim (reliable post-reboot, unlike the up column which stays stale-true), then
-// force a single recompute. Startup-only: drift must not recompute or it darkens
-// freshly attached EIPs. No-op without a verifier or guest port.
+// ensureGuestPortDatapath verifies the guest ENI behind an EIP is reachable on the
+// ingress path. AddEIP installs the DNAT and primes the host neigh, but until the
+// guest port's SB Port_Binding is up the gatewayLRP->guest flow is missing and the
+// DNAT-translated packet blackholes. Probe the binding; on a miss force an
+// ovn-controller recompute and re-probe until a deadline. Recompute on every miss,
+// not once: post-reboot the guest tap is replumbed seconds after this runs, so a
+// single early nudge fires before the port exists and never binds it. No-op when no
+// verifier is wired or the EIP carries no guest port.
 func (r *reconciler) ensureGuestPortDatapath(ctx context.Context, vpcID, lspName string) {
 	if r.gwClaim == nil || lspName == "" {
 		return
 	}
 	deadline := time.Now().Add(guestPortDatapathTimeout)
+	nudged := false
 	for {
-		bound, err := r.gwClaim.GuestPortBound(ctx, lspName)
+		up, err := r.gwClaim.GuestPortUp(ctx, lspName)
 		if err != nil {
-			slog.Warn("reconcile/apply: guest port bind probe failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+			slog.Warn("reconcile/apply: guest port datapath probe failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
 			return
 		}
-		if bound {
-			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
-				slog.Warn("reconcile/apply: post-reboot recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
-				return
+		if up {
+			if nudged {
+				slog.Info("reconcile/apply: guest port datapath converged after recompute", "vpc_id", vpcID, "lsp", lspName)
 			}
-			slog.Info("reconcile/apply: guest port bound; recomputed to realise EIP ingress", "vpc_id", vpcID, "lsp", lspName)
 			return
 		}
+		slog.Warn("reconcile/apply: guest port SB binding not up; nudging ovn-controller recompute",
+			"vpc_id", vpcID, "lsp", lspName)
+		if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
+			slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+		}
+		nudged = true
 		if time.Now().After(deadline) {
-			slog.Error("reconcile/apply: guest port did not bind; EIP ingress may stay unreachable",
+			slog.Error("reconcile/apply: guest port datapath did not converge; EIP ingress may be unreachable",
 				"vpc_id", vpcID, "lsp", lspName, "timeout", guestPortDatapathTimeout)
 			return
 		}

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -449,6 +450,57 @@ func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ Actual
 		}
 		r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
 	}
+}
+
+// applyPublicInstanceEgress exempts every public-IP instance from its subnet egress
+// drop gate. Public IPs come from two disjoint sources: auto-assigned and ELB
+// addresses recorded on the ENI (intent.Ports) and user EIPs in the EIP bucket
+// (intent.EIPs). Both need the same /32 reroute above the gate.
+func (r *reconciler) applyPublicInstanceEgress(ctx context.Context, intent IntentState, _ ActualState) {
+	for _, p := range intent.Ports {
+		if p.PublicIP.IsValid() {
+			r.ensureEIPEgressExemption(ctx, intent, p.VPCID, p.SubnetID, p.PrivateIP.String())
+		}
+	}
+	for _, e := range intent.EIPs {
+		r.ensureEIPEgressExemption(ctx, intent, e.VPCID, subnetIDForIP(intent.Subnets, e.LogicalIP), e.LogicalIP)
+	}
+}
+
+// ensureEIPEgressExemption punches a public-IP instance through its subnet's egress
+// drop gate. The drop gate (installed for an IGW-attached subnet with no 0.0.0.0/0
+// route) drops the instance's WAN-bound traffic — including the reply leg of an
+// inbound connection, since lr_in_policy runs before lr_out un-DNAT/SNAT so the reply
+// still carries its private source at the gate. A /32 reroute above the gate restores
+// the datapath; the instance's dnat_and_snat supplies SNAT. No-op when the VPC has no
+// IGW (no drop gate) or the instance maps to no known subnet.
+func (r *reconciler) ensureEIPEgressExemption(ctx context.Context, intent IntentState, vpcID, subnetID, instanceIP string) {
+	if _, hasIGW := intent.IGWs[vpcID]; !hasIGW {
+		return
+	}
+	if subnetID == "" {
+		slog.Warn("reconcile/apply: public instance maps to no subnet; skipping egress exemption",
+			"vpc_id", vpcID, "instance_ip", instanceIP)
+		return
+	}
+	if err := r.igw.EnsureEIPInstanceEgress(ctx, vpcID, subnetID, instanceIP); err != nil {
+		slog.Error("reconcile/apply: EnsureEIPInstanceEgress failed",
+			"vpc_id", vpcID, "subnet_id", subnetID, "instance_ip", instanceIP, "err", err)
+	}
+}
+
+// subnetIDForIP returns the SubnetID whose CIDR contains ip, or "" if none match.
+func subnetIDForIP(subnets map[string]topology.SubnetSpec, ip string) string {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return ""
+	}
+	for _, s := range subnets {
+		if s.CIDR.IsValid() && s.CIDR.Contains(addr) {
+			return s.SubnetID
+		}
+	}
+	return ""
 }
 
 // ensureGuestPortDatapath verifies the guest ENI behind an EIP is reachable on the

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -24,6 +24,14 @@ var (
 	gatewayDatapathInterval = 2 * time.Second
 )
 
+// Bounds for the guest-port SB Port_Binding convergence wait. Long enough to span
+// a guest's post-reboot boot: the tap is replumbed several seconds after the host
+// reconcile starts, so the window must outlast that. Package vars so tests shorten.
+var (
+	guestPortDatapathTimeout  = 45 * time.Second
+	guestPortDatapathInterval = 5 * time.Second
+)
+
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
 // routers are left alone.
 func (r *reconciler) applyVPCs(ctx context.Context, intent IntentState, actual ActualState) {
@@ -429,11 +437,61 @@ func (r *reconciler) ensureGatewayClaimed(ctx context.Context, crPortName string
 	}
 }
 
-// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent.
+// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent. After the
+// DNAT row is in place it gates on the guest ENI's SB Port_Binding: AddEIP only
+// proves the gateway-chassis flow exists, not the gatewayLRP->guest hop, so a guest
+// whose port has not converged (e.g. just after a host reboot) stays dark while
+// every other signal is green.
 func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ ActualState) {
 	for _, spec := range intent.EIPs {
 		if err := r.nat.AddEIP(ctx, spec); err != nil {
 			slog.Error("reconcile/apply: AddEIP failed", "external_ip", spec.ExternalIP, "logical_ip", spec.LogicalIP, "err", err)
+		}
+		r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
+	}
+}
+
+// ensureGuestPortDatapath verifies the guest ENI behind an EIP is reachable on the
+// ingress path. AddEIP installs the DNAT and primes the host neigh, but until the
+// guest port's SB Port_Binding is up the gatewayLRP->guest flow is missing and the
+// DNAT-translated packet blackholes. Probe the binding; on a miss force an
+// ovn-controller recompute and re-probe until a deadline. Recompute on every miss,
+// not once: post-reboot the guest tap is replumbed seconds after this runs, so a
+// single early nudge fires before the port exists and never binds it. No-op when no
+// verifier is wired or the EIP carries no guest port.
+func (r *reconciler) ensureGuestPortDatapath(ctx context.Context, vpcID, lspName string) {
+	if r.gwClaim == nil || lspName == "" {
+		return
+	}
+	deadline := time.Now().Add(guestPortDatapathTimeout)
+	nudged := false
+	for {
+		up, err := r.gwClaim.GuestPortUp(ctx, lspName)
+		if err != nil {
+			slog.Warn("reconcile/apply: guest port datapath probe failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+			return
+		}
+		if up {
+			if nudged {
+				slog.Info("reconcile/apply: guest port datapath converged after recompute", "vpc_id", vpcID, "lsp", lspName)
+			}
+			return
+		}
+		slog.Warn("reconcile/apply: guest port SB binding not up; nudging ovn-controller recompute",
+			"vpc_id", vpcID, "lsp", lspName)
+		if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
+			slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
+		}
+		nudged = true
+		if time.Now().After(deadline) {
+			slog.Error("reconcile/apply: guest port datapath did not converge; EIP ingress may be unreachable",
+				"vpc_id", vpcID, "lsp", lspName, "timeout", guestPortDatapathTimeout)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(guestPortDatapathInterval):
 		}
 	}
 }

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -24,14 +24,6 @@ var (
 	gatewayDatapathInterval = 2 * time.Second
 )
 
-// Bounds for the guest-port SB Port_Binding convergence wait. Shorter than the
-// gateway gate: a guest port binds quickly once its tap is plugged, and this runs
-// per EIP. Package vars so tests can shorten.
-var (
-	guestPortDatapathTimeout  = 20 * time.Second
-	guestPortDatapathInterval = 2 * time.Second
-)
-
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
 // routers are left alone.
 func (r *reconciler) applyVPCs(ctx context.Context, intent IntentState, actual ActualState) {
@@ -411,62 +403,11 @@ func (r *reconciler) ensureGatewayClaimed(ctx context.Context, crPortName string
 	}
 }
 
-// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent. After the
-// DNAT row + neigh prime are in place it gates on the guest ENI's SB Port_Binding:
-// AddEIP only proves the gateway-chassis flow exists, not the gatewayLRP->guest
-// geneve hop, so a fresh post-churn guest can stay dark (SSH to the public IP times
-// out) while every control-plane signal is green.
+// applyEIPs runs every intent EIP through NATManager.AddEIP; idempotent.
 func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ ActualState) {
 	for _, spec := range intent.EIPs {
 		if err := r.nat.AddEIP(ctx, spec); err != nil {
 			slog.Error("reconcile/apply: AddEIP failed", "external_ip", spec.ExternalIP, "logical_ip", spec.LogicalIP, "err", err)
-		}
-		r.ensureGuestPortDatapath(ctx, spec.VPCID, spec.PortName)
-	}
-}
-
-// ensureGuestPortDatapath verifies the guest ENI behind an EIP is actually
-// reachable on the ingress path. AddEIP installs the DNAT and primes the host
-// neigh, but the DNAT-translated packet still has to cross geneve to the guest's
-// chassis; until that port's SB Port_Binding is up the flow is missing and the EIP
-// blackholes. Probe the guest Port_Binding; on a miss force one ovn-controller
-// recompute (binds the port / installs the remote flow) and re-probe until a short
-// deadline. No-op when no verifier is wired or the EIP carries no guest port.
-func (r *reconciler) ensureGuestPortDatapath(ctx context.Context, vpcID, lspName string) {
-	if r.gwClaim == nil || lspName == "" {
-		return
-	}
-	deadline := time.Now().Add(guestPortDatapathTimeout)
-	nudged := false
-	for {
-		up, err := r.gwClaim.GuestPortUp(ctx, lspName)
-		if err != nil {
-			slog.Warn("reconcile/apply: guest port datapath probe failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
-			return
-		}
-		if up {
-			if nudged {
-				slog.Info("reconcile/apply: guest port datapath converged after recompute", "vpc_id", vpcID, "lsp", lspName)
-			}
-			return
-		}
-		if !nudged {
-			slog.Warn("reconcile/apply: guest port SB binding not up; nudging ovn-controller recompute",
-				"vpc_id", vpcID, "lsp", lspName)
-			if err := r.gwClaim.NudgeRecompute(ctx); err != nil {
-				slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
-			}
-			nudged = true
-		}
-		if time.Now().After(deadline) {
-			slog.Error("reconcile/apply: guest port datapath did not converge; EIP ingress may be unreachable",
-				"vpc_id", vpcID, "lsp", lspName, "timeout", guestPortDatapathTimeout)
-			return
-		}
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(guestPortDatapathInterval):
 		}
 	}
 }

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -472,15 +472,16 @@ func (r *reconciler) applyPublicInstanceEgress(ctx context.Context, intent Inten
 // route) drops the instance's WAN-bound traffic — including the reply leg of an
 // inbound connection, since lr_in_policy runs before lr_out un-DNAT/SNAT so the reply
 // still carries its private source at the gate. A /32 reroute above the gate restores
-// the datapath; the instance's dnat_and_snat supplies SNAT. No-op when the VPC has no
-// IGW (no drop gate) or the instance maps to no known subnet.
+// the datapath; the instance's dnat_and_snat supplies SNAT. Scoped to subnets that
+// actually carry a drop gate: routed subnets egress via their priority-1000 reroute
+// and need no exemption, so the gate presence bounds the blast radius.
 func (r *reconciler) ensureEIPEgressExemption(ctx context.Context, intent IntentState, vpcID, subnetID, instanceIP string) {
-	if _, hasIGW := intent.IGWs[vpcID]; !hasIGW {
-		return
-	}
 	if subnetID == "" {
 		slog.Warn("reconcile/apply: public instance maps to no subnet; skipping egress exemption",
 			"vpc_id", vpcID, "instance_ip", instanceIP)
+		return
+	}
+	if _, gated := intent.DropGates[subnetEgressKey(subnetID, netip.MustParsePrefix("0.0.0.0/0"))]; !gated {
 		return
 	}
 	if err := r.igw.EnsureEIPInstanceEgress(ctx, vpcID, subnetID, instanceIP); err != nil {

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -278,12 +278,25 @@ func (r *reconciler) applyIGWs(ctx context.Context, intent IntentState, actual A
 			}
 			actual.ExternalSwch[vpcID] = struct{}{}
 		}
-		r.rebindGatewayChassis(ctx, vpcID)
+		r.rebindGatewayChassis(ctx, vpcID, eipProbeIP(intent, vpcID))
 	}
 }
 
+// eipProbeIP returns an associated EIP's external IP for vpcID, or "" if the VPC
+// has none. Used as the gateway datapath probe target: an EIP exercises the NAT
+// pipeline + WAN uplink, unlike the gateway LRP IP which OVN answers natively.
+// Any associated EIP suffices; map order is irrelevant.
+func eipProbeIP(intent IntentState, vpcID string) string {
+	for _, spec := range intent.EIPs {
+		if spec.VPCID == vpcID && spec.ExternalIP != "" {
+			return spec.ExternalIP
+		}
+	}
+	return ""
+}
+
 // rebindGatewayChassis re-asserts chassis priority tuples on the gateway LRP.
-func (r *reconciler) rebindGatewayChassis(ctx context.Context, vpcID string) {
+func (r *reconciler) rebindGatewayChassis(ctx context.Context, vpcID, eipIP string) {
 	if len(r.chassis) == 0 {
 		return
 	}
@@ -299,7 +312,7 @@ func (r *reconciler) rebindGatewayChassis(ctx context.Context, vpcID string) {
 		}
 	}
 	r.ensureGatewayClaimed(ctx, topology.GatewayChassisRedirectPort(vpcID))
-	r.ensureGatewayDatapath(ctx, vpcID, gatewayLRPIP(lrp))
+	r.ensureGatewayDatapath(ctx, vpcID, gatewayLRPIP(lrp), eipIP)
 }
 
 // gatewayLRPIP returns the bare IPv4 of the gateway router port, parsed from its
@@ -318,40 +331,53 @@ func gatewayLRPIP(lrp *nbdb.LogicalRouterPort) string {
 
 // ensureGatewayDatapath verifies the external datapath actually forwards after the
 // SB claim converges. A claimed chassisredirect binding is not proof the flows are
-// installed: post-reboot a boot race can leave the WAN-glue veth admin-down or the
-// gateway flows stale, leaving every control-plane signal green while EIPs stay
-// unreachable. Probe the gateway LRP IP (OVN answers ICMP natively, no guest or
-// security-group dependency); on a miss repair the uplink + recompute, then re-probe
-// until a short deadline. No-op when no verifier is wired or no gateway IP resolved.
-func (r *reconciler) ensureGatewayDatapath(ctx context.Context, vpcID, gwIP string) {
-	if r.gwClaim == nil || gwIP == "" {
+// installed: a boot race or a later ovn-controller restart can leave the WAN-glue
+// veth admin-down or the EIP NAT flows stale, leaving every control-plane signal
+// green while EIPs stay unreachable. Prefer probing an associated EIP — forcing an
+// ARP of the dnat_and_snat external IP exercises the NAT pipeline + WAN uplink
+// without a guest dependency, whereas the gateway LRP IP OVN answers natively and
+// stays green even when the EIP datapath is dead. Fall back to the LRP IP when the
+// VPC has no EIP. On a miss repair the uplink + recompute, then re-probe until a
+// short deadline. No-op when no verifier is wired or no probe target resolved.
+func (r *reconciler) ensureGatewayDatapath(ctx context.Context, vpcID, gwIP, eipIP string) {
+	if r.gwClaim == nil || (gwIP == "" && eipIP == "") {
 		return
+	}
+	target := eipIP
+	if target == "" {
+		target = gwIP
+	}
+	probe := func() (bool, error) {
+		if eipIP != "" {
+			return r.gwClaim.EIPReachable(ctx, eipIP)
+		}
+		return r.gwClaim.GatewayReachable(ctx, gwIP)
 	}
 	deadline := time.Now().Add(gatewayDatapathTimeout)
 	repaired := false
 	for {
-		reachable, err := r.gwClaim.GatewayReachable(ctx, gwIP)
+		reachable, err := probe()
 		if err != nil {
-			slog.Warn("reconcile/apply: gateway datapath probe failed", "vpc_id", vpcID, "gw_ip", gwIP, "err", err)
+			slog.Warn("reconcile/apply: gateway datapath probe failed", "vpc_id", vpcID, "target", target, "err", err)
 			return
 		}
 		if reachable {
 			if repaired {
-				slog.Info("reconcile/apply: gateway datapath recovered after uplink repair", "vpc_id", vpcID, "gw_ip", gwIP)
+				slog.Info("reconcile/apply: gateway datapath recovered after uplink repair", "vpc_id", vpcID, "target", target)
 			}
 			return
 		}
 		if !repaired {
 			slog.Warn("reconcile/apply: gateway datapath unreachable despite SB claim; repairing uplink + forcing recompute",
-				"vpc_id", vpcID, "gw_ip", gwIP)
+				"vpc_id", vpcID, "target", target)
 			if err := r.gwClaim.RepairDatapath(ctx); err != nil {
-				slog.Warn("reconcile/apply: gateway datapath repair failed", "vpc_id", vpcID, "gw_ip", gwIP, "err", err)
+				slog.Warn("reconcile/apply: gateway datapath repair failed", "vpc_id", vpcID, "target", target, "err", err)
 			}
 			repaired = true
 		}
 		if time.Now().After(deadline) {
 			slog.Error("reconcile/apply: gateway datapath did not recover after uplink repair; external connectivity degraded",
-				"vpc_id", vpcID, "gw_ip", gwIP, "timeout", gatewayDatapathTimeout)
+				"vpc_id", vpcID, "target", target, "timeout", gatewayDatapathTimeout)
 			return
 		}
 		select {

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -12,22 +12,22 @@ import (
 // once nudgeCount reaches it (or immediately for 0), claimed reports true.
 // reachableAfter mirrors claimedAfter for the datapath probe.
 type fakeClaimVerifier struct {
-	claimedAfter    int // nudges required before the port reports claimed; <0 never
-	reachableAfter  int // nudges required before the datapath reports reachable; <0 never
-	guestBoundAfter int // probe calls before the guest port reports bound; <0 never
-	checkErr        error
-	nudgeErr        error
-	reachErr        error
-	guestErr        error
-	checks          int
-	nudges          int
-	repairs         int
-	reachChecks     int
-	guestChecks     int
-	lastPort        string // most recent port name passed to GatewayPortClaimed
-	lastGwIP        string // most recent IP passed to GatewayReachable
-	lastEIP         string // most recent IP passed to EIPReachable
-	lastLSP         string // most recent lsp passed to GuestPortBound
+	claimedAfter   int // nudges required before the port reports claimed; <0 never
+	reachableAfter int // nudges required before the datapath reports reachable; <0 never
+	guestUpAfter   int // nudges required before the guest port reports up; <0 never
+	checkErr       error
+	nudgeErr       error
+	reachErr       error
+	guestErr       error
+	checks         int
+	nudges         int
+	repairs        int
+	reachChecks    int
+	guestChecks    int
+	lastPort       string // most recent port name passed to GatewayPortClaimed
+	lastGwIP       string // most recent IP passed to GatewayReachable
+	lastEIP        string // most recent IP passed to EIPReachable
+	lastLSP        string // most recent lsp passed to GuestPortUp
 }
 
 func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (bool, error) {
@@ -82,20 +82,19 @@ func (f *fakeClaimVerifier) EIPReachable(_ context.Context, eip string) (bool, e
 	return f.nudges >= f.reachableAfter, nil
 }
 
-// GuestPortBound reports bound once the probe has been called more than
-// guestBoundAfter times (immediately for 0; never for <0). It keys off the probe
-// count, not nudges: the post-reboot logic polls the bind, then recomputes once.
-// lastLSP records the probed port.
-func (f *fakeClaimVerifier) GuestPortBound(_ context.Context, lspName string) (bool, error) {
+// GuestPortUp reports up once nudges reach guestUpAfter (immediately for 0; never
+// for <0), sharing the nudge counter so the recompute-each-miss loop is scripted
+// the same way as the other gates. lastLSP records the probed port.
+func (f *fakeClaimVerifier) GuestPortUp(_ context.Context, lspName string) (bool, error) {
 	f.guestChecks++
 	f.lastLSP = lspName
 	if f.guestErr != nil {
 		return false, f.guestErr
 	}
-	if f.guestBoundAfter < 0 {
+	if f.guestUpAfter < 0 {
 		return false, nil
 	}
-	return f.guestChecks > f.guestBoundAfter, nil
+	return f.nudges >= f.guestUpAfter, nil
 }
 
 func withFastGuestPortBounds(t *testing.T) {
@@ -375,43 +374,40 @@ func TestEnsureGuestPortDatapath_EmptyLSPIsNoop(t *testing.T) {
 	}
 }
 
-func TestEnsureGuestPortDatapath_BoundRecomputesOnce(t *testing.T) {
+func TestEnsureGuestPortDatapath_UpNoNudge(t *testing.T) {
 	withFastGuestPortBounds(t)
-	f := &fakeClaimVerifier{guestBoundAfter: 0} // bound on first probe
+	f := &fakeClaimVerifier{guestUpAfter: 0}
 	r := &reconciler{gwClaim: f}
 
 	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
 
-	if f.nudges != 1 {
-		t.Errorf("bound guest port nudged %d times, want exactly 1 (recompute once after bind)", f.nudges)
+	if f.nudges != 0 {
+		t.Errorf("up guest port nudged %d times, want 0", f.nudges)
 	}
 	if f.guestChecks != 1 {
-		t.Errorf("guestChecks = %d, want 1 (single bind probe)", f.guestChecks)
+		t.Errorf("guestChecks = %d, want 1 (single up probe)", f.guestChecks)
 	}
 	if f.lastLSP != "port-eni-1" {
 		t.Errorf("lastLSP = %q, want port-eni-1", f.lastLSP)
 	}
 }
 
-func TestEnsureGuestPortDatapath_PollsThenBoundRecomputesOnce(t *testing.T) {
+func TestEnsureGuestPortDatapath_NudgeThenConverge(t *testing.T) {
 	withFastGuestPortBounds(t)
-	// Unbound for one probe, then bound. The recompute fires only after the bind.
-	f := &fakeClaimVerifier{guestBoundAfter: 1}
+	// Down until one recompute nudge, then up.
+	f := &fakeClaimVerifier{guestUpAfter: 1}
 	r := &reconciler{gwClaim: f}
 
 	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
 
 	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (recompute once, after the port binds)", f.nudges)
-	}
-	if f.guestChecks != 2 {
-		t.Errorf("guestChecks = %d, want 2 (one miss, then bound)", f.guestChecks)
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, then converge)", f.nudges)
 	}
 }
 
-func TestEnsureGuestPortDatapath_NeverBoundNoRecompute(t *testing.T) {
+func TestEnsureGuestPortDatapath_NeverConvergesRecomputesEachMiss(t *testing.T) {
 	withFastGuestPortBounds(t)
-	f := &fakeClaimVerifier{guestBoundAfter: -1} // never binds
+	f := &fakeClaimVerifier{guestUpAfter: -1} // never up
 	r := &reconciler{gwClaim: f}
 
 	done := make(chan struct{})
@@ -425,13 +421,13 @@ func TestEnsureGuestPortDatapath_NeverBoundNoRecompute(t *testing.T) {
 		t.Fatal("ensureGuestPortDatapath did not return within deadline; blocking reconcile")
 	}
 
-	// Recompute only after a real bind: a port that never binds cannot be realised,
-	// so nudging would just churn flows (the #351 EIP-darkening regression).
-	if f.nudges != 0 {
-		t.Errorf("nudges = %d, want 0 (no recompute without a bind)", f.nudges)
+	// Recompute on every miss, not once: the guest tap may appear only after the
+	// first nudge, so a single nudge would never bind it.
+	if f.nudges < 2 {
+		t.Errorf("nudges = %d, want >=2 (recompute on each miss, not once)", f.nudges)
 	}
 	if f.guestChecks < 2 {
-		t.Errorf("guestChecks = %d, want >=2 (polled to the deadline)", f.guestChecks)
+		t.Errorf("guestChecks = %d, want >=2 (polled past the first nudge)", f.guestChecks)
 	}
 }
 
@@ -453,7 +449,7 @@ func TestEnsureGuestPortDatapath_ContextCancelStops(t *testing.T) {
 	guestPortDatapathInterval = 50 * time.Millisecond
 	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
 
-	f := &fakeClaimVerifier{guestBoundAfter: -1}
+	f := &fakeClaimVerifier{guestUpAfter: -1}
 	r := &reconciler{gwClaim: f}
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -19,6 +19,7 @@ type fakeClaimVerifier struct {
 	reachErr       error
 	checks         int
 	nudges         int
+	repairs        int
 	reachChecks    int
 	lastPort       string // most recent port name passed to GatewayPortClaimed
 	lastGwIP       string // most recent IP passed to GatewayReachable
@@ -37,6 +38,14 @@ func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (
 }
 
 func (f *fakeClaimVerifier) NudgeRecompute(_ context.Context) error {
+	f.nudges++
+	return f.nudgeErr
+}
+
+// RepairDatapath re-asserts the uplink then recomputes. Shares the nudge counter so
+// the reachableAfter scripting (nudges-to-recover) covers both gates uniformly.
+func (f *fakeClaimVerifier) RepairDatapath(_ context.Context) error {
+	f.repairs++
 	f.nudges++
 	return f.nudgeErr
 }
@@ -206,8 +215,11 @@ func TestEnsureGatewayDatapath_NudgeThenRecover(t *testing.T) {
 
 	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
 
+	if f.repairs != 1 {
+		t.Errorf("repairs = %d, want exactly 1 (repair once, then recover)", f.repairs)
+	}
 	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (nudge once, then recover)", f.nudges)
+		t.Errorf("nudges = %d, want exactly 1 (repair includes a recompute)", f.nudges)
 	}
 }
 
@@ -227,11 +239,11 @@ func TestEnsureGatewayDatapath_NeverRecoversNudgesOnceThenGivesUp(t *testing.T) 
 		t.Fatal("ensureGatewayDatapath did not return within deadline; blocking reconcile")
 	}
 
-	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (nudge once, do not spam)", f.nudges)
+	if f.repairs != 1 {
+		t.Errorf("repairs = %d, want exactly 1 (repair once, do not spam)", f.repairs)
 	}
 	if f.reachChecks < 2 {
-		t.Errorf("reachChecks = %d, want >=2 (polled past the first nudge)", f.reachChecks)
+		t.Errorf("reachChecks = %d, want >=2 (polled past the first repair)", f.reachChecks)
 	}
 }
 

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -12,22 +12,22 @@ import (
 // once nudgeCount reaches it (or immediately for 0), claimed reports true.
 // reachableAfter mirrors claimedAfter for the datapath probe.
 type fakeClaimVerifier struct {
-	claimedAfter   int // nudges required before the port reports claimed; <0 never
-	reachableAfter int // nudges required before the datapath reports reachable; <0 never
-	guestUpAfter   int // nudges required before the guest port reports up; <0 never
-	checkErr       error
-	nudgeErr       error
-	reachErr       error
-	guestErr       error
-	checks         int
-	nudges         int
-	repairs        int
-	reachChecks    int
-	guestChecks    int
-	lastPort       string // most recent port name passed to GatewayPortClaimed
-	lastGwIP       string // most recent IP passed to GatewayReachable
-	lastEIP        string // most recent IP passed to EIPReachable
-	lastLSP        string // most recent lsp passed to GuestPortUp
+	claimedAfter    int // nudges required before the port reports claimed; <0 never
+	reachableAfter  int // nudges required before the datapath reports reachable; <0 never
+	guestBoundAfter int // probe calls before the guest port reports bound; <0 never
+	checkErr        error
+	nudgeErr        error
+	reachErr        error
+	guestErr        error
+	checks          int
+	nudges          int
+	repairs         int
+	reachChecks     int
+	guestChecks     int
+	lastPort        string // most recent port name passed to GatewayPortClaimed
+	lastGwIP        string // most recent IP passed to GatewayReachable
+	lastEIP         string // most recent IP passed to EIPReachable
+	lastLSP         string // most recent lsp passed to GuestPortBound
 }
 
 func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (bool, error) {
@@ -82,19 +82,20 @@ func (f *fakeClaimVerifier) EIPReachable(_ context.Context, eip string) (bool, e
 	return f.nudges >= f.reachableAfter, nil
 }
 
-// GuestPortUp reports up once nudges reach guestUpAfter (immediately for 0; never
-// for <0), sharing the nudge counter so the recompute-each-miss loop is scripted
-// the same way as the other gates. lastLSP records the probed port.
-func (f *fakeClaimVerifier) GuestPortUp(_ context.Context, lspName string) (bool, error) {
+// GuestPortBound reports bound once the probe has been called more than
+// guestBoundAfter times (immediately for 0; never for <0). It keys off the probe
+// count, not nudges: the post-reboot logic polls the bind, then recomputes once.
+// lastLSP records the probed port.
+func (f *fakeClaimVerifier) GuestPortBound(_ context.Context, lspName string) (bool, error) {
 	f.guestChecks++
 	f.lastLSP = lspName
 	if f.guestErr != nil {
 		return false, f.guestErr
 	}
-	if f.guestUpAfter < 0 {
+	if f.guestBoundAfter < 0 {
 		return false, nil
 	}
-	return f.nudges >= f.guestUpAfter, nil
+	return f.guestChecks > f.guestBoundAfter, nil
 }
 
 func withFastGuestPortBounds(t *testing.T) {
@@ -374,40 +375,43 @@ func TestEnsureGuestPortDatapath_EmptyLSPIsNoop(t *testing.T) {
 	}
 }
 
-func TestEnsureGuestPortDatapath_UpNoNudge(t *testing.T) {
+func TestEnsureGuestPortDatapath_BoundRecomputesOnce(t *testing.T) {
 	withFastGuestPortBounds(t)
-	f := &fakeClaimVerifier{guestUpAfter: 0}
+	f := &fakeClaimVerifier{guestBoundAfter: 0} // bound on first probe
 	r := &reconciler{gwClaim: f}
 
 	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
 
-	if f.nudges != 0 {
-		t.Errorf("up guest port nudged %d times, want 0", f.nudges)
+	if f.nudges != 1 {
+		t.Errorf("bound guest port nudged %d times, want exactly 1 (recompute once after bind)", f.nudges)
 	}
 	if f.guestChecks != 1 {
-		t.Errorf("guestChecks = %d, want 1 (single up probe)", f.guestChecks)
+		t.Errorf("guestChecks = %d, want 1 (single bind probe)", f.guestChecks)
 	}
 	if f.lastLSP != "port-eni-1" {
 		t.Errorf("lastLSP = %q, want port-eni-1", f.lastLSP)
 	}
 }
 
-func TestEnsureGuestPortDatapath_NudgeThenConverge(t *testing.T) {
+func TestEnsureGuestPortDatapath_PollsThenBoundRecomputesOnce(t *testing.T) {
 	withFastGuestPortBounds(t)
-	// Down until one recompute nudge, then up.
-	f := &fakeClaimVerifier{guestUpAfter: 1}
+	// Unbound for one probe, then bound. The recompute fires only after the bind.
+	f := &fakeClaimVerifier{guestBoundAfter: 1}
 	r := &reconciler{gwClaim: f}
 
 	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
 
 	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (nudge once, then converge)", f.nudges)
+		t.Errorf("nudges = %d, want exactly 1 (recompute once, after the port binds)", f.nudges)
+	}
+	if f.guestChecks != 2 {
+		t.Errorf("guestChecks = %d, want 2 (one miss, then bound)", f.guestChecks)
 	}
 }
 
-func TestEnsureGuestPortDatapath_NeverConvergesRecomputesEachMiss(t *testing.T) {
+func TestEnsureGuestPortDatapath_NeverBoundNoRecompute(t *testing.T) {
 	withFastGuestPortBounds(t)
-	f := &fakeClaimVerifier{guestUpAfter: -1} // never up
+	f := &fakeClaimVerifier{guestBoundAfter: -1} // never binds
 	r := &reconciler{gwClaim: f}
 
 	done := make(chan struct{})
@@ -421,13 +425,13 @@ func TestEnsureGuestPortDatapath_NeverConvergesRecomputesEachMiss(t *testing.T) 
 		t.Fatal("ensureGuestPortDatapath did not return within deadline; blocking reconcile")
 	}
 
-	// Recompute on every miss, not once: the guest tap may appear only after the
-	// first nudge, so a single nudge would never bind it.
-	if f.nudges < 2 {
-		t.Errorf("nudges = %d, want >=2 (recompute on each miss, not once)", f.nudges)
+	// Recompute only after a real bind: a port that never binds cannot be realised,
+	// so nudging would just churn flows (the #351 EIP-darkening regression).
+	if f.nudges != 0 {
+		t.Errorf("nudges = %d, want 0 (no recompute without a bind)", f.nudges)
 	}
 	if f.guestChecks < 2 {
-		t.Errorf("guestChecks = %d, want >=2 (polled past the first nudge)", f.guestChecks)
+		t.Errorf("guestChecks = %d, want >=2 (polled to the deadline)", f.guestChecks)
 	}
 }
 
@@ -449,7 +453,7 @@ func TestEnsureGuestPortDatapath_ContextCancelStops(t *testing.T) {
 	guestPortDatapathInterval = 50 * time.Millisecond
 	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
 
-	f := &fakeClaimVerifier{guestUpAfter: -1}
+	f := &fakeClaimVerifier{guestBoundAfter: -1}
 	r := &reconciler{gwClaim: f}
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -10,13 +10,18 @@ import (
 // fakeClaimVerifier scripts a sequence of GatewayPortClaimed results and counts
 // NudgeRecompute calls. claimedAfter controls when the port flips to claimed:
 // once nudgeCount reaches it (or immediately for 0), claimed reports true.
+// reachableAfter mirrors claimedAfter for the datapath probe.
 type fakeClaimVerifier struct {
-	claimedAfter int // nudges required before the port reports claimed; <0 never
-	checkErr     error
-	nudgeErr     error
-	checks       int
-	nudges       int
-	lastPort     string // most recent port name passed to GatewayPortClaimed
+	claimedAfter   int // nudges required before the port reports claimed; <0 never
+	reachableAfter int // nudges required before the datapath reports reachable; <0 never
+	checkErr       error
+	nudgeErr       error
+	reachErr       error
+	checks         int
+	nudges         int
+	reachChecks    int
+	lastPort       string // most recent port name passed to GatewayPortClaimed
+	lastGwIP       string // most recent IP passed to GatewayReachable
 }
 
 func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (bool, error) {
@@ -34,6 +39,26 @@ func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (
 func (f *fakeClaimVerifier) NudgeRecompute(_ context.Context) error {
 	f.nudges++
 	return f.nudgeErr
+}
+
+func (f *fakeClaimVerifier) GatewayReachable(_ context.Context, gwIP string) (bool, error) {
+	f.reachChecks++
+	f.lastGwIP = gwIP
+	if f.reachErr != nil {
+		return false, f.reachErr
+	}
+	if f.reachableAfter < 0 {
+		return false, nil
+	}
+	return f.nudges >= f.reachableAfter, nil
+}
+
+func withFastDatapathBounds(t *testing.T) {
+	t.Helper()
+	to, iv := gatewayDatapathTimeout, gatewayDatapathInterval
+	gatewayDatapathTimeout = 200 * time.Millisecond
+	gatewayDatapathInterval = 1 * time.Millisecond
+	t.Cleanup(func() { gatewayDatapathTimeout, gatewayDatapathInterval = to, iv })
 }
 
 func withFastClaimBounds(t *testing.T) {
@@ -135,5 +160,113 @@ func TestEnsureGatewayClaimed_ContextCancelStops(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("ensureGatewayClaimed ignored context cancellation")
+	}
+}
+
+func TestEnsureGatewayDatapath_NoVerifierIsNoop(t *testing.T) {
+	r := &reconciler{} // gwClaim nil
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+	// Reaching here without panic is the assertion.
+}
+
+func TestEnsureGatewayDatapath_EmptyIPIsNoop(t *testing.T) {
+	f := &fakeClaimVerifier{}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "")
+
+	if f.reachChecks != 0 {
+		t.Errorf("reachChecks = %d, want 0 (empty gw IP must skip the probe)", f.reachChecks)
+	}
+}
+
+func TestEnsureGatewayDatapath_ReachableNoNudge(t *testing.T) {
+	withFastDatapathBounds(t)
+	f := &fakeClaimVerifier{reachableAfter: 0}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+
+	if f.nudges != 0 {
+		t.Errorf("reachable datapath nudged %d times, want 0", f.nudges)
+	}
+	if f.reachChecks != 1 {
+		t.Errorf("reachChecks = %d, want 1 (single reachable probe)", f.reachChecks)
+	}
+	if f.lastGwIP != "192.168.1.241" {
+		t.Errorf("lastGwIP = %q, want 192.168.1.241", f.lastGwIP)
+	}
+}
+
+func TestEnsureGatewayDatapath_NudgeThenRecover(t *testing.T) {
+	withFastDatapathBounds(t)
+	// Unreachable until one recompute nudge, then reachable.
+	f := &fakeClaimVerifier{reachableAfter: 1}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, then recover)", f.nudges)
+	}
+}
+
+func TestEnsureGatewayDatapath_NeverRecoversNudgesOnceThenGivesUp(t *testing.T) {
+	withFastDatapathBounds(t)
+	f := &fakeClaimVerifier{reachableAfter: -1} // never reachable
+	r := &reconciler{gwClaim: f}
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGatewayDatapath did not return within deadline; blocking reconcile")
+	}
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, do not spam)", f.nudges)
+	}
+	if f.reachChecks < 2 {
+		t.Errorf("reachChecks = %d, want >=2 (polled past the first nudge)", f.reachChecks)
+	}
+}
+
+func TestEnsureGatewayDatapath_ProbeErrorBailsOut(t *testing.T) {
+	withFastDatapathBounds(t)
+	f := &fakeClaimVerifier{reachErr: errors.New("ping unavailable")}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+
+	if f.nudges != 0 {
+		t.Errorf("nudges = %d, want 0 (bail out on probe error, do not nudge blindly)", f.nudges)
+	}
+}
+
+func TestEnsureGatewayDatapath_ContextCancelStops(t *testing.T) {
+	to, iv := gatewayDatapathTimeout, gatewayDatapathInterval
+	gatewayDatapathTimeout = 10 * time.Second
+	gatewayDatapathInterval = 50 * time.Millisecond
+	t.Cleanup(func() { gatewayDatapathTimeout, gatewayDatapathInterval = to, iv })
+
+	f := &fakeClaimVerifier{reachableAfter: -1}
+	r := &reconciler{gwClaim: f}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGatewayDatapath(ctx, "vpc-a", "192.168.1.241")
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGatewayDatapath ignored context cancellation")
 	}
 }

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -23,6 +23,7 @@ type fakeClaimVerifier struct {
 	reachChecks    int
 	lastPort       string // most recent port name passed to GatewayPortClaimed
 	lastGwIP       string // most recent IP passed to GatewayReachable
+	lastEIP        string // most recent IP passed to EIPReachable
 }
 
 func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (bool, error) {
@@ -53,6 +54,21 @@ func (f *fakeClaimVerifier) RepairDatapath(_ context.Context) error {
 func (f *fakeClaimVerifier) GatewayReachable(_ context.Context, gwIP string) (bool, error) {
 	f.reachChecks++
 	f.lastGwIP = gwIP
+	if f.reachErr != nil {
+		return false, f.reachErr
+	}
+	if f.reachableAfter < 0 {
+		return false, nil
+	}
+	return f.nudges >= f.reachableAfter, nil
+}
+
+// EIPReachable shares the reachableAfter/reachErr scripting with GatewayReachable
+// (the recover/give-up/error paths are identical regardless of probe target);
+// lastEIP records the target so tests can assert the EIP path was taken.
+func (f *fakeClaimVerifier) EIPReachable(_ context.Context, eip string) (bool, error) {
+	f.reachChecks++
+	f.lastEIP = eip
 	if f.reachErr != nil {
 		return false, f.reachErr
 	}
@@ -174,7 +190,7 @@ func TestEnsureGatewayClaimed_ContextCancelStops(t *testing.T) {
 
 func TestEnsureGatewayDatapath_NoVerifierIsNoop(t *testing.T) {
 	r := &reconciler{} // gwClaim nil
-	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241", "")
 	// Reaching here without panic is the assertion.
 }
 
@@ -182,10 +198,10 @@ func TestEnsureGatewayDatapath_EmptyIPIsNoop(t *testing.T) {
 	f := &fakeClaimVerifier{}
 	r := &reconciler{gwClaim: f}
 
-	r.ensureGatewayDatapath(context.Background(), "vpc-a", "")
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "", "")
 
 	if f.reachChecks != 0 {
-		t.Errorf("reachChecks = %d, want 0 (empty gw IP must skip the probe)", f.reachChecks)
+		t.Errorf("reachChecks = %d, want 0 (no probe target must skip the probe)", f.reachChecks)
 	}
 }
 
@@ -194,7 +210,7 @@ func TestEnsureGatewayDatapath_ReachableNoNudge(t *testing.T) {
 	f := &fakeClaimVerifier{reachableAfter: 0}
 	r := &reconciler{gwClaim: f}
 
-	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241", "")
 
 	if f.nudges != 0 {
 		t.Errorf("reachable datapath nudged %d times, want 0", f.nudges)
@@ -213,7 +229,7 @@ func TestEnsureGatewayDatapath_NudgeThenRecover(t *testing.T) {
 	f := &fakeClaimVerifier{reachableAfter: 1}
 	r := &reconciler{gwClaim: f}
 
-	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241", "")
 
 	if f.repairs != 1 {
 		t.Errorf("repairs = %d, want exactly 1 (repair once, then recover)", f.repairs)
@@ -230,7 +246,7 @@ func TestEnsureGatewayDatapath_NeverRecoversNudgesOnceThenGivesUp(t *testing.T) 
 
 	done := make(chan struct{})
 	go func() {
-		r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+		r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241", "")
 		close(done)
 	}()
 	select {
@@ -252,7 +268,7 @@ func TestEnsureGatewayDatapath_ProbeErrorBailsOut(t *testing.T) {
 	f := &fakeClaimVerifier{reachErr: errors.New("ping unavailable")}
 	r := &reconciler{gwClaim: f}
 
-	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241")
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241", "")
 
 	if f.nudges != 0 {
 		t.Errorf("nudges = %d, want 0 (bail out on probe error, do not nudge blindly)", f.nudges)
@@ -271,7 +287,7 @@ func TestEnsureGatewayDatapath_ContextCancelStops(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		r.ensureGatewayDatapath(ctx, "vpc-a", "192.168.1.241")
+		r.ensureGatewayDatapath(ctx, "vpc-a", "192.168.1.241", "")
 		close(done)
 	}()
 	time.Sleep(20 * time.Millisecond)
@@ -280,5 +296,36 @@ func TestEnsureGatewayDatapath_ContextCancelStops(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("ensureGatewayDatapath ignored context cancellation")
+	}
+}
+
+func TestEnsureGatewayDatapath_PrefersEIPProbe(t *testing.T) {
+	withFastDatapathBounds(t)
+	f := &fakeClaimVerifier{reachableAfter: 0}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241", "203.0.113.5")
+
+	if f.lastEIP != "203.0.113.5" {
+		t.Errorf("lastEIP = %q, want 203.0.113.5 (EIP must be the probe target when present)", f.lastEIP)
+	}
+	if f.lastGwIP != "" {
+		t.Errorf("lastGwIP = %q, want empty (LRP probe must not run when an EIP is present)", f.lastGwIP)
+	}
+}
+
+func TestEnsureGatewayDatapath_EIPUnreachableRepairs(t *testing.T) {
+	withFastDatapathBounds(t)
+	// EIP unreachable until one repair-recompute, then reachable.
+	f := &fakeClaimVerifier{reachableAfter: 1}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGatewayDatapath(context.Background(), "vpc-a", "192.168.1.241", "203.0.113.5")
+
+	if f.repairs != 1 {
+		t.Errorf("repairs = %d, want exactly 1 (a stranded EIP datapath must trigger repair)", f.repairs)
+	}
+	if f.lastEIP != "203.0.113.5" {
+		t.Errorf("lastEIP = %q, want 203.0.113.5", f.lastEIP)
 	}
 }

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -14,16 +14,20 @@ import (
 type fakeClaimVerifier struct {
 	claimedAfter   int // nudges required before the port reports claimed; <0 never
 	reachableAfter int // nudges required before the datapath reports reachable; <0 never
+	guestUpAfter   int // nudges required before the guest port reports up; <0 never
 	checkErr       error
 	nudgeErr       error
 	reachErr       error
+	guestErr       error
 	checks         int
 	nudges         int
 	repairs        int
 	reachChecks    int
+	guestChecks    int
 	lastPort       string // most recent port name passed to GatewayPortClaimed
 	lastGwIP       string // most recent IP passed to GatewayReachable
 	lastEIP        string // most recent IP passed to EIPReachable
+	lastLSP        string // most recent lsp passed to GuestPortUp
 }
 
 func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (bool, error) {
@@ -76,6 +80,29 @@ func (f *fakeClaimVerifier) EIPReachable(_ context.Context, eip string) (bool, e
 		return false, nil
 	}
 	return f.nudges >= f.reachableAfter, nil
+}
+
+// GuestPortUp reports up once nudges reach guestUpAfter (immediately for 0; never
+// for <0), sharing the nudge counter so the recompute-each-miss loop is scripted
+// the same way as the other gates. lastLSP records the probed port.
+func (f *fakeClaimVerifier) GuestPortUp(_ context.Context, lspName string) (bool, error) {
+	f.guestChecks++
+	f.lastLSP = lspName
+	if f.guestErr != nil {
+		return false, f.guestErr
+	}
+	if f.guestUpAfter < 0 {
+		return false, nil
+	}
+	return f.nudges >= f.guestUpAfter, nil
+}
+
+func withFastGuestPortBounds(t *testing.T) {
+	t.Helper()
+	to, iv := guestPortDatapathTimeout, guestPortDatapathInterval
+	guestPortDatapathTimeout = 200 * time.Millisecond
+	guestPortDatapathInterval = 1 * time.Millisecond
+	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
 }
 
 func withFastDatapathBounds(t *testing.T) {
@@ -327,5 +354,115 @@ func TestEnsureGatewayDatapath_EIPUnreachableRepairs(t *testing.T) {
 	}
 	if f.lastEIP != "203.0.113.5" {
 		t.Errorf("lastEIP = %q, want 203.0.113.5", f.lastEIP)
+	}
+}
+
+func TestEnsureGuestPortDatapath_NoVerifierIsNoop(t *testing.T) {
+	r := &reconciler{} // gwClaim nil
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+	// Reaching here without panic is the assertion.
+}
+
+func TestEnsureGuestPortDatapath_EmptyLSPIsNoop(t *testing.T) {
+	f := &fakeClaimVerifier{}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "")
+
+	if f.guestChecks != 0 {
+		t.Errorf("guestChecks = %d, want 0 (empty lsp must skip the probe)", f.guestChecks)
+	}
+}
+
+func TestEnsureGuestPortDatapath_UpNoNudge(t *testing.T) {
+	withFastGuestPortBounds(t)
+	f := &fakeClaimVerifier{guestUpAfter: 0}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+
+	if f.nudges != 0 {
+		t.Errorf("up guest port nudged %d times, want 0", f.nudges)
+	}
+	if f.guestChecks != 1 {
+		t.Errorf("guestChecks = %d, want 1 (single up probe)", f.guestChecks)
+	}
+	if f.lastLSP != "port-eni-1" {
+		t.Errorf("lastLSP = %q, want port-eni-1", f.lastLSP)
+	}
+}
+
+func TestEnsureGuestPortDatapath_NudgeThenConverge(t *testing.T) {
+	withFastGuestPortBounds(t)
+	// Down until one recompute nudge, then up.
+	f := &fakeClaimVerifier{guestUpAfter: 1}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, then converge)", f.nudges)
+	}
+}
+
+func TestEnsureGuestPortDatapath_NeverConvergesRecomputesEachMiss(t *testing.T) {
+	withFastGuestPortBounds(t)
+	f := &fakeClaimVerifier{guestUpAfter: -1} // never up
+	r := &reconciler{gwClaim: f}
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGuestPortDatapath did not return within deadline; blocking reconcile")
+	}
+
+	// Recompute on every miss, not once: the guest tap may appear only after the
+	// first nudge, so a single nudge would never bind it.
+	if f.nudges < 2 {
+		t.Errorf("nudges = %d, want >=2 (recompute on each miss, not once)", f.nudges)
+	}
+	if f.guestChecks < 2 {
+		t.Errorf("guestChecks = %d, want >=2 (polled past the first nudge)", f.guestChecks)
+	}
+}
+
+func TestEnsureGuestPortDatapath_ProbeErrorBailsOut(t *testing.T) {
+	withFastGuestPortBounds(t)
+	f := &fakeClaimVerifier{guestErr: errors.New("ovn-sbctl down")}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+
+	if f.nudges != 0 {
+		t.Errorf("nudges = %d, want 0 (bail out on probe error, do not nudge blindly)", f.nudges)
+	}
+}
+
+func TestEnsureGuestPortDatapath_ContextCancelStops(t *testing.T) {
+	to, iv := guestPortDatapathTimeout, guestPortDatapathInterval
+	guestPortDatapathTimeout = 10 * time.Second
+	guestPortDatapathInterval = 50 * time.Millisecond
+	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
+
+	f := &fakeClaimVerifier{guestUpAfter: -1}
+	r := &reconciler{gwClaim: f}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGuestPortDatapath(ctx, "vpc-a", "port-eni-1")
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGuestPortDatapath ignored context cancellation")
 	}
 }

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -14,19 +14,15 @@ import (
 type fakeClaimVerifier struct {
 	claimedAfter   int // nudges required before the port reports claimed; <0 never
 	reachableAfter int // nudges required before the datapath reports reachable; <0 never
-	guestUpAfter   int // nudges required before the guest port reports up; <0 never
 	checkErr       error
 	nudgeErr       error
 	reachErr       error
-	guestErr       error
 	checks         int
 	nudges         int
 	repairs        int
 	reachChecks    int
-	guestChecks    int
 	lastPort       string // most recent port name passed to GatewayPortClaimed
 	lastGwIP       string // most recent IP passed to GatewayReachable
-	lastLSP        string // most recent lsp passed to GuestPortUp
 }
 
 func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (bool, error) {
@@ -66,18 +62,6 @@ func (f *fakeClaimVerifier) GatewayReachable(_ context.Context, gwIP string) (bo
 	return f.nudges >= f.reachableAfter, nil
 }
 
-func (f *fakeClaimVerifier) GuestPortUp(_ context.Context, lspName string) (bool, error) {
-	f.guestChecks++
-	f.lastLSP = lspName
-	if f.guestErr != nil {
-		return false, f.guestErr
-	}
-	if f.guestUpAfter < 0 {
-		return false, nil
-	}
-	return f.nudges >= f.guestUpAfter, nil
-}
-
 func withFastDatapathBounds(t *testing.T) {
 	t.Helper()
 	to, iv := gatewayDatapathTimeout, gatewayDatapathInterval
@@ -92,14 +76,6 @@ func withFastClaimBounds(t *testing.T) {
 	gatewayClaimTimeout = 200 * time.Millisecond
 	gatewayClaimInterval = 1 * time.Millisecond
 	t.Cleanup(func() { gatewayClaimTimeout, gatewayClaimInterval = to, iv })
-}
-
-func withFastGuestPortBounds(t *testing.T) {
-	t.Helper()
-	to, iv := guestPortDatapathTimeout, guestPortDatapathInterval
-	guestPortDatapathTimeout = 200 * time.Millisecond
-	guestPortDatapathInterval = 1 * time.Millisecond
-	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
 }
 
 func TestEnsureGatewayClaimed_NoVerifierIsNoop(t *testing.T) {
@@ -304,113 +280,5 @@ func TestEnsureGatewayDatapath_ContextCancelStops(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("ensureGatewayDatapath ignored context cancellation")
-	}
-}
-
-func TestEnsureGuestPortDatapath_NoVerifierIsNoop(t *testing.T) {
-	r := &reconciler{} // gwClaim nil
-	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
-	// Reaching here without panic is the assertion.
-}
-
-func TestEnsureGuestPortDatapath_EmptyLSPIsNoop(t *testing.T) {
-	f := &fakeClaimVerifier{}
-	r := &reconciler{gwClaim: f}
-
-	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "")
-
-	if f.guestChecks != 0 {
-		t.Errorf("guestChecks = %d, want 0 (empty lsp must skip the probe)", f.guestChecks)
-	}
-}
-
-func TestEnsureGuestPortDatapath_UpNoNudge(t *testing.T) {
-	withFastGuestPortBounds(t)
-	f := &fakeClaimVerifier{guestUpAfter: 0}
-	r := &reconciler{gwClaim: f}
-
-	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
-
-	if f.nudges != 0 {
-		t.Errorf("up guest port nudged %d times, want 0", f.nudges)
-	}
-	if f.guestChecks != 1 {
-		t.Errorf("guestChecks = %d, want 1 (single up probe)", f.guestChecks)
-	}
-	if f.lastLSP != "port-eni-1" {
-		t.Errorf("lastLSP = %q, want port-eni-1", f.lastLSP)
-	}
-}
-
-func TestEnsureGuestPortDatapath_NudgeThenConverge(t *testing.T) {
-	withFastGuestPortBounds(t)
-	// Down until one recompute nudge, then up.
-	f := &fakeClaimVerifier{guestUpAfter: 1}
-	r := &reconciler{gwClaim: f}
-
-	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
-
-	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (nudge once, then converge)", f.nudges)
-	}
-}
-
-func TestEnsureGuestPortDatapath_NeverConvergesNudgesOnceThenGivesUp(t *testing.T) {
-	withFastGuestPortBounds(t)
-	f := &fakeClaimVerifier{guestUpAfter: -1} // never up
-	r := &reconciler{gwClaim: f}
-
-	done := make(chan struct{})
-	go func() {
-		r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("ensureGuestPortDatapath did not return within deadline; blocking reconcile")
-	}
-
-	if f.nudges != 1 {
-		t.Errorf("nudges = %d, want exactly 1 (nudge once, do not spam)", f.nudges)
-	}
-	if f.guestChecks < 2 {
-		t.Errorf("guestChecks = %d, want >=2 (polled past the first nudge)", f.guestChecks)
-	}
-}
-
-func TestEnsureGuestPortDatapath_ProbeErrorBailsOut(t *testing.T) {
-	withFastGuestPortBounds(t)
-	f := &fakeClaimVerifier{guestErr: errors.New("ovn-sbctl down")}
-	r := &reconciler{gwClaim: f}
-
-	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
-
-	if f.nudges != 0 {
-		t.Errorf("nudges = %d, want 0 (bail out on probe error, do not nudge blindly)", f.nudges)
-	}
-}
-
-func TestEnsureGuestPortDatapath_ContextCancelStops(t *testing.T) {
-	to, iv := guestPortDatapathTimeout, guestPortDatapathInterval
-	guestPortDatapathTimeout = 10 * time.Second
-	guestPortDatapathInterval = 50 * time.Millisecond
-	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
-
-	f := &fakeClaimVerifier{guestUpAfter: -1}
-	r := &reconciler{gwClaim: f}
-	ctx, cancel := context.WithCancel(context.Background())
-
-	done := make(chan struct{})
-	go func() {
-		r.ensureGuestPortDatapath(ctx, "vpc-a", "port-eni-1")
-		close(done)
-	}()
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("ensureGuestPortDatapath ignored context cancellation")
 	}
 }

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -14,15 +14,19 @@ import (
 type fakeClaimVerifier struct {
 	claimedAfter   int // nudges required before the port reports claimed; <0 never
 	reachableAfter int // nudges required before the datapath reports reachable; <0 never
+	guestUpAfter   int // nudges required before the guest port reports up; <0 never
 	checkErr       error
 	nudgeErr       error
 	reachErr       error
+	guestErr       error
 	checks         int
 	nudges         int
 	repairs        int
 	reachChecks    int
+	guestChecks    int
 	lastPort       string // most recent port name passed to GatewayPortClaimed
 	lastGwIP       string // most recent IP passed to GatewayReachable
+	lastLSP        string // most recent lsp passed to GuestPortUp
 }
 
 func (f *fakeClaimVerifier) GatewayPortClaimed(_ context.Context, port string) (bool, error) {
@@ -62,6 +66,18 @@ func (f *fakeClaimVerifier) GatewayReachable(_ context.Context, gwIP string) (bo
 	return f.nudges >= f.reachableAfter, nil
 }
 
+func (f *fakeClaimVerifier) GuestPortUp(_ context.Context, lspName string) (bool, error) {
+	f.guestChecks++
+	f.lastLSP = lspName
+	if f.guestErr != nil {
+		return false, f.guestErr
+	}
+	if f.guestUpAfter < 0 {
+		return false, nil
+	}
+	return f.nudges >= f.guestUpAfter, nil
+}
+
 func withFastDatapathBounds(t *testing.T) {
 	t.Helper()
 	to, iv := gatewayDatapathTimeout, gatewayDatapathInterval
@@ -76,6 +92,14 @@ func withFastClaimBounds(t *testing.T) {
 	gatewayClaimTimeout = 200 * time.Millisecond
 	gatewayClaimInterval = 1 * time.Millisecond
 	t.Cleanup(func() { gatewayClaimTimeout, gatewayClaimInterval = to, iv })
+}
+
+func withFastGuestPortBounds(t *testing.T) {
+	t.Helper()
+	to, iv := guestPortDatapathTimeout, guestPortDatapathInterval
+	guestPortDatapathTimeout = 200 * time.Millisecond
+	guestPortDatapathInterval = 1 * time.Millisecond
+	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
 }
 
 func TestEnsureGatewayClaimed_NoVerifierIsNoop(t *testing.T) {
@@ -280,5 +304,113 @@ func TestEnsureGatewayDatapath_ContextCancelStops(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("ensureGatewayDatapath ignored context cancellation")
+	}
+}
+
+func TestEnsureGuestPortDatapath_NoVerifierIsNoop(t *testing.T) {
+	r := &reconciler{} // gwClaim nil
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+	// Reaching here without panic is the assertion.
+}
+
+func TestEnsureGuestPortDatapath_EmptyLSPIsNoop(t *testing.T) {
+	f := &fakeClaimVerifier{}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "")
+
+	if f.guestChecks != 0 {
+		t.Errorf("guestChecks = %d, want 0 (empty lsp must skip the probe)", f.guestChecks)
+	}
+}
+
+func TestEnsureGuestPortDatapath_UpNoNudge(t *testing.T) {
+	withFastGuestPortBounds(t)
+	f := &fakeClaimVerifier{guestUpAfter: 0}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+
+	if f.nudges != 0 {
+		t.Errorf("up guest port nudged %d times, want 0", f.nudges)
+	}
+	if f.guestChecks != 1 {
+		t.Errorf("guestChecks = %d, want 1 (single up probe)", f.guestChecks)
+	}
+	if f.lastLSP != "port-eni-1" {
+		t.Errorf("lastLSP = %q, want port-eni-1", f.lastLSP)
+	}
+}
+
+func TestEnsureGuestPortDatapath_NudgeThenConverge(t *testing.T) {
+	withFastGuestPortBounds(t)
+	// Down until one recompute nudge, then up.
+	f := &fakeClaimVerifier{guestUpAfter: 1}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, then converge)", f.nudges)
+	}
+}
+
+func TestEnsureGuestPortDatapath_NeverConvergesNudgesOnceThenGivesUp(t *testing.T) {
+	withFastGuestPortBounds(t)
+	f := &fakeClaimVerifier{guestUpAfter: -1} // never up
+	r := &reconciler{gwClaim: f}
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGuestPortDatapath did not return within deadline; blocking reconcile")
+	}
+
+	if f.nudges != 1 {
+		t.Errorf("nudges = %d, want exactly 1 (nudge once, do not spam)", f.nudges)
+	}
+	if f.guestChecks < 2 {
+		t.Errorf("guestChecks = %d, want >=2 (polled past the first nudge)", f.guestChecks)
+	}
+}
+
+func TestEnsureGuestPortDatapath_ProbeErrorBailsOut(t *testing.T) {
+	withFastGuestPortBounds(t)
+	f := &fakeClaimVerifier{guestErr: errors.New("ovn-sbctl down")}
+	r := &reconciler{gwClaim: f}
+
+	r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1")
+
+	if f.nudges != 0 {
+		t.Errorf("nudges = %d, want 0 (bail out on probe error, do not nudge blindly)", f.nudges)
+	}
+}
+
+func TestEnsureGuestPortDatapath_ContextCancelStops(t *testing.T) {
+	to, iv := guestPortDatapathTimeout, guestPortDatapathInterval
+	guestPortDatapathTimeout = 10 * time.Second
+	guestPortDatapathInterval = 50 * time.Millisecond
+	t.Cleanup(func() { guestPortDatapathTimeout, guestPortDatapathInterval = to, iv })
+
+	f := &fakeClaimVerifier{guestUpAfter: -1}
+	r := &reconciler{gwClaim: f}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		r.ensureGuestPortDatapath(ctx, "vpc-a", "port-eni-1")
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensureGuestPortDatapath ignored context cancellation")
 	}
 }

--- a/spinifex/network/reconcile/apply_test.go
+++ b/spinifex/network/reconcile/apply_test.go
@@ -387,8 +387,8 @@ func TestReconcile_IGWAttachWhenTopologyMissing(t *testing.T) {
 		t.Fatalf("Reconcile: %v", err)
 	}
 
-	if _, ok := m.Switches[topology.ExternalSwitch("vpc-a")]; !ok {
-		t.Errorf("external switch not created by reconciler AttachIGW path")
+	if _, ok := m.Switches[topology.ExternalSwitchShared()]; !ok {
+		t.Errorf("shared external switch not created by reconciler AttachIGW path")
 	}
 	gwPort := topology.GatewayRouterPort("vpc-a")
 	if _, ok := m.RouterPorts[gwPort]; !ok {

--- a/spinifex/network/reconcile/apply_test.go
+++ b/spinifex/network/reconcile/apply_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/network/external"
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/mock"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
 	"github.com/mulgadc/spinifex/spinifex/network/policy"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 )
@@ -192,6 +193,44 @@ func TestReconcile_ApplyOnlyKeepsOrphanPortGroup(t *testing.T) {
 	}
 	if _, ok := m.PortGroups["sg_orphan"]; ok {
 		t.Errorf("Reconcile failed to prune orphan after ApplyOnly path")
+	}
+}
+
+// ReconcileApplyOnly must not prune orphan ENI LSPs on startup (in-flight ports
+// before subscribers converge); full Reconcile must prune them.
+func TestReconcile_ApplyOnlyKeepsOrphanLSP(t *testing.T) {
+	rec, m := newTestReconciler(t)
+	ctx := context.Background()
+
+	intent := freshIntent(t)
+	if err := rec.Reconcile(ctx, intent); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	orphan := &nbdb.LogicalSwitchPort{
+		Name: topology.Port("eni-orphan"),
+		ExternalIDs: map[string]string{
+			"spinifex:eni_id":    "eni-orphan",
+			"spinifex:subnet_id": "subnet-a",
+			"spinifex:vpc_id":    "vpc-a",
+		},
+	}
+	if err := m.CreateLogicalSwitchPort(ctx, topology.SubnetSwitch("subnet-a"), orphan); err != nil {
+		t.Fatalf("seed orphan LSP: %v", err)
+	}
+
+	if err := rec.ReconcileApplyOnly(ctx, intent); err != nil {
+		t.Fatalf("ReconcileApplyOnly: %v", err)
+	}
+	if _, ok := m.Ports[topology.Port("eni-orphan")]; !ok {
+		t.Errorf("ReconcileApplyOnly pruned orphan LSP; startup race fix regressed")
+	}
+
+	if err := rec.Reconcile(ctx, intent); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, ok := m.Ports[topology.Port("eni-orphan")]; ok {
+		t.Errorf("Reconcile failed to prune orphan LSP after ApplyOnly path")
 	}
 }
 

--- a/spinifex/network/reconcile/apply_test.go
+++ b/spinifex/network/reconcile/apply_test.go
@@ -484,6 +484,36 @@ func TestReconcile_PublicInstanceExemptFromDropGate(t *testing.T) {
 	}
 }
 
+// TestReconcile_PublicInstanceNoExemptionWithoutDropGate bounds the blast radius: a
+// public-IP instance in a subnet with NO drop gate (routed subnet) must not get the
+// /32 reroute — its priority-1000 subnet egress reroute already carries it, and an
+// extra policy would needlessly override routed/NATGW egress.
+func TestReconcile_PublicInstanceNoExemptionWithoutDropGate(t *testing.T) {
+	ctx := context.Background()
+	rec, m := newTestReconciler(t)
+
+	intent := freshIntent(t)
+	intent.IGWs["vpc-a"] = external.IGWSpec{VPCID: "vpc-a", InternetGatewayID: "igw-a"}
+	port := intent.Ports["eni-a"]
+	port.PublicIP = netip.MustParseAddr("192.168.0.50")
+	intent.Ports["eni-a"] = port
+	// No DropGates entry: the subnet is routed, not gated.
+
+	if err := rec.Reconcile(ctx, intent); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	policies, err := m.ListLogicalRouterPolicies(ctx, topology.VPCRouter("vpc-a"))
+	if err != nil {
+		t.Fatalf("ListLogicalRouterPolicies: %v", err)
+	}
+	for _, p := range policies {
+		if p.Priority == policy.SystemInstanceEgressPriority {
+			t.Errorf("unexpected priority-%d reroute on an ungated subnet: %q", p.Priority, p.Match)
+		}
+	}
+}
+
 func TestDiffSets(t *testing.T) {
 	add, remove := diffSets([]string{"a", "b", "c"}, []string{"b", "c", "d"})
 	if !slices.Equal(sortedCopy(add), []string{"a"}) {

--- a/spinifex/network/reconcile/apply_test.go
+++ b/spinifex/network/reconcile/apply_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/netip"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/mulgadc/spinifex/spinifex/network/external"
@@ -428,6 +429,58 @@ func TestReconcile_PortMembershipDriftCorrected(t *testing.T) {
 	storedPort := m.Ports["port-"+port.PortID]
 	if !slices.Contains(pgB.Ports, storedPort.UUID) {
 		t.Errorf("ENI port not joined to new SG port group on drift")
+	}
+}
+
+// TestReconcile_PublicInstanceExemptFromDropGate locks the post-reboot regression: a
+// reconcile that drop-gates an IGW-attached subnet with no 0.0.0.0/0 route must also
+// install the /32 reroute above the gate for every public-IP instance in that subnet,
+// else the gate drops the instance's inbound-connection reply and the ALB/EIP datapath
+// goes dark post-reboot while every control-plane signal stays green. The reboot suite
+// drives this via auto-assigned public IPs (ENI records), not the EIP bucket.
+func TestReconcile_PublicInstanceExemptFromDropGate(t *testing.T) {
+	ctx := context.Background()
+	rec, m := newTestReconciler(t)
+
+	intent := freshIntent(t)
+	intent.IGWs["vpc-a"] = external.IGWSpec{VPCID: "vpc-a", InternetGatewayID: "igw-a"}
+	// Auto-assigned public IP on the ENI (MapPublicIpOnLaunch / ELB), not an EIP.
+	port := intent.Ports["eni-a"]
+	port.PublicIP = netip.MustParseAddr("192.168.0.50")
+	intent.Ports["eni-a"] = port
+	intent.DropGates[subnetEgressKey("subnet-a", netip.MustParsePrefix("0.0.0.0/0"))] = SubnetEgressIntent{
+		VPCID: "vpc-a", SubnetID: "subnet-a", DestCIDR: netip.MustParsePrefix("0.0.0.0/0"),
+	}
+
+	if err := rec.Reconcile(ctx, intent); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	policies, err := m.ListLogicalRouterPolicies(ctx, topology.VPCRouter("vpc-a"))
+	if err != nil {
+		t.Fatalf("ListLogicalRouterPolicies: %v", err)
+	}
+	var reroute, drop *nbdb.LogicalRouterPolicy
+	for i := range policies {
+		switch policies[i].Priority {
+		case policy.SystemInstanceEgressPriority:
+			reroute = &policies[i]
+		case policy.SubnetEgressPriorityDrop:
+			drop = &policies[i]
+		}
+	}
+	if drop == nil {
+		t.Fatalf("drop gate (priority %d) missing: a routeless IGW subnet must be gated", policy.SubnetEgressPriorityDrop)
+	}
+	if reroute == nil {
+		t.Fatalf("public-instance exemption (priority %d) missing: the drop gate kills the reply post-reboot",
+			policy.SystemInstanceEgressPriority)
+	}
+	if !strings.Contains(reroute.Match, "ip4.src == 10.0.1.10/32") {
+		t.Errorf("exemption reroute match = %q, want it to confine to ip4.src == 10.0.1.10/32", reroute.Match)
+	}
+	if reroute.Priority <= drop.Priority {
+		t.Errorf("exemption reroute priority %d must sit above drop gate %d", reroute.Priority, drop.Priority)
 	}
 }
 

--- a/spinifex/network/reconcile/intent.go
+++ b/spinifex/network/reconcile/intent.go
@@ -389,6 +389,9 @@ func loadPorts(js nats.JetStreamContext, localVPCs map[string]struct{}, out map[
 			slog.Warn("reconcile/intent: ENI MAC parse failed", "eni", rec.NetworkInterfaceId, "mac", rec.MacAddress, "err", err)
 			continue
 		}
+		// PublicIP (auto-assigned or ELB) marks the ENI for drop-gate exemption;
+		// zero/invalid when absent. User EIPs come from the EIP bucket instead.
+		publicIP, _ := netip.ParseAddr(rec.PublicIpAddress)
 		out[rec.NetworkInterfaceId] = topology.PortSpec{
 			PortID:    rec.NetworkInterfaceId,
 			SubnetID:  rec.SubnetId,
@@ -396,6 +399,7 @@ func loadPorts(js nats.JetStreamContext, localVPCs map[string]struct{}, out map[
 			PrivateIP: addr,
 			MAC:       mac,
 			SGIDs:     append([]string(nil), rec.SecurityGroupIds...),
+			PublicIP:  publicIP,
 		}
 	}
 	return nil

--- a/spinifex/network/reconcile/invariants_test.go
+++ b/spinifex/network/reconcile/invariants_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/mock"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 )
 
@@ -54,6 +55,50 @@ func TestI1_GuestLSPMustHavePortSecurity(t *testing.T) {
 		want := port.MAC.String() + " " + port.PrivateIP.String()
 		assertPortSecurity(t, m, topology.Port(port.PortID), want)
 	})
+}
+
+// TestRLC5_OrphanLSPPrunedAfterReconcile asserts ADR-0003 §4 "OVN LSP prune":
+// an LSP whose spinifex:eni_id has no matching intent ENI is deleted by one
+// reconcile. Without it, guest LSPs leak across instance terminate and host
+// reinstall — the orphan-LSP capacity-drift root cause.
+func TestRLC5_OrphanLSPPrunedAfterReconcile(t *testing.T) {
+	ctx := context.Background()
+	rec, m := newTestReconciler(t)
+	intent := freshIntent(t)
+
+	// First reconcile builds subnet-a, the sg_a port group, and port-eni-a.
+	if err := rec.Reconcile(ctx, intent); err != nil {
+		t.Fatalf("Reconcile #1: %v", err)
+	}
+
+	// Seed an orphan ENI LSP joined to the SG port group: prune must clear its
+	// memberships then delete it (composed DeletePort cascade).
+	orphan := &nbdb.LogicalSwitchPort{
+		Name: topology.Port("eni-orphan"),
+		ExternalIDs: map[string]string{
+			"spinifex:eni_id":    "eni-orphan",
+			"spinifex:subnet_id": "subnet-a",
+			"spinifex:vpc_id":    "vpc-a",
+		},
+	}
+	if err := m.CreateLogicalSwitchPortInGroups(ctx, topology.SubnetSwitch("subnet-a"), orphan,
+		[]string{topology.SecurityGroupPortGroup("sg-a")}); err != nil {
+		t.Fatalf("seed orphan LSP: %v", err)
+	}
+
+	if err := rec.Reconcile(ctx, intent); err != nil {
+		t.Fatalf("Reconcile #2: %v", err)
+	}
+
+	if _, ok := m.Ports[topology.Port("eni-orphan")]; ok {
+		t.Errorf("orphan LSP %s survived reconcile: ADR-0003 §4 requires an LSP "+
+			"whose spinifex:eni_id has no intent ENI to be pruned; create-only gap "+
+			"leaks OVN ports across terminate/reinstall", topology.Port("eni-orphan"))
+	}
+	if _, ok := m.Ports[topology.Port("eni-a")]; !ok {
+		t.Errorf("desired ENI LSP %s was pruned: prune must never delete an LSP "+
+			"present in intent", topology.Port("eni-a"))
+	}
 }
 
 // assertPortSecurity fails when the LSP's port_security doesn't match its addresses.

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -38,8 +38,15 @@ type GatewayClaimVerifier interface {
 	// gwIP (the gateway LRP IP). A claimed SB binding does not prove flows are
 	// installed: post-reboot ovn-controller can claim the chassisredirect port yet
 	// leave stale gateway/localnet flows, so every control-plane signal is green
-	// while EIPs stay unreachable.
+	// while EIPs stay unreachable. Used as a fallback for VPCs with no EIP; the LRP
+	// IP OVN answers natively, so it cannot detect a stranded EIP NAT pipeline.
 	GatewayReachable(ctx context.Context, gwIP string) (bool, error)
+	// EIPReachable reports whether the NAT external-IP datapath for eip is live, by
+	// forcing a fresh ARP resolution of the EIP. OVN answers ARP for a dnat_and_snat
+	// external IP from the gateway chassis independent of the guest behind it, so a
+	// resolved MAC proves the WAN uplink forwards and the EIP NAT flows are installed
+	// — the signal the gateway LRP IP cannot give. Preferred over GatewayReachable.
+	EIPReachable(ctx context.Context, eip string) (bool, error)
 	// RepairDatapath re-asserts the host external uplink, then forces a recompute.
 	// The post-reboot boot race that strands the datapath has two shapes: the veth
 	// gluing br-ext to the WAN bridge comes up admin-down (a recompute cannot revive

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -40,6 +40,13 @@ type GatewayClaimVerifier interface {
 	// leave stale gateway/localnet flows, so every control-plane signal is green
 	// while EIPs stay unreachable.
 	GatewayReachable(ctx context.Context, gwIP string) (bool, error)
+	// RepairDatapath re-asserts the host external uplink, then forces a recompute.
+	// The post-reboot boot race that strands the datapath has two shapes: the veth
+	// gluing br-ext to the WAN bridge comes up admin-down (a recompute cannot revive
+	// a dead link), or its OVS ofport renumbered and the gateway flows went stale (a
+	// recompute fixes that). Bringing the veth up (a no-op in physical mode where the
+	// device is absent) then recomputing covers both, idempotently.
+	RepairDatapath(ctx context.Context) error
 }
 
 // Config is the construction-time bag for the reconciler. All fields except

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -54,12 +54,12 @@ type GatewayClaimVerifier interface {
 	// recompute fixes that). Bringing the veth up (a no-op in physical mode where the
 	// device is absent) then recomputing covers both, idempotently.
 	RepairDatapath(ctx context.Context) error
-	// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up
-	// (bound to a chassis with flows installed). A guest port that is not up means
-	// the gatewayLRP->guest flow is not installed, so the ingress EIP datapath
-	// blackholes after DNAT and the public IP is dark against an otherwise-running
-	// instance — the post-reboot state until an ovn-controller recompute binds it.
-	GuestPortUp(ctx context.Context, lspName string) (bool, error)
+	// GuestPortBound reports whether the SB Port_Binding for a guest ENI LSP is
+	// claimed by a chassis. Post-reboot the chassis reference is released until
+	// ovn-controller re-claims the replumbed tap, making it the reliable signal —
+	// unlike the up column, which stays stale-true — that the gatewayLRP->guest leg
+	// is realisable and a recompute can install the centralised DNAT flows.
+	GuestPortBound(ctx context.Context, lspName string) (bool, error)
 }
 
 // Config is the construction-time bag for the reconciler. All fields except
@@ -144,15 +144,20 @@ func New(cfg Config) (Reconciler, error) {
 // Reconcile diffs intent vs. actual OVN state and applies in topological order.
 // Per-stage errors are logged; only a scan failure is returned.
 func (r *reconciler) Reconcile(ctx context.Context, intent IntentState) error {
-	return r.reconcile(ctx, intent, true)
+	return r.reconcile(ctx, intent, true, false)
 }
 
 // ReconcileApplyOnly is documented on the Reconciler interface.
 func (r *reconciler) ReconcileApplyOnly(ctx context.Context, intent IntentState) error {
-	return r.reconcile(ctx, intent, false)
+	return r.reconcile(ctx, intent, false, true)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrphans bool) error {
+// reconcile applies intent in topological order. pruneOrphans gates orphan
+// teardown (drift only). startup marks the one-shot post-reboot apply: only then
+// does applyEIPs force the guest-datapath recompute, since the centralised gateway
+// DNAT flows need a kick once the guest taps re-bind after a host reboot — a kick
+// drift must not repeat or it darkens freshly attached EIPs.
+func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrphans, startup bool) error {
 	actual, err := scanActual(ctx, r.ovn)
 	if err != nil {
 		return fmt.Errorf("scan actual OVN state: %w", err)
@@ -177,7 +182,7 @@ func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrp
 	r.applySGs(ctx, intent, actual, pruneOrphans)
 	r.applyPorts(ctx, intent, actual, pruneOrphans)
 	r.applyIGWs(ctx, intent, actual)
-	r.applyEIPs(ctx, intent, actual)
+	r.applyEIPs(ctx, intent, actual, startup)
 	r.applyNATGWs(ctx, intent, actual)
 	r.applyIGWRoutes(ctx, intent, actual)
 	r.applyNATGWRoutes(ctx, intent, actual)

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -149,7 +149,7 @@ func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrp
 	r.applyVPCs(ctx, intent, actual)
 	r.applySubnets(ctx, intent, actual)
 	r.applySGs(ctx, intent, actual, pruneOrphans)
-	r.applyPorts(ctx, intent, actual)
+	r.applyPorts(ctx, intent, actual, pruneOrphans)
 	r.applyIGWs(ctx, intent, actual)
 	r.applyEIPs(ctx, intent, actual)
 	r.applyNATGWs(ctx, intent, actual)

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -47,12 +47,6 @@ type GatewayClaimVerifier interface {
 	// recompute fixes that). Bringing the veth up (a no-op in physical mode where the
 	// device is absent) then recomputing covers both, idempotently.
 	RepairDatapath(ctx context.Context) error
-	// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up
-	// (bound to a chassis with flows installed). A guest port that is not up means
-	// the cross-node geneve flow to its chassis is not installed, so the ingress
-	// EIP datapath blackholes after DNAT and SSH to the public IP times out against
-	// an otherwise-running instance.
-	GuestPortUp(ctx context.Context, lspName string) (bool, error)
 }
 
 // Config is the construction-time bag for the reconciler. All fields except

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -182,6 +182,7 @@ func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrp
 	r.applyIGWRoutes(ctx, intent, actual)
 	r.applyNATGWRoutes(ctx, intent, actual)
 	r.applyDropGates(ctx, intent, actual)
+	r.applyPublicInstanceEgress(ctx, intent, actual)
 
 	slog.Info("reconcile: complete")
 	return nil

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -54,12 +54,12 @@ type GatewayClaimVerifier interface {
 	// recompute fixes that). Bringing the veth up (a no-op in physical mode where the
 	// device is absent) then recomputing covers both, idempotently.
 	RepairDatapath(ctx context.Context) error
-	// GuestPortBound reports whether the SB Port_Binding for a guest ENI LSP is
-	// claimed by a chassis. Post-reboot the chassis reference is released until
-	// ovn-controller re-claims the replumbed tap, making it the reliable signal —
-	// unlike the up column, which stays stale-true — that the gatewayLRP->guest leg
-	// is realisable and a recompute can install the centralised DNAT flows.
-	GuestPortBound(ctx context.Context, lspName string) (bool, error)
+	// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up
+	// (bound to a chassis with flows installed). A guest port that is not up means
+	// the gatewayLRP->guest flow is not installed, so the ingress EIP datapath
+	// blackholes after DNAT and the public IP is dark against an otherwise-running
+	// instance — the post-reboot state until an ovn-controller recompute binds it.
+	GuestPortUp(ctx context.Context, lspName string) (bool, error)
 }
 
 // Config is the construction-time bag for the reconciler. All fields except
@@ -144,20 +144,15 @@ func New(cfg Config) (Reconciler, error) {
 // Reconcile diffs intent vs. actual OVN state and applies in topological order.
 // Per-stage errors are logged; only a scan failure is returned.
 func (r *reconciler) Reconcile(ctx context.Context, intent IntentState) error {
-	return r.reconcile(ctx, intent, true, false)
+	return r.reconcile(ctx, intent, true)
 }
 
 // ReconcileApplyOnly is documented on the Reconciler interface.
 func (r *reconciler) ReconcileApplyOnly(ctx context.Context, intent IntentState) error {
-	return r.reconcile(ctx, intent, false, true)
+	return r.reconcile(ctx, intent, false)
 }
 
-// reconcile applies intent in topological order. pruneOrphans gates orphan
-// teardown (drift only). startup marks the one-shot post-reboot apply: only then
-// does applyEIPs force the guest-datapath recompute, since the centralised gateway
-// DNAT flows need a kick once the guest taps re-bind after a host reboot — a kick
-// drift must not repeat or it darkens freshly attached EIPs.
-func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrphans, startup bool) error {
+func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrphans bool) error {
 	actual, err := scanActual(ctx, r.ovn)
 	if err != nil {
 		return fmt.Errorf("scan actual OVN state: %w", err)
@@ -182,7 +177,7 @@ func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrp
 	r.applySGs(ctx, intent, actual, pruneOrphans)
 	r.applyPorts(ctx, intent, actual, pruneOrphans)
 	r.applyIGWs(ctx, intent, actual)
-	r.applyEIPs(ctx, intent, actual, startup)
+	r.applyEIPs(ctx, intent, actual)
 	r.applyNATGWs(ctx, intent, actual)
 	r.applyIGWRoutes(ctx, intent, actual)
 	r.applyNATGWRoutes(ctx, intent, actual)

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -47,6 +47,12 @@ type GatewayClaimVerifier interface {
 	// recompute fixes that). Bringing the veth up (a no-op in physical mode where the
 	// device is absent) then recomputing covers both, idempotently.
 	RepairDatapath(ctx context.Context) error
+	// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up
+	// (bound to a chassis with flows installed). A guest port that is not up means
+	// the cross-node geneve flow to its chassis is not installed, so the ingress
+	// EIP datapath blackholes after DNAT and SSH to the public IP times out against
+	// an otherwise-running instance.
+	GuestPortUp(ctx context.Context, lspName string) (bool, error)
 }
 
 // Config is the construction-time bag for the reconciler. All fields except

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -54,6 +54,12 @@ type GatewayClaimVerifier interface {
 	// recompute fixes that). Bringing the veth up (a no-op in physical mode where the
 	// device is absent) then recomputing covers both, idempotently.
 	RepairDatapath(ctx context.Context) error
+	// GuestPortUp reports whether the SB Port_Binding for a guest ENI LSP is up
+	// (bound to a chassis with flows installed). A guest port that is not up means
+	// the gatewayLRP->guest flow is not installed, so the ingress EIP datapath
+	// blackholes after DNAT and the public IP is dark against an otherwise-running
+	// instance — the post-reboot state until an ovn-controller recompute binds it.
+	GuestPortUp(ctx context.Context, lspName string) (bool, error)
 }
 
 // Config is the construction-time bag for the reconciler. All fields except

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -34,6 +34,12 @@ type GatewayClaimVerifier interface {
 	GatewayPortClaimed(ctx context.Context, crPortName string) (bool, error)
 	// NudgeRecompute asks the local ovn-controller to re-evaluate logical flows.
 	NudgeRecompute(ctx context.Context) error
+	// GatewayReachable reports whether the external datapath actually forwards to
+	// gwIP (the gateway LRP IP). A claimed SB binding does not prove flows are
+	// installed: post-reboot ovn-controller can claim the chassisredirect port yet
+	// leave stale gateway/localnet flows, so every control-plane signal is green
+	// while EIPs stay unreachable.
+	GatewayReachable(ctx context.Context, gwIP string) (bool, error)
 }
 
 // Config is the construction-time bag for the reconciler. All fields except

--- a/spinifex/network/subscribers/topology.go
+++ b/spinifex/network/subscribers/topology.go
@@ -265,7 +265,7 @@ func (s *Subscriber) handleDeleteNAT(msg *nats.Msg) {
 		respond(msg, err)
 		return
 	}
-	if err := s.eip.DetachEIP(context.Background(), evt.VpcId, evt.ExternalIP, evt.LogicalIP); err != nil {
+	if err := s.eip.DetachEIP(context.Background(), evt.VpcId, evt.ExternalIP, evt.LogicalIP, evt.PortName); err != nil {
 		slog.Error("subscribers: DeleteEIP failed",
 			"vpc_id", evt.VpcId, "logical_ip", evt.LogicalIP, "err", err)
 		respond(msg, err)

--- a/spinifex/network/topology/manager.go
+++ b/spinifex/network/topology/manager.go
@@ -58,4 +58,8 @@ type PortSpec struct {
 	PrivateIP netip.Addr
 	MAC       net.HardwareAddr
 	SGIDs     []string
+	// PublicIP is the ENI's auto-assigned or ELB public address, when present.
+	// It does not affect the L2 LSP; the reconciler reads it to exempt the
+	// instance from its subnet egress drop gate (the dnat_and_snat datapath).
+	PublicIP netip.Addr
 }

--- a/spinifex/network/topology/manager_live.go
+++ b/spinifex/network/topology/manager_live.go
@@ -138,6 +138,14 @@ func (m *liveManager) DeleteVPC(ctx context.Context, vpcID string) error {
 		}
 	}
 
+	// The gateway switch port lives on the shared external switch, which the
+	// vpc_id cascade above intentionally skips; remove it explicitly so deleting
+	// the router below does not leave a dangling router-type LSP behind.
+	gwSwitchPort := GatewaySwitchPort(vpcID)
+	if err := m.ovn.DeleteLogicalSwitchPort(ctx, ExternalSwitchShared(), gwSwitchPort); err != nil {
+		slog.Warn("topology: DeleteVPC remove gateway switch port", "port", gwSwitchPort, "err", err)
+	}
+
 	if err := m.ovn.DeleteLogicalRouter(ctx, routerName); err != nil {
 		return fmt.Errorf("delete logical router %q: %w", routerName, err)
 	}

--- a/spinifex/network/topology/names.go
+++ b/spinifex/network/topology/names.go
@@ -32,13 +32,23 @@ func GatewaySwitchPort(vpcID string) string { return "gw-port-" + vpcID }
 // Only this binding carries the gateway-chassis claim; the LRP binding stays chassis-less.
 func GatewayChassisRedirectPort(vpcID string) string { return "cr-" + GatewayRouterPort(vpcID) }
 
-// ExternalSwitch is the OVN logical switch name for the per-VPC external
-// switch bridging the gateway LRP to the localnet.
+// ExternalSwitch is the OVN logical switch name for the legacy per-VPC external
+// switch. Retained only so the reconciler/teardown can identify and remove
+// pre-shared-switch deployments; new attaches use ExternalSwitchShared.
 func ExternalSwitch(vpcID string) string { return "ext-" + vpcID }
 
-// ExternalLocalnetPort is the OVN LSP name for the localnet bridging the
-// external switch onto the host uplink.
+// ExternalLocalnetPort is the legacy per-VPC localnet LSP name. Retained for
+// legacy cleanup only; see ExternalLocalnetPortShared.
 func ExternalLocalnetPort(vpcID string) string { return "ext-port-" + vpcID }
+
+// ExternalSwitchShared is the single shared external logical switch. Every VPC
+// gateway router port attaches here so only one untagged localnet exists per
+// physical network — multiple per-VPC localnets on one uplink collide on L2.
+func ExternalSwitchShared() string { return "ext-shared" }
+
+// ExternalLocalnetPortShared is the single localnet LSP on the shared external
+// switch bridging it onto the host uplink.
+func ExternalLocalnetPortShared() string { return "ext-port-shared" }
 
 // IMDSPort is the host-owned localport LSP that claims 169.254.169.254 on the
 // subnet switch. Bound on every chassis; serves IMDS over a single L2 hop.

--- a/spinifex/network/topology/names_test.go
+++ b/spinifex/network/topology/names_test.go
@@ -18,6 +18,8 @@ func TestNameHelpers(t *testing.T) {
 		{"GatewayChassisRedirectPort", GatewayChassisRedirectPort("vpc-abc"), "cr-gw-vpc-abc"},
 		{"ExternalSwitch", ExternalSwitch("vpc-abc"), "ext-vpc-abc"},
 		{"ExternalLocalnetPort", ExternalLocalnetPort("vpc-abc"), "ext-port-vpc-abc"},
+		{"ExternalSwitchShared", ExternalSwitchShared(), "ext-shared"},
+		{"ExternalLocalnetPortShared", ExternalLocalnetPortShared(), "ext-port-shared"},
 		{"SecurityGroupPortGroup", SecurityGroupPortGroup("sg-abc-123"), "sg_abc_123"},
 		{"TransitSwitch", TransitSwitch("az-1", "vpc-abc"), "ts-az-1-vpc-abc"},
 		{"TransitRouterPort", TransitRouterPort("az-1", "vpc-abc"), "trp-az-1-vpc-abc"},

--- a/spinifex/tags/tags.go
+++ b/spinifex/tags/tags.go
@@ -18,3 +18,11 @@ const (
 	// LBARNKey stores the parent LB ARN on ELBv2-managed ENIs.
 	LBARNKey = "spinifex:lb-arn"
 )
+
+// IsSystemManaged reports whether a ManagedBy value denotes a Spinifex
+// platform-owned system VM (an empty value is a customer instance). System
+// VMs bind a system.TerminateInstance.{id} subject so a cluster-wide teardown
+// invoked on any node can route a terminate to the owning node.
+func IsSystemManaged(managedBy string) bool {
+	return managedBy == ManagedByELBv2 || managedBy == ManagedByEKS
+}

--- a/spinifex/vm/fakes_test.go
+++ b/spinifex/vm/fakes_test.go
@@ -198,12 +198,20 @@ type recordingInstanceCleaner struct {
 	detachAndDeleteENI  []string
 	removeFromPlacement []string
 	releaseGPU          []string
+
+	// Injectable per-method errors so tests can drive failed-teardown marks.
+	deleteVolumesErr   error
+	releasePublicIPErr error
+	detachENIErr       error
+	removePlacementErr error
+	releaseGPUErr      error
 }
 
-func (c *recordingInstanceCleaner) DeleteVolumes(v *VM) {
+func (c *recordingInstanceCleaner) DeleteVolumes(v *VM) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.deleteVolumes = append(c.deleteVolumes, v.ID)
+	return c.deleteVolumesErr
 }
 
 func (c *recordingInstanceCleaner) CleanupMgmtNetwork(v *VM) {
@@ -212,28 +220,32 @@ func (c *recordingInstanceCleaner) CleanupMgmtNetwork(v *VM) {
 	c.cleanupMgmt = append(c.cleanupMgmt, v.ID)
 }
 
-func (c *recordingInstanceCleaner) ReleasePublicIP(v *VM) {
+func (c *recordingInstanceCleaner) ReleasePublicIP(v *VM) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.releasePublicIP = append(c.releasePublicIP, v.ID)
+	return c.releasePublicIPErr
 }
 
-func (c *recordingInstanceCleaner) DetachAndDeleteENI(v *VM) {
+func (c *recordingInstanceCleaner) DetachAndDeleteENI(v *VM) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.detachAndDeleteENI = append(c.detachAndDeleteENI, v.ID)
+	return c.detachENIErr
 }
 
-func (c *recordingInstanceCleaner) RemoveFromPlacementGroup(v *VM) {
+func (c *recordingInstanceCleaner) RemoveFromPlacementGroup(v *VM) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.removeFromPlacement = append(c.removeFromPlacement, v.ID)
+	return c.removePlacementErr
 }
 
-func (c *recordingInstanceCleaner) ReleaseGPU(v *VM) {
+func (c *recordingInstanceCleaner) ReleaseGPU(v *VM) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.releaseGPU = append(c.releaseGPU, v.ID)
+	return c.releaseGPUErr
 }
 
 func (c *recordingInstanceCleaner) deleteVolumesCount() int {

--- a/spinifex/vm/gc.go
+++ b/spinifex/vm/gc.go
@@ -1,0 +1,110 @@
+package vm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// GCInterval is the cadence of the reality→desired garbage-collection sweep.
+// Var (not const) so integration tests can shrink it.
+var GCInterval = 2 * time.Minute
+
+// ReaperScope separates resource classes a node owns alone (NodeLocal) from
+// cluster-wide classes a single elected leader must sweep (ClusterWide).
+type ReaperScope int
+
+const (
+	ScopeNodeLocal ReaperScope = iota
+	ScopeClusterWide
+)
+
+// Reaper sweeps one managed resource class: enumerate live ("actual") state and
+// reap whatever is absent from desired (KV) state. Sweep MUST be idempotent —
+// reaping an already-absent resource is a no-op — and reports how many
+// resources it reaped so the GC can log a per-class summary.
+type Reaper interface {
+	Class() string
+	Scope() ReaperScope
+	Sweep(ctx context.Context) (reaped int, err error)
+}
+
+// GarbageCollector is the shared reconciler GC backstop (ADR-0003 §3): the
+// inverse of Restore. It runs every registered Reaper on startup and on a
+// periodic tick, gated on KV health so it never reaps against a desired-state
+// it cannot trust. ClusterWide reapers run only on the elected leader;
+// NodeLocal reapers run on every node for the resources it owns.
+type GarbageCollector struct {
+	reapers       []Reaper
+	kvHealthy     func() bool
+	acquireLeader func() (release func(), elected bool)
+}
+
+// NewGarbageCollector builds a GC over the given reapers. kvHealthy gates every
+// sweep: a nil probe is treated as always-healthy (single-node / test).
+func NewGarbageCollector(kvHealthy func() bool, reapers ...Reaper) *GarbageCollector {
+	return &GarbageCollector{reapers: reapers, kvHealthy: kvHealthy}
+}
+
+// WithLeaderElection wires the cluster-wide leader gate. When unset, every
+// ClusterWide reaper is skipped (no elector available); NodeLocal reapers are
+// unaffected.
+func (g *GarbageCollector) WithLeaderElection(acquire func() (release func(), elected bool)) *GarbageCollector {
+	g.acquireLeader = acquire
+	return g
+}
+
+// Start runs an immediate sweep, then one every GCInterval until ctx is done.
+// Call once per GC to avoid duplicating the goroutine.
+func (g *GarbageCollector) Start(ctx context.Context) {
+	go func() {
+		g.SweepOnce(ctx)
+		ticker := time.NewTicker(GCInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				g.SweepOnce(ctx)
+			}
+		}
+	}()
+}
+
+// SweepOnce runs one full pass: every reaper once, KV-health gated. Split out so
+// tests drive it deterministically without waiting for GCInterval.
+func (g *GarbageCollector) SweepOnce(ctx context.Context) {
+	if g.kvHealthy != nil && !g.kvHealthy() {
+		// Hold, do not reap: an unreadable/partial desired-state cannot be
+		// trusted to declare any actual resource an orphan (ADR-0003 §3).
+		slog.Warn("vm/gc: KV unhealthy, holding sweep (will not reap against untrusted desired-state)")
+		return
+	}
+	for _, r := range g.reapers {
+		if r.Scope() == ScopeClusterWide {
+			if g.acquireLeader == nil {
+				continue
+			}
+			release, elected := g.acquireLeader()
+			if !elected {
+				continue
+			}
+			g.runReaper(ctx, r)
+			release()
+			continue
+		}
+		g.runReaper(ctx, r)
+	}
+}
+
+func (g *GarbageCollector) runReaper(ctx context.Context, r Reaper) {
+	reaped, err := r.Sweep(ctx)
+	if err != nil {
+		slog.Warn("vm/gc: reaper failed", "class", r.Class(), "err", err)
+		return
+	}
+	if reaped > 0 {
+		slog.Info("vm/gc: reaped orphans", "class", r.Class(), "count", reaped)
+	}
+}

--- a/spinifex/vm/gc_invariants_test.go
+++ b/spinifex/vm/gc_invariants_test.go
@@ -1,0 +1,129 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedTerminated writes a terminated VM owned by the test node with the given
+// teardown marks into the store, and returns the manager + reaper under test.
+func seedTerminated(t *testing.T, marks map[string]string) (*Manager, *recordingInstanceCleaner, *fakeStateStore, *TerminatedTeardownReaper, *VM) {
+	t.Helper()
+	store := newFakeStateStore()
+	m, cleaner, _, _, _ := terminateTestManager(t, store)
+	v := &VM{
+		ID:       "i-gc",
+		Status:   StateTerminated,
+		LastNode: "test-node",
+		ENIId:    "eni-gc",
+		PublicIP: "203.0.113.9",
+		Instance: &ec2.Instance{},
+		Teardown: marks,
+	}
+	require.NoError(t, store.WriteTerminatedInstance(v.ID, v))
+	return m, cleaner, store, m.NewTerminatedTeardownReaper(), v
+}
+
+// TestRLC5_GCRetriesPendingTeardownToDoneThenPurges enforces ADR-0003 §1/§3
+// (retry pending teardown): a terminated record left with outstanding
+// pending/failed dependents by an interrupted terminate must be driven to all
+// `done` by the GC and then purged — never abandoned.
+func TestRLC5_GCRetriesPendingTeardownToDoneThenPurges(t *testing.T) {
+	m, cleaner, store, reaper, v := seedTerminated(t, map[string]string{
+		TeardownVolumes: string(TeardownFailed),
+		TeardownNAT:     string(TeardownPending),
+		TeardownENI:     string(TeardownFailed),
+		TeardownOVN:     string(TeardownPending),
+	})
+
+	reaped, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, reaped, "ADR-0003 §3: the GC must complete and purge the record")
+	assert.True(t, v.TeardownComplete(), "ADR-0003 §1: every dependent must reach done")
+	remaining, err := store.ListTerminatedInstances()
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "ADR-0003 §3: a record whose teardown the GC completed must be purged")
+	// The reaper re-drove the real idempotent cleaner calls.
+	assert.Equal(t, []string{v.ID}, cleaner.deleteVolumes)
+	assert.Equal(t, []string{v.ID}, cleaner.releasePublicIP)
+	assert.Equal(t, []string{v.ID}, cleaner.detachAndDeleteENI)
+	_ = m
+}
+
+// TestRLC5_GCNeverPurgesIncompleteRecord enforces ADR-0003 §4 (no-orphan
+// completeness / never abandon): a dependent that keeps failing must leave the
+// terminated record present and marked, not purged, so a later sweep retries it.
+func TestRLC5_GCNeverPurgesIncompleteRecord(t *testing.T) {
+	m, cleaner, store, reaper, v := seedTerminated(t, map[string]string{
+		TeardownVolumes: string(TeardownDone),
+		TeardownENI:     string(TeardownFailed),
+		TeardownOVN:     string(TeardownPending),
+	})
+	cleaner.detachENIErr = errors.New("eni delete still failing")
+
+	reaped, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, reaped, "ADR-0003 §4: a record with a still-failing dependent must not be purged")
+	assert.False(t, v.TeardownComplete())
+	assert.Equal(t, string(TeardownFailed), v.Teardown[TeardownENI], "a failed retry must stay Failed, not silently drop")
+	remaining, err := store.ListTerminatedInstances()
+	require.NoError(t, err)
+	require.Len(t, remaining, 1, "ADR-0003 §4: an incomplete record must be retained (GC-visible) for the next sweep")
+	_ = m
+}
+
+// TestRLC5_GCSkipsOtherNodesRecords enforces home-node ownership: a node must
+// not run node-local teardown for a record another node owns.
+func TestRLC5_GCSkipsOtherNodesRecords(t *testing.T) {
+	store := newFakeStateStore()
+	m, cleaner, _, _, _ := terminateTestManager(t, store)
+	other := &VM{
+		ID:       "i-other",
+		Status:   StateTerminated,
+		LastNode: "some-other-node",
+		ENIId:    "eni-other",
+		Instance: &ec2.Instance{},
+		Teardown: map[string]string{TeardownENI: string(TeardownFailed)},
+	}
+	require.NoError(t, store.WriteTerminatedInstance(other.ID, other))
+
+	reaped, err := m.NewTerminatedTeardownReaper().Sweep(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, reaped)
+	assert.Empty(t, cleaner.detachAndDeleteENI, "must not tear down a record another node owns")
+	remaining, err := store.ListTerminatedInstances()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
+}
+
+// TestRLC5_GCHoldsWhenKVDegraded enforces ADR-0003 §3 (KV-health gated): while
+// KV is unhealthy the GC holds — a completable record is left untouched rather
+// than reaped against a desired-state the node cannot trust — and resumes once
+// KV is healthy again.
+func TestRLC5_GCHoldsWhenKVDegraded(t *testing.T) {
+	_, _, store, reaper, _ := seedTerminated(t, map[string]string{
+		TeardownVolumes: string(TeardownFailed),
+	})
+
+	healthy := false
+	gc := NewGarbageCollector(func() bool { return healthy }, reaper)
+
+	gc.SweepOnce(context.Background())
+	remaining, err := store.ListTerminatedInstances()
+	require.NoError(t, err)
+	require.Len(t, remaining, 1, "ADR-0003 §3: GC must hold (not purge) while KV is degraded")
+
+	healthy = true
+	gc.SweepOnce(context.Background())
+	remaining, err = store.ListTerminatedInstances()
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "ADR-0003 §3: GC resumes and completes once KV is healthy")
+}

--- a/spinifex/vm/gc_test.go
+++ b/spinifex/vm/gc_test.go
@@ -1,0 +1,117 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// countingReaper is a test Reaper that records how many times Sweep ran and
+// returns canned (reaped, err) values.
+type countingReaper struct {
+	class  string
+	scope  ReaperScope
+	reaped int
+	err    error
+	calls  atomic.Int64
+}
+
+func (c *countingReaper) Class() string      { return c.class }
+func (c *countingReaper) Scope() ReaperScope { return c.scope }
+func (c *countingReaper) Sweep(context.Context) (int, error) {
+	c.calls.Add(1)
+	return c.reaped, c.err
+}
+
+func TestSweepOnce_HoldsWhenKVUnhealthy(t *testing.T) {
+	r := &countingReaper{class: "x", scope: ScopeNodeLocal}
+	gc := NewGarbageCollector(func() bool { return false }, r)
+
+	gc.SweepOnce(context.Background())
+
+	assert.Zero(t, r.calls.Load(), "no reaper may run while KV is unhealthy")
+}
+
+func TestSweepOnce_RunsNodeLocalWhenHealthy(t *testing.T) {
+	r := &countingReaper{class: "x", scope: ScopeNodeLocal, reaped: 2}
+	gc := NewGarbageCollector(func() bool { return true }, r)
+
+	gc.SweepOnce(context.Background())
+
+	assert.Equal(t, int64(1), r.calls.Load())
+}
+
+func TestSweepOnce_NilHealthProbeTreatedHealthy(t *testing.T) {
+	r := &countingReaper{class: "x", scope: ScopeNodeLocal}
+	gc := NewGarbageCollector(nil, r)
+
+	gc.SweepOnce(context.Background())
+
+	assert.Equal(t, int64(1), r.calls.Load())
+}
+
+func TestSweepOnce_ReaperErrorDoesNotAbortOthers(t *testing.T) {
+	bad := &countingReaper{class: "bad", scope: ScopeNodeLocal, err: errors.New("boom")}
+	good := &countingReaper{class: "good", scope: ScopeNodeLocal}
+	gc := NewGarbageCollector(nil, bad, good)
+
+	gc.SweepOnce(context.Background())
+
+	assert.Equal(t, int64(1), bad.calls.Load())
+	assert.Equal(t, int64(1), good.calls.Load(), "a failing reaper must not skip later reapers")
+}
+
+func TestSweepOnce_ClusterScopeSkippedWithoutElector(t *testing.T) {
+	r := &countingReaper{class: "cluster", scope: ScopeClusterWide}
+	gc := NewGarbageCollector(nil, r)
+
+	gc.SweepOnce(context.Background())
+
+	assert.Zero(t, r.calls.Load(), "cluster-wide reaper must not run without a leader elector")
+}
+
+func TestSweepOnce_ClusterScopeRunsOnlyWhenElected(t *testing.T) {
+	r := &countingReaper{class: "cluster", scope: ScopeClusterWide}
+	var released atomic.Int64
+	elected := true
+	gc := NewGarbageCollector(nil, r).WithLeaderElection(func() (func(), bool) {
+		return func() { released.Add(1) }, elected
+	})
+
+	gc.SweepOnce(context.Background())
+	assert.Equal(t, int64(1), r.calls.Load(), "elected leader must run the cluster reaper")
+	assert.Equal(t, int64(1), released.Load(), "leader lock must be released after the sweep")
+
+	elected = false
+	gc.SweepOnce(context.Background())
+	assert.Equal(t, int64(1), r.calls.Load(), "a non-leader must not run the cluster reaper")
+}
+
+func TestStart_SweepsImmediatelyThenStopsOnCtxCancel(t *testing.T) {
+	old := GCInterval
+	GCInterval = 5 * time.Millisecond
+	defer func() { GCInterval = old }()
+
+	var mu sync.Mutex
+	r := &countingReaper{class: "x", scope: ScopeNodeLocal}
+	gc := NewGarbageCollector(nil, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	gc.Start(ctx)
+
+	assert.Eventually(t, func() bool { return r.calls.Load() >= 1 }, time.Second, 2*time.Millisecond,
+		"Start must sweep immediately, not wait a full interval")
+
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	stopped := r.calls.Load()
+	mu.Unlock()
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, stopped, r.calls.Load(), "ctx cancel must stop the sweep loop")
+}

--- a/spinifex/vm/instance_cleaner.go
+++ b/spinifex/vm/instance_cleaner.go
@@ -6,8 +6,8 @@ package vm
 type InstanceCleaner interface {
 	// DeleteVolumes deletes EFI / cloud-init internal volumes via ebs.delete
 	// and user volumes flagged DeleteOnTermination via the volume service.
-	// Called only on Terminate, never on Stop.
-	DeleteVolumes(v *VM)
+	// Called only on Terminate, never on Stop. Returns the first delete error.
+	DeleteVolumes(v *VM) error
 
 	// CleanupMgmtNetwork removes the management TAP device and releases the
 	// management IP allocation. Called on both Stop and Terminate.
@@ -15,19 +15,20 @@ type InstanceCleaner interface {
 
 	// ReleasePublicIP publishes vpc.delete-nat and releases the public IP
 	// back to the external IPAM pool. Called only on Terminate when the
-	// instance has a public IP allocated.
-	ReleasePublicIP(v *VM)
+	// instance has a public IP allocated. Returns the IPAM release error.
+	ReleasePublicIP(v *VM) error
 
-	// DetachAndDeleteENI detaches and deletes the primary ENI. NotFound is
-	// tolerated. Called only on Terminate.
-	DetachAndDeleteENI(v *VM)
+	// DetachAndDeleteENI detaches and force-deletes the primary ENI (bypassing
+	// the in-use guard for the owning instance). NotFound is tolerated. Called
+	// only on Terminate. Returns the delete error.
+	DetachAndDeleteENI(v *VM) error
 
 	// RemoveFromPlacementGroup removes the instance from its placement
 	// group, if one is set. Called only on Terminate.
-	RemoveFromPlacementGroup(v *VM)
+	RemoveFromPlacementGroup(v *VM) error
 
 	// ReleaseGPU unbinds the instance's GPU from vfio-pci and rebinds to
 	// its original host driver. Called on both Stop and Terminate. No-op
 	// when the instance has no GPU allocation.
-	ReleaseGPU(v *VM)
+	ReleaseGPU(v *VM) error
 }

--- a/spinifex/vm/lifecycle_invariants_test.go
+++ b/spinifex/vm/lifecycle_invariants_test.go
@@ -1,0 +1,115 @@
+package vm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLC1_TerminateIdempotentOnAbsent enforces the Common Resource Lifecycle
+// Contract rule #1 / ADR-0003 §2 (idempotent terminate): terminating an
+// instance that is absent — or already terminated/shutting-down — is success,
+// not a NotFound / invalid-transition error, so tofu destroy retries and the
+// gateway's KV-health-gated idempotent path converge instead of looping.
+func TestRLC1_TerminateIdempotentOnAbsent(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(m *Manager) string
+	}{
+		{"absent", func(*Manager) string { return "i-never-existed" }},
+		{"terminated", func(m *Manager) string {
+			v := &VM{ID: "i-already-terminated", Status: StateTerminated, Instance: &ec2.Instance{}}
+			m.Insert(v)
+			return v.ID
+		}},
+		{"shutting-down", func(m *Manager) string {
+			v := &VM{ID: "i-already-shutting", Status: StateShuttingDown, Instance: &ec2.Instance{}}
+			m.Insert(v)
+			return v.ID
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, cleaner, rt, down, _ := terminateTestManager(t, newFakeStateStore())
+			id := tc.setup(m)
+
+			err := m.Terminate(id)
+
+			require.NoErrorf(t, err, "Terminate of an %s instance must be idempotent success, not an error (RLC rule #1 / ADR-0003 §2): return nil so destroy retries converge", tc.name)
+			assert.Emptyf(t, cleaner.deleteVolumes, "%s: idempotent terminate must run no cleanup", tc.name)
+			assert.Zerof(t, down.Load(), "%s: idempotent terminate must not fire OnInstanceDown", tc.name)
+			assert.Emptyf(t, rt.snapshot(), "%s: idempotent terminate must drive no state transition", tc.name)
+		})
+	}
+}
+
+// TestRLC4_TerminateStampsTeardownMap enforces ADR-0003 §1 (deterministic
+// tracked teardown): a successful terminate must record a Teardown entry for
+// every dependency it touches so the GC backstop (ADR-0003 §3) can later
+// distinguish a fully-reaped instance from one with lingering async teardown.
+// A missing mark is an untracked dependency — the reaper would purge the
+// terminated record while an OVN port or NAT rule still dangles.
+func TestRLC4_TerminateStampsTeardownMap(t *testing.T) {
+	m, _, _, _, _ := terminateTestManager(t, newFakeStateStore())
+
+	v := &VM{
+		ID:                 "i-teardown-marks",
+		Status:             StateRunning,
+		InstanceType:       "t3.micro",
+		ENIId:              "eni-abc",
+		PublicIP:           "203.0.113.7",
+		PlacementGroupName: "pg-1",
+		Instance:           &ec2.Instance{},
+	}
+	m.Insert(v)
+
+	require.NoError(t, m.Terminate(v.ID))
+
+	// Sync steps that completed are Done; fire-and-forget async steps (OVN
+	// LSP, NAT rule) are Pending until the reconciler/GC reaps them.
+	want := map[string]TeardownState{
+		TeardownQEMU:      TeardownDone,
+		TeardownVolumes:   TeardownDone,
+		TeardownTap:       TeardownDone,
+		TeardownENI:       TeardownDone,
+		TeardownOVN:       TeardownPending,
+		TeardownNAT:       TeardownPending,
+		TeardownPlacement: TeardownDone,
+	}
+	for dep, state := range want {
+		assert.Equalf(t, string(state), v.Teardown[dep],
+			"ADR-0003 §1: terminate must stamp Teardown[%q]=%s; an unstamped dependency is untracked and the GC reaper could purge the terminated record while it still dangles", dep, state)
+	}
+	// No GPU was attached, so the GPU dependency must not be stamped.
+	_, gpuStamped := v.Teardown[TeardownGPU]
+	assert.Falsef(t, gpuStamped, "ADR-0003 §1: dependency that does not apply (no GPU attached) must not be stamped")
+}
+
+// TestRLC4_TerminateMarksFailedDependency enforces ADR-0003 §1: a teardown
+// step that errors is recorded as Failed, never silently dropped or marked
+// Done. TeardownComplete must then report false so the GC backstop retains
+// the record for a later sweep rather than declaring the instance fully reaped.
+func TestRLC4_TerminateMarksFailedDependency(t *testing.T) {
+	m, cleaner, _, _, _ := terminateTestManager(t, newFakeStateStore())
+	cleaner.detachENIErr = errors.New("eni detach raced")
+
+	v := &VM{
+		ID:           "i-eni-fail",
+		Status:       StateRunning,
+		InstanceType: "t3.micro",
+		ENIId:        "eni-fail",
+		Instance:     &ec2.Instance{},
+	}
+	m.Insert(v)
+
+	require.NoError(t, m.Terminate(v.ID))
+
+	assert.Equalf(t, string(TeardownFailed), v.Teardown[TeardownENI],
+		"ADR-0003 §1: a failed teardown step must be stamped Failed, not Done or dropped")
+	assert.Falsef(t, v.TeardownComplete(),
+		"ADR-0003 §1: TeardownComplete must be false while any dependency is Failed/Pending so the GC backstop retains the record for retry")
+}

--- a/spinifex/vm/manager_deps_test.go
+++ b/spinifex/vm/manager_deps_test.go
@@ -98,6 +98,13 @@ func (f *fakeStateStore) ListTerminatedInstances() ([]*VM, error) {
 	return out, nil
 }
 
+func (f *fakeStateStore) DeleteTerminatedInstance(id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.terminated, id)
+	return nil
+}
+
 var _ StateStore = (*fakeStateStore)(nil)
 
 // fakeVolumeMounter records every call so lifecycle tests can assert ordering.

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -116,11 +116,13 @@ func (m *Manager) StopAll() error {
 func (m *Manager) Terminate(id string) error {
 	instance, ok := m.Get(id)
 	if !ok {
-		return ErrInstanceNotFound
+		// Idempotent terminate (rule #1): an absent instance is already gone,
+		// so destroy retries converge.
+		return nil
 	}
 
-	if current := m.Status(instance); current == StateShuttingDown {
-		// Concurrent failed-launch goroutine already owns cleanup.
+	if current := m.Status(instance); current == StateShuttingDown || current == StateTerminated {
+		// Already terminating/terminated: cleanup is owned elsewhere. Idempotent.
 		return nil
 	}
 
@@ -269,7 +271,9 @@ func (m *Manager) stopCleanup(instance *VM) {
 	m.shutdownAndUnmount(instance)
 	m.cleanupTapDevices(instance)
 	if m.deps.InstanceCleaner != nil {
-		m.deps.InstanceCleaner.ReleaseGPU(instance)
+		if err := m.deps.InstanceCleaner.ReleaseGPU(instance); err != nil {
+			slog.Warn("ReleaseGPU failed on stop", "instanceId", instance.ID, "err", err)
+		}
 	}
 	m.deallocateResources(instance)
 }
@@ -279,18 +283,44 @@ func (m *Manager) stopCleanup(instance *VM) {
 // deletion, placement-group removal.
 func (m *Manager) terminateCleanup(instance *VM) {
 	m.shutdownAndUnmount(instance)
+	m.markTeardown(instance, TeardownQEMU, TeardownDone)
 
 	if m.deps.InstanceCleaner != nil {
-		m.deps.InstanceCleaner.DeleteVolumes(instance)
+		m.markTeardownResult(instance, TeardownVolumes, m.deps.InstanceCleaner.DeleteVolumes(instance))
 	}
 
 	m.cleanupTapDevices(instance)
+	m.markTeardown(instance, TeardownTap, TeardownDone)
 
 	if m.deps.InstanceCleaner != nil {
-		m.deps.InstanceCleaner.ReleaseGPU(instance)
-		m.deps.InstanceCleaner.ReleasePublicIP(instance)
-		m.deps.InstanceCleaner.DetachAndDeleteENI(instance)
-		m.deps.InstanceCleaner.RemoveFromPlacementGroup(instance)
+		gpuErr := m.deps.InstanceCleaner.ReleaseGPU(instance)
+		if len(instance.GPUAttachments) > 0 {
+			m.markTeardownResult(instance, TeardownGPU, gpuErr)
+		}
+
+		// Public IP: ReleaseIP is sync; vpc.delete-nat is fire-and-forget, so the
+		// NAT rule removal is recorded pending (drift reconciler / GC reaps it).
+		natErr := m.deps.InstanceCleaner.ReleasePublicIP(instance)
+		if instance.PublicIP != "" {
+			if natErr != nil {
+				m.markTeardown(instance, TeardownNAT, TeardownFailed)
+			} else {
+				m.markTeardown(instance, TeardownNAT, TeardownPending)
+			}
+		}
+
+		// ENI KV delete is sync; vpc.delete-port (OVN LSP) is fire-and-forget, so
+		// the OVN port removal is recorded pending (reconcile LSP prune reaps it).
+		eniErr := m.deps.InstanceCleaner.DetachAndDeleteENI(instance)
+		if instance.ENIId != "" {
+			m.markTeardownResult(instance, TeardownENI, eniErr)
+			m.markTeardown(instance, TeardownOVN, TeardownPending)
+		}
+
+		placementErr := m.deps.InstanceCleaner.RemoveFromPlacementGroup(instance)
+		if instance.PlacementGroupName != "" {
+			m.markTeardownResult(instance, TeardownPlacement, placementErr)
+		}
 	}
 
 	m.deallocateResources(instance)

--- a/spinifex/vm/shutdown_test.go
+++ b/spinifex/vm/shutdown_test.go
@@ -1113,6 +1113,7 @@ func (s *signalingStore) DeleteStoppedInstance(string) error        { return nil
 func (s *signalingStore) ListStoppedInstances() ([]*VM, error)      { return nil, nil }
 func (s *signalingStore) WriteTerminatedInstance(string, *VM) error { return nil }
 func (s *signalingStore) ListTerminatedInstances() ([]*VM, error)   { return nil, nil }
+func (s *signalingStore) DeleteTerminatedInstance(string) error     { return nil }
 
 var _ StateStore = (*signalingStore)(nil)
 

--- a/spinifex/vm/shutdown_test.go
+++ b/spinifex/vm/shutdown_test.go
@@ -755,15 +755,15 @@ func terminateTestManager(t *testing.T, store StateStore) (m *Manager, cleaner *
 	return m, cleaner, rt, downCount, downIDs
 }
 
-// TestTerminate_NotFound covers the validation guard at the top of
-// Terminate. An unknown id must return ErrInstanceNotFound without
-// touching cleaners, transitions, or hooks.
-func TestTerminate_NotFound(t *testing.T) {
+// TestTerminate_AbsentIdempotent covers the idempotent guard at the top of
+// Terminate (ADR-0003 §2, rule #1). An unknown id returns success without
+// touching cleaners, transitions, or hooks so destroy retries converge.
+func TestTerminate_AbsentIdempotent(t *testing.T) {
 	m, cleaner, rt, down, _ := terminateTestManager(t, newFakeStateStore())
 
 	err := m.Terminate("i-missing")
 
-	require.ErrorIs(t, err, ErrInstanceNotFound)
+	require.NoError(t, err)
 	assert.Empty(t, cleaner.deleteVolumes)
 	assert.Empty(t, rt.snapshot())
 	assert.Zero(t, down.Load())
@@ -788,19 +788,18 @@ func TestTerminate_AlreadyShuttingDown_Idempotent(t *testing.T) {
 	assert.Equal(t, StateShuttingDown, m.Status(v))
 }
 
-// TestTerminate_InvalidTransition covers transitionWithPrecheck rejecting
-// an illegal initial transition. StateTerminated → StateShuttingDown is
-// not in ValidTransitions, so the daemon-side handler can map this to
-// AWS IncorrectInstanceState.
-func TestTerminate_InvalidTransition(t *testing.T) {
+// TestTerminate_AlreadyTerminated_Idempotent covers the idempotent short-circuit
+// for an already-terminated instance (ADR-0003 §2). Terminate returns nil and
+// runs no cleanup or transition rather than failing the terminal-state precheck.
+func TestTerminate_AlreadyTerminated_Idempotent(t *testing.T) {
 	m, cleaner, _, down, _ := terminateTestManager(t, newFakeStateStore())
 	v := &VM{ID: "i-already-terminated", Status: StateTerminated, Instance: &ec2.Instance{}}
 	m.Insert(v)
 
 	err := m.Terminate(v.ID)
 
-	require.ErrorIs(t, err, ErrInvalidTransition)
-	assert.Empty(t, cleaner.deleteVolumes, "terminateCleanup must not run when precheck rejects")
+	require.NoError(t, err)
+	assert.Empty(t, cleaner.deleteVolumes, "terminateCleanup must not run on idempotent path")
 	assert.Zero(t, down.Load())
 }
 

--- a/spinifex/vm/state_store.go
+++ b/spinifex/vm/state_store.go
@@ -19,4 +19,5 @@ type StateStore interface {
 
 	WriteTerminatedInstance(id string, v *VM) error
 	ListTerminatedInstances() ([]*VM, error)
+	DeleteTerminatedInstance(id string) error
 }

--- a/spinifex/vm/teardown.go
+++ b/spinifex/vm/teardown.go
@@ -1,0 +1,57 @@
+package vm
+
+// TeardownState is the per-dependent teardown progress recorded on a VM's KV
+// record during terminate. A record is fully reapable only once every tracked
+// dependent is TeardownDone; pending/failed entries are completed by the GC
+// backstop (ADR-0003 §1).
+type TeardownState string
+
+const (
+	TeardownDone    TeardownState = "done"
+	TeardownPending TeardownState = "pending"
+	TeardownFailed  TeardownState = "failed"
+)
+
+// Teardown dependent keys. OVN and NAT are fire-and-forget publishes recorded
+// as pending; the reconcile LSP prune / drift NAT heal complete them.
+const (
+	TeardownQEMU      = "qemu"
+	TeardownVolumes   = "volumes"
+	TeardownTap       = "tap"
+	TeardownGPU       = "gpu"
+	TeardownNAT       = "nat"
+	TeardownENI       = "eni"
+	TeardownOVN       = "ovn"
+	TeardownPlacement = "placement"
+)
+
+// markTeardown records dep → state on the VM under the manager lock. Inspect
+// (not UpdateState) so it also works for a not-yet-inserted instance.
+func (m *Manager) markTeardown(instance *VM, dep string, state TeardownState) {
+	m.Inspect(instance, func(v *VM) {
+		if v.Teardown == nil {
+			v.Teardown = make(map[string]string)
+		}
+		v.Teardown[dep] = string(state)
+	})
+}
+
+// markTeardownResult records done on nil error, failed otherwise.
+func (m *Manager) markTeardownResult(instance *VM, dep string, err error) {
+	if err != nil {
+		m.markTeardown(instance, dep, TeardownFailed)
+		return
+	}
+	m.markTeardown(instance, dep, TeardownDone)
+}
+
+// TeardownComplete reports whether every tracked dependent is done. A terminated
+// record with any pending/failed dependent is retained (GC-visible).
+func (v *VM) TeardownComplete() bool {
+	for _, state := range v.Teardown {
+		if TeardownState(state) != TeardownDone {
+			return false
+		}
+	}
+	return true
+}

--- a/spinifex/vm/teardown_reaper.go
+++ b/spinifex/vm/teardown_reaper.go
@@ -1,0 +1,118 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// TerminatedTeardownReaper completes interrupted instance teardown (ADR-0003
+// §1/§3). It scans the terminated KV bucket for records this node owns whose
+// per-dependent teardown is not all `done`, re-drives each outstanding
+// dependent through the now-idempotent cleaner, and purges the terminated
+// record once every dependent reaches `done`. A node-down mid-cascade leaves
+// dependents `pending`/`failed`; this reaper finishes them rather than
+// abandoning them.
+type TerminatedTeardownReaper struct {
+	m *Manager
+}
+
+var _ Reaper = (*TerminatedTeardownReaper)(nil)
+
+// NewTerminatedTeardownReaper builds the reaper bound to this Manager's cleaner
+// and state store.
+func (m *Manager) NewTerminatedTeardownReaper() *TerminatedTeardownReaper {
+	return &TerminatedTeardownReaper{m: m}
+}
+
+func (r *TerminatedTeardownReaper) Class() string      { return "instance-teardown" }
+func (r *TerminatedTeardownReaper) Scope() ReaperScope { return ScopeNodeLocal }
+
+// Sweep finishes outstanding teardown for this node's terminated instances.
+// Records already complete on arrival are left to the bucket's TTL (preserving
+// describe-visibility); only records this sweep brings to completion are purged.
+func (r *TerminatedTeardownReaper) Sweep(context.Context) (int, error) {
+	if r.m.deps.StateStore == nil {
+		return 0, nil
+	}
+	terminated, err := r.m.deps.StateStore.ListTerminatedInstances()
+	if err != nil {
+		return 0, fmt.Errorf("list terminated instances: %w", err)
+	}
+
+	reaped := 0
+	for _, v := range terminated {
+		if v.LastNode != "" && v.LastNode != r.m.deps.NodeID {
+			continue // home-node owns its node-local teardown
+		}
+		if v.TeardownComplete() {
+			continue // already done on arrival: leave to the 1h bucket TTL
+		}
+
+		r.retryOutstanding(v)
+
+		if v.TeardownComplete() {
+			if r.purge(v) {
+				reaped++
+			}
+			continue
+		}
+		if err := r.m.deps.StateStore.WriteTerminatedInstance(v.ID, v); err != nil {
+			slog.Warn("vm/gc: failed to persist advanced teardown marks",
+				"instanceId", v.ID, "err", err)
+		}
+	}
+	return reaped, nil
+}
+
+// retryOutstanding re-drives every not-`done` dependent through the idempotent
+// cleaner and re-stamps the result. The cleaner calls are idempotent (absent →
+// success), so a successful re-drive confirms the Spinifex-side teardown; the
+// dataplane object (OVN LSP, NAT rule) is pruned by the cluster reconciler.
+func (r *TerminatedTeardownReaper) retryOutstanding(v *VM) {
+	c := r.m.deps.InstanceCleaner
+	if c == nil {
+		return
+	}
+
+	if outstanding(v, TeardownVolumes) {
+		r.m.markTeardownResult(v, TeardownVolumes, c.DeleteVolumes(v))
+	}
+	if outstanding(v, TeardownGPU) {
+		r.m.markTeardownResult(v, TeardownGPU, c.ReleaseGPU(v))
+	}
+	if outstanding(v, TeardownPlacement) {
+		r.m.markTeardownResult(v, TeardownPlacement, c.RemoveFromPlacementGroup(v))
+	}
+
+	// NAT: re-publishes vpc.delete-nat + frees the IPAM slot. The cluster
+	// reconciler heals the dataplane NAT rule.
+	if outstanding(v, TeardownNAT) {
+		r.m.markTeardownResult(v, TeardownNAT, c.ReleasePublicIP(v))
+	}
+
+	// ENI delete + OVN: deleting the ENI KV record turns its LSP into an orphan
+	// the cluster reconcile prune reaps, so a successful ENI delete completes
+	// both eni and ovn.
+	if outstanding(v, TeardownENI) || outstanding(v, TeardownOVN) {
+		eniErr := c.DetachAndDeleteENI(v)
+		r.m.markTeardownResult(v, TeardownENI, eniErr)
+		r.m.markTeardownResult(v, TeardownOVN, eniErr)
+	}
+}
+
+func (r *TerminatedTeardownReaper) purge(v *VM) bool {
+	if err := r.m.deps.StateStore.DeleteTerminatedInstance(v.ID); err != nil {
+		slog.Warn("vm/gc: failed to purge completed terminated record",
+			"instanceId", v.ID, "err", err)
+		return false
+	}
+	slog.Info("vm/gc: purged terminated record, teardown complete", "instanceId", v.ID)
+	return true
+}
+
+// outstanding reports whether a teardown dependency is tracked and not yet done.
+func outstanding(v *VM, dep string) bool {
+	state, ok := v.Teardown[dep]
+	return ok && TeardownState(state) != TeardownDone
+}

--- a/spinifex/vm/vm.go
+++ b/spinifex/vm/vm.go
@@ -129,6 +129,11 @@ type VM struct {
 	// BootMode captures the AMI's boot mode at launch so firmware choice survives
 	// restarts. Empty for legacy VMs; treated as "bios" by the launch path.
 	BootMode string `json:"boot_mode,omitempty"`
+
+	// Teardown records per-dependent terminate progress (dependent → done|
+	// pending|failed). Stamped by terminateCleanup; the GC backstop retries
+	// pending/failed and purges the record once all dependents are done.
+	Teardown map[string]string `json:"teardown,omitempty"`
 }
 
 // ResetNodeLocalState zeroes node-specific fields after deserializing a VM

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -1022,10 +1022,29 @@ if [ -n "$GWMAC" ]; then
   for p in $(sudo ovs-vsctl list-ports br-int 2>/dev/null | grep -aE 'patch-br-int-to-ext'); do
     echo "--- in_port=$p ---"
     sudo ovs-appctl ofproto/trace br-int "in_port=$p,tcp,dl_src=02:00:00:00:00:01,dl_dst=$GWMAC,nw_src=192.168.0.11,nw_dst=$EIP,tp_src=40000,tp_dst=80" 2>&1 \
-      | grep -aE 'bridge|ct_|nat|dnat|load|output|resubmit|drop|Final flow|Megaflow|Datapath actions' | head -50
+      | grep -aE 'bridge|ct_|nat|dnat|load|output|resubmit|drop|Final flow|Megaflow|Datapath actions' | head -120
   done
 else
   echo "(no cr-gw MAC resolved — ARP itself failed)"
+fi
+echo "=== south->north RETURN trace (guest reply -> un-DNAT -> WAN) ==="
+PRIV=$(sudo ovn-nbctl --no-leader-only --bare --columns=logical_ip find NAT external_ip="\"$EIP\"" 2>/dev/null | head -1)
+CLIENT=$({ sudo ovs-appctl dpctl/dump-conntrack 2>/dev/null || sudo conntrack -L 2>/dev/null; } | grep -aE "dst=$EIP" | grep -aoE 'src=[0-9.]+' | head -1 | cut -d= -f2)
+[ -z "$CLIENT" ] && CLIENT=192.168.1.1
+GLSP=""; GMAC=""
+for lp in $(sudo ovn-sbctl --no-leader-only --bare --columns=logical_port find Port_Binding type='""' 2>/dev/null); do
+  m=$(sudo ovn-sbctl --no-leader-only --bare --columns=mac find Port_Binding logical_port="$lp" 2>/dev/null)
+  case "$m" in *"$PRIV"*) GLSP="$lp"; GMAC=$(echo "$m" | awk '{print $1}'); break;; esac
+done
+TAP=$(sudo ovs-vsctl --bare --columns=name find Interface external_ids:iface-id="$GLSP" 2>/dev/null | head -1)
+SUBNET_GW=$(echo "$PRIV" | awk -F. '{print $1"."$2"."$3".1"}')
+LRPMAC=$(sudo ovn-nbctl --no-leader-only --bare --columns=mac find Logical_Router_Port networks~="$SUBNET_GW/" 2>/dev/null | head -1)
+echo "PRIV=[$PRIV] CLIENT=[$CLIENT] GLSP=[$GLSP] GMAC=[$GMAC] TAP=[$TAP] LRPMAC=[$LRPMAC]"
+if [ -n "$TAP" ] && [ -n "$GMAC" ] && [ -n "$LRPMAC" ]; then
+  sudo ovs-appctl ofproto/trace br-int "in_port=$TAP,tcp,dl_src=$GMAC,dl_dst=$LRPMAC,nw_src=$PRIV,nw_dst=$CLIENT,tp_src=80,tp_dst=40000,tcp_flags=ack" 2>&1 \
+    | grep -aE 'bridge|ct_|nat|dnat|snat|load|output|resubmit|drop|Final flow|Megaflow|Datapath actions' | head -150
+else
+  echo "(return-trace discovery incomplete — skipping)"
 fi
 echo "=== conntrack DNAT entries (EIP/guest) ==="
 { sudo ovs-appctl dpctl/dump-conntrack 2>/dev/null || sudo conntrack -L 2>/dev/null; } | grep -aE "$EIP|10\.210\.1\." | head -30 || echo "(none)"

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -588,19 +588,37 @@ func phase8Asserts(t *testing.T, fix *fixture) {
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer probeCancel()
 	seen := map[string]bool{}
-	harness.Eventually(t, func() bool {
+	served := false
+	serveDeadline := time.Now().Add(180 * time.Second)
+	for time.Now().Before(serveDeadline) {
 		out, err := fix.ssh.Run(probeCtx, fix.env.WANHost,
 			fmt.Sprintf("curl -s --connect-timeout 2 --max-time 3 'http://%s:%d/' 2>/dev/null", fix.albPublicIP, httpPort))
-		if err != nil {
-			return false
+		if err == nil {
+			if id := instanceIDFromResponse(out); id != "" {
+				seen[id] = true
+			}
 		}
-		id := instanceIDFromResponse(out)
-		if id != "" {
-			seen[id] = true
+		if len(seen) >= 2 {
+			served = true
+			break
 		}
-		return len(seen) >= 2
-	}, 180*time.Second, 1*time.Second,
-		fmt.Sprintf("ALB did not serve from both backends within 180s post-reboot (saw=%v)", seen))
+		time.Sleep(1 * time.Second)
+	}
+	// 8.5 reports targets healthy via the daemon's own view, which can be green
+	// while the north-south EIP datapath is dark. Capture dataplane diagnostics on
+	// a serve failure too — otherwise this path leaves no flow/ARP evidence.
+	if !served {
+		harness.Step(t, "ALB serve FAILED — capturing datapath diagnostics")
+		dctx, dcancel := context.WithTimeout(context.Background(), 120*time.Second)
+		dumpALBProbe(dctx, t, fix)
+		dumpOVNDataplane(dctx, t, fix)
+		dumpOVNClaimState(dctx, t, fix)
+		dumpHeartbeatDiagnostics(dctx, t, fix)
+		dumpAppDiagnostics(t, fix)
+		dcancel()
+		t.Fatalf("ALB did not serve from both backends within 180s post-reboot (saw=%v) "+
+			"— see diag-ovn-flows.txt / diag-alb-probe.txt / diag-heartbeat.txt", seen)
+	}
 
 	runHTTPBurst(t, fix, "ALB post-reboot")
 
@@ -976,6 +994,10 @@ echo "=== ovs-vsctl show (bridges + ports) ==="
 sudo ovs-vsctl show 2>&1 | head -120
 echo "=== ovs-ofctl dump-flows br-int (forwarding flows) ==="
 sudo ovs-ofctl dump-flows br-int 2>&1 | head -200
+echo "=== ovs-ofctl dump-flows br-ext (north-south / localnet forwarding) ==="
+sudo ovs-ofctl dump-flows br-ext 2>&1 | head -120
+echo "=== ovs-appctl fdb/show br-ext (WAN-side MAC learning) ==="
+sudo ovs-appctl fdb/show br-ext 2>&1 | head -40
 echo "=== ovn-sbctl chassis + port bindings ==="
 sudo ovn-sbctl --no-leader-only show 2>&1 | head -80
 echo "=== ovn-sbctl Port_Binding (chassis assignment) ==="
@@ -984,8 +1006,11 @@ echo "=== ovn-nbctl dnat_and_snat NAT rows ==="
 sudo ovn-nbctl --no-leader-only list NAT 2>&1 | grep -E "external_ip|logical_ip|external_mac|type " | head -60
 echo "=== host neigh (all floating IPs) ==="
 ip neigh show 2>&1 | grep -E "br-wan|br-int" | head -40
-echo "=== host->ALB floating IP %[1]s reachability ==="
+echo "=== host->ALB floating IP %[1]s reachability (REAL ARP: flush primed neigh first) ==="
+sudo ip neigh flush %[1]s 2>&1 || true
 ping -c 2 -W 2 %[1]s 2>&1
+echo "--- neigh after real resolution attempt (INCOMPLETE/FAILED => gateway not answering ARP) ---"
+ip neigh show %[1]s 2>&1
 sudo ovs-appctl ofproto/trace br-int "in_port=LOCAL,ip,nw_dst=%[1]s" 2>&1 | tail -20 || echo "(ofproto/trace unavailable)"
 `, fix.albPublicIP)
 

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -1055,16 +1055,29 @@ sleep 1
 curl -s --connect-timeout 2 --max-time 4 "http://$EIP/" >/dev/null 2>&1 &
 wait $TCPID 2>/dev/null
 echo "=== (end tap capture) ==="
-echo "=== REMEDIATION EXPERIMENT: which reset heals south->north? ==="
+echo "=== PERSISTED-STATE DUMP (survives ovn-controller restart) ==="
+echo "--- external next-hop MACs (regenerated each boot) ---"
+for IF in veth-wan-ovs veth-wan-br br-wan br-ext; do
+  M=$(ip link show "$IF" 2>/dev/null | grep -aoE 'link/ether [0-9a-f:]+' | awk '{print $2}')
+  echo "  $IF mac=[$M]"
+done
+echo "--- SB MAC_Binding (logical_port ip mac) ---"
+sudo ovn-sbctl --no-leader-only list MAC_Binding 2>&1 | grep -aE 'ip|mac|logical_port' | head -40 || echo "(none)"
+echo "--- host neigh on external subnet ---"
+ip neigh show 2>/dev/null | grep -aE '192\.168\.' | head -20 || echo "(none)"
+echo "=== REMEDIATION EXPERIMENT: which flush heals south->north? ==="
 curl -s -o /dev/null -w "before-remediation HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
-echo "--- inc-engine/recompute ---"
-sudo ovn-appctl -t ovn-controller inc-engine/recompute 2>&1 | head -3
+echo "--- flush kernel + OVS conntrack ---"
+sudo conntrack -F 2>&1 | head -2
+sudo ovs-appctl dpctl/flush-conntrack 2>&1 | head -2
+sleep 2
+curl -s -o /dev/null -w "after-ct-flush HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
+echo "--- destroy SB MAC_Binding (force ARP relearn of external next-hop) ---"
+sudo ovn-sbctl --no-leader-only --all destroy MAC_Binding 2>&1 | head -2
 sleep 4
-curl -s -o /dev/null -w "after-recompute HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
-echo "--- systemctl restart ovn-controller ---"
-sudo systemctl restart ovn-controller 2>&1 | head -3
-sleep 8
-curl -s -o /dev/null -w "after-ovn-restart HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 6 "http://$EIP/" 2>&1
+curl -s -o /dev/null -w "after-macbinding-flush HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 6 "http://$EIP/" 2>&1
+sleep 3
+curl -s -o /dev/null -w "after-macbinding-flush-retry HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 6 "http://$EIP/" 2>&1
 echo "=== (end remediation experiment) ==="
 `, fix.albPublicIP)
 

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -1082,20 +1082,20 @@ echo "--- SB MAC_Binding (logical_port ip mac) ---"
 sudo ovn-sbctl --no-leader-only list MAC_Binding 2>&1 | grep -aE 'ip|mac|logical_port' | head -40 || echo "(none)"
 echo "--- host neigh on external subnet ---"
 ip neigh show 2>/dev/null | grep -aE '192\.168\.' | head -20 || echo "(none)"
-echo "=== REMEDIATION EXPERIMENT: which flush heals south->north? ==="
-curl -s -o /dev/null -w "before-remediation HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
-echo "--- flush kernel + OVS conntrack ---"
-sudo conntrack -F 2>&1 | head -2
-sudo ovs-appctl dpctl/flush-conntrack 2>&1 | head -2
-sleep 2
-curl -s -o /dev/null -w "after-ct-flush HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
-echo "--- destroy SB MAC_Binding (force ARP relearn of external next-hop) ---"
-sudo ovn-sbctl --no-leader-only --all destroy MAC_Binding 2>&1 | head -2
-sleep 4
-curl -s -o /dev/null -w "after-macbinding-flush HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 6 "http://$EIP/" 2>&1
-sleep 3
-curl -s -o /dev/null -w "after-macbinding-flush-retry HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 6 "http://$EIP/" 2>&1
-echo "=== (end remediation experiment) ==="
+echo "=== live failure marker (confirms drop is active during dump) ==="
+curl -s -o /dev/null -w "eip-probe HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
+echo "=== NB-SOURCE OF THE RETURN-PATH DROP (names what installs table-79 drop) ==="
+echo "--- SB lflow stages that DROP the guest reply (match nw_src=$PRIV) ---"
+sudo ovn-sbctl --no-leader-only lflow-list 2>/dev/null | grep -aiE 'drop' | grep -aF "$PRIV" | head -20 || echo "(none — drop is not a northd logical flow; likely ovn-controller port-security)"
+echo "--- SB lflow lines mentioning guest MAC $GMAC (stage + match context) ---"
+sudo ovn-sbctl --no-leader-only lflow-list 2>/dev/null | grep -aiF "$GMAC" | head -20 || echo "(none)"
+echo "--- NB NAT rows: type/external_mac/logical_port/options (centralised=[] vs distributed) ---"
+sudo ovn-nbctl --no-leader-only --columns=external_ip,logical_ip,type,external_mac,logical_port,options list NAT 2>/dev/null | head -60 || echo "(none)"
+echo "--- NB Logical_Router_Policy (drop-gate + per-instance reroute) ---"
+sudo ovn-nbctl --no-leader-only --columns=priority,match,action,nexthop list Logical_Router_Policy 2>/dev/null | head -40 || echo "(none)"
+echo "--- NB LSP addresses + port_security (source if drop is physical port-sec) ---"
+sudo ovn-nbctl --no-leader-only --columns=name,addresses,port_security list Logical_Switch_Port 2>/dev/null | grep -aF -A0 "$PRIV" | head -20 || echo "(none)"
+echo "=== (end NB-source dump) ==="
 `, fix.albPublicIP)
 
 	out, err := fix.ssh.Run(ctx, fix.env.WANHost, bundle)

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -884,6 +884,12 @@ echo "=== ovs-vsctl show ==="
 sudo ovs-vsctl show 2>&1
 echo "=== ovs-vsctl list-ports br-int ==="
 sudo ovs-vsctl list-ports br-int 2>&1
+echo "=== ip -d link show veth-wan-ovs (admin/carrier state) ==="
+ip -d link show veth-wan-ovs 2>&1
+echo "=== ip -d link show veth-wan-br (admin/carrier state) ==="
+ip -d link show veth-wan-br 2>&1
+echo "=== ovs-ofctl show br-ext (ofport numbering) ==="
+sudo ovs-ofctl show br-ext 2>&1
 `
 	out, err := fix.ssh.Run(ctx, fix.env.WANHost, bundle)
 	harness.DumpFile(t, fix.artifacts, "diag-host-net.txt", out)

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -990,28 +990,52 @@ sudo journalctl -u spinifex-awsgw --no-pager --since "3 min ago" 2>/dev/null | g
 func dumpOVNDataplane(ctx context.Context, t *testing.T, fix *fixture) {
 	t.Helper()
 	bundle := fmt.Sprintf(`set +e
+EIP=%[1]s
 echo "=== ovs-vsctl show (bridges + ports) ==="
 sudo ovs-vsctl show 2>&1 | head -120
-echo "=== ovs-ofctl dump-flows br-int (forwarding flows) ==="
-sudo ovs-ofctl dump-flows br-int 2>&1 | head -200
-echo "=== ovs-ofctl dump-flows br-ext (north-south / localnet forwarding) ==="
+echo "=== ovs-ofctl show br-int (port->ofport map) ==="
+sudo ovs-ofctl show br-int 2>&1 | grep -aE '\(' | head -50
+echo "=== br-int flows: DNAT/conntrack (ct_/nat/ct) ==="
+sudo ovs-ofctl dump-flows br-int 2>&1 | grep -aE 'ct_|nat\(|ct\(' | head -120
+echo "=== br-int flows: EIP + guest subnet 10.210 (forwarding) ==="
+sudo ovs-ofctl dump-flows br-int 2>&1 | grep -aE "nw_dst=$EIP|10\.210\.1\.|192\.168\.0\.21" | head -150
+echo "=== br-int flows: terminal output: actions ==="
+sudo ovs-ofctl dump-flows br-int 2>&1 | grep -aE 'output:|resubmit' | grep -avE 'table=(0|8|9|10|11),' | head -60
+echo "=== ovs-ofctl dump-flows br-ext ==="
 sudo ovs-ofctl dump-flows br-ext 2>&1 | head -120
 echo "=== ovs-appctl fdb/show br-ext (WAN-side MAC learning) ==="
 sudo ovs-appctl fdb/show br-ext 2>&1 | head -40
-echo "=== ovn-sbctl chassis + port bindings ==="
-sudo ovn-sbctl --no-leader-only show 2>&1 | head -80
 echo "=== ovn-sbctl Port_Binding (chassis assignment) ==="
 sudo ovn-sbctl --no-leader-only list Port_Binding 2>&1 | grep -E "logical_port|chassis|mac|type " | head -80
 echo "=== ovn-nbctl dnat_and_snat NAT rows ==="
 sudo ovn-nbctl --no-leader-only list NAT 2>&1 | grep -E "external_ip|logical_ip|external_mac|type " | head -60
 echo "=== host neigh (all floating IPs) ==="
 ip neigh show 2>&1 | grep -E "br-wan|br-int" | head -40
-echo "=== host->ALB floating IP %[1]s reachability (REAL ARP: flush primed neigh first) ==="
-sudo ip neigh flush %[1]s 2>&1 || true
-ping -c 2 -W 2 %[1]s 2>&1
-echo "--- neigh after real resolution attempt (INCOMPLETE/FAILED => gateway not answering ARP) ---"
-ip neigh show %[1]s 2>&1
-sudo ovs-appctl ofproto/trace br-int "in_port=LOCAL,ip,nw_dst=%[1]s" 2>&1 | tail -20 || echo "(ofproto/trace unavailable)"
+echo "=== REAL ARP to EIP $EIP (flush primed neigh first) ==="
+sudo ip neigh flush $EIP 2>&1 || true
+ping -c 2 -W 2 $EIP 2>&1
+ip neigh show $EIP 2>&1
+GWMAC=$(ip neigh show $EIP | awk '{for(i=1;i<=NF;i++) if($i=="lladdr") print $(i+1)}')
+echo "discovered cr-gw MAC for EIP: [$GWMAC]"
+echo "=== ofproto/trace north-south DNAT (real ingress per br-int patch port, dl_dst=cr-gw) ==="
+if [ -n "$GWMAC" ]; then
+  for p in $(sudo ovs-vsctl list-ports br-int 2>/dev/null | grep -aE 'patch-br-int-to-ext'); do
+    echo "--- in_port=$p ---"
+    sudo ovs-appctl ofproto/trace br-int "in_port=$p,tcp,dl_src=02:00:00:00:00:01,dl_dst=$GWMAC,nw_src=192.168.0.11,nw_dst=$EIP,tp_src=40000,tp_dst=80" 2>&1 \
+      | grep -aE 'bridge|ct_|nat|dnat|load|output|resubmit|drop|Final flow|Megaflow|Datapath actions' | head -50
+  done
+else
+  echo "(no cr-gw MAC resolved — ARP itself failed)"
+fi
+echo "=== conntrack DNAT entries (EIP/guest) ==="
+{ sudo ovs-appctl dpctl/dump-conntrack 2>/dev/null || sudo conntrack -L 2>/dev/null; } | grep -aE "$EIP|10\.210\.1\." | head -30 || echo "(none)"
+echo "=== tap capture: does the SYN reach the guest? (tcpdump -i any while curling EIP) ==="
+sudo timeout 6 tcpdump -i any -nn -c 25 "host $EIP or net 10.210.0.0/16" 2>&1 &
+TCPID=$!
+sleep 1
+curl -s --connect-timeout 2 --max-time 4 "http://$EIP/" >/dev/null 2>&1 &
+wait $TCPID 2>/dev/null
+echo "=== (end tap capture) ==="
 `, fix.albPublicIP)
 
 	out, err := fix.ssh.Run(ctx, fix.env.WANHost, bundle)

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -1006,7 +1006,24 @@ sudo ovs-ofctl dump-flows br-ext 2>&1 | head -120
 echo "=== ovs-appctl fdb/show br-ext (WAN-side MAC learning) ==="
 sudo ovs-appctl fdb/show br-ext 2>&1 | head -40
 echo "=== ovn-sbctl Port_Binding (chassis assignment) ==="
-sudo ovn-sbctl --no-leader-only list Port_Binding 2>&1 | grep -E "logical_port|chassis|mac|type " | head -80
+sudo ovn-sbctl --no-leader-only list Port_Binding 2>&1 | grep -E "logical_port|chassis|mac|type " | head -400
+echo "=== DGP / chassisredirect claim state (untruncated) ==="
+echo "--- every chassisredirect Port_Binding -> resident chassis ---"
+for cr in $(sudo ovn-sbctl --no-leader-only --bare --columns=logical_port find Port_Binding type=chassisredirect 2>/dev/null); do
+  ch=$(sudo ovn-sbctl --no-leader-only --bare --columns=chassis find Port_Binding logical_port="$cr" 2>/dev/null)
+  hg=$(sudo ovn-sbctl --no-leader-only --bare --columns=ha_chassis_group find Port_Binding logical_port="$cr" 2>/dev/null)
+  echo "  CR=[$cr] chassis=[$ch] ha_chassis_group=[$hg]"
+done
+echo "--- every gw-vpc LRP -> its referenced chassis-redirect-port (does the CR row exist?) ---"
+for gp in $(sudo ovn-sbctl --no-leader-only --bare --columns=logical_port find Port_Binding 2>/dev/null | tr ' ' '\n' | grep -aE '^gw-vpc'); do
+  crp=$(sudo ovn-sbctl --no-leader-only --bare --columns=options find Port_Binding logical_port="$gp" 2>/dev/null | tr ',' '\n' | grep -a chassis-redirect-port | cut -d= -f2)
+  exists=$(sudo ovn-sbctl --no-leader-only --bare --columns=_uuid find Port_Binding logical_port="$crp" 2>/dev/null)
+  echo "  GW-LRP=[$gp] redirect-port=[$crp] CR_row_exists=[$exists]"
+done
+echo "--- NB Gateway_Chassis bindings (DGP HA) ---"
+sudo ovn-nbctl --no-leader-only list Gateway_Chassis 2>&1 | grep -aE 'name|chassis_name|priority' | head -60
+echo "--- NB Logical_Router_Port (name + gateway_chassis + networks) ---"
+sudo ovn-nbctl --no-leader-only --columns=name,gateway_chassis,networks list Logical_Router_Port 2>&1 | head -80
 echo "=== ovn-nbctl dnat_and_snat NAT rows ==="
 sudo ovn-nbctl --no-leader-only list NAT 2>&1 | grep -E "external_ip|logical_ip|external_mac|type " | head -60
 echo "=== host neigh (all floating IPs) ==="

--- a/tests/e2e/reboot/reboot_test.go
+++ b/tests/e2e/reboot/reboot_test.go
@@ -1038,7 +1038,7 @@ for lp in $(sudo ovn-sbctl --no-leader-only --bare --columns=logical_port find P
 done
 TAP=$(sudo ovs-vsctl --bare --columns=name find Interface external_ids:iface-id="$GLSP" 2>/dev/null | head -1)
 SUBNET_GW=$(echo "$PRIV" | awk -F. '{print $1"."$2"."$3".1"}')
-LRPMAC=$(sudo ovn-nbctl --no-leader-only --bare --columns=mac find Logical_Router_Port networks~="$SUBNET_GW/" 2>/dev/null | head -1)
+LRPMAC=$(sudo ovs-ofctl dump-flows br-int 2>/dev/null | grep -a "arp_tpa=$SUBNET_GW," | grep -aoE 'mod_dl_src:[0-9a-f:]+' | head -1 | cut -d: -f2-)
 echo "PRIV=[$PRIV] CLIENT=[$CLIENT] GLSP=[$GLSP] GMAC=[$GMAC] TAP=[$TAP] LRPMAC=[$LRPMAC]"
 if [ -n "$TAP" ] && [ -n "$GMAC" ] && [ -n "$LRPMAC" ]; then
   sudo ovs-appctl ofproto/trace br-int "in_port=$TAP,tcp,dl_src=$GMAC,dl_dst=$LRPMAC,nw_src=$PRIV,nw_dst=$CLIENT,tp_src=80,tp_dst=40000,tcp_flags=ack" 2>&1 \
@@ -1055,6 +1055,17 @@ sleep 1
 curl -s --connect-timeout 2 --max-time 4 "http://$EIP/" >/dev/null 2>&1 &
 wait $TCPID 2>/dev/null
 echo "=== (end tap capture) ==="
+echo "=== REMEDIATION EXPERIMENT: which reset heals south->north? ==="
+curl -s -o /dev/null -w "before-remediation HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
+echo "--- inc-engine/recompute ---"
+sudo ovn-appctl -t ovn-controller inc-engine/recompute 2>&1 | head -3
+sleep 4
+curl -s -o /dev/null -w "after-recompute HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 5 "http://$EIP/" 2>&1
+echo "--- systemctl restart ovn-controller ---"
+sudo systemctl restart ovn-controller 2>&1 | head -3
+sleep 8
+curl -s -o /dev/null -w "after-ovn-restart HTTP=%%{http_code} time=%%{time_total}\n" --connect-timeout 2 --max-time 6 "http://$EIP/" 2>&1
+echo "=== (end remediation experiment) ==="
 `, fix.albPublicIP)
 
 	out, err := fix.ssh.Run(ctx, fix.env.WANHost, bundle)

--- a/tests/e2e/single/baseline_test.go
+++ b/tests/e2e/single/baseline_test.go
@@ -153,7 +153,7 @@ func runDefaultSGReachabilityBaseline(t *testing.T, fix *Fixture) {
 
 	harness.Step(t, "authorizing tcp/22 ingress, expecting reachability")
 	harness.AuthorizeSSHIngress(t, fix.AWS, sgID)
-	require.Truef(t, trySSHReady(pubIP, 22, keyPath, 3*time.Minute),
+	require.Truef(t, trySSHReady(pubIP, 22, keyPath, sshReadyBudget),
 		"tcp/22 to %s never became reachable after authorizing ingress — "+
 			"default subnet egress/IGW datapath is broken", pubIP)
 
@@ -272,7 +272,7 @@ func runNewVPCEgressBaseline(t *testing.T, fix *Fixture) {
 	harness.Detail(t, "instance", instanceID, "public_ip", pubIP)
 
 	harness.Step(t, "expecting external SSH to instance in fresh-VPC public subnet")
-	if !trySSHReady(pubIP, 22, keyPath, 3*time.Minute) {
+	if !trySSHReady(pubIP, 22, keyPath, sshReadyBudget) {
 		harness.DumpVPCFlowDiagnostics(t, c, instanceID,
 			fmt.Sprintf("fresh-VPC egress baseline SSH timeout — vpc=%s igw=%s pub=%s", vpcID, igwID, pubIP),
 			harness.VPCDiagnosticsOpts{

--- a/tests/e2e/single/datapath_test.go
+++ b/tests/e2e/single/datapath_test.go
@@ -187,12 +187,19 @@ func runSGToSGDatapath(t *testing.T, fix *Fixture) {
 	clientHost, clientPort := harness.InstancePublicSSHHost(t, clientInst)
 	clientTgt := harness.SSHTarget{User: "ec2-user", Host: clientHost, Port: clientPort, KeyPath: keyPath}
 	harness.Step(t, "8e-3 wait for client-vm SSH at %s:%d", clientHost, clientPort)
-	harness.EventuallyErr(t, func() error {
-		if _, err := runSSHCombined(clientTgt, "true"); err != nil {
-			return fmt.Errorf("client-vm SSH not ready: %w", err)
-		}
-		return nil
-	}, 2*time.Minute, 2*time.Second)
+	// Non-fatal probe so a timeout dumps the guest console + OVN/datapath
+	// state before Fatal. A full 2min unreachable window on a fresh public-IP
+	// VM is the flake signature; capture it from CI artifacts alone.
+	if !trySSHReady(clientHost, clientPort, keyPath, 2*time.Minute) {
+		harness.DumpVPCFlowDiagnostics(t, fix.AWS, clientID,
+			fmt.Sprintf("8e-3 client-vm SSH timeout — vpc=%s sg=%s pub=%s", def.VPCID, clientSG, clientHost),
+			harness.VPCDiagnosticsOpts{
+				ExternalIP:  clientHost,
+				LogicalIP:   clientPriv,
+				ArtifactDir: fix.ArtifactDir(t),
+			})
+		t.Fatalf("client-vm SSH %s:%d never became reachable within 2min (see diagnostics above)", clientHost, clientPort)
+	}
 
 	// Step 4: Allowed traffic — client -> target:8080 must succeed.
 	// Retry to give target's cloud-init time to start python3 -m http.server.

--- a/tests/e2e/single/lifecycle_test.go
+++ b/tests/e2e/single/lifecycle_test.go
@@ -4,6 +4,7 @@ package single
 
 import (
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -23,6 +24,20 @@ import (
 // rather than re-running the same 3-minute timeout against the same
 // broken datapath.
 var sshDatapathBroken atomic.Bool
+
+// sshReadyBudget bounds the single-node SSH-handshake probes. Baremetal boots
+// q35 guests slower (OVMF + NBD disks), so the harness widens it via
+// SPINIFEX_SSH_READY_TIMEOUT (Go duration); default 3m bounds shared runners.
+var sshReadyBudget = resolveSSHReadyBudget(3 * time.Minute)
+
+func resolveSSHReadyBudget(def time.Duration) time.Duration {
+	if v := os.Getenv("SPINIFEX_SSH_READY_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
+}
 
 // requireSSHHealthy skips the calling test if a prior SSH probe on this
 // single-node VM has already failed. Cuts the cascade cost of a broken
@@ -413,11 +428,11 @@ func waitForSSHReady(t *testing.T, host string, port int, keyPath string) {
 	requireSSHHealthy(t)
 	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	harness.Step(t, "waiting for SSH handshake %s", addr)
-	if !trySSHReady(host, port, keyPath, 3*time.Minute) {
+	if !trySSHReady(host, port, keyPath, sshReadyBudget) {
 		sshDatapathBroken.Store(true)
-		t.Fatalf("Eventually: condition not met within 3m0s: "+
+		t.Fatalf("Eventually: condition not met within %s: "+
 			"[SSH handshake %s never completed] "+
-			"(sticky-skip enabled for downstream)", addr)
+			"(sticky-skip enabled for downstream)", sshReadyBudget, addr)
 	}
 }
 

--- a/tests/e2e/single/vpc_test.go
+++ b/tests/e2e/single/vpc_test.go
@@ -246,9 +246,9 @@ func runVPCSubnetE2E(t *testing.T, fix *Fixture) {
 
 	// --- SSH + external connectivity ---------------------------------------
 	// Use the non-fatal probe so we can dump VPC/IGW datapath diagnostics
-	// before Fatal. Same 3min budget — fresh-VPC unreachability beyond that
-	// is a real product bug, not test flake.
-	if !trySSHReady(pubIP, 22, keyPath, 3*time.Minute) {
+	// before Fatal. fresh-VPC unreachability beyond the budget is a real
+	// product bug, not test flake.
+	if !trySSHReady(pubIP, 22, keyPath, sshReadyBudget) {
 		harness.DumpVPCFlowDiagnostics(t, c, instID,
 			fmt.Sprintf("Phase 8b SSH timeout — vpc=%s igw=%s pub=%s", vpcID, igwID, pubIP),
 			harness.VPCDiagnosticsOpts{
@@ -256,7 +256,7 @@ func runVPCSubnetE2E(t *testing.T, fix *Fixture) {
 				LogicalIP:   privIP,
 				ArtifactDir: fix.ArtifactDir(t),
 			})
-		t.Fatalf("SSH handshake %s:22 never completed within 3min (see diagnostics above)", pubIP)
+		t.Fatalf("SSH handshake %s:22 never completed within %s (see diagnostics above)", pubIP, sshReadyBudget)
 	}
 
 	tgt := harness.SSHTarget{User: "ec2-user", Host: pubIP, Port: 22, KeyPath: keyPath}


### PR DESCRIPTION
Resilient-resource-lifecycle epic (`mulga-siv-295`, ADR-0001..0006). 12 commits; 68 files (+2806/-278).

## What

Makes resource teardown across the stack **idempotent, tracked, and self-healing** so failed/partial deletes no longer strand billable infra (EIPs, NAT gateways, ENIs, volumes) or wedge clusters.

### EKS multi-node teardown (latest, live-validated env19)
- **Cross-node CP VM terminate routing** — `TerminateSystemInstance` split into a local body + a routing wrapper that issues `system.TerminateInstance.<id>` to the owning node. Previously node-local: terminating a CP VM owned by another node returned NotFound → idempotent → ENI deleted while qemu still held it → `InvalidNetworkInterface.InUse`, which short-circuited `purgeClusterInfra` before the NAT-GW EIP release.
- **Terminate subscription on every launch path** — `tags.IsSystemManaged` (elbv2 + eks) now gates the `OnInstanceUp` re-arm, the one funnel every launch path crosses (local placement, remote handler, restart reconnect). Fixes CP VMs placed on the coordinator's own node being unreachable for cross-node terminate.
- **DELETING backstop reaper** — `EKSDeletingReaper` re-drives clusters wedged in DELETING past a min-age, gated by the per-cluster reconciler leader lease. `ClusterMeta.DeletingSince` stamped on transition.
- **NAT-GW / route-table tag persistence + CP-VPC teardown reorder** so the billable NAT-GW EIP is reclaimed on delete.
- **Billable GC reaper** reclaims orphan NLB + NAT-GW EIP + control-plane VMs whose cluster meta is GONE.

### Lifecycle framework (ADR-0003..0006)
- Idempotent + tracked instance terminate; idempotent `Delete*` across the VPC family + volumes.
- Reconciler GC backstop framework + terminated-teardown reaper.
- VPC-family dependency guards; EBS volume data-safety GC override.
- Orphan ENI LSP pruning in reconcile `applyPorts`.
- ADR-0006 lifecycle invariants; ADR-0002 §3 live-only TG in-use guard.

## Beads
- Closed: `295.4`, `295.8`, `294`, `295.10`, `295.11`, `303` (+ earlier RLC items).
- Open: `295.12` (synchronous-path concurrent-handler herd lock) — partially mitigated, left as separate hardening item.

## Testing
- `make preflight` green (tests, race, vet, lint, govulncheck).
- **Live env19 3-node:** first `delete-cluster` of a spread HA cluster converges in **29s** — both remote CP VMs terminated cross-node, NAT-GW EIP released in the synchronous path, backstop never fires, zero `InUse`. Progression across iterations: ~5min wedge → 125s via backstop → 29s clean.

## Notes
- Mulga submodule pointer intentionally **not** bumped.