### PR TITLE
feat: ECR TLS SAN wildcard + hostmatch host-routing middleware

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -1145,7 +1145,7 @@ func runAdminInit(cmd *cobra.Command, args []string) {
 	fmt.Printf("   AWS Profile: spinifex\n")
 
 	// Generate SSL certificates (with bind IP in SANs for multi-node support)
-	certPath := admin.GenerateCertificatesIfNeeded(configDir, force, bindIP)
+	certPath := admin.GenerateCertificatesIfNeeded(configDir, force, bindIP, region, config.DefaultAWSInternalSuffix)
 
 	// Generate per-node IPsec peer cert when cluster-wide IPsec is enabled
 	// (default true). Reuses the cluster CA — no intermediate strongSwan PKI.
@@ -1959,7 +1959,7 @@ func runAdminJoin(cmd *cobra.Command, args []string) {
 	}
 
 	// Generate server cert signed by CA with this node's bind IP
-	if err := admin.GenerateServerCertOnly(configDir, bindIP); err != nil {
+	if err := admin.GenerateServerCertOnly(configDir, bindIP, region, config.DefaultAWSInternalSuffix); err != nil {
 		fmt.Fprintf(os.Stderr, "Error generating server certificate: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/spinifex/cmd/templates/spinifex.toml
+++ b/cmd/spinifex/cmd/templates/spinifex.toml
@@ -8,6 +8,10 @@ node = "{{.Node}}"
 email = "{{.OperatorEmail}}"
 {{- end}}
 
+[aws]
+region = "{{.Region}}"
+internal_suffix = "mulga.internal"
+
 [network]
 ipsec_enabled = {{.IPSecEnabled}}
 {{- if .ExternalMode}}

--- a/spinifex/admin/admin.go
+++ b/spinifex/admin/admin.go
@@ -155,7 +155,22 @@ func GenerateConfigFile(configPath string, configTemplate string, configSettings
 	return nil
 }
 
-func GenerateCertificatesIfNeeded(configDir string, force bool, bindIP string) (caCertPath string) {
+// AWSGWServiceDNSNames builds the AWS-parity TLS SANs for the awsgw cert from
+// the cluster region and internal suffix: the exact ECR control-plane host and
+// the wildcard covering per-account registry hosts. Returns nil if either input
+// is empty so callers omit the SANs rather than emitting malformed names.
+func AWSGWServiceDNSNames(region, suffix string) []string {
+	if region == "" || suffix == "" {
+		return nil
+	}
+	base := "ecr." + region + "." + suffix
+	return []string{
+		base,            // control plane: ecr.{region}.{suffix}
+		"*.dkr." + base, // registry: *.dkr.ecr.{region}.{suffix}
+	}
+}
+
+func GenerateCertificatesIfNeeded(configDir string, force bool, bindIP string, awsRegion, internalSuffix string) (caCertPath string) {
 	caCertPath = filepath.Join(configDir, "ca.pem")
 	caKeyPath := filepath.Join(configDir, "ca.key")
 	serverCertPath := filepath.Join(configDir, "server.pem")
@@ -177,7 +192,8 @@ func GenerateCertificatesIfNeeded(configDir string, force bool, bindIP string) (
 		fmt.Printf("   CA Certificate: %s\n", caCertPath)
 		fmt.Printf("   CA Key: %s\n", caKeyPath)
 
-		if err := GenerateSignedCert(serverCertPath, serverKeyPath, caCertPath, caKeyPath, bindIP); err != nil {
+		extraDNS := AWSGWServiceDNSNames(awsRegion, internalSuffix)
+		if err := GenerateSignedCertWithDNS(serverCertPath, serverKeyPath, caCertPath, caKeyPath, []string{bindIP}, extraDNS); err != nil {
 			fmt.Fprintf(os.Stderr, "Error generating server certificate: %v\n", err)
 			os.Exit(1)
 		}
@@ -200,8 +216,9 @@ func GenerateCertificatesIfNeeded(configDir string, force bool, bindIP string) (
 }
 
 // GenerateServerCertOnly generates a server certificate signed by an existing CA.
-// Used by joining nodes that receive the CA from the leader.
-func GenerateServerCertOnly(configDir string, bindIP string) error {
+// Used by joining nodes that receive the CA from the leader. awsRegion and
+// internalSuffix add the AWS-parity ECR SANs; empty values omit them.
+func GenerateServerCertOnly(configDir string, bindIP, awsRegion, internalSuffix string) error {
 	caCertPath := filepath.Join(configDir, "ca.pem")
 	caKeyPath := filepath.Join(configDir, "ca.key")
 	serverCertPath := filepath.Join(configDir, "server.pem")
@@ -211,7 +228,8 @@ func GenerateServerCertOnly(configDir string, bindIP string) error {
 		return fmt.Errorf("CA files not found in %s", configDir)
 	}
 
-	return GenerateSignedCert(serverCertPath, serverKeyPath, caCertPath, caKeyPath, bindIP)
+	extraDNS := AWSGWServiceDNSNames(awsRegion, internalSuffix)
+	return GenerateSignedCertWithDNS(serverCertPath, serverKeyPath, caCertPath, caKeyPath, []string{bindIP}, extraDNS)
 }
 
 func CreateServiceDirectories(spxRoot string) {

--- a/spinifex/admin/admin_test.go
+++ b/spinifex/admin/admin_test.go
@@ -621,7 +621,7 @@ func TestGenerateCertificatesIfNeeded(t *testing.T) {
 	dir := t.TempDir()
 
 	// First call generates all certs
-	caCertPath := GenerateCertificatesIfNeeded(dir, false, "")
+	caCertPath := GenerateCertificatesIfNeeded(dir, false, "", "us-east-1", "mulga.internal")
 	assert.Equal(t, filepath.Join(dir, "ca.pem"), caCertPath)
 	assert.True(t, FileExists(filepath.Join(dir, "ca.pem")))
 	assert.True(t, FileExists(filepath.Join(dir, "ca.key")))
@@ -632,7 +632,7 @@ func TestGenerateCertificatesIfNeeded(t *testing.T) {
 		caInfo, _ := os.Stat(filepath.Join(dir, "ca.pem"))
 		origModTime := caInfo.ModTime()
 
-		GenerateCertificatesIfNeeded(dir, false, "")
+		GenerateCertificatesIfNeeded(dir, false, "", "us-east-1", "mulga.internal")
 		caInfo2, _ := os.Stat(filepath.Join(dir, "ca.pem"))
 		assert.Equal(t, origModTime, caInfo2.ModTime())
 	})
@@ -640,7 +640,7 @@ func TestGenerateCertificatesIfNeeded(t *testing.T) {
 	t.Run("ForceRegenerates", func(t *testing.T) {
 		origCA, _ := os.ReadFile(filepath.Join(dir, "ca.pem"))
 
-		GenerateCertificatesIfNeeded(dir, true, "")
+		GenerateCertificatesIfNeeded(dir, true, "", "us-east-1", "mulga.internal")
 		newCA, _ := os.ReadFile(filepath.Join(dir, "ca.pem"))
 		assert.NotEqual(t, origCA, newCA)
 	})
@@ -660,7 +660,7 @@ func TestGenerateServerCertOnly(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.pem"), caCert, 0600))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "ca.key"), caKey, 0600))
 
-		err := GenerateServerCertOnly(dir, "10.0.0.5")
+		err := GenerateServerCertOnly(dir, "10.0.0.5", "us-east-1", "mulga.internal")
 		require.NoError(t, err)
 		assert.True(t, FileExists(filepath.Join(dir, "server.pem")))
 		assert.True(t, FileExists(filepath.Join(dir, "server.key")))
@@ -676,14 +676,32 @@ func TestGenerateServerCertOnly(t *testing.T) {
 			}
 		}
 		assert.True(t, hasBindIP)
+
+		// AWS-parity ECR SANs must be present.
+		assert.Contains(t, cert.DNSNames, "ecr.us-east-1.mulga.internal")
+		assert.Contains(t, cert.DNSNames, "*.dkr.ecr.us-east-1.mulga.internal")
 	})
 
 	t.Run("MissingCA", func(t *testing.T) {
 		dir := t.TempDir()
-		err := GenerateServerCertOnly(dir, "10.0.0.5")
+		err := GenerateServerCertOnly(dir, "10.0.0.5", "us-east-1", "mulga.internal")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "CA files not found")
 	})
+}
+
+func TestAWSGWServiceDNSNames(t *testing.T) {
+	t.Parallel()
+
+	got := AWSGWServiceDNSNames("us-east-1", "mulga.internal")
+	assert.Equal(t, []string{
+		"ecr.us-east-1.mulga.internal",
+		"*.dkr.ecr.us-east-1.mulga.internal",
+	}, got)
+
+	assert.Nil(t, AWSGWServiceDNSNames("", "mulga.internal"))
+	assert.Nil(t, AWSGWServiceDNSNames("us-east-1", ""))
+	assert.Nil(t, AWSGWServiceDNSNames("", ""))
 }
 
 // --- Directory creation ---

--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -17,7 +17,22 @@ type ClusterConfig struct {
 	Version   string            `mapstructure:"version"`   // spinifex version
 	Network   NetworkConfig     `mapstructure:"network"`   // cluster-wide external network settings
 	Bootstrap BootstrapConfig   `mapstructure:"bootstrap"` // default VPC IDs for OVN reconciliation
+	AWS       AWSConfig         `mapstructure:"aws"`       // cluster-wide AWS-parity settings (region, endpoint suffix)
 	Nodes     map[string]Config `mapstructure:"nodes"`     // full config for every node
+}
+
+// Defaults for cluster-wide AWS-parity settings.
+const (
+	DefaultAWSRegion         = "us-east-1"
+	DefaultAWSInternalSuffix = "mulga.internal"
+)
+
+// AWSConfig holds cluster-wide AWS-parity settings shared across services.
+// Region scopes the default AWS region; InternalSuffix is the internal DNS
+// suffix used to build service endpoints (e.g. ecr.{region}.{suffix}).
+type AWSConfig struct {
+	Region         string `mapstructure:"region"`
+	InternalSuffix string `mapstructure:"internal_suffix"`
 }
 
 // ExternalPool defines a range of routable IPs that Spinifex manages for public subnets.
@@ -210,6 +225,10 @@ func LoadConfig(configPath string) (*ClusterConfig, error) {
 	// Default ipsec_enabled to true; operators must explicitly set false to disable.
 	viper.SetDefault("network.ipsec_enabled", true)
 
+	// Cluster-wide AWS-parity defaults so existing deployments keep working.
+	viper.SetDefault("aws.region", DefaultAWSRegion)
+	viper.SetDefault("aws.internal_suffix", DefaultAWSInternalSuffix)
+
 	// Try to load config file if it exists
 	if configPath != "" {
 		// Check if file exists
@@ -230,6 +249,14 @@ func LoadConfig(configPath string) (*ClusterConfig, error) {
 	var config ClusterConfig
 	if err := viper.Unmarshal(&config); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
+	}
+
+	// Backfill AWS-parity defaults when keys are unset so callers never see empties.
+	if config.AWS.Region == "" {
+		config.AWS.Region = DefaultAWSRegion
+	}
+	if config.AWS.InternalSuffix == "" {
+		config.AWS.InternalSuffix = DefaultAWSInternalSuffix
 	}
 
 	// Rewrite 0.0.0.0 in Predastore.Host to 127.0.0.1 for the local node only (not a valid connect address).

--- a/spinifex/config/config_test.go
+++ b/spinifex/config/config_test.go
@@ -98,6 +98,38 @@ func TestLoadConfig_EmptyConfigPath(t *testing.T) {
 	assert.Empty(t, cfg.Node)
 }
 
+func TestLoadConfig_AWSDefaults(t *testing.T) {
+	resetViper(t)
+	cfg, err := LoadConfig("")
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, DefaultAWSRegion, cfg.AWS.Region)
+	assert.Equal(t, DefaultAWSInternalSuffix, cfg.AWS.InternalSuffix)
+}
+
+func TestLoadConfig_AWSOverride(t *testing.T) {
+	resetViper(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+
+	toml := `
+node = "n1"
+
+[aws]
+region = "ap-southeast-2"
+internal_suffix = "dev.local"
+
+[nodes.n1]
+region = "ap-southeast-2"
+`
+	require.NoError(t, os.WriteFile(path, []byte(toml), 0600))
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, "ap-southeast-2", cfg.AWS.Region)
+	assert.Equal(t, "dev.local", cfg.AWS.InternalSuffix)
+}
+
 func TestLoadConfig_NonexistentFile(t *testing.T) {
 	resetViper(t)
 	cfg, err := LoadConfig("/tmp/nonexistent-spinifex-config-test-12345.toml")

--- a/spinifex/gateway/ecr.go
+++ b/spinifex/gateway/ecr.go
@@ -8,8 +8,8 @@ import (
 
 // mountOCIRegistry registers the OCI Distribution Spec v2 surface (/v2/*) on r.
 // These endpoints are host- and token-authenticated rather than
-// SigV4-credential-scoped, so they mount outside the SigV4 group under the
-// no-op hostMatch skeleton.
+// SigV4-credential-scoped, so they mount outside the SigV4 group behind the
+// hostMatch host-routing middleware.
 //
 // OCI repository names may contain slashes (e.g. team/app), so the blob,
 // manifest and tag paths can't be expressed as fixed chi segments. Everything
@@ -18,7 +18,7 @@ import (
 // version-check probe succeeds.
 func (gw *GatewayConfig) mountOCIRegistry(r chi.Router) {
 	r.Route("/v2", func(v2 chi.Router) {
-		v2.Use(hostMatch)
+		v2.Use(gw.hostMatch)
 		v2.Get("/", gateway_ecr.APIVersion)
 		v2.HandleFunc("/*", gateway_ecr.NotImplemented)
 	})

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -45,6 +45,12 @@ const (
 	// Policy enforcement resolves the role name from this, never from ctxIdentity
 	// (attacker-influenced RoleSessionName).
 	ctxUnderlyingRoleARN contextKey = "sigv4.underlyingRoleARN"
+
+	// ctxTargetAccount carries the accountID parsed from a registry host
+	// ({accountID}.dkr.ecr.{region}.{suffix}) by the host-routing middleware.
+	ctxTargetAccount contextKey = "host.targetAccount"
+	// ctxTargetRegion carries the region parsed from the same registry host.
+	ctxTargetRegion contextKey = "host.targetRegion"
 )
 
 // Values stored under ctxPrincipalType. Downstream handlers that interpret
@@ -63,6 +69,7 @@ type GatewayConfig struct {
 	Config         string     // Shared AWS Gateway config for S3 auth
 	ExpectedNodes  int        // Number of expected spinifex nodes for multi-node operations
 	Region         string     // Region this gateway is running in
+	InternalSuffix string     // Internal DNS suffix for AWS-parity endpoints (e.g. mulga.internal)
 	AZ             string     // Availability zone this gateway is running in
 	IAMService     handlers_iam.IAMService
 	STSService     handlers_sts.STSService

--- a/spinifex/gateway/hostmatch.go
+++ b/spinifex/gateway/hostmatch.go
@@ -1,17 +1,87 @@
 package gateway
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+	"strings"
+)
 
-// hostMatch is the skeleton for the ECR registry host-routing middleware. The
-// registry surface (/v2/*) is addressed at {accountID}.dkr.ecr.{region}.{suffix};
-// once the auth bridge lands this middleware will parse the request Host,
-// extract the target accountID, and stash it on the request context for the
-// registry handlers and auth bridge.
-//
-// It is currently a transparent pass-through so the /v2 route group has a stable
-// seam to grow into without yet changing request handling.
-func hostMatch(next http.Handler) http.Handler {
+// hostMatch routes the OCI registry surface (/v2/*) by request Host. The
+// registry is addressed at {accountID}.dkr.ecr.{region}.{suffix}; when the Host
+// matches, the parsed accountID and region are stashed on the request context
+// for the registry handlers and auth bridge. Non-registry hosts pass through
+// unchanged — rejection is the auth bridge's responsibility.
+func (gw *GatewayConfig) hostMatch(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accountID, region, ok := parseRegistryHost(r.Host, gw.InternalSuffix)
+		if ok {
+			ctx := context.WithValue(r.Context(), ctxTargetAccount, accountID)
+			ctx = context.WithValue(ctx, ctxTargetRegion, region)
+			r = r.WithContext(ctx)
+		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// parseRegistryHost extracts the accountID and region from a registry host of
+// the form {accountID}.dkr.ecr.{region}.{suffix}. Any :port is stripped first.
+// When suffix is non-empty the host must carry that exact suffix; when suffix
+// is empty a permissive parse is used so dev/hosts-file setups still work.
+// ok is false for any host that does not match the registry shape.
+func parseRegistryHost(host, suffix string) (accountID, region string, ok bool) {
+	host = stripPort(host)
+	if host == "" {
+		return "", "", false
+	}
+
+	// minLabels is the label count after any suffix is removed. With a configured
+	// suffix the registry host reduces to {accountID}.dkr.ecr.{region} (4 labels);
+	// without one the permissive parse needs an extra suffix label (5).
+	rest := host
+	minLabels := 5
+	if suffix != "" {
+		trimmed := strings.TrimSuffix(host, "."+suffix)
+		if trimmed == host {
+			return "", "", false
+		}
+		rest = trimmed
+		minLabels = 4
+	}
+
+	// rest must now be {accountID}.dkr.ecr.{region}[.{remainder}].
+	labels := strings.Split(rest, ".")
+	if len(labels) < minLabels {
+		return "", "", false
+	}
+	if labels[1] != "dkr" || labels[2] != "ecr" {
+		return "", "", false
+	}
+	accountID = labels[0]
+	region = labels[3]
+	if accountID == "" || region == "" {
+		return "", "", false
+	}
+	return accountID, region, true
+}
+
+// stripPort removes a trailing :port from a host, leaving bare IPv6 intact.
+func stripPort(host string) string {
+	if host == "" {
+		return ""
+	}
+	// Bracketed IPv6 with optional port: [::1]:5000 or [::1].
+	if strings.HasPrefix(host, "[") {
+		if end := strings.IndexByte(host, ']'); end >= 0 {
+			return host[1:end]
+		}
+		return host
+	}
+	// Single colon means host:port; multiple colons mean bare IPv6, never a
+	// registry host, so leave it untouched.
+	if strings.Count(host, ":") == 1 {
+		if h, _, found := strings.Cut(host, ":"); found {
+			return h
+		}
+	}
+	return host
 }

--- a/spinifex/gateway/hostmatch_test.go
+++ b/spinifex/gateway/hostmatch_test.go
@@ -1,0 +1,136 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseRegistryHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		host     string
+		suffix   string
+		wantAcct string
+		wantRegn string
+		wantOK   bool
+	}{
+		{
+			name:     "match with suffix",
+			host:     "123456789012.dkr.ecr.us-east-1.mulga.internal",
+			suffix:   "mulga.internal",
+			wantAcct: "123456789012",
+			wantRegn: "us-east-1",
+			wantOK:   true,
+		},
+		{
+			name:     "match strips port",
+			host:     "123456789012.dkr.ecr.us-east-1.mulga.internal:9999",
+			suffix:   "mulga.internal",
+			wantAcct: "123456789012",
+			wantRegn: "us-east-1",
+			wantOK:   true,
+		},
+		{
+			name:     "permissive match when suffix empty",
+			host:     "555.dkr.ecr.ap-southeast-2.example.test",
+			suffix:   "",
+			wantAcct: "555",
+			wantRegn: "ap-southeast-2",
+			wantOK:   true,
+		},
+		{
+			name:   "control plane host is not a registry host",
+			host:   "ecr.us-east-1.mulga.internal",
+			suffix: "mulga.internal",
+			wantOK: false,
+		},
+		{
+			name:   "wrong suffix does not match",
+			host:   "123456789012.dkr.ecr.us-east-1.other.internal",
+			suffix: "mulga.internal",
+			wantOK: false,
+		},
+		{
+			name:   "missing dkr.ecr labels",
+			host:   "123456789012.foo.bar.us-east-1.mulga.internal",
+			suffix: "mulga.internal",
+			wantOK: false,
+		},
+		{
+			name:   "empty host",
+			host:   "",
+			suffix: "mulga.internal",
+			wantOK: false,
+		},
+		{
+			name:   "too few labels permissive",
+			host:   "dkr.ecr.us-east-1",
+			suffix: "",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			acct, regn, ok := parseRegistryHost(tc.host, tc.suffix)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok {
+				if acct != tc.wantAcct {
+					t.Errorf("accountID = %q, want %q", acct, tc.wantAcct)
+				}
+				if regn != tc.wantRegn {
+					t.Errorf("region = %q, want %q", regn, tc.wantRegn)
+				}
+			}
+		})
+	}
+}
+
+func TestHostMatch_PopulatesContextOnRegistryHost(t *testing.T) {
+	t.Parallel()
+
+	gw := &GatewayConfig{InternalSuffix: "mulga.internal"}
+
+	var gotAcct, gotRegn string
+	var acctOK, regnOK bool
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotAcct, acctOK = r.Context().Value(ctxTargetAccount).(string)
+		gotRegn, regnOK = r.Context().Value(ctxTargetRegion).(string)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+	req.Host = "123456789012.dkr.ecr.us-east-1.mulga.internal"
+	gw.hostMatch(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if !acctOK || gotAcct != "123456789012" {
+		t.Errorf("target account = %q (ok=%v), want 123456789012", gotAcct, acctOK)
+	}
+	if !regnOK || gotRegn != "us-east-1" {
+		t.Errorf("target region = %q (ok=%v), want us-east-1", gotRegn, regnOK)
+	}
+}
+
+func TestHostMatch_PassesThroughNonRegistryHost(t *testing.T) {
+	t.Parallel()
+
+	gw := &GatewayConfig{InternalSuffix: "mulga.internal"}
+
+	var hadAccount bool
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, hadAccount = r.Context().Value(ctxTargetAccount).(string)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+	req.Host = "ecr.us-east-1.mulga.internal"
+	gw.hostMatch(next).ServeHTTP(httptest.NewRecorder(), req)
+
+	if hadAccount {
+		t.Error("non-registry host should not populate target account context")
+	}
+}

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -203,6 +203,7 @@ func launchService(config *config.ClusterConfig) error {
 		Config:         nodeConfig.AWSGW.Config,
 		ExpectedNodes:  len(config.Nodes),
 		Region:         nodeConfig.Region,
+		InternalSuffix: config.AWS.InternalSuffix,
 		AZ:             nodeConfig.AZ,
 		IAMService:     iamService,
 		STSService:     stsService,


### PR DESCRIPTION
## Summary

Sprint 2d for the ECR registry: implement the host-routing middleware and the AWS-parity TLS SANs, plus shared AWS config knobs.

### hostMatch middleware
- `hostMatch` (now a `*GatewayConfig` method) parses the request `Host`, strips any `:port`, and when it matches `{accountID}.dkr.ecr.{region}.{suffix}` stashes the parsed account and region on the request context (`ctxTargetAccount`, `ctxTargetRegion`).
- Non-registry hosts (e.g. the control plane `ecr.{region}.{suffix}`) pass through unchanged — rejection is left to the auth bridge.
- Matches against the configured `internal_suffix`; falls back to a permissive parse when the suffix is unset so dev/`/etc/hosts` setups work.
- New unexported helper `parseRegistryHost(host, suffix)` is unit-tested (match, no-match, port-stripping, missing/empty suffix).

### TLS SAN wildcard
- New `admin.AWSGWServiceDNSNames(region, suffix)` builds the AWS-parity SANs: exact `ecr.{region}.{suffix}` and wildcard `*.dkr.ecr.{region}.{suffix}`.
- Threaded through `GenerateCertificatesIfNeeded` and `GenerateServerCertOnly` (init + join paths) via the existing `GenerateSignedCertWithDNS` `extraDNS` seam.

### Config
- New cluster-wide `[aws]` section: `region` (default `us-east-1`), `internal_suffix` (default `mulga.internal`), with viper defaults + backfill. Added to the `spinifex.toml` template. Wired into `GatewayConfig.InternalSuffix` in awsgw.

DNS/Route53 record creation is out of scope (TLS SANs + hostmatch + config only).

## Testing
- `go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), `gofmt` clean.
- New in-package tests for `parseRegistryHost`/`hostMatch`, the SAN builder, and AWS config defaults/override.
- Diff coverage 73.3% (threshold 60%).

Tracking: mulgadc/mulga#78 (Epic #63)