### PR TITLE
fix: install chrony on host (curl|bash setup path)

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -221,6 +221,7 @@ install_apt_deps() {
             pciutils \
             jq curl iproute2 netcat-openbsd wget unzip xz-utils file \
             ovn-central ovn-host openvswitch-switch openvswitch-ipsec strongswan-charon dhcpcd-base \
+            chrony \
             > /dev/null
 
         info "System dependencies installed"


### PR DESCRIPTION
## Problem

The Spinifex host installs no NTP daemon. The clock drifts and `timedatectl set-ntp` fails with `NTP not supported`. Once skew passes the SigV4 5-minute window, signed AWS requests are rejected (403) and the web console kicks the user back to `/login` seconds after a successful login. Also threatens TLS validity windows, STS expiry, and etcd timing.

## Fix

Add `chrony` to `install_apt_deps()` so the `curl|bash` host-install path ships a time daemon. apt auto-enables chrony on Debian; it syncs against the public Debian NTP pool by default.

Mirrors the ISO rootfs change in mulga (`iso-builder/build/packages.list` + `build-rootfs.sh`, commit `ac29644`) so both host-install paths stay in sync.

Guest VMs are unaffected — they track the host via kvm-clock and need no in-guest NTP.

## Testing

- `curl|bash` install on a fresh host → `systemctl is-enabled chrony` = enabled, `chronyc tracking` syncs.
- Web console stays logged in past the prior few-seconds kickout.

Bug: mulga-siv-335