### PR TITLE
fix(eks): stop leaking cluster SGs that pin the customer VPC on teardown

### DIFF
--- a/spinifex/handlers/eks/delete_cluster_test.go
+++ b/spinifex/handlers/eks/delete_cluster_test.go
@@ -109,6 +109,7 @@ type deleteClusterFixture struct {
 	inst *fakeK3sInst
 	vpc  *fakeK3sVPC
 	eip  *fakeEIPProvisioner
+	sg   *fakeSGProvisioner
 }
 
 func newDeleteClusterFixture(t *testing.T, clusterName string) *deleteClusterFixture {
@@ -131,7 +132,32 @@ func newDeleteClusterFixture(t *testing.T, clusterName string) *deleteClusterFix
 	_, _, err := GenerateClusterOIDCKeypair(kv, clusterName, bootstrapTestMasterKey)
 	require.NoError(t, err)
 
-	return &deleteClusterFixture{svc: f.svc, kv: kv, nlb: f.nlb, inst: f.inst, vpc: f.vpc, eip: f.eip}
+	return &deleteClusterFixture{svc: f.svc, kv: kv, nlb: f.nlb, inst: f.inst, vpc: f.vpc, eip: f.eip, sg: f.sg}
+}
+
+// TestDeleteCluster_LeakedSGKeepsClusterDeleting guards the customer-VPC SG
+// no-orphan contract (mulga-siv-340): the cluster SGs live in the customer VPC,
+// so a DeleteClusterSGs failure must surface and leave the cluster DELETING — its
+// meta intact for a retry — never complete deletion with an SG stranded that pins
+// the VPC on DependencyViolation. All other teardown steps succeed, isolating the
+// SG failure as the sole cause.
+func TestDeleteCluster_LeakedSGKeepsClusterDeleting(t *testing.T) {
+	origBudget, origInterval := sgDeleteWaitBudget, sgDeleteWaitInterval
+	sgDeleteWaitBudget, sgDeleteWaitInterval = 50*time.Millisecond, time.Millisecond
+	defer func() { sgDeleteWaitBudget, sgDeleteWaitInterval = origBudget, origInterval }()
+
+	f := newDeleteClusterFixture(t, "alpha")
+	f.sg.existing["eks-cluster-alpha-control-plane-sg|vpc-aaa"] = "sg-cp"
+	f.sg.existing["eks-cluster-alpha-nodegroup-sg|vpc-aaa"] = "sg-ng"
+	// A worker ENI never detaches — the SG delete keeps returning DependencyViolation.
+	f.sg.deleteErr = errors.New("DependencyViolation: resource has a dependent object")
+
+	_, err := f.svc.DeleteCluster(deleteInput("alpha"), testAccountID)
+	require.Error(t, err, "a leaked customer-VPC SG must surface, not be swallowed")
+
+	meta, getErr := GetClusterMeta(f.kv, "alpha")
+	require.NoError(t, getErr, "the KV sweep must NOT run while an SG is still leaked — meta must survive for retry")
+	assert.Equal(t, ClusterStatusDeleting, meta.Status, "a cluster with a leaked SG must stay DELETING")
 }
 
 // TestRLC5_DeleteClusterCPVPCReleasesNATGWEIPAfterRoutes locks the mulga-siv-303

--- a/spinifex/handlers/eks/security_groups.go
+++ b/spinifex/handlers/eks/security_groups.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -132,12 +133,46 @@ func DeleteClusterSGs(sgp sgProvisioner, accountID, clusterName, vpcID string) e
 	}
 
 	for _, id := range ids {
-		if _, err := sgp.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: aws.String(id)}, accountID); err != nil && !awserrors.IsNotFound(err) {
+		if err := deleteSGAwaitingDetach(sgp, accountID, id); err != nil {
 			slog.Warn("DeleteClusterSGs: SG delete failed", "sg", id, "err", err)
 			record(fmt.Errorf("delete SG %s: %w", id, err))
 		}
 	}
 	return firstErr
+}
+
+var (
+	// sgDeleteWaitBudget bounds how long deleteSGAwaitingDetach retries a
+	// DeleteSecurityGroup returning DependencyViolation while a terminating
+	// worker's ENI still references the nodegroup SG. The instance-terminate
+	// cascade releases the ENI asynchronously, so the immediate delete can lose
+	// the race. Vars (not consts) so tests can shrink them.
+	sgDeleteWaitBudget   = 45 * time.Second
+	sgDeleteWaitInterval = 1 * time.Second
+)
+
+// deleteSGAwaitingDetach deletes a cluster SG, tolerating the DependencyViolation
+// window while the async instance-terminate cascade releases the last worker ENI
+// still referencing it. A missing SG is idempotent success. A persistent
+// DependencyViolation past the budget is surfaced so the teardown backstop retries
+// rather than leaking the SG — a leaked cluster SG sits in the customer VPC and
+// pins it on DependencyViolation.
+func deleteSGAwaitingDetach(sgp sgProvisioner, accountID, sgID string) error {
+	deadline := time.Now().Add(sgDeleteWaitBudget)
+	for {
+		_, err := sgp.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: aws.String(sgID)}, accountID)
+		switch {
+		case err == nil, awserrors.IsNotFound(err):
+			return nil
+		case awserrors.IsErrorCode(err, awserrors.ErrorDependencyViolation):
+			if time.Now().After(deadline) {
+				return err
+			}
+			time.Sleep(sgDeleteWaitInterval)
+		default:
+			return err
+		}
+	}
 }
 
 // revokeAllSGIngress clears every ingress rule on an SG so cross-references from a

--- a/spinifex/handlers/eks/security_groups_test.go
+++ b/spinifex/handlers/eks/security_groups_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -32,6 +33,11 @@ type fakeSGProvisioner struct {
 	// ingress rules (e.g. a sibling cross-reference), so a test proves the
 	// revoke-before-delete ordering.
 	enforceDepViolation bool
+
+	// deleteFailsBefore maps groupId → the number of DeleteSecurityGroup calls
+	// that return DependencyViolation before succeeding, modelling a worker ENI
+	// detaching after a few retries.
+	deleteFailsBefore map[string]int
 
 	// nextCreateID is returned by the next CreateSecurityGroup call. Tests can
 	// pre-seed a queue via createIDs to differentiate the control-plane vs
@@ -114,6 +120,10 @@ func (f *fakeSGProvisioner) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupIn
 	f.deleteCalls = append(f.deleteCalls, input)
 	if f.deleteErr != nil {
 		return nil, f.deleteErr
+	}
+	if input.GroupId != nil && f.deleteFailsBefore[*input.GroupId] > 0 {
+		f.deleteFailsBefore[*input.GroupId]--
+		return nil, errors.New("DependencyViolation: resource has a dependent object")
 	}
 	if f.enforceDepViolation && input.GroupId != nil && len(f.perms[*input.GroupId]) > 0 {
 		return nil, errors.New("DependencyViolation: resource has a dependent object")
@@ -229,12 +239,46 @@ func TestDeleteClusterSGs_FirstErrorSurfacedSweepContinues(t *testing.T) {
 	sgp := newFakeSGProvisioner()
 	sgp.existing["eks-cluster-alpha-control-plane-sg|vpc-aaa"] = "sg-existing-cp"
 	sgp.existing["eks-cluster-alpha-nodegroup-sg|vpc-aaa"] = "sg-existing-ng"
-	sgp.deleteErr = errors.New("DependencyViolation")
+	// A non-DependencyViolation error is not retried, so the sweep surfaces it
+	// after a single attempt per SG (the retry path is covered separately).
+	sgp.deleteErr = errors.New("vpcd unavailable")
 
 	err := DeleteClusterSGs(sgp, "111122223333", "alpha", "vpc-aaa")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sg-existing-cp")
 	assert.Len(t, sgp.deleteCalls, 2, "both delete calls should be attempted despite first error")
+}
+
+// TestDeleteClusterSGs_RetriesDependencyViolation guards the worker-ENI-detach
+// race: a terminating worker's ENI can still reference the nodegroup SG when the
+// delete runs. DeleteSecurityGroup must retry the DependencyViolation until the
+// instance-terminate cascade releases the ENI (delete succeeds) and surface a
+// persistent one past the budget so the SG is never silently leaked — a leaked
+// cluster SG pins the customer VPC.
+func TestDeleteClusterSGs_RetriesDependencyViolation(t *testing.T) {
+	origBudget, origInterval := sgDeleteWaitBudget, sgDeleteWaitInterval
+	sgDeleteWaitBudget, sgDeleteWaitInterval = 200*time.Millisecond, time.Millisecond
+	defer func() { sgDeleteWaitBudget, sgDeleteWaitInterval = origBudget, origInterval }()
+
+	t.Run("transient then succeeds", func(t *testing.T) {
+		sgp := newFakeSGProvisioner()
+		sgp.existing["eks-cluster-alpha-nodegroup-sg|vpc-aaa"] = "sg-ng"
+		sgp.deleteFailsBefore = map[string]int{"sg-ng": 2} // 2 DepViolations, then ok
+
+		err := DeleteClusterSGs(sgp, "111122223333", "alpha", "vpc-aaa")
+		require.NoError(t, err, "delete must succeed once the ENI detaches")
+		assert.GreaterOrEqual(t, len(sgp.deleteCalls), 3, "retried past the transient violations")
+	})
+
+	t.Run("persistent surfaced past budget", func(t *testing.T) {
+		sgp := newFakeSGProvisioner()
+		sgp.existing["eks-cluster-alpha-nodegroup-sg|vpc-aaa"] = "sg-ng"
+		sgp.deleteErr = errors.New("DependencyViolation: still referenced")
+
+		err := DeleteClusterSGs(sgp, "111122223333", "alpha", "vpc-aaa")
+		require.Error(t, err, "a persistent DependencyViolation must surface, not leak the SG")
+		assert.Contains(t, err.Error(), "sg-ng")
+	})
 }
 
 // TestDeleteClusterSGs_RevokesCrossRefsBeforeDelete guards the no-orphan

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -867,11 +867,12 @@ func (s *EKSServiceImpl) claimClusterName(accountID string, acctKV nats.KeyValue
 
 // purgeClusterInfra tears down a cluster's live AWS resources and erases its
 // per-cluster KV state. Zeroize (a security guarantee — no recoverable key
-// material) plus NLB and VM teardown are blocking: their failures are joined
-// and returned BEFORE the KV sweep, so a billable resource is never orphaned
-// without the meta record that owns its ARNs/IDs. SG cleanup is best-effort
-// (a leaked SG strands no owning record). Shared by DeleteCluster and the
-// FAILED-cluster reclaim path in CreateCluster.
+// material), NLB, VM, SG, IGW, and CP-VPC teardown are all blocking: their
+// failures are joined and returned BEFORE the KV sweep, so neither a billable
+// resource nor a VPC-pinning SG is orphaned without the meta record that owns
+// its IDs. The cluster SGs sit in the customer VPC, so a leaked SG pins the VPC
+// on DependencyViolation — leaving the cluster DELETING for a retry is correct.
+// Shared by DeleteCluster and the FAILED-cluster reclaim path in CreateCluster.
 func (s *EKSServiceImpl) purgeClusterInfra(accountID, name string, meta *ClusterMeta, acctKV nats.KeyValue, deleteMeta bool) error {
 	s.registry.Stop(accountID, name)
 
@@ -961,10 +962,6 @@ func (s *EKSServiceImpl) purgeClusterInfra(accountID, name string, meta *Cluster
 		}
 	}
 
-	if len(teardownErrs) > 0 {
-		return errors.Join(teardownErrs...)
-	}
-
 	// Private endpoint (301): reclaim the customer-VPC SG now its ENI is gone.
 	// Best-effort — its only billable dependant (the ENI) is already deleted.
 	if meta.ResourcesVpcConfig != nil && meta.ResourcesVpcConfig.VpcId != "" {
@@ -973,29 +970,29 @@ func (s *EKSServiceImpl) purgeClusterInfra(accountID, name string, meta *Cluster
 		}
 	}
 
+	// SG / IGW / CP-VPC cleanup runs even when an earlier step failed: the cluster
+	// SGs sit in the customer VPC, so skipping them would pin the VPC. Failures are
+	// joined into teardownErrs (not swallowed) so the meta survives for a retry.
 	if meta.ManagedCPVPC != nil && meta.ManagedCPVPC.VpcId != "" {
 		// New topology: SGs + IGW + subnets + route tables + NAT GW + VPC all live
 		// in the managed CP VPC under the system account. DeleteClusterCPVPC removes
 		// the IGW + VPC after the SGs, so SG cleanup must precede it.
 		if err := DeleteClusterSGs(s.deps.VPCSG, infraAcct, name, meta.ManagedCPVPC.VpcId); err != nil {
-			slog.Warn("purgeClusterInfra: DeleteClusterSGs failed", "cluster", name, "err", err)
+			teardownErrs = append(teardownErrs, fmt.Errorf("delete cluster SGs: %w", err))
 		}
-		// The CP VPC holds a billable NAT-GW EIP, so a teardown failure is surfaced
-		// (not best-effort): returning before the KV sweep keeps the meta refs alive
-		// for a delete retry rather than orphaning the EIP.
 		if err := DeleteClusterCPVPC(s.cpVPCDeps(), infraAcct, name); err != nil {
-			return fmt.Errorf("delete managed CP VPC: %w", err)
+			teardownErrs = append(teardownErrs, fmt.Errorf("delete managed CP VPC: %w", err))
 		}
 	} else if meta.ResourcesVpcConfig != nil && meta.ResourcesVpcConfig.VpcId != "" {
 		// Legacy topology: CP lived in the customer VPC; reclaim its SGs + the
 		// cluster-owned IGW (ownership-scoped — a reused customer IGW is left
 		// intact). IGW delete must precede any VPC delete to avoid DependencyViolation.
 		if err := DeleteClusterSGs(s.deps.VPCSG, accountID, name, meta.ResourcesVpcConfig.VpcId); err != nil {
-			slog.Warn("purgeClusterInfra: DeleteClusterSGs failed", "cluster", name, "err", err)
+			teardownErrs = append(teardownErrs, fmt.Errorf("delete cluster SGs: %w", err))
 		}
 		if s.deps.IGW != nil {
 			if err := DeleteClusterIGW(s.deps.IGW, accountID, meta.ResourcesVpcConfig.VpcId, name); err != nil {
-				slog.Warn("purgeClusterInfra: DeleteClusterIGW failed", "cluster", name, "err", err)
+				teardownErrs = append(teardownErrs, fmt.Errorf("delete cluster IGW: %w", err))
 			}
 		}
 	}
@@ -1004,6 +1001,13 @@ func (s *EKSServiceImpl) purgeClusterInfra(accountID, name string, meta *Cluster
 	// clusters). Best-effort: the VMs are already gone, so a leaked internal
 	// group strands nothing.
 	s.teardownSpreadGroup(meta)
+
+	// Any blocking-teardown failure (billable infra or a VPC-pinning SG) keeps the
+	// meta — and the IDs that own the stranded resources — alive for a delete retry
+	// or the DELETING backstop, rather than completing deletion with infra leaked.
+	if len(teardownErrs) > 0 {
+		return errors.Join(teardownErrs...)
+	}
 
 	// Only now, with NLB + VM confirmed gone, erase the meta + per-cluster KV.
 	// The reclaim path passes deleteMeta=false: it has already CAS-claimed the


### PR DESCRIPTION
## Problem

`tofu destroy` of an EKS workbook leaves the auto-managed cluster security groups behind. Because the nodegroup and control-plane SGs live in the **customer VPC**, the leaked SGs pin `aws_vpc` deletion on `DependencyViolation`, forcing the operator to manually revoke SG rules and delete the SGs before the VPC will destroy.

`purgeClusterInfra` stranded the SGs two ways:

1. **Early return skipped SG cleanup.** The `if len(teardownErrs) > 0 { return }` guard sat *before* the SG / IGW / CP-VPC cleanup block, so a single earlier best-effort hiccup (NLB / private-endpoint ENI / CP-VM terminate / EIP release) meant `DeleteClusterSGs` never ran.
2. **SG-delete failures were swallowed.** Even when reached, `DeleteClusterSGs` was invoked best-effort — `slog.Warn` and discarded. The common trigger is the worker-ENI detach race: `DeleteNodegroup` terminates workers asynchronously, so when the subsequent `DeleteCluster` runs `DeleteSecurityGroup` on the nodegroup SG, a terminating worker's ENI may still reference it → `DependencyViolation`. Swallowed, the cluster completed deletion (KV swept) with the SG leaked and no reaper retry.

The stale doc comment claimed *"a leaked SG strands no owning record"* — wrong for the customer-VPC cluster SGs.

## Fix

- **Surface SG / IGW / CP-VPC cleanup errors** into `teardownErrs` and gate the KV sweep on them, so a leaked VPC-pinning SG keeps the cluster `DELETING` for a delete retry / the DELETING backstop to converge instead of completing deletion with infra stranded. Removed the early return so SG cleanup is always attempted.
- **Bounded `DependencyViolation` retry** on the SG delete (`deleteSGAwaitingDetach`, mirroring the existing `deleteENIAwaitingTerminate`) to ride out the worker-ENI-detach window in the common case so the first `tofu destroy` succeeds cleanly.
- Fixed the stale doc comment.

## Tests

- `TestDeleteClusterSGs_RetriesDependencyViolation` — retries past a transient violation then succeeds; surfaces a persistent one past the (shrunk) budget.
- `TestDeleteCluster_LeakedSGKeepsClusterDeleting` — a persistent SG-delete failure surfaces and leaves the cluster `DELETING` with meta intact (no KV sweep), all other teardown steps succeeding.
- Existing `TestRLC2` (billable-before-sweep) still green — SG errors now route through the same gate.

`make preflight` green (one unrelated daemon GPU-rebind flake on the first run, passed on rerun).

Plan: `docs/development/bugs/eks-teardown-sg-leak.md` (mulga). Bead: mulga-siv-340.

A separate `kubernetes_service_v1` / `kubernetes_deployment_v1` delete hang during the same destroy is tracked separately (needs runtime logs).