### PR TITLE
feat: scaffold ECR control-plane + OCI registry gateway (501 stubs)

### DIFF
--- a/spinifex/gateway/ecr.go
+++ b/spinifex/gateway/ecr.go
@@ -1,0 +1,25 @@
+package gateway
+
+import (
+	"github.com/go-chi/chi/v5"
+
+	gateway_ecr "github.com/mulgadc/spinifex/spinifex/gateway/ecr"
+)
+
+// mountOCIRegistry registers the OCI Distribution Spec v2 surface (/v2/*) on r.
+// These endpoints are host- and token-authenticated rather than
+// SigV4-credential-scoped, so they mount outside the SigV4 group under the
+// no-op hostMatch skeleton.
+//
+// OCI repository names may contain slashes (e.g. team/app), so the blob,
+// manifest and tag paths can't be expressed as fixed chi segments. Everything
+// under /v2 therefore routes through a single catch-all 501 stub until a
+// path-parsing dispatcher and storage exist. GET /v2/ is live so the registry
+// version-check probe succeeds.
+func (gw *GatewayConfig) mountOCIRegistry(r chi.Router) {
+	r.Route("/v2", func(v2 chi.Router) {
+		v2.Use(hostMatch)
+		v2.Get("/", gateway_ecr.APIVersion)
+		v2.HandleFunc("/*", gateway_ecr.NotImplemented)
+	})
+}

--- a/spinifex/gateway/ecr/handler.go
+++ b/spinifex/gateway/ecr/handler.go
@@ -1,0 +1,58 @@
+// Package gateway_ecr is the HTTP-side glue for the OCI Distribution Spec v2
+// registry surface (/v2/*) served by awsgw. It speaks the OCI error envelope
+// ({"errors":[{code,message,detail}]}), not the AWS JSON 1.1 envelope used by
+// the ECR control plane (see package gateway_ecrapi). Handlers currently return
+// 501 Unsupported; the storage and auth-bridge layers replace them as they land.
+package gateway_ecr
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// OCIContentType is the OCI error/document content type registry clients expect.
+const OCIContentType = "application/json"
+
+// OCIError is one entry in an OCI Distribution error response.
+type OCIError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Detail  any    `json:"detail,omitempty"`
+}
+
+// ociErrorEnvelope is the OCI Distribution top-level error body.
+type ociErrorEnvelope struct {
+	Errors []OCIError `json:"errors"`
+}
+
+// WriteError writes an OCI Distribution error envelope with the given HTTP
+// status. code is an OCI error code (e.g. "UNSUPPORTED", "MANIFEST_UNKNOWN").
+func WriteError(w http.ResponseWriter, status int, code, message string) {
+	body, err := json.Marshal(ociErrorEnvelope{Errors: []OCIError{{Code: code, Message: message}}})
+	if err != nil {
+		slog.Error("ECR/OCI: failed to marshal error envelope", "err", err)
+		http.Error(w, `{"errors":[{"code":"UNKNOWN","message":"internal error"}]}`, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", OCIContentType)
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		slog.Error("ECR/OCI: failed to write error response", "err", err)
+	}
+}
+
+// NotImplemented is the placeholder for every unimplemented /v2 endpoint: a
+// 501 carrying the OCI "UNSUPPORTED" code so clients see a well-formed refusal.
+func NotImplemented(w http.ResponseWriter, r *http.Request) {
+	slog.Debug("ECR/OCI: endpoint not implemented", "method", r.Method, "path", r.URL.Path)
+	WriteError(w, http.StatusNotImplemented, "UNSUPPORTED", "ECR registry endpoint not implemented")
+}
+
+// APIVersion handles GET /v2/ — the registry version-check probe. Real clients
+// expect 200 with the Docker-Distribution-API-Version header even before any
+// repository exists, so this endpoint is always live.
+func APIVersion(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Docker-Distribution-Api-Version", "registry/2.0")
+	w.WriteHeader(http.StatusOK)
+}

--- a/spinifex/gateway/ecr/handler_test.go
+++ b/spinifex/gateway/ecr/handler_test.go
@@ -1,0 +1,50 @@
+package gateway_ecr
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func decodeEnvelope(t *testing.T, body []byte) ociErrorEnvelope {
+	t.Helper()
+	var env ociErrorEnvelope
+	require.NoError(t, json.Unmarshal(body, &env))
+	return env
+}
+
+func TestAPIVersion(t *testing.T) {
+	w := httptest.NewRecorder()
+	APIVersion(w, httptest.NewRequest(http.MethodGet, "/v2/", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "registry/2.0", w.Header().Get("Docker-Distribution-Api-Version"))
+}
+
+func TestNotImplemented(t *testing.T) {
+	w := httptest.NewRecorder()
+	NotImplemented(w, httptest.NewRequest(http.MethodGet, "/v2/team/app/tags/list", nil))
+
+	assert.Equal(t, http.StatusNotImplemented, w.Code)
+	assert.Equal(t, OCIContentType, w.Header().Get("Content-Type"))
+
+	env := decodeEnvelope(t, w.Body.Bytes())
+	require.Len(t, env.Errors, 1)
+	assert.Equal(t, "UNSUPPORTED", env.Errors[0].Code)
+	assert.NotEmpty(t, env.Errors[0].Message)
+}
+
+func TestWriteError(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteError(w, http.StatusNotFound, "MANIFEST_UNKNOWN", "manifest tagged v1 not found")
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	env := decodeEnvelope(t, w.Body.Bytes())
+	require.Len(t, env.Errors, 1)
+	assert.Equal(t, "MANIFEST_UNKNOWN", env.Errors[0].Code)
+	assert.Equal(t, "manifest tagged v1 not found", env.Errors[0].Message)
+}

--- a/spinifex/gateway/ecr_test.go
+++ b/spinifex/gateway/ecr_test.go
@@ -1,0 +1,101 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_ecrapi "github.com/mulgadc/spinifex/spinifex/gateway/ecrapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupECRRequest(target, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	if target != "" {
+		req.Header.Set("X-Amz-Target", target)
+	}
+	ctx := context.WithValue(req.Context(), ctxService, "ecr")
+	ctx = context.WithValue(ctx, ctxAccountID, "123456789012")
+	return req.WithContext(ctx)
+}
+
+func TestECRActionFromTarget(t *testing.T) {
+	assert.Equal(t, "CreateRepository",
+		ecrActionFromTarget("AmazonEC2ContainerRegistry_V20150921.CreateRepository"))
+	assert.Equal(t, "GetAuthorizationToken", ecrActionFromTarget("GetAuthorizationToken"))
+	assert.Equal(t, "", ecrActionFromTarget(""))
+}
+
+func TestECRActionsMap_CoreActionsRegistered(t *testing.T) {
+	core := []string{
+		"GetAuthorizationToken", "CreateRepository", "DeleteRepository",
+		"DescribeRepositories", "BatchGetImage", "BatchCheckLayerAvailability",
+		"PutImage", "InitiateLayerUpload", "UploadLayerPart", "CompleteLayerUpload",
+	}
+	for _, action := range core {
+		_, ok := gateway_ecrapi.Actions[action]
+		assert.True(t, ok, "action %q should be registered", action)
+	}
+}
+
+func TestECRRequest_MissingTarget(t *testing.T) {
+	gw := &GatewayConfig{DisableLogging: true}
+	err := gw.ECR_Request(httptest.NewRecorder(), setupECRRequest("", ""))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorMissingAction, err.Error())
+}
+
+func TestECRRequest_UnknownAction(t *testing.T) {
+	gw := &GatewayConfig{DisableLogging: true}
+	err := gw.ECR_Request(httptest.NewRecorder(),
+		setupECRRequest("AmazonEC2ContainerRegistry_V20150921.MadeUpAction", "{}"))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidAction, err.Error())
+}
+
+// Every registered action resolves to the 501 stub until its handler lands.
+func TestECRRequest_KnownActionNotImplemented(t *testing.T) {
+	gw := &GatewayConfig{DisableLogging: true}
+	err := gw.ECR_Request(httptest.NewRecorder(),
+		setupECRRequest("AmazonEC2ContainerRegistry_V20150921.CreateRepository", "{}"))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorNotImplemented, err.Error())
+}
+
+func TestOCIRegistry_VersionCheck(t *testing.T) {
+	gw := &GatewayConfig{DisableLogging: true}
+	r := chi.NewRouter()
+	gw.mountOCIRegistry(r)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v2/", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "registry/2.0", w.Header().Get("Docker-Distribution-Api-Version"))
+}
+
+func TestOCIRegistry_StubReturns501(t *testing.T) {
+	gw := &GatewayConfig{DisableLogging: true}
+	r := chi.NewRouter()
+	gw.mountOCIRegistry(r)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v2/team/app/tags/list", nil))
+
+	assert.Equal(t, http.StatusNotImplemented, w.Code)
+
+	var body struct {
+		Errors []struct {
+			Code string `json:"code"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body.Errors, 1)
+	assert.Equal(t, "UNSUPPORTED", body.Errors[0].Code)
+}

--- a/spinifex/gateway/ecrapi.go
+++ b/spinifex/gateway/ecrapi.go
@@ -1,0 +1,61 @@
+package gateway
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_ecrapi "github.com/mulgadc/spinifex/spinifex/gateway/ecrapi"
+)
+
+// ecrActionFromTarget extracts the action suffix from an X-Amz-Target header.
+// Any "<Prefix>.<Action>" or bare "<Action>" form is accepted.
+func ecrActionFromTarget(target string) string {
+	if i := strings.LastIndex(target, "."); i >= 0 {
+		return target[i+1:]
+	}
+	return target
+}
+
+// ECR_Request dispatches AWS JSON 1.1 ECR control-plane requests. The action
+// comes from X-Amz-Target; errors are returned as awserrors codes and rendered
+// by the shared ErrorHandler.
+func (gw *GatewayConfig) ECR_Request(w http.ResponseWriter, r *http.Request) error {
+	action := ecrActionFromTarget(r.Header.Get("X-Amz-Target"))
+	if action == "" {
+		return errors.New(awserrors.ErrorMissingAction)
+	}
+
+	handler, ok := gateway_ecrapi.Actions[action]
+	if !ok {
+		slog.Debug("ECR: unknown action", "action", action)
+		return errors.New(awserrors.ErrorInvalidAction)
+	}
+
+	if err := gw.checkPolicy(r, "ecr", action); err != nil {
+		return err
+	}
+
+	accountID, _ := r.Context().Value(ctxAccountID).(string)
+	if accountID == "" {
+		slog.Error("ECR_Request: no account ID in auth context")
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.Error("ECR_Request: failed to read body", "err", err)
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	output, err := handler(gw.NATSConn, accountID, body)
+	if err != nil {
+		return err
+	}
+
+	gateway_ecrapi.WriteJSONResponse(w, output)
+	return nil
+}

--- a/spinifex/gateway/ecrapi/handler.go
+++ b/spinifex/gateway/ecrapi/handler.go
@@ -1,0 +1,104 @@
+// Package gateway_ecrapi is the HTTP-side glue for the ECR control plane: the
+// AWS JSON 1.1 surface dispatched by X-Amz-Target
+// (AmazonEC2ContainerRegistry_V20150921.<Action>), matching aws-sdk-go's
+// service/ecr request shape. It is distinct from package gateway_ecr, which
+// serves the OCI Distribution registry (/v2/*).
+//
+// The full action namespace is registered as the API contract; every action
+// resolves to the shared NotImplemented stub until its real handler lands.
+package gateway_ecrapi
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
+)
+
+// TargetPrefix is the X-Amz-Target service prefix for ECR control-plane calls.
+const TargetPrefix = "AmazonEC2ContainerRegistry_V20150921"
+
+// JSONContentType is the AWS JSON 1.1 content type ECR clients expect.
+const JSONContentType = "application/x-amz-json-1.1"
+
+// Handler is the signature every ECR control-plane action implements. nc is the
+// gateway NATS connection (handlers relay onto ecr.* subjects); accountID is the
+// resolved caller account; body is the raw JSON 1.1 request payload.
+type Handler func(nc *nats.Conn, accountID string, body []byte) (any, error)
+
+// NotImplemented is the placeholder for every unimplemented ECR control-plane
+// action. It returns the AWS NotImplemented error, which the shared gateway
+// ErrorHandler renders as a 501 JSON 1.1 envelope.
+func NotImplemented(_ *nats.Conn, _ string, _ []byte) (any, error) {
+	return nil, errors.New(awserrors.ErrorNotImplemented)
+}
+
+// Actions is the authoritative ECR control-plane action namespace. Real
+// implementations replace the NotImplemented value as each action lands; the
+// key set is the v1 API contract.
+var Actions = map[string]Handler{
+	// Auth.
+	"GetAuthorizationToken": NotImplemented,
+
+	// Repositories.
+	"CreateRepository":      NotImplemented,
+	"DeleteRepository":      NotImplemented,
+	"DescribeRepositories":  NotImplemented,
+	"ListRepositories":      NotImplemented,
+	"PutImageTagMutability": NotImplemented,
+
+	// Images / layers.
+	"BatchGetImage":               NotImplemented,
+	"BatchCheckLayerAvailability": NotImplemented,
+	"BatchDeleteImage":            NotImplemented,
+	"PutImage":                    NotImplemented,
+	"ListImages":                  NotImplemented,
+	"DescribeImages":              NotImplemented,
+	"GetDownloadUrlForLayer":      NotImplemented,
+	"InitiateLayerUpload":         NotImplemented,
+	"UploadLayerPart":             NotImplemented,
+	"CompleteLayerUpload":         NotImplemented,
+
+	// Repository / registry policy.
+	"SetRepositoryPolicy":    NotImplemented,
+	"GetRepositoryPolicy":    NotImplemented,
+	"DeleteRepositoryPolicy": NotImplemented,
+	"GetRegistryPolicy":      NotImplemented,
+	"PutRegistryPolicy":      NotImplemented,
+	"DescribeRegistry":       NotImplemented,
+
+	// Deferred-feature surface (image scan, lifecycle, replication, tagging).
+	"PutImageScanningConfiguration": NotImplemented,
+	"GetImageScanningConfiguration": NotImplemented,
+	"StartImageScan":                NotImplemented,
+	"DescribeImageScanFindings":     NotImplemented,
+	"PutLifecyclePolicy":            NotImplemented,
+	"GetLifecyclePolicy":            NotImplemented,
+	"DeleteLifecyclePolicy":         NotImplemented,
+	"StartLifecyclePolicyPreview":   NotImplemented,
+	"GetLifecyclePolicyPreview":     NotImplemented,
+	"PutReplicationConfiguration":   NotImplemented,
+	"ReplicateImage":                NotImplemented,
+	"TagResource":                   NotImplemented,
+	"UntagResource":                 NotImplemented,
+	"ListTagsForResource":           NotImplemented,
+}
+
+// WriteJSONResponse serialises obj as a 200 AWS JSON 1.1 response using the
+// SDK's jsonutil marshaler (epoch-second time encoding), matching ACM/EKS.
+func WriteJSONResponse(w http.ResponseWriter, obj any) {
+	body, err := jsonutil.BuildJSON(obj)
+	if err != nil {
+		slog.Error("ECR: failed to marshal response JSON", "err", err)
+		http.Error(w, awserrors.ErrorInternalError, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", JSONContentType)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		slog.Error("ECR: failed to write response", "err", err)
+	}
+}

--- a/spinifex/gateway/ecrapi/handler_test.go
+++ b/spinifex/gateway/ecrapi/handler_test.go
@@ -1,0 +1,51 @@
+package gateway_ecrapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotImplemented(t *testing.T) {
+	out, err := NotImplemented(nil, "123456789012", []byte("{}"))
+	assert.Nil(t, out)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorNotImplemented, err.Error())
+}
+
+func TestActions_CoreRegisteredAsStub(t *testing.T) {
+	core := []string{
+		"GetAuthorizationToken", "CreateRepository", "DeleteRepository",
+		"DescribeRepositories", "ListRepositories", "BatchGetImage",
+		"BatchCheckLayerAvailability", "PutImage", "InitiateLayerUpload",
+		"UploadLayerPart", "CompleteLayerUpload",
+	}
+	for _, action := range core {
+		h, ok := Actions[action]
+		require.True(t, ok, "action %q should be registered", action)
+		_, err := h(nil, "123456789012", nil)
+		assert.Equal(t, awserrors.ErrorNotImplemented, err.Error(),
+			"action %q should resolve to the 501 stub", action)
+	}
+}
+
+func TestWriteJSONResponse(t *testing.T) {
+	type repo struct {
+		RepositoryName *string `locationName:"repositoryName" type:"string"`
+	}
+	name := "team/app"
+	w := httptest.NewRecorder()
+	WriteJSONResponse(w, &repo{RepositoryName: &name})
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, JSONContentType, w.Header().Get("Content-Type"))
+
+	var decoded map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &decoded))
+	assert.Equal(t, "team/app", decoded["repositoryName"])
+}

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -79,6 +79,7 @@ var supportedServices = map[string]bool{
 	"account":              true,
 	"elasticloadbalancing": true,
 	"eks":                  true,
+	"ecr":                  true,
 	"acm":                  true,
 	"tagging":              true,
 	"spinifex":             true,
@@ -139,6 +140,10 @@ func (gw *GatewayConfig) SetupRoutes() http.Handler {
 		pub.Get("/oidc/eks/{region}/{accountID}/{clusterName}/.well-known/openid-configuration", gw.OIDCDiscoveryDocument)
 		pub.Get("/oidc/eks/{region}/{accountID}/{clusterName}/keys", gw.OIDCJWKS)
 	})
+
+	// OCI Distribution registry (/v2/*). Token/host-authenticated rather than
+	// SigV4-credential-scoped, so it mounts outside the SigV4 group.
+	gw.mountOCIRegistry(r)
 
 	// Authenticated AWS API surface.
 	r.Group(func(auth chi.Router) {
@@ -299,6 +304,8 @@ func (gw *GatewayConfig) Request(w http.ResponseWriter, r *http.Request) {
 		err = gw.ELBv2_Request(w, r)
 	case "eks":
 		err = gw.EKS_Request(w, r)
+	case "ecr":
+		err = gw.ECR_Request(w, r)
 	case "acm":
 		err = gw.ACM_Request(w, r)
 	case "tagging":
@@ -456,8 +463,8 @@ func (gw *GatewayConfig) ErrorHandler(w http.ResponseWriter, r *http.Request, er
 		errorMsg.HTTPCode = 500
 	}
 
-	// EKS, ACM, and tagging use AWS JSON 1.1; query/XML services fall through.
-	if svc == "eks" || svc == "acm" || svc == "tagging" {
+	// EKS, ECR, ACM, and tagging use AWS JSON 1.1; query/XML services fall through.
+	if svc == "eks" || svc == "ecr" || svc == "acm" || svc == "tagging" {
 		body := GenerateEKSErrorResponse(err.Error(), errorMsg.Message, requestId)
 		slog.Debug("Generated JSON error response", "service", svc, "error", err.Error(), "json", string(body), "requestId", requestId)
 		w.Header().Set("Content-Type", eksJSONContentType)

--- a/spinifex/gateway/hostmatch.go
+++ b/spinifex/gateway/hostmatch.go
@@ -1,0 +1,17 @@
+package gateway
+
+import "net/http"
+
+// hostMatch is the skeleton for the ECR registry host-routing middleware. The
+// registry surface (/v2/*) is addressed at {accountID}.dkr.ecr.{region}.{suffix};
+// once the auth bridge lands this middleware will parse the request Host,
+// extract the target accountID, and stash it on the request context for the
+// registry handlers and auth bridge.
+//
+// It is currently a transparent pass-through so the /v2 route group has a stable
+// seam to grow into without yet changing request handling.
+func hostMatch(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+	})
+}

--- a/spinifex/handlers/ecr/storage.go
+++ b/spinifex/handlers/ecr/storage.go
@@ -1,0 +1,69 @@
+// Package ecr holds the ECR registry handlers and the predastore storage
+// layout that backs them. v1 stores everything for one account in a single
+// per-account bucket; blobs are content-addressable and deduplicated per
+// account, while manifests and tags are indexed per repository.
+package ecr
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BucketPrefix is the per-account bucket name prefix. The bucket for an account
+// is BucketPrefix + accountID (e.g. "ecr-000000000000"), lazily created on the
+// first CreateRepository for that account.
+const BucketPrefix = "ecr-"
+
+// AccountBucket returns the predastore bucket name holding all ECR objects for
+// the given account.
+func AccountBucket(accountID string) string {
+	return BucketPrefix + accountID
+}
+
+// Object-key layout within an account bucket. These are the canonical key
+// shapes every ECR storage path must use. Blobs are pooled per account for
+// dedup; manifests and tags are indexed per repository.
+const (
+	// repoMetaKeyFmt is the repo config object (scan-on-push, tag mutability).
+	repoMetaKeyFmt = "repos/%s/_meta.json"
+	// tagKeyFmt maps a tag to a digest pointer (body is "sha256:...").
+	tagKeyFmt = "repos/%s/manifests/by-tag/%s"
+	// manifestKeyFmt holds manifest JSON keyed by its own digest.
+	manifestKeyFmt = "repos/%s/manifests/by-digest/%s"
+	// indexKeyFmt is the rolling tag->digest index used by ListImages.
+	indexKeyFmt = "repos/%s/manifests/index.json"
+	// blobKeyFmt is the account-wide blob pool, two-char hex shard.
+	blobKeyFmt = "blobs/%s/%s"
+	// uploadKeyFmt holds in-progress chunked upload bytes.
+	uploadKeyFmt = "uploads/%s"
+)
+
+// RepoMetaKey returns the key for a repository's config object.
+func RepoMetaKey(repo string) string { return fmt.Sprintf(repoMetaKeyFmt, repo) }
+
+// TagKey returns the key for a tag's digest pointer.
+func TagKey(repo, tag string) string { return fmt.Sprintf(tagKeyFmt, repo, tag) }
+
+// ManifestKey returns the key for a manifest stored by its digest.
+func ManifestKey(repo, digest string) string { return fmt.Sprintf(manifestKeyFmt, repo, digest) }
+
+// IndexKey returns the key for a repository's tag->digest index.
+func IndexKey(repo string) string { return fmt.Sprintf(indexKeyFmt, repo) }
+
+// UploadKey returns the key for an in-progress upload's bytes.
+func UploadKey(uploadID string) string { return fmt.Sprintf(uploadKeyFmt, uploadID) }
+
+// BlobKey returns the account-pool key for a blob digest ("sha256:<hex>"). The
+// two-char shard is taken from the first hex bytes after the "sha256:" prefix,
+// matching the on-disk layout used by upstream OCI registries.
+func BlobKey(digest string) string {
+	hex := digest
+	if _, after, found := strings.Cut(digest, ":"); found {
+		hex = after
+	}
+	shard := hex
+	if len(hex) >= 2 {
+		shard = hex[:2]
+	}
+	return fmt.Sprintf(blobKeyFmt, shard, digest)
+}

--- a/spinifex/handlers/ecr/storage_test.go
+++ b/spinifex/handlers/ecr/storage_test.go
@@ -1,0 +1,45 @@
+package ecr
+
+import "testing"
+
+func TestAccountBucket(t *testing.T) {
+	if got := AccountBucket("123456789012"); got != "ecr-123456789012" {
+		t.Fatalf("AccountBucket = %q, want ecr-123456789012", got)
+	}
+}
+
+func TestKeyHelpers(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"repo meta", RepoMetaKey("team/app"), "repos/team/app/_meta.json"},
+		{"tag", TagKey("team/app", "v1"), "repos/team/app/manifests/by-tag/v1"},
+		{"manifest", ManifestKey("team/app", "sha256:abcd"), "repos/team/app/manifests/by-digest/sha256:abcd"},
+		{"index", IndexKey("team/app"), "repos/team/app/manifests/index.json"},
+		{"upload", UploadKey("u-1"), "uploads/u-1"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestBlobKey(t *testing.T) {
+	cases := []struct {
+		name   string
+		digest string
+		want   string
+	}{
+		{"sha256 prefixed", "sha256:abcdef0123", "blobs/ab/sha256:abcdef0123"},
+		{"bare hex", "abcdef0123", "blobs/ab/abcdef0123"},
+		{"short digest", "a", "blobs/a/a"},
+	}
+	for _, c := range cases {
+		if got := BlobKey(c.digest); got != c.want {
+			t.Errorf("%s: BlobKey(%q) = %q, want %q", c.name, c.digest, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

ECR HTTP surface on awsgw as compiling skeletons returning `NotImplemented`. Later sprints implement against a fixed contract; build stays green on `dev`.

- **`gateway/ecrapi`** — ECR control plane (AWS JSON 1.1, `X-Amz-Target` dispatch). Full action namespace registered; every action → shared 501 stub.
- **`gateway/ecr`** — OCI Distribution v2 (`/v2/*`). Catch-all 501 with OCI error envelope; `GET /v2/` live for the registry version-check probe (repo names span slashes, so a path-parsing dispatcher replaces the catch-all when storage lands).
- **`gateway/hostmatch`** — no-op host-routing middleware skeleton for the registry host group.
- **`handlers/ecr/storage`** — per-account bucket + object-key layout constants.
- **Wiring** (`gateway/gateway.go`) — `ecr` in `supportedServices`, dispatch case, JSON 1.1 error branch, `/v2` mounted outside the SigV4 group.

## Testing

`go build ./...`, `go vet`, `gofmt`, `golangci-lint` (0 issues), `go test ./gateway/...` all pass — incl. new dispatch / unknown-action / 501-stub / OCI-version-probe tests.

Tracking: mulgadc/mulga#69 (Epic mulgadc/mulga#63)