### PR TITLE
fix(workbooks): split EKS demo workloads into separate root module

### DIFF
--- a/docs/terraform-workbooks/eks-addons-access/README.md
+++ b/docs/terraform-workbooks/eks-addons-access/README.md
@@ -95,17 +95,31 @@ Or create a `main.tf` file and paste the full configuration below.
 
 ### Step 2. Deploy
 
+The cluster and the demo app are **two root modules with separate state**. Apply the cluster first:
+
 ```bash
 export AWS_PROFILE=spinifex
 tofu init
 tofu apply
 ```
 
-Allow a few minutes for the cluster to reach `ACTIVE` and the worker to register. Argo CD installs onto the worker, then Terraform deploys the demo app.
+Allow a few minutes for the cluster to reach `ACTIVE`, the worker to register, and Argo CD to install. Then deploy the demo app from the nested `workloads/` module:
 
-> Keep `AWS_PROFILE=spinifex` exported for the whole `apply` — the Kubernetes provider runs `aws eks get-token` against the Spinifex STS endpoint.
+```bash
+cd workloads
+tofu init
+tofu apply
+```
+
+> **Why two modules?** The Kubernetes provider in `workloads/` reads the cluster endpoint from a live `data "aws_eks_cluster"` source, so it's only ever configured while the cluster exists. Keeping it out of the cluster module means `destroy` never tries to refresh a workload against a cluster that's already gone — the failure mode where the provider falls back to `http://localhost:80` and reports `connection refused`. Always destroy `workloads/` before the cluster.
+
+> Keep `AWS_PROFILE=spinifex` exported for both applies — the Kubernetes provider runs `aws eks get-token` against the Spinifex STS endpoint.
+
+<!-- INCLUDE: workloads/main.tf lang:hcl -->
 
 ### Step 3. Open the Demo
+
+Run from the cluster module directory (`cd ..` if you're still in `workloads/`):
 
 ```bash
 tofu output demo_url
@@ -129,7 +143,12 @@ The viewer principal is bound to `AmazonEKSViewPolicy` at cluster scope — it c
 
 ### Cleanup
 
+Destroy in reverse — the demo app first (while the cluster is still up), then the cluster:
+
 ```bash
+cd workloads
+tofu destroy
+cd ..
 tofu destroy
 ```
 

--- a/docs/terraform-workbooks/eks-addons-access/main.tf
+++ b/docs/terraform-workbooks/eks-addons-access/main.tf
@@ -25,10 +25,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.40, < 6.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
-    }
   }
 }
 
@@ -61,11 +57,6 @@ variable "node_port" {
   default = 30080
 }
 
-variable "replicas" {
-  type    = number
-  default = 2
-}
-
 variable "browse_cidr" {
   type        = string
   default     = "0.0.0.0/0"
@@ -95,17 +86,6 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
   skip_region_validation      = true
-}
-
-provider "kubernetes" {
-  host                   = aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name, "--region", var.region]
-  }
 }
 
 data "aws_availability_zones" "available" {
@@ -379,65 +359,6 @@ resource "aws_vpc_security_group_ingress_rule" "nodeport" {
   }
 }
 
-# ---------------------------------------------------------------------------
-# Demo workload — deployed after the Argo CD addon reaches ACTIVE
-# ---------------------------------------------------------------------------
-
-resource "kubernetes_deployment_v1" "hello" {
-  metadata {
-    name      = "hello"
-    namespace = "default"
-    labels    = { app = "hello" }
-  }
-
-  spec {
-    replicas = var.replicas
-
-    selector {
-      match_labels = { app = "hello" }
-    }
-
-    template {
-      metadata {
-        labels = { app = "hello" }
-      }
-
-      spec {
-        container {
-          name  = "hello"
-          image = "nginxdemos/hello"
-
-          port {
-            container_port = 80
-          }
-        }
-      }
-    }
-  }
-
-  depends_on = [aws_eks_addon.argocd]
-}
-
-resource "kubernetes_service_v1" "hello" {
-  metadata {
-    name      = "hello"
-    namespace = "default"
-  }
-
-  spec {
-    selector = { app = "hello" }
-    type     = "NodePort"
-
-    port {
-      port        = 80
-      target_port = 80
-      node_port   = var.node_port
-    }
-  }
-
-  depends_on = [kubernetes_deployment_v1.hello]
-}
-
 data "aws_instances" "workers" {
   instance_tags = {
     "spinifex:eks-cluster" = aws_eks_cluster.this.name
@@ -452,6 +373,14 @@ data "aws_instances" "workers" {
 
 output "cluster_name" {
   value = aws_eks_cluster.this.name
+}
+
+output "region" {
+  value = var.region
+}
+
+output "node_port" {
+  value = var.node_port
 }
 
 output "viewer_principal_arn" {

--- a/docs/terraform-workbooks/eks-addons-access/workloads/main.tf
+++ b/docs/terraform-workbooks/eks-addons-access/workloads/main.tf
@@ -1,0 +1,138 @@
+# Demo workload for eks-addons-access — separate root module / state.
+#
+# Kept apart from the cluster root module on purpose: the kubernetes provider
+# below reads the cluster endpoint from a *live* data source, so it is only ever
+# configured while the cluster exists. Destroy this module before the parent and
+# the provider never falls back to localhost.
+#
+# Usage:
+#   cd spinifex/docs/terraform-workbooks/eks-addons-access
+#   tofu init && tofu apply                    # parent: cluster + infra
+#   cd workloads && tofu init && tofu apply    # this module: demo app
+#   # teardown is the reverse — destroy here first, then the parent.
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40, < 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}
+
+variable "spinifex_endpoint" {
+  type    = string
+  default = "https://127.0.0.1:9999"
+}
+
+variable "replicas" {
+  type    = number
+  default = 2
+}
+
+provider "aws" {
+  region = data.terraform_remote_state.infra.outputs.region
+
+  endpoints {
+    ec2 = var.spinifex_endpoint
+    iam = var.spinifex_endpoint
+    sts = var.spinifex_endpoint
+    eks = var.spinifex_endpoint
+  }
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+}
+
+# Cluster identity comes from the parent module's state; the live endpoint/CA
+# come from a data source so the provider is only configured while the cluster
+# is up.
+data "terraform_remote_state" "infra" {
+  backend = "local"
+
+  config = {
+    path = "../terraform.tfstate"
+  }
+}
+
+locals {
+  cluster_name = data.terraform_remote_state.infra.outputs.cluster_name
+  region       = data.terraform_remote_state.infra.outputs.region
+  node_port    = data.terraform_remote_state.infra.outputs.node_port
+}
+
+data "aws_eks_cluster" "this" {
+  name = local.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--region", local.region]
+  }
+}
+
+resource "kubernetes_deployment_v1" "hello" {
+  metadata {
+    name      = "hello"
+    namespace = "default"
+    labels    = { app = "hello" }
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = { app = "hello" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "hello" }
+      }
+
+      spec {
+        container {
+          name  = "hello"
+          image = "nginxdemos/hello"
+
+          port {
+            container_port = 80
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "hello" {
+  metadata {
+    name      = "hello"
+    namespace = "default"
+  }
+
+  spec {
+    selector = { app = "hello" }
+    type     = "NodePort"
+
+    port {
+      port        = 80
+      target_port = 80
+      node_port   = local.node_port
+    }
+  }
+
+  depends_on = [kubernetes_deployment_v1.hello]
+}

--- a/docs/terraform-workbooks/eks-https-ingress/README.md
+++ b/docs/terraform-workbooks/eks-https-ingress/README.md
@@ -108,15 +108,29 @@ Or create a `main.tf` file and paste the full configuration below.
 
 ### Step 2. Deploy
 
+The cluster (with its ALB and ACM cert) and the demo app are **two root modules with separate state**. Apply the cluster first:
+
 ```bash
 export AWS_PROFILE=spinifex
 tofu init
 tofu apply
 ```
 
-Expect several minutes: the control plane bootstraps, three workers launch and join over the private endpoint, the NAT gateway comes up, CoreDNS installs, the ALB is provisioned, and the Kubernetes provider rolls out the demo app.
+Expect several minutes: the control plane bootstraps, three workers launch and join over the private endpoint, the NAT gateway comes up, CoreDNS installs, and the ALB is provisioned. Then deploy the demo app from the nested `workloads/` module:
 
-> **Keep `AWS_PROFILE=spinifex` exported** for the whole `apply` — the Kubernetes provider authenticates with `aws eks get-token` against the Spinifex STS endpoint.
+```bash
+cd workloads
+tofu init
+tofu apply
+```
+
+The ALB target group already points at the workers' NodePort; once these pods are running the targets turn healthy.
+
+> **Why two modules?** The Kubernetes provider in `workloads/` reads the cluster endpoint from a live `data "aws_eks_cluster"` source, so it's only ever configured while the cluster exists. Keeping it out of the cluster module means `destroy` never tries to refresh a workload against a cluster that's already gone — the failure mode where the provider falls back to `http://localhost:80` and reports `connection refused`. Always destroy `workloads/` before the cluster.
+
+> **Keep `AWS_PROFILE=spinifex` exported** for both applies — the Kubernetes provider authenticates with `aws eks get-token` against the Spinifex STS endpoint.
+
+<!-- INCLUDE: workloads/main.tf lang:hcl -->
 
 > **Tighten access in production.** `api_public_access_cidr` and `alb_ingress_cidr` both default to `0.0.0.0/0`. Set them to your own CIDR:
 >
@@ -158,7 +172,12 @@ aws elbv2 describe-target-health --target-group-arn "$TG_ARN"
 
 ### Cleanup
 
+Destroy in reverse — the demo app first (while the cluster is still up), then the cluster:
+
 ```bash
+cd workloads
+tofu destroy
+cd ..
 tofu destroy
 ```
 

--- a/docs/terraform-workbooks/eks-https-ingress/main.tf
+++ b/docs/terraform-workbooks/eks-https-ingress/main.tf
@@ -40,10 +40,6 @@ terraform {
       source  = "hashicorp/tls"
       version = ">= 4.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
-    }
   }
 }
 
@@ -125,17 +121,6 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
   skip_region_validation      = true
-}
-
-provider "kubernetes" {
-  host                   = aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name, "--region", var.region]
-  }
 }
 
 data "aws_availability_zones" "available" {
@@ -573,81 +558,23 @@ resource "aws_vpc_security_group_ingress_rule" "nodeport_from_alb" {
 }
 
 # ---------------------------------------------------------------------------
-# Demo workload — three replicas spread across the workers
-# ---------------------------------------------------------------------------
-
-resource "kubernetes_deployment_v1" "hello" {
-  metadata {
-    name      = "hello"
-    namespace = "default"
-    labels    = { app = "hello" }
-  }
-
-  spec {
-    replicas = var.node_desired_size
-
-    selector {
-      match_labels = { app = "hello" }
-    }
-
-    template {
-      metadata {
-        labels = { app = "hello" }
-      }
-
-      spec {
-        container {
-          name  = "hello"
-          image = "nginxdemos/hello"
-
-          port {
-            container_port = 80
-          }
-        }
-
-        # Spread one replica per node so a refresh visibly hits different nodes.
-        topology_spread_constraint {
-          max_skew           = 1
-          topology_key       = "kubernetes.io/hostname"
-          when_unsatisfiable = "ScheduleAnyway"
-
-          label_selector {
-            match_labels = { app = "hello" }
-          }
-        }
-      }
-    }
-  }
-
-  depends_on = [aws_eks_addon.coredns]
-}
-
-resource "kubernetes_service_v1" "hello" {
-  metadata {
-    name      = "hello"
-    namespace = "default"
-  }
-
-  spec {
-    selector = { app = "hello" }
-    type     = "NodePort"
-
-    port {
-      port        = 80
-      target_port = 80
-      node_port   = var.node_port
-    }
-  }
-
-  depends_on = [kubernetes_deployment_v1.hello]
-}
-
-# ---------------------------------------------------------------------------
 # Outputs
 # ---------------------------------------------------------------------------
 
 output "cluster_name" {
   value = aws_eks_cluster.this.name
+}
+
+output "region" {
+  value = var.region
+}
+
+output "node_port" {
+  value = var.node_port
+}
+
+output "node_desired_size" {
+  value = var.node_desired_size
 }
 
 output "certificate_arn" {

--- a/docs/terraform-workbooks/eks-https-ingress/workloads/main.tf
+++ b/docs/terraform-workbooks/eks-https-ingress/workloads/main.tf
@@ -1,0 +1,148 @@
+# Demo workload for eks-https-ingress — separate root module / state.
+#
+# Kept apart from the cluster root module on purpose: the kubernetes provider
+# below reads the cluster endpoint from a *live* data source, so it is only ever
+# configured while the cluster exists. Destroy this module before the parent and
+# the provider never falls back to localhost.
+#
+# The ALB target group in the parent forwards to the workers' NodePort; this
+# module is what actually answers on that port.
+#
+# Usage:
+#   cd spinifex/docs/terraform-workbooks/eks-https-ingress
+#   tofu init && tofu apply                    # parent: cluster + ALB + infra
+#   cd workloads && tofu init && tofu apply    # this module: demo app
+#   # teardown is the reverse — destroy here first, then the parent.
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40, < 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}
+
+variable "spinifex_endpoint" {
+  type    = string
+  default = "https://127.0.0.1:9999"
+}
+
+provider "aws" {
+  region = data.terraform_remote_state.infra.outputs.region
+
+  endpoints {
+    ec2 = var.spinifex_endpoint
+    iam = var.spinifex_endpoint
+    sts = var.spinifex_endpoint
+    eks = var.spinifex_endpoint
+  }
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+}
+
+# Cluster identity comes from the parent module's state; the live endpoint/CA
+# come from a data source so the provider is only configured while the cluster
+# is up.
+data "terraform_remote_state" "infra" {
+  backend = "local"
+
+  config = {
+    path = "../terraform.tfstate"
+  }
+}
+
+locals {
+  cluster_name = data.terraform_remote_state.infra.outputs.cluster_name
+  region       = data.terraform_remote_state.infra.outputs.region
+  node_port    = data.terraform_remote_state.infra.outputs.node_port
+  replicas     = data.terraform_remote_state.infra.outputs.node_desired_size
+}
+
+data "aws_eks_cluster" "this" {
+  name = local.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--region", local.region]
+  }
+}
+
+resource "kubernetes_deployment_v1" "hello" {
+  metadata {
+    name      = "hello"
+    namespace = "default"
+    labels    = { app = "hello" }
+  }
+
+  spec {
+    replicas = local.replicas
+
+    selector {
+      match_labels = { app = "hello" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "hello" }
+      }
+
+      spec {
+        container {
+          name  = "hello"
+          image = "nginxdemos/hello"
+
+          port {
+            container_port = 80
+          }
+        }
+
+        # Spread one replica per node so a refresh visibly hits different nodes.
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "kubernetes.io/hostname"
+          when_unsatisfiable = "ScheduleAnyway"
+
+          label_selector {
+            match_labels = { app = "hello" }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "hello" {
+  metadata {
+    name      = "hello"
+    namespace = "default"
+  }
+
+  spec {
+    selector = { app = "hello" }
+    type     = "NodePort"
+
+    port {
+      port        = 80
+      target_port = 80
+      node_port   = local.node_port
+    }
+  }
+
+  depends_on = [kubernetes_deployment_v1.hello]
+}

--- a/docs/terraform-workbooks/eks-quickstart/README.md
+++ b/docs/terraform-workbooks/eks-quickstart/README.md
@@ -90,17 +90,31 @@ Or create a `main.tf` file and paste the full configuration below.
 
 ### Step 2. Deploy
 
+The cluster and the demo app are **two root modules with separate state**. Apply the cluster first:
+
 ```bash
 export AWS_PROFILE=spinifex
 tofu init
 tofu apply
 ```
 
-This single `apply` does the whole job: it creates the cluster (which bootstraps a control-plane VM and brings up k3s — a few minutes in `CREATING`), launches the worker, opens the NodePort, then deploys the demo app and waits for the pods to roll out.
+This creates the cluster (which bootstraps a control-plane VM and brings up k3s — a few minutes in `CREATING`), launches the worker, and opens the NodePort. Once it's `ACTIVE`, deploy the demo app from the nested `workloads/` module:
 
-> **Same profile for the Kubernetes provider.** The Kubernetes provider authenticates by shelling out to `aws eks get-token`, which has to reach the Spinifex STS endpoint. Keep `AWS_PROFILE=spinifex` exported for the whole `apply`.
+```bash
+cd workloads
+tofu init
+tofu apply
+```
+
+> **Why two modules?** The Kubernetes provider in `workloads/` reads the cluster endpoint from a live `data "aws_eks_cluster"` source, so it's only ever configured while the cluster exists. Keeping it out of the cluster module means `destroy` never tries to refresh a workload against a cluster that's already gone — the failure mode where the provider falls back to `http://localhost:80` and reports `connection refused`. Always destroy `workloads/` before the cluster.
+
+> **Same profile for the Kubernetes provider.** The Kubernetes provider authenticates by shelling out to `aws eks get-token`, which has to reach the Spinifex STS endpoint. Keep `AWS_PROFILE=spinifex` exported for both applies.
+
+<!-- INCLUDE: workloads/main.tf lang:hcl -->
 
 ### Step 3. Open the Demo
+
+Run from the cluster module directory (`cd ..` if you're still in `workloads/`):
 
 ```bash
 tofu output demo_url
@@ -120,7 +134,12 @@ kubectl get pods -o wide
 
 ### Cleanup
 
+Destroy in reverse — the demo app first (while the cluster is still up), then the cluster:
+
 ```bash
+cd workloads
+tofu destroy
+cd ..
 tofu destroy
 ```
 

--- a/docs/terraform-workbooks/eks-quickstart/main.tf
+++ b/docs/terraform-workbooks/eks-quickstart/main.tf
@@ -27,10 +27,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.40, < 6.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
-    }
   }
 }
 
@@ -65,12 +61,6 @@ variable "node_port" {
   description = "NodePort the demo Service is published on"
 }
 
-variable "replicas" {
-  type        = number
-  default     = 2
-  description = "Demo app replicas; refresh the page to see requests land on different pods"
-}
-
 variable "browse_cidr" {
   type        = string
   default     = "0.0.0.0/0"
@@ -101,19 +91,6 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
   skip_region_validation      = true
-}
-
-# Authenticates to the cluster with the same `aws eks get-token` exec flow the
-# generated kubeconfig uses, so the Kubernetes provider can deploy the demo app.
-provider "kubernetes" {
-  host                   = aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.this.name, "--region", var.region]
-  }
 }
 
 # ---------------------------------------------------------------------------
@@ -337,68 +314,6 @@ resource "aws_vpc_security_group_ingress_rule" "nodeport" {
 }
 
 # ---------------------------------------------------------------------------
-# Demo workload — deployed onto the cluster by Terraform
-#
-# nginxdemos/hello renders a page showing which pod served the request; with
-# multiple replicas, refreshing the demo_url alternates between them.
-# ---------------------------------------------------------------------------
-
-resource "kubernetes_deployment_v1" "hello" {
-  metadata {
-    name      = "hello"
-    namespace = "default"
-    labels    = { app = "hello" }
-  }
-
-  spec {
-    replicas = var.replicas
-
-    selector {
-      match_labels = { app = "hello" }
-    }
-
-    template {
-      metadata {
-        labels = { app = "hello" }
-      }
-
-      spec {
-        container {
-          name  = "hello"
-          image = "nginxdemos/hello"
-
-          port {
-            container_port = 80
-          }
-        }
-      }
-    }
-  }
-
-  depends_on = [aws_eks_node_group.default]
-}
-
-resource "kubernetes_service_v1" "hello" {
-  metadata {
-    name      = "hello"
-    namespace = "default"
-  }
-
-  spec {
-    selector = { app = "hello" }
-    type     = "NodePort"
-
-    port {
-      port        = 80
-      target_port = 80
-      node_port   = var.node_port
-    }
-  }
-
-  depends_on = [kubernetes_deployment_v1.hello]
-}
-
-# ---------------------------------------------------------------------------
 # Discover the worker's public IP for the demo URL
 # ---------------------------------------------------------------------------
 
@@ -416,6 +331,14 @@ data "aws_instances" "workers" {
 
 output "cluster_name" {
   value = aws_eks_cluster.this.name
+}
+
+output "region" {
+  value = var.region
+}
+
+output "node_port" {
+  value = var.node_port
 }
 
 output "demo_url" {

--- a/docs/terraform-workbooks/eks-quickstart/workloads/main.tf
+++ b/docs/terraform-workbooks/eks-quickstart/workloads/main.tf
@@ -1,0 +1,144 @@
+# Demo workload for eks-quickstart — separate root module / state.
+#
+# Kept apart from the cluster root module on purpose: the kubernetes provider
+# below reads the cluster endpoint from a *live* data source, so it is only ever
+# configured while the cluster exists. Destroy this module before the parent and
+# the provider never falls back to localhost.
+#
+# Usage:
+#   cd spinifex/docs/terraform-workbooks/eks-quickstart
+#   tofu init && tofu apply                    # parent: cluster + infra
+#   cd workloads && tofu init && tofu apply    # this module: demo app
+#   # teardown is the reverse — destroy here first, then the parent.
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40, < 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}
+
+variable "spinifex_endpoint" {
+  type        = string
+  default     = "https://127.0.0.1:9999"
+  description = "Spinifex AWS gateway endpoint"
+}
+
+variable "replicas" {
+  type        = number
+  default     = 2
+  description = "Demo app replicas; refresh the page to see requests land on different pods"
+}
+
+provider "aws" {
+  region = data.terraform_remote_state.infra.outputs.region
+
+  endpoints {
+    ec2 = var.spinifex_endpoint
+    iam = var.spinifex_endpoint
+    sts = var.spinifex_endpoint
+    eks = var.spinifex_endpoint
+  }
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+}
+
+# Cluster identity comes from the parent module's state; the live endpoint/CA
+# come from a data source so the provider is only configured while the cluster
+# is up.
+data "terraform_remote_state" "infra" {
+  backend = "local"
+
+  config = {
+    path = "../terraform.tfstate"
+  }
+}
+
+locals {
+  cluster_name = data.terraform_remote_state.infra.outputs.cluster_name
+  region       = data.terraform_remote_state.infra.outputs.region
+  node_port    = data.terraform_remote_state.infra.outputs.node_port
+}
+
+data "aws_eks_cluster" "this" {
+  name = local.cluster_name
+}
+
+# Authenticates with the same `aws eks get-token` exec flow the generated
+# kubeconfig uses, so the Kubernetes provider can deploy the demo app.
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--region", local.region]
+  }
+}
+
+# nginxdemos/hello renders a page showing which pod served the request; with
+# multiple replicas, refreshing the demo_url alternates between them.
+resource "kubernetes_deployment_v1" "hello" {
+  metadata {
+    name      = "hello"
+    namespace = "default"
+    labels    = { app = "hello" }
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = { app = "hello" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "hello" }
+      }
+
+      spec {
+        container {
+          name  = "hello"
+          image = "nginxdemos/hello"
+
+          port {
+            container_port = 80
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "hello" {
+  metadata {
+    name      = "hello"
+    namespace = "default"
+  }
+
+  spec {
+    selector = { app = "hello" }
+    type     = "NodePort"
+
+    port {
+      port        = 80
+      target_port = 80
+      node_port   = local.node_port
+    }
+  }
+
+  depends_on = [kubernetes_deployment_v1.hello]
+}


### PR DESCRIPTION
## Problem

The `kubernetes` provider in the `eks-quickstart`, `eks-addons-access` and `eks-https-ingress` workbooks was configured directly from the managed cluster resource:

```hcl
provider "kubernetes" {
  host = aws_eks_cluster.this.endpoint
  ...
}
```

On `tofu destroy` the cluster endpoint resolved empty, so the provider host fell back to `localhost:80` and refreshing `kubernetes_deployment_v1.hello` / `kubernetes_service_v1.hello` failed:

```
Get "http://localhost/apis/apps/v1/namespaces/default/deployments/hello":
dial tcp [::1]:80: connect: connection refused
```

Canonical Terraform anti-pattern — a provider configured from a resource in the same destroy graph. Not a Spinifex defect.

## Change

Each workbook splits into two root modules with independent state:

- **parent** — all AWS infra + cluster + addon + ALB/ACM (https) + NodePort SG rule. Drops the `kubernetes` provider and the two `hello` resources; adds `region`/`node_port`(/`node_desired_size`) outputs.
- **`workloads/` child** — own state; reads cluster identity from the parent via `terraform_remote_state` and the live endpoint/CA via `data "aws_eks_cluster"`. Holds the `kubernetes` provider + `hello` Deployment/Service.

Because workloads are destroyed **before** the cluster, `data.aws_eks_cluster` always resolves a live endpoint — no localhost fallback.

### Lifecycle
```
tofu apply                       # parent: cluster + infra
cd workloads && tofu apply       # child: demo app
# destroy reverse:
cd workloads && tofu destroy
cd .. && tofu destroy
```

## Testing

- `tofu fmt -check` + `tofu validate` pass on all six modules (3 parents + 3 children).
- READMEs updated with the two-stage apply/destroy flow and a note on why.

Bead: mulga-siv-342