### PR TITLE
fix: build microVM rootfs via buildx to stop overlay2 export leak

### DIFF
--- a/.github/workflows/e2e-suites.yml
+++ b/.github/workflows/e2e-suites.yml
@@ -119,10 +119,10 @@ jobs:
           JSON=$(printf '%s\n' $LIST | jq -R . | jq -cs .)
           echo "matrix=${JSON}" >> "$GITHUB_OUTPUT"
 
-      - name: Prune rootless docker cache
+      - name: Reclaim docker build cache
         run: |
           docker container prune -f || true
-          docker image prune -af || true
+          docker image prune -f || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
 
@@ -524,10 +524,10 @@ jobs:
       - name: Re-enable Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Prune rootless docker cache
+      - name: Reclaim docker build cache
         run: |
           docker container prune -f || true
-          docker image prune -af || true
+          docker image prune -f || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -137,10 +137,10 @@ jobs:
       - name: Re-enable Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Prune rootless docker cache
+      - name: Reclaim docker build cache
         run: |
           docker container prune -f || true
-          docker image prune -af || true
+          docker image prune -f || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
 
@@ -533,10 +533,10 @@ jobs:
       - name: Re-enable Go toolchain auto-download
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Prune rootless docker cache
+      - name: Reclaim docker build cache
         run: |
           docker container prune -f || true
-          docker image prune -af || true
+          docker image prune -f || true
           docker buildx prune -af --filter "until=24h" || true
           docker system df || true
 

--- a/scripts/build-microvm-image.sh
+++ b/scripts/build-microvm-image.sh
@@ -81,30 +81,46 @@ EOF
         --initdb \
         $ALPINE_PACKAGES
 
-# Strategy 2/3: container runtime (dev machines)
-else
-    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-        CONTAINER_TOOL=docker
-    elif command -v podman >/dev/null 2>&1; then
-        CONTAINER_TOOL=podman
-    else
-        echo "ERROR: no rootfs build tool available." >&2
-        echo "       Install one of: apk (Alpine), docker, podman" >&2
-        exit 1
-    fi
+# Strategy 2: docker -> BuildKit local export.
+# Do NOT use `docker export` here. On Docker's overlay2 driver it leaks the
+# container's overlay mount (the mount survives `docker rm`), orphaning layers
+# under /var/lib/docker that only a daemon restart reclaims; on a busy CI host
+# this grows without bound. `buildx --output type=local` writes the image
+# filesystem straight to a directory and releases every mount, so nothing leaks.
+elif command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    echo "[build-microvm-image] rootfs: docker buildx --output type=local (alpine:${ALPINE_VERSION})"
+    BUILD_CTX=$(mktemp -d)
+    cat > "$BUILD_CTX/Dockerfile" <<DOCKERFILE
+FROM alpine:${ALPINE_VERSION}
+RUN apk add --no-cache ${ALPINE_PACKAGES}
+DOCKERFILE
+    docker buildx build \
+        --platform linux/amd64 \
+        --output "type=local,dest=${CHROOT_DIR}" \
+        "$BUILD_CTX"
+    rm -rf "$BUILD_CTX"
 
-    echo "[build-microvm-image] rootfs: $CONTAINER_TOOL export (alpine:${ALPINE_VERSION})"
-    CONTAINER_CID=$($CONTAINER_TOOL run -d \
+# Strategy 3: podman -> run + export. Podman's store does not exhibit the docker
+# overlay2 export-mount leak, and podman has no buildx.
+elif command -v podman >/dev/null 2>&1; then
+    echo "[build-microvm-image] rootfs: podman export (alpine:${ALPINE_VERSION})"
+    CONTAINER_TOOL=podman
+    CONTAINER_CID=$(podman run -d \
         "alpine:${ALPINE_VERSION}" \
         sh -c "apk add --no-cache ${ALPINE_PACKAGES}")
 
-    exit_code=$($CONTAINER_TOOL wait "$CONTAINER_CID")
+    exit_code=$(podman wait "$CONTAINER_CID")
     if [ "$exit_code" != "0" ]; then
         echo "ERROR: package installation failed in container (exit $exit_code)" >&2
         exit 1
     fi
 
-    $CONTAINER_TOOL export "$CONTAINER_CID" | tar -x -C "$CHROOT_DIR"
+    podman export "$CONTAINER_CID" | tar -x -C "$CHROOT_DIR"
+
+else
+    echo "ERROR: no rootfs build tool available." >&2
+    echo "       Install one of: apk (Alpine), docker, podman" >&2
+    exit 1
 fi
 
 # --- /dev: empty mountpoint only ---


### PR DESCRIPTION
## Problem

`docker export` of a container **leaks its overlay mount** on Docker's overlay2 driver — the mount survives `docker rm`, so the container's overlay2 layer dirs are never reaped except by a daemon restart.

`build-microvm-image.sh` ran `docker run + docker export` on **every e2e job** across ~9 self-hosted runners on banksia, accumulating **~69G** of orphaned overlay2 layers (disk hit 94%).

### Proven (banksia, overlay2, Docker 26.1.5)
| action | Δ overlay2 dirs | leaked mounts |
|---|---|---|
| run + rm (no export) | +0 | 0 |
| run + **export** + rm | **+2/call** | +1–2/call |

Reproduced on both the default and a clean isolated daemon → Docker overlay2 `export` bug.

## Fix
- `build-microvm-image.sh`: rootfs via `docker buildx --output type=local` (no `docker export`). Podman path kept (unaffected).
- `e2e.yml` / `e2e-suites.yml`: cleanup `docker image prune -af` → `-f` (keep alpine base cached, no re-pull).

## Validation
End-to-end run produces valid `vmlinuz` + `initramfs.cpio.gz` (size gate PASS). 5 buildx cycles leak **0** mounts vs +2/call for export.