### PR TITLE
feat: EC2 Capacity Reservations (carve-out, in-memory)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -433,9 +433,9 @@ EIP commands are only registered when an external IPAM pool is configured.
 | `delete-dhcp-options` | — | `--dhcp-options-id`, `--dry-run` | **NOT STARTED** |
 | `describe-dhcp-options` | — | `--dhcp-options-ids`, `--filters`, `--max-results` | **NOT STARTED** |
 | `associate-dhcp-options` | — | `--dhcp-options-id`, `--vpc-id`, `--dry-run` | **NOT STARTED** |
-| `create-capacity-reservation` | — | `--instance-type`, `--instance-platform`, `--availability-zone`, `--instance-count`, `--end-date`, `--end-date-type`, `--instance-match-criteria`, `--tag-specifications` | **NOT STARTED** |
-| `cancel-capacity-reservation` | — | `--capacity-reservation-id`, `--dry-run` | **NOT STARTED** |
-| `describe-capacity-reservations` | — | `--capacity-reservation-ids`, `--filters`, `--max-results` | **NOT STARTED** |
+| `create-capacity-reservation` | `--instance-type`, `--instance-count`, `--availability-zone`, `--instance-platform`, `--instance-match-criteria`, `--tenancy` (default only), `--dry-run` | `--end-date`, `--end-date-type` (unlimited only), `--availability-zone-id`, `--tag-specifications` | **DONE** |
+| `cancel-capacity-reservation` | `--capacity-reservation-id`, `--dry-run` | — | **DONE** |
+| `describe-capacity-reservations` | `--capacity-reservation-ids`, `--filters` | `--max-results`, `--next-token` | **DONE** |
 | `modify-capacity-reservation` | — | `--capacity-reservation-id`, `--instance-count`, `--end-date`, `--end-date-type` | **NOT STARTED** |
 
 ### EC2 — Misc

--- a/spinifex/daemon/capacityreservation.go
+++ b/spinifex/daemon/capacityreservation.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"errors"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// capacityReservation is an in-memory On-Demand Capacity Reservation pinned to
+// this node. The carve-out it holds (TotalInstanceCount × per-instance compute)
+// is subtracted from schedulable capacity via reservedCR*. Records are immutable
+// after creation; an active reservation is simply present in the map, and
+// cancelling removes it. Lost on daemon restart (no persistence in Phase 1).
+type capacityReservation struct {
+	ID                    string
+	AccountID             string
+	InstanceType          string
+	AvailabilityZone      string
+	TotalInstanceCount    int
+	VCPUPerInstance       int
+	MemGBPerInstance      float64
+	InstanceMatchCriteria string
+	Tenancy               string
+	InstancePlatform      string
+	CreateDate            time.Time
+}
+
+// reservationCompute returns the headline compute carve-out for a reservation:
+// InstanceCount × catalog (vCPU, memory), with no nbdkit overhead in Phase 1.
+func (r *capacityReservation) reservationCompute() (vcpu int, memGB float64) {
+	return r.TotalInstanceCount * r.VCPUPerInstance, float64(r.TotalInstanceCount) * r.MemGBPerInstance
+}
+
+// CreateReservation re-checks that the reservation's headline compute fits in
+// this node's remaining schedulable capacity, and on success bumps reservedCR*,
+// stores the record, and refreshes subscriptions. The check-and-commit run under
+// a single write-lock so a concurrent allocate or CreateReservation cannot
+// overcommit the host. Returns InsufficientInstanceCapacity if it no longer fits.
+func (rm *ResourceManager) CreateReservation(rec *capacityReservation) error {
+	wantVCPU, wantMem := rec.reservationCompute()
+
+	rm.mu.Lock()
+	remVCPU := rm.hostVCPU - rm.reservedVCPU - rm.reservedCRVCPU - rm.allocatedVCPU
+	remMem := rm.hostMemGB - rm.reservedMem - rm.reservedCRMem - rm.allocatedMem
+	if wantVCPU > remVCPU || wantMem > remMem {
+		rm.mu.Unlock()
+		return errors.New(awserrors.ErrorInsufficientInstanceCapacity)
+	}
+	rm.reservedCRVCPU += wantVCPU
+	rm.reservedCRMem += wantMem
+	rm.reservations[rec.ID] = rec
+	rm.mu.Unlock()
+
+	rm.updateInstanceSubscriptions()
+	return nil
+}
+
+// CancelReservation releases the carve-out for an account-owned reservation and
+// removes it from the map, then refreshes subscriptions. Returns the removed
+// record and true on success, or (nil, false) if no reservation with that id is
+// owned by the account.
+func (rm *ResourceManager) CancelReservation(id, accountID string) (*capacityReservation, bool) {
+	rm.mu.Lock()
+	rec, ok := rm.reservations[id]
+	if !ok || rec.AccountID != accountID {
+		rm.mu.Unlock()
+		return nil, false
+	}
+	freedVCPU, freedMem := rec.reservationCompute()
+	rm.reservedCRVCPU -= freedVCPU
+	rm.reservedCRMem -= freedMem
+	delete(rm.reservations, id)
+	rm.mu.Unlock()
+
+	rm.updateInstanceSubscriptions()
+	return rec, true
+}
+
+// ListReservations returns a snapshot of the account's reservations on this node.
+// Records are immutable, so the returned pointers are safe to read concurrently.
+func (rm *ResourceManager) ListReservations(accountID string) []*capacityReservation {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	var out []*capacityReservation
+	for _, rec := range rm.reservations {
+		if rec.AccountID == accountID {
+			out = append(out, rec)
+		}
+	}
+	return out
+}

--- a/spinifex/daemon/capacityreservation.go
+++ b/spinifex/daemon/capacityreservation.go
@@ -8,10 +8,8 @@ import (
 )
 
 // capacityReservation is an in-memory On-Demand Capacity Reservation pinned to
-// this node. The carve-out it holds (TotalInstanceCount × per-instance compute)
-// is subtracted from schedulable capacity via reservedCR*. Records are immutable
-// after creation; an active reservation is simply present in the map, and
-// cancelling removes it. Lost on daemon restart (no persistence in Phase 1).
+// this node, holding a TotalInstanceCount × per-instance compute carve-out via
+// reservedCR*. Present in the map means active; cancel removes it. Lost on restart.
 type capacityReservation struct {
 	ID                    string
 	AccountID             string
@@ -27,16 +25,14 @@ type capacityReservation struct {
 }
 
 // reservationCompute returns the headline compute carve-out for a reservation:
-// InstanceCount × catalog (vCPU, memory), with no nbdkit overhead in Phase 1.
+// InstanceCount × catalog (vCPU, memory), with no nbdkit overhead.
 func (r *capacityReservation) reservationCompute() (vcpu int, memGB float64) {
 	return r.TotalInstanceCount * r.VCPUPerInstance, float64(r.TotalInstanceCount) * r.MemGBPerInstance
 }
 
-// CreateReservation re-checks that the reservation's headline compute fits in
-// this node's remaining schedulable capacity, and on success bumps reservedCR*,
-// stores the record, and refreshes subscriptions. The check-and-commit run under
-// a single write-lock so a concurrent allocate or CreateReservation cannot
-// overcommit the host. Returns InsufficientInstanceCapacity if it no longer fits.
+// CreateReservation re-checks fit under a single write-lock, then bumps reservedCR*,
+// stores the record, and refreshes subscriptions, so a concurrent allocate cannot
+// overcommit. Returns InsufficientInstanceCapacity if the carve-out no longer fits.
 func (rm *ResourceManager) CreateReservation(rec *capacityReservation) error {
 	wantVCPU, wantMem := rec.reservationCompute()
 

--- a/spinifex/daemon/capacityreservation_test.go
+++ b/spinifex/daemon/capacityreservation_test.go
@@ -1,0 +1,171 @@
+package daemon
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// microType is a deterministic 2 vCPU / 1 GB instance type for carve-out math.
+// With nbdkit charges left at 0 the memory charge equals the catalog figure.
+func microType() *ec2.InstanceTypeInfo {
+	return &ec2.InstanceTypeInfo{
+		InstanceType: aws.String("t3.micro"),
+		VCpuInfo:     &ec2.VCpuInfo{DefaultVCpus: aws.Int64(2)},
+		MemoryInfo:   &ec2.MemoryInfo{SizeInMiB: aws.Int64(1024)},
+	}
+}
+
+// newReservationTestRM builds an 8 vCPU / 16 GB node with no host reserve, so a
+// fresh node fits exactly 4 t3.micro (CPU-bound: 8/2).
+func newReservationTestRM() *ResourceManager {
+	return &ResourceManager{
+		hostVCPU:  8,
+		hostMemGB: 16.0,
+		instanceTypes: map[string]*ec2.InstanceTypeInfo{
+			"t3.micro": microType(),
+		},
+		reservations: make(map[string]*capacityReservation),
+	}
+}
+
+func microReservation(id, accountID string, count int) *capacityReservation {
+	return &capacityReservation{
+		ID:                    id,
+		AccountID:             accountID,
+		InstanceType:          "t3.micro",
+		AvailabilityZone:      "ap-southeast-2a",
+		TotalInstanceCount:    count,
+		VCPUPerInstance:       2,
+		MemGBPerInstance:      1.0,
+		InstanceMatchCriteria: "open",
+		Tenancy:               "default",
+		InstancePlatform:      "Linux/UNIX",
+		CreateDate:            time.Now(),
+	}
+}
+
+// A reservation lowers both canAllocate and the GetResourceStats Available count
+// by its headline compute, then cancelling restores them.
+func TestCapacityReservation_CarveOutAndRestore(t *testing.T) {
+	rm := newReservationTestRM()
+	mt := microType()
+
+	require.Equal(t, 4, rm.canAllocate(mt, 100), "fresh node fits 4 t3.micro")
+
+	require.NoError(t, rm.CreateReservation(microReservation("cr-1", "acct-a", 2)))
+
+	assert.Equal(t, 4, rm.reservedCRVCPU)
+	assert.Equal(t, 2.0, rm.reservedCRMem)
+	assert.Equal(t, 2, rm.canAllocate(mt, 100), "carve-out of 2 leaves room for 2 more")
+
+	// GetResourceStats folds the carve-out into the reported reserve and Available.
+	_, _, reservedVCPU, reservedMem, _, _, caps := rm.GetResourceStats()
+	assert.Equal(t, 4, reservedVCPU)
+	assert.Equal(t, 2.0, reservedMem)
+	var available int
+	for _, c := range caps {
+		if c.Name == "t3.micro" {
+			available = c.Available
+		}
+	}
+	assert.Equal(t, 2, available, "GetResourceStats Available reflects the carve-out")
+
+	rec, ok := rm.CancelReservation("cr-1", "acct-a")
+	require.True(t, ok)
+	assert.Equal(t, "cr-1", rec.ID)
+	assert.Equal(t, 0, rm.reservedCRVCPU)
+	assert.Equal(t, 0.0, rm.reservedCRMem)
+	assert.Equal(t, 4, rm.canAllocate(mt, 100), "cancel restores full capacity")
+}
+
+// A reservation larger than remaining schedulable capacity is rejected and
+// leaves the carve-out untouched.
+func TestCapacityReservation_OverReserveRejected(t *testing.T) {
+	rm := newReservationTestRM()
+
+	err := rm.CreateReservation(microReservation("cr-big", "acct-a", 5)) // 10 vCPU > 8
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInsufficientInstanceCapacity, err.Error())
+	assert.Equal(t, 0, rm.reservedCRVCPU)
+	assert.Equal(t, 0.0, rm.reservedCRMem)
+	assert.Empty(t, rm.reservations)
+}
+
+// Cancel is account-scoped: a foreign account cannot release another's hold, and
+// an unknown id is reported missing.
+func TestCapacityReservation_CancelScoping(t *testing.T) {
+	rm := newReservationTestRM()
+	require.NoError(t, rm.CreateReservation(microReservation("cr-1", "acct-a", 1)))
+
+	_, ok := rm.CancelReservation("cr-1", "acct-b")
+	assert.False(t, ok, "another account cannot cancel the reservation")
+	assert.Equal(t, 2, rm.reservedCRVCPU, "carve-out unchanged after foreign cancel")
+
+	_, ok = rm.CancelReservation("cr-unknown", "acct-a")
+	assert.False(t, ok, "unknown id reports not found")
+
+	_, ok = rm.CancelReservation("cr-1", "acct-a")
+	assert.True(t, ok)
+}
+
+// ListReservations returns only the account's reservations.
+func TestCapacityReservation_ListScoping(t *testing.T) {
+	rm := newReservationTestRM()
+	require.NoError(t, rm.CreateReservation(microReservation("cr-1", "acct-a", 1)))
+	require.NoError(t, rm.CreateReservation(microReservation("cr-2", "acct-b", 1)))
+
+	a := rm.ListReservations("acct-a")
+	require.Len(t, a, 1)
+	assert.Equal(t, "cr-1", a[0].ID)
+
+	assert.Empty(t, rm.ListReservations("acct-c"))
+}
+
+// Concurrent CreateReservation and allocate share the same rm.mu re-check gate,
+// so the combined committed compute can never exceed the host's schedulable pool.
+func TestCapacityReservation_ConcurrentNoOvercommit(t *testing.T) {
+	rm := newReservationTestRM()
+	mt := microType()
+
+	const workers = 32
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := range workers {
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				_ = rm.CreateReservation(microReservation(fmt.Sprintf("cr-%d", i), "acct-a", 1))
+			} else {
+				_ = rm.allocate(mt)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	committedVCPU := rm.reservedCRVCPU + rm.allocatedVCPU
+	committedMem := rm.reservedCRMem + rm.allocatedMem
+	assert.LessOrEqual(t, committedVCPU, rm.hostVCPU, "vCPU never overcommitted")
+	assert.LessOrEqual(t, committedMem, rm.hostMemGB, "memory never overcommitted")
+
+	// reservedCR* stays consistent with the surviving reservation records.
+	var sumVCPU int
+	var sumMem float64
+	for _, rec := range rm.reservations {
+		v, m := rec.reservationCompute()
+		sumVCPU += v
+		sumMem += m
+	}
+	assert.Equal(t, sumVCPU, rm.reservedCRVCPU)
+	assert.Equal(t, sumMem, rm.reservedCRMem)
+}

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -579,8 +579,8 @@ func (rm *ResourceManager) GetAvailableInstanceTypeInfos(showCapacity bool) []*e
 		}
 
 		count := canAllocateCount(
-			rm.hostVCPU-rm.reservedVCPU, rm.allocatedVCPU,
-			rm.hostMemGB-rm.reservedMem, rm.allocatedMem,
+			rm.hostVCPU-rm.reservedVCPU-rm.reservedCRVCPU, rm.allocatedVCPU,
+			rm.hostMemGB-rm.reservedMem-rm.reservedCRMem, rm.allocatedMem,
 			vCPUs, rm.instanceMemChargeMiB(it),
 			1<<30, // effectively unlimited — let resources be the constraint
 			0, false,
@@ -598,6 +598,7 @@ func (rm *ResourceManager) GetAvailableInstanceTypeInfos(showCapacity bool) []*e
 	slog.Info("GetAvailableInstanceTypeInfos", "total_types", len(rm.instanceTypes), "total_available_slots", len(infos),
 		"hostVCPU", rm.hostVCPU, "hostMem", rm.hostMemGB,
 		"reservedVCPU", rm.reservedVCPU, "reservedMem", rm.reservedMem,
+		"reservedCRVCPU", rm.reservedCRVCPU, "reservedCRMem", rm.reservedCRMem,
 		"showCapacity", showCapacity)
 
 	return infos

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -95,6 +95,14 @@ type ResourceManager struct {
 	reservedMem   float64
 	allocatedVCPU int
 	allocatedMem  float64
+	// reservedCRVCPU / reservedCRMem: compute held by capacity reservations
+	// pinned to this node. Subtracted from schedulable capacity exactly like
+	// the host reserve. In-memory only — lost on daemon restart.
+	reservedCRVCPU int
+	reservedCRMem  float64
+	// reservations: in-memory capacity reservations owned by this node, keyed
+	// by id. Mutated together with reservedCR* under mu.
+	reservations map[string]*capacityReservation
 	// nbdkitMainMiB / nbdkitAuxMiB: per-volume nbdkit memory charged at
 	// admission so nbdkit backing a guest's volumes is accounted explicitly.
 	nbdkitMainMiB int
@@ -485,6 +493,7 @@ func NewResourceManager(gpuModels []instancetypes.GPUModel, migProfiles []instan
 		instanceTypes:      instanceTypes,
 		gpuManager:         gpuMgr,
 		readMemAvailableGB: memReader,
+		reservations:       make(map[string]*capacityReservation),
 	}, nil
 }
 
@@ -624,17 +633,19 @@ func (rm *ResourceManager) GetResourceStats() (totalVCPU int, totalMemGB float64
 
 	totalVCPU = rm.hostVCPU
 	totalMemGB = rm.hostMemGB
-	reservedVCPU = rm.reservedVCPU
-	reservedMemGB = rm.reservedMem
+	// Fold the capacity-reservation carve-out into the reported reserve figures;
+	// Phase 1 has no separate status field for it.
+	reservedVCPU = rm.reservedVCPU + rm.reservedCRVCPU
+	reservedMemGB = rm.reservedMem + rm.reservedCRMem
 	allocVCPU = rm.allocatedVCPU
 	allocMemGB = rm.allocatedMem
 
-	remainingVCPU := rm.hostVCPU - rm.reservedVCPU - rm.allocatedVCPU
-	remainingMem := rm.hostMemGB - rm.reservedMem - rm.allocatedMem
+	remainingVCPU := rm.hostVCPU - reservedVCPU - rm.allocatedVCPU
+	remainingMem := rm.hostMemGB - reservedMemGB - rm.allocatedMem
 	if remainingVCPU < 0 || remainingMem < 0 {
 		slog.Error("schedulable capacity negative — reserve misconfigured or allocation drift",
-			"hostVCPU", rm.hostVCPU, "reservedVCPU", rm.reservedVCPU, "allocatedVCPU", rm.allocatedVCPU,
-			"hostMemGB", rm.hostMemGB, "reservedMem", rm.reservedMem, "allocatedMem", rm.allocatedMem,
+			"hostVCPU", rm.hostVCPU, "reservedVCPU", reservedVCPU, "allocatedVCPU", rm.allocatedVCPU,
+			"hostMemGB", rm.hostMemGB, "reservedMem", reservedMemGB, "allocatedMem", rm.allocatedMem,
 			"remainingVCPU", remainingVCPU, "remainingMem", remainingMem)
 	}
 
@@ -771,6 +782,11 @@ func (d *Daemon) subscribeAll() error {
 		{"ec2.RemoveInstanceFromPlacementGroup", d.handleEC2RemoveInstanceFromPlacementGroup, "spinifex-workers"},
 		{"ec2.ReserveClusterNode", d.handleEC2ReserveClusterNode, "spinifex-workers"},
 		{"ec2.FinalizeClusterInstances", d.handleEC2FinalizeClusterInstances, "spinifex-workers"},
+		// Capacity reservations: Create is node-targeted (gateway pins one node);
+		// Describe fans out and Cancel broadcasts, so both use plain Subscribe.
+		{fmt.Sprintf("ec2.CreateCapacityReservation.%s", d.node), d.handleEC2CreateCapacityReservation, ""},
+		{"ec2.DescribeCapacityReservations", d.handleEC2DescribeCapacityReservations, ""},
+		{"ec2.CancelCapacityReservation", d.handleEC2CancelCapacityReservation, ""},
 		{"ec2.CreateNatGateway", d.handleEC2CreateNatGateway, "spinifex-workers"},
 		{"ec2.DeleteNatGateway", d.handleEC2DeleteNatGateway, "spinifex-workers"},
 		{"ec2.DescribeNatGateways", d.handleEC2DescribeNatGateways, "spinifex-workers"},
@@ -2023,8 +2039,8 @@ func (rm *ResourceManager) canAllocateLocked(instanceType *ec2.InstanceTypeInfo,
 	}
 
 	n := canAllocateCount(
-		rm.hostVCPU-rm.reservedVCPU, rm.allocatedVCPU,
-		rm.hostMemGB-rm.reservedMem, rm.allocatedMem,
+		rm.hostVCPU-rm.reservedVCPU-rm.reservedCRVCPU, rm.allocatedVCPU,
+		rm.hostMemGB-rm.reservedMem-rm.reservedCRMem, rm.allocatedMem,
 		instanceTypeVCPUs(instanceType),
 		rm.instanceMemChargeMiB(instanceType),
 		count,
@@ -2044,7 +2060,7 @@ func (rm *ResourceManager) liveMemGate(n int, instanceType *ec2.InstanceTypeInfo
 		return n
 	}
 	memGB := float64(rm.instanceMemChargeMiB(instanceType)) / 1024.0
-	return liveMemCount(n, availGB, rm.reservedMem, memGB)
+	return liveMemCount(n, availGB, rm.reservedMem+rm.reservedCRMem, memGB)
 }
 
 // allocate reserves resources for one instance and updates NATS subscriptions.

--- a/spinifex/daemon/daemon_handlers_capacityreservation.go
+++ b/spinifex/daemon/daemon_handlers_capacityreservation.go
@@ -12,11 +12,9 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-// handleEC2CreateCapacityReservation is the node-targeted Create handler. The
-// gateway has already validated input and pinned this node; here we resolve the
-// per-instance carve-out from the local catalog, generate the id, and commit it
-// under the ResourceManager's fit re-check. A lost race returns
-// InsufficientInstanceCapacity and the client retries.
+// handleEC2CreateCapacityReservation is the node-targeted Create handler: resolve
+// the per-instance carve-out from the local catalog, generate the id, and commit
+// under the fit re-check. A lost race returns InsufficientInstanceCapacity.
 func (d *Daemon) handleEC2CreateCapacityReservation(msg *nats.Msg) {
 	accountID := utils.AccountIDFromMsg(msg)
 	input := new(ec2.CreateCapacityReservationInput)
@@ -98,8 +96,8 @@ func (d *Daemon) handleEC2CancelCapacityReservation(msg *nats.Msg) {
 }
 
 // toAWSCapacityReservation renders the in-memory record as the AWS API type.
-// Phase 1 reservations are always active with AvailableInstanceCount equal to
-// the total, and never expire (EndDateType=unlimited).
+// Reservations are always active with AvailableInstanceCount equal to the total,
+// and never expire (EndDateType=unlimited).
 func (r *capacityReservation) toAWSCapacityReservation() *ec2.CapacityReservation {
 	count := int64(r.TotalInstanceCount)
 	return &ec2.CapacityReservation{

--- a/spinifex/daemon/daemon_handlers_capacityreservation.go
+++ b/spinifex/daemon/daemon_handlers_capacityreservation.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/instancetypes"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// handleEC2CreateCapacityReservation is the node-targeted Create handler. The
+// gateway has already validated input and pinned this node; here we resolve the
+// per-instance carve-out from the local catalog, generate the id, and commit it
+// under the ResourceManager's fit re-check. A lost race returns
+// InsufficientInstanceCapacity and the client retries.
+func (d *Daemon) handleEC2CreateCapacityReservation(msg *nats.Msg) {
+	accountID := utils.AccountIDFromMsg(msg)
+	input := new(ec2.CreateCapacityReservationInput)
+	if errResp := utils.UnmarshalJsonPayload(input, msg.Data); errResp != nil {
+		if err := msg.Respond(errResp); err != nil {
+			slog.Error("Failed to respond to NATS request", "err", err)
+		}
+		return
+	}
+
+	// GPU capacity reservations are out of scope; an unknown type is equally
+	// unreservable. Both reject as InvalidInstanceType.
+	instanceType := aws.StringValue(input.InstanceType)
+	it := d.resourceMgr.instanceTypes[instanceType]
+	if it == nil || instancetypes.IsGPUType(it) {
+		respondWithError(msg, awserrors.ErrorInvalidInstanceType)
+		return
+	}
+
+	matchCriteria := aws.StringValue(input.InstanceMatchCriteria)
+	if matchCriteria == "" {
+		matchCriteria = ec2.InstanceMatchCriteriaOpen
+	}
+	tenancy := aws.StringValue(input.Tenancy)
+	if tenancy == "" {
+		tenancy = ec2.CapacityReservationTenancyDefault
+	}
+
+	rec := &capacityReservation{
+		ID:                    utils.GenerateResourceID("cr"),
+		AccountID:             accountID,
+		InstanceType:          instanceType,
+		AvailabilityZone:      aws.StringValue(input.AvailabilityZone),
+		TotalInstanceCount:    int(aws.Int64Value(input.InstanceCount)),
+		VCPUPerInstance:       int(instanceTypeVCPUs(it)),
+		MemGBPerInstance:      float64(instanceTypeMemoryMiB(it)) / 1024.0,
+		InstanceMatchCriteria: matchCriteria,
+		Tenancy:               tenancy,
+		InstancePlatform:      aws.StringValue(input.InstancePlatform),
+		CreateDate:            time.Now().UTC(),
+	}
+
+	if err := d.resourceMgr.CreateReservation(rec); err != nil {
+		respondWithError(msg, awserrors.ValidErrorCode(err.Error()))
+		return
+	}
+
+	respondWithJSON(msg, rec.toAWSCapacityReservation())
+}
+
+// handleEC2DescribeCapacityReservations is the fan-out Describe handler. Each
+// node returns its own in-memory reservations for the account (possibly empty);
+// the gateway aggregates and applies id/filter scoping.
+func (d *Daemon) handleEC2DescribeCapacityReservations(msg *nats.Msg) {
+	accountID := utils.AccountIDFromMsg(msg)
+
+	out := &ec2.DescribeCapacityReservationsOutput{}
+	for _, rec := range d.resourceMgr.ListReservations(accountID) {
+		out.CapacityReservations = append(out.CapacityReservations, rec.toAWSCapacityReservation())
+	}
+	respondWithJSON(msg, out)
+}
+
+// handleEC2CancelCapacityReservation is the broadcast Cancel handler. Only the
+// node owning the reservation releases it; every node acks with Return set so
+// the gateway can tell "cancelled" from "no node owns this id".
+func (d *Daemon) handleEC2CancelCapacityReservation(msg *nats.Msg) {
+	accountID := utils.AccountIDFromMsg(msg)
+	input := new(ec2.CancelCapacityReservationInput)
+	if errResp := utils.UnmarshalJsonPayload(input, msg.Data); errResp != nil {
+		if err := msg.Respond(errResp); err != nil {
+			slog.Error("Failed to respond to NATS request", "err", err)
+		}
+		return
+	}
+
+	_, found := d.resourceMgr.CancelReservation(aws.StringValue(input.CapacityReservationId), accountID)
+	respondWithJSON(msg, &ec2.CancelCapacityReservationOutput{Return: aws.Bool(found)})
+}
+
+// toAWSCapacityReservation renders the in-memory record as the AWS API type.
+// Phase 1 reservations are always active with AvailableInstanceCount equal to
+// the total, and never expire (EndDateType=unlimited).
+func (r *capacityReservation) toAWSCapacityReservation() *ec2.CapacityReservation {
+	count := int64(r.TotalInstanceCount)
+	return &ec2.CapacityReservation{
+		CapacityReservationId:  aws.String(r.ID),
+		OwnerId:                aws.String(r.AccountID),
+		InstanceType:           aws.String(r.InstanceType),
+		InstancePlatform:       aws.String(r.InstancePlatform),
+		AvailabilityZone:       aws.String(r.AvailabilityZone),
+		TotalInstanceCount:     aws.Int64(count),
+		AvailableInstanceCount: aws.Int64(count),
+		State:                  aws.String(ec2.CapacityReservationStateActive),
+		StartDate:              aws.Time(r.CreateDate),
+		CreateDate:             aws.Time(r.CreateDate),
+		InstanceMatchCriteria:  aws.String(r.InstanceMatchCriteria),
+		Tenancy:                aws.String(r.Tenancy),
+		EndDateType:            aws.String(ec2.EndDateTypeUnlimited),
+		EbsOptimized:           aws.Bool(false),
+		EphemeralStorage:       aws.Bool(false),
+		ReservationType:        aws.String(ec2.CapacityReservationTypeDefault),
+	}
+}

--- a/spinifex/daemon/daemon_handlers_capacityreservation_test.go
+++ b/spinifex/daemon/daemon_handlers_capacityreservation_test.go
@@ -1,0 +1,251 @@
+package daemon
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// crIDPattern matches the cr-<17 hex> id minted by GenerateResourceID("cr").
+var crIDPattern = regexp.MustCompile(`^cr-[0-9a-f]{17}$`)
+
+// natsRequestAs is natsRequest with an explicit account, for exercising the
+// handlers' account scoping (natsRequest always uses testAccountID).
+func natsRequestAs(nc *nats.Conn, subject string, data []byte, account string, timeout time.Duration) (*nats.Msg, error) {
+	msg := nats.NewMsg(subject)
+	msg.Data = data
+	msg.Header.Set("X-Account-ID", account)
+	return nc.RequestMsg(msg, timeout)
+}
+
+// replyErrCode returns the awserror Code on an error reply, or "" if the reply
+// is a normal (non-error) payload.
+func replyErrCode(t *testing.T, data []byte) string {
+	t.Helper()
+	var re struct {
+		Code string `json:"Code"`
+	}
+	require.NoError(t, json.Unmarshal(data, &re))
+	return re.Code
+}
+
+// seedReservation inserts a reservation directly into the node's map, bypassing
+// the fit gate so scoping tests can hold several records (the schedulable pool
+// only fits one t3.micro under the pinned 4-vCPU test host).
+func seedReservation(rm *ResourceManager, id, account, instanceType string) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.reservations[id] = &capacityReservation{
+		ID:                    id,
+		AccountID:             account,
+		InstanceType:          instanceType,
+		AvailabilityZone:      "ap-southeast-2a",
+		TotalInstanceCount:    1,
+		VCPUPerInstance:       2,
+		MemGBPerInstance:      1.0,
+		InstanceMatchCriteria: ec2.InstanceMatchCriteriaOpen,
+		Tenancy:               ec2.CapacityReservationTenancyDefault,
+		InstancePlatform:      "Linux/UNIX",
+		CreateDate:            time.Now().UTC(),
+	}
+}
+
+// The node-targeted Create handler resolves per-instance compute from the local
+// catalog, mints a cr-id, commits the carve-out, and renders the AWS view.
+func TestHandleEC2CreateCapacityReservation_RoundTrip(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	instType := getTestInstanceType(t)
+	it := daemon.resourceMgr.instanceTypes[instType]
+	require.NotNil(t, it, "test instance type missing from catalog")
+	wantVCPU := int(instanceTypeVCPUs(it))
+	require.GreaterOrEqual(t, daemon.resourceMgr.canAllocate(it, 1000), 1, "host must fit one for the round-trip")
+
+	subject := "ec2.CreateCapacityReservation." + daemon.node
+	sub, err := daemon.natsConn.Subscribe(subject, daemon.handleEC2CreateCapacityReservation)
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	reqData, _ := json.Marshal(&ec2.CreateCapacityReservationInput{
+		InstanceType:     aws.String(instType),
+		InstanceCount:    aws.Int64(1),
+		AvailabilityZone: aws.String("ap-southeast-2a"),
+		InstancePlatform: aws.String("Linux/UNIX"),
+	})
+	reply, err := natsRequest(daemon.natsConn, subject, reqData, 5*time.Second)
+	require.NoError(t, err)
+	require.Empty(t, replyErrCode(t, reply.Data), "create should not error: %s", reply.Data)
+
+	var cr ec2.CapacityReservation
+	require.NoError(t, json.Unmarshal(reply.Data, &cr))
+	assert.Regexp(t, crIDPattern, aws.StringValue(cr.CapacityReservationId))
+	assert.Equal(t, testAccountID, aws.StringValue(cr.OwnerId))
+	assert.Equal(t, instType, aws.StringValue(cr.InstanceType))
+	assert.Equal(t, "ap-southeast-2a", aws.StringValue(cr.AvailabilityZone))
+	assert.Equal(t, "Linux/UNIX", aws.StringValue(cr.InstancePlatform))
+	assert.Equal(t, int64(1), aws.Int64Value(cr.TotalInstanceCount))
+	assert.Equal(t, int64(1), aws.Int64Value(cr.AvailableInstanceCount))
+	assert.Equal(t, ec2.CapacityReservationStateActive, aws.StringValue(cr.State))
+	assert.Equal(t, ec2.InstanceMatchCriteriaOpen, aws.StringValue(cr.InstanceMatchCriteria), "match criteria defaults to open")
+	assert.Equal(t, ec2.CapacityReservationTenancyDefault, aws.StringValue(cr.Tenancy), "tenancy defaults to default")
+	assert.Equal(t, ec2.EndDateTypeUnlimited, aws.StringValue(cr.EndDateType))
+
+	daemon.resourceMgr.mu.RLock()
+	gotVCPU := daemon.resourceMgr.reservedCRVCPU
+	daemon.resourceMgr.mu.RUnlock()
+	assert.Equal(t, wantVCPU, gotVCPU, "carve-out committed to the resource manager")
+}
+
+// Create rejects an unknown type, a GPU type, and a request larger than the
+// node's remaining schedulable pool, leaving no carve-out behind in any case.
+func TestHandleEC2CreateCapacityReservation_Rejections(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	// Inject a synthetic GPU type; the catalog otherwise has none.
+	daemon.resourceMgr.instanceTypes["g4dn.xlarge"] = &ec2.InstanceTypeInfo{
+		InstanceType: aws.String("g4dn.xlarge"),
+		VCpuInfo:     &ec2.VCpuInfo{DefaultVCpus: aws.Int64(4)},
+		MemoryInfo:   &ec2.MemoryInfo{SizeInMiB: aws.Int64(16384)},
+		GpuInfo:      &ec2.GpuInfo{Gpus: []*ec2.GpuDeviceInfo{{Name: aws.String("T4"), Count: aws.Int64(1)}}},
+	}
+
+	instType := getTestInstanceType(t)
+	it := daemon.resourceMgr.instanceTypes[instType]
+	require.NotNil(t, it)
+	overCount := int64(daemon.resourceMgr.canAllocate(it, 1000) + 1)
+
+	subject := "ec2.CreateCapacityReservation." + daemon.node
+	sub, err := daemon.natsConn.Subscribe(subject, daemon.handleEC2CreateCapacityReservation)
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	tests := []struct {
+		name    string
+		input   *ec2.CreateCapacityReservationInput
+		wantErr string
+	}{
+		{
+			name: "unknown type",
+			input: &ec2.CreateCapacityReservationInput{
+				InstanceType: aws.String("nonexistent.type"), InstanceCount: aws.Int64(1),
+				AvailabilityZone: aws.String("ap-southeast-2a"),
+			},
+			wantErr: awserrors.ErrorInvalidInstanceType,
+		},
+		{
+			name: "gpu type",
+			input: &ec2.CreateCapacityReservationInput{
+				InstanceType: aws.String("g4dn.xlarge"), InstanceCount: aws.Int64(1),
+				AvailabilityZone: aws.String("ap-southeast-2a"),
+			},
+			wantErr: awserrors.ErrorInvalidInstanceType,
+		},
+		{
+			name: "exceeds schedulable",
+			input: &ec2.CreateCapacityReservationInput{
+				InstanceType: aws.String(instType), InstanceCount: aws.Int64(overCount),
+				AvailabilityZone: aws.String("ap-southeast-2a"),
+			},
+			wantErr: awserrors.ErrorInsufficientInstanceCapacity,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqData, _ := json.Marshal(tt.input)
+			reply, err := natsRequest(daemon.natsConn, subject, reqData, 5*time.Second)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantErr, replyErrCode(t, reply.Data))
+		})
+	}
+
+	daemon.resourceMgr.mu.RLock()
+	defer daemon.resourceMgr.mu.RUnlock()
+	assert.Equal(t, 0, daemon.resourceMgr.reservedCRVCPU, "no carve-out after rejected creates")
+	assert.Empty(t, daemon.resourceMgr.reservations)
+}
+
+// The fan-out Describe handler returns only the caller's reservations.
+func TestHandleEC2DescribeCapacityReservations_Scoping(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+	seedReservation(daemon.resourceMgr, "cr-aaaaaaaaaaaaaaaaa", testAccountID, getTestInstanceType(t))
+	seedReservation(daemon.resourceMgr, "cr-bbbbbbbbbbbbbbbbb", "999999999999", getTestInstanceType(t))
+
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeCapacityReservations", daemon.handleEC2DescribeCapacityReservations)
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	reqData, _ := json.Marshal(&ec2.DescribeCapacityReservationsInput{})
+
+	reply, err := natsRequest(daemon.natsConn, "ec2.DescribeCapacityReservations", reqData, 5*time.Second)
+	require.NoError(t, err)
+	var out ec2.DescribeCapacityReservationsOutput
+	require.NoError(t, json.Unmarshal(reply.Data, &out))
+	require.Len(t, out.CapacityReservations, 1, "only the caller's reservation is returned")
+	assert.Equal(t, "cr-aaaaaaaaaaaaaaaaa", aws.StringValue(out.CapacityReservations[0].CapacityReservationId))
+
+	reply, err = natsRequestAs(daemon.natsConn, "ec2.DescribeCapacityReservations", reqData, "111111111111", 5*time.Second)
+	require.NoError(t, err)
+	var empty ec2.DescribeCapacityReservationsOutput
+	require.NoError(t, json.Unmarshal(reply.Data, &empty))
+	assert.Empty(t, empty.CapacityReservations, "an account with no reservations sees none")
+}
+
+// The broadcast Cancel handler releases the carve-out only for the owning
+// account, and every node acks found/not-found so the gateway can disambiguate.
+func TestHandleEC2CancelCapacityReservation_ScopingAndAck(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	instType := getTestInstanceType(t)
+	it := daemon.resourceMgr.instanceTypes[instType]
+	require.NotNil(t, it)
+	require.GreaterOrEqual(t, daemon.resourceMgr.canAllocate(it, 1000), 1)
+	rec := &capacityReservation{
+		ID:                    "cr-ccccccccccccccccc",
+		AccountID:             testAccountID,
+		InstanceType:          instType,
+		AvailabilityZone:      "ap-southeast-2a",
+		TotalInstanceCount:    1,
+		VCPUPerInstance:       int(instanceTypeVCPUs(it)),
+		MemGBPerInstance:      float64(instanceTypeMemoryMiB(it)) / 1024.0,
+		InstanceMatchCriteria: ec2.InstanceMatchCriteriaOpen,
+		Tenancy:               ec2.CapacityReservationTenancyDefault,
+		InstancePlatform:      "Linux/UNIX",
+		CreateDate:            time.Now().UTC(),
+	}
+	require.NoError(t, daemon.resourceMgr.CreateReservation(rec))
+
+	sub, err := daemon.natsConn.Subscribe("ec2.CancelCapacityReservation", daemon.handleEC2CancelCapacityReservation)
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	cancel := func(account string) bool {
+		reqData, _ := json.Marshal(&ec2.CancelCapacityReservationInput{CapacityReservationId: aws.String(rec.ID)})
+		reply, rerr := natsRequestAs(daemon.natsConn, "ec2.CancelCapacityReservation", reqData, account, 5*time.Second)
+		require.NoError(t, rerr)
+		var out ec2.CancelCapacityReservationOutput
+		require.NoError(t, json.Unmarshal(reply.Data, &out))
+		return aws.BoolValue(out.Return)
+	}
+
+	assert.False(t, cancel("999999999999"), "a foreign account cannot cancel")
+	daemon.resourceMgr.mu.RLock()
+	heldVCPU := daemon.resourceMgr.reservedCRVCPU
+	daemon.resourceMgr.mu.RUnlock()
+	assert.Equal(t, rec.VCPUPerInstance, heldVCPU, "carve-out untouched after foreign cancel")
+
+	assert.True(t, cancel(testAccountID), "the owner cancels successfully")
+	daemon.resourceMgr.mu.RLock()
+	freedVCPU := daemon.resourceMgr.reservedCRVCPU
+	daemon.resourceMgr.mu.RUnlock()
+	assert.Equal(t, 0, freedVCPU, "carve-out released on cancel")
+
+	assert.False(t, cancel(testAccountID), "a second cancel reports not-found")
+}

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awsec2query"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_ec2_account "github.com/mulgadc/spinifex/spinifex/gateway/ec2/account"
+	gateway_ec2_capacityreservation "github.com/mulgadc/spinifex/spinifex/gateway/ec2/capacityreservation"
 	gateway_ec2_eigw "github.com/mulgadc/spinifex/spinifex/gateway/ec2/eigw"
 	gateway_ec2_eip "github.com/mulgadc/spinifex/spinifex/gateway/ec2/eip"
 	gateway_ec2_igw "github.com/mulgadc/spinifex/spinifex/gateway/ec2/igw"
@@ -290,6 +291,15 @@ var ec2Actions = map[string]EC2Handler{
 	}),
 	"DescribePlacementGroups": ec2Handler(func(input *ec2.DescribePlacementGroupsInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_placementgroup.DescribePlacementGroups(input, gw.NATSConn, accountID)
+	}),
+	"CreateCapacityReservation": ec2Handler(func(input *ec2.CreateCapacityReservationInput, gw *GatewayConfig, accountID string) (any, error) {
+		return gateway_ec2_capacityreservation.CreateCapacityReservation(input, gw.NATSConn, gw.ExpectedNodes, accountID)
+	}),
+	"DescribeCapacityReservations": ec2Handler(func(input *ec2.DescribeCapacityReservationsInput, gw *GatewayConfig, accountID string) (any, error) {
+		return gateway_ec2_capacityreservation.DescribeCapacityReservations(input, gw.NATSConn, gw.ExpectedNodes, accountID)
+	}),
+	"CancelCapacityReservation": ec2Handler(func(input *ec2.CancelCapacityReservationInput, gw *GatewayConfig, accountID string) (any, error) {
+		return gateway_ec2_capacityreservation.CancelCapacityReservation(input, gw.NATSConn, gw.ExpectedNodes, accountID)
 	}),
 	"CreateVpc": ec2Handler(func(input *ec2.CreateVpcInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_vpc.CreateVpc(input, gw.NATSConn, accountID)

--- a/spinifex/gateway/ec2/capacityreservation/CancelCapacityReservation.go
+++ b/spinifex/gateway/ec2/capacityreservation/CancelCapacityReservation.go
@@ -1,0 +1,54 @@
+package gateway_ec2_capacityreservation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go"
+)
+
+// CancelCapacityReservation broadcasts the cancel to every node; only the daemon
+// that owns the reservation releases its carve-out, but all daemons ack so the
+// gateway can tell "cancelled" from "no node owns this id". Any ack with Return
+// true means success; none means the id is unknown.
+func CancelCapacityReservation(input *ec2.CancelCapacityReservationInput, natsConn *nats.Conn, expectedNodes int, accountID string) (ec2.CancelCapacityReservationOutput, error) {
+	var output ec2.CancelCapacityReservationOutput
+	if input == nil {
+		return output, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	id := aws.StringValue(input.CapacityReservationId)
+	if id == "" {
+		return output, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if !strings.HasPrefix(id, "cr-") {
+		return output, errors.New(awserrors.ErrorInvalidCapacityReservationIdMalformed)
+	}
+	if aws.BoolValue(input.DryRun) {
+		return output, errors.New(awserrors.ErrorDryRunOperation)
+	}
+
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return output, fmt.Errorf("failed to marshal input: %w", err)
+	}
+
+	acks, err := fanoutCollect[ec2.CancelCapacityReservationOutput](natsConn, "ec2.CancelCapacityReservation", payload, expectedNodes, accountID)
+	if err != nil {
+		return output, err
+	}
+
+	for _, ack := range acks {
+		if aws.BoolValue(ack.Return) {
+			output.Return = aws.Bool(true)
+			return output, nil
+		}
+	}
+
+	return output, errors.New(awserrors.ErrorInvalidCapacityReservationIdNotFound)
+}

--- a/spinifex/gateway/ec2/capacityreservation/CreateCapacityReservation.go
+++ b/spinifex/gateway/ec2/capacityreservation/CreateCapacityReservation.go
@@ -1,0 +1,100 @@
+package gateway_ec2_capacityreservation
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// createReservationTimeout bounds the node-targeted Create request-reply. The
+// pinned daemon only re-checks fit and mutates in-memory state, so it is fast.
+const createReservationTimeout = 30 * time.Second
+
+// ValidateCreateCapacityReservationInput enforces the parameter rules that need no
+// cluster knowledge. Type and AZ existence are validated against the census in
+// CreateCapacityReservation. Cosmetic fields (InstancePlatform, InstanceMatchCriteria)
+// are accepted and stored unchanged.
+func ValidateCreateCapacityReservationInput(input *ec2.CreateCapacityReservationInput) error {
+	if input == nil {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	if aws.StringValue(input.InstanceType) == "" {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	if aws.Int64Value(input.InstanceCount) <= 0 {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	if aws.StringValue(input.AvailabilityZone) == "" {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	// No AZ-id mapping exists; only AvailabilityZone is honoured.
+	if aws.StringValue(input.AvailabilityZoneId) != "" {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	// Phase 1 reservations never auto-expire: reject any limited end date.
+	if input.EndDate != nil {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	if t := aws.StringValue(input.EndDateType); t != "" && t != ec2.EndDateTypeUnlimited {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	if t := aws.StringValue(input.Tenancy); t != "" && t != ec2.CapacityReservationTenancyDefault {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	return nil
+}
+
+// CreateCapacityReservation validates the request, runs a census-complete node
+// status fan-out, pins the highest-available in-AZ node that fits the whole
+// InstanceCount, and node-targets the Create to that daemon. An unknown AZ or
+// instance type is rejected from the census; no eligible node or a lost fit
+// re-check on the pinned daemon yields InsufficientInstanceCapacity (the client
+// retries — the gateway does not try another node).
+func CreateCapacityReservation(input *ec2.CreateCapacityReservationInput, natsConn *nats.Conn, expectedNodes int, accountID string) (ec2.CreateCapacityReservationOutput, error) {
+	var output ec2.CreateCapacityReservationOutput
+
+	if err := ValidateCreateCapacityReservationInput(input); err != nil {
+		return output, err
+	}
+	if aws.BoolValue(input.DryRun) {
+		return output, errors.New(awserrors.ErrorDryRunOperation)
+	}
+
+	census, err := collectCensus(natsConn, expectedNodes)
+	if err != nil {
+		return output, err
+	}
+	if len(census) == 0 {
+		return output, errors.New(awserrors.ErrorInsufficientInstanceCapacity)
+	}
+
+	az := aws.StringValue(input.AvailabilityZone)
+	if !azInCensus(census, az) {
+		return output, errors.New(awserrors.ErrorInvalidAvailabilityZone)
+	}
+
+	instanceType := aws.StringValue(input.InstanceType)
+	if !typeInCensus(census, instanceType) {
+		return output, errors.New(awserrors.ErrorInvalidInstanceType)
+	}
+
+	node := selectNode(census, az, instanceType, int(aws.Int64Value(input.InstanceCount)))
+	if node == "" {
+		return output, errors.New(awserrors.ErrorInsufficientInstanceCapacity)
+	}
+
+	subject := fmt.Sprintf("ec2.CreateCapacityReservation.%s", node)
+	reservation, err := utils.NATSRequest[ec2.CapacityReservation](natsConn, subject, input, createReservationTimeout, accountID)
+	if err != nil {
+		return output, err
+	}
+
+	output.CapacityReservation = reservation
+	return output, nil
+}

--- a/spinifex/gateway/ec2/capacityreservation/CreateCapacityReservation.go
+++ b/spinifex/gateway/ec2/capacityreservation/CreateCapacityReservation.go
@@ -37,7 +37,7 @@ func ValidateCreateCapacityReservationInput(input *ec2.CreateCapacityReservation
 	if aws.StringValue(input.AvailabilityZoneId) != "" {
 		return errors.New(awserrors.ErrorInvalidParameterValue)
 	}
-	// Phase 1 reservations never auto-expire: reject any limited end date.
+	// Reservations never auto-expire: reject any limited end date.
 	if input.EndDate != nil {
 		return errors.New(awserrors.ErrorInvalidParameterValue)
 	}
@@ -50,12 +50,9 @@ func ValidateCreateCapacityReservationInput(input *ec2.CreateCapacityReservation
 	return nil
 }
 
-// CreateCapacityReservation validates the request, runs a census-complete node
-// status fan-out, pins the highest-available in-AZ node that fits the whole
-// InstanceCount, and node-targets the Create to that daemon. An unknown AZ or
-// instance type is rejected from the census; no eligible node or a lost fit
-// re-check on the pinned daemon yields InsufficientInstanceCapacity (the client
-// retries — the gateway does not try another node).
+// CreateCapacityReservation runs a census-complete fan-out, pins the highest-
+// available in-AZ node that fits the whole InstanceCount, and node-targets Create.
+// No eligible node (or a lost fit re-check) yields InsufficientInstanceCapacity.
 func CreateCapacityReservation(input *ec2.CreateCapacityReservationInput, natsConn *nats.Conn, expectedNodes int, accountID string) (ec2.CreateCapacityReservationOutput, error) {
 	var output ec2.CreateCapacityReservationOutput
 

--- a/spinifex/gateway/ec2/capacityreservation/DescribeCapacityReservations.go
+++ b/spinifex/gateway/ec2/capacityreservation/DescribeCapacityReservations.go
@@ -14,7 +14,7 @@ import (
 
 // validCapacityReservationFilters is the set of Describe filter names matched
 // against reservation fields. tag: filters are accepted by ParseFilters but never
-// match, since Phase 1 reservations carry no tags.
+// match, since reservations carry no tags.
 var validCapacityReservationFilters = map[string]bool{
 	"instance-type":           true,
 	"availability-zone":       true,
@@ -87,7 +87,7 @@ func filterReservations(reservations []*ec2.CapacityReservation, ids []string, f
 
 // reservationMatchesFilters reports whether r satisfies every filter. Each filter's
 // values are OR'd (with wildcard support); filters are AND'd together. A tag: or
-// otherwise unhandled filter never matches an untagged Phase 1 reservation.
+// otherwise unhandled filter never matches an untagged reservation.
 func reservationMatchesFilters(r *ec2.CapacityReservation, filters map[string][]string) bool {
 	for name, values := range filters {
 		var field string

--- a/spinifex/gateway/ec2/capacityreservation/DescribeCapacityReservations.go
+++ b/spinifex/gateway/ec2/capacityreservation/DescribeCapacityReservations.go
@@ -1,0 +1,117 @@
+package gateway_ec2_capacityreservation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/filterutil"
+	"github.com/nats-io/nats.go"
+)
+
+// validCapacityReservationFilters is the set of Describe filter names matched
+// against reservation fields. tag: filters are accepted by ParseFilters but never
+// match, since Phase 1 reservations carry no tags.
+var validCapacityReservationFilters = map[string]bool{
+	"instance-type":           true,
+	"availability-zone":       true,
+	"state":                   true,
+	"tenancy":                 true,
+	"instance-platform":       true,
+	"instance-match-criteria": true,
+	"owner-id":                true,
+}
+
+// DescribeCapacityReservations fans out to every node, aggregates each daemon's
+// in-memory reservations, and applies the requested ids and filters. Account
+// scoping is enforced by the daemons (which key ListReservations on the caller's
+// account id from the request header).
+func DescribeCapacityReservations(input *ec2.DescribeCapacityReservationsInput, natsConn *nats.Conn, expectedNodes int, accountID string) (ec2.DescribeCapacityReservationsOutput, error) {
+	var output ec2.DescribeCapacityReservationsOutput
+	if input == nil {
+		input = &ec2.DescribeCapacityReservationsInput{}
+	}
+
+	filters, err := filterutil.ParseFilters(input.Filters, validCapacityReservationFilters)
+	if err != nil {
+		return output, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return output, fmt.Errorf("failed to marshal input: %w", err)
+	}
+
+	nodeOutputs, err := fanoutCollect[ec2.DescribeCapacityReservationsOutput](natsConn, "ec2.DescribeCapacityReservations", payload, expectedNodes, accountID)
+	if err != nil {
+		return output, err
+	}
+
+	var all []*ec2.CapacityReservation
+	for _, o := range nodeOutputs {
+		all = append(all, o.CapacityReservations...)
+	}
+
+	output.CapacityReservations = filterReservations(all, aws.StringValueSlice(input.CapacityReservationIds), filters)
+	return output, nil
+}
+
+// filterReservations keeps the reservations whose id is in ids (when non-empty)
+// and that satisfy every parsed filter.
+func filterReservations(reservations []*ec2.CapacityReservation, ids []string, filters map[string][]string) []*ec2.CapacityReservation {
+	idSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		idSet[id] = struct{}{}
+	}
+
+	var out []*ec2.CapacityReservation
+	for _, r := range reservations {
+		if r == nil {
+			continue
+		}
+		if len(idSet) > 0 {
+			if _, ok := idSet[aws.StringValue(r.CapacityReservationId)]; !ok {
+				continue
+			}
+		}
+		if !reservationMatchesFilters(r, filters) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// reservationMatchesFilters reports whether r satisfies every filter. Each filter's
+// values are OR'd (with wildcard support); filters are AND'd together. A tag: or
+// otherwise unhandled filter never matches an untagged Phase 1 reservation.
+func reservationMatchesFilters(r *ec2.CapacityReservation, filters map[string][]string) bool {
+	for name, values := range filters {
+		var field string
+		switch name {
+		case "instance-type":
+			field = aws.StringValue(r.InstanceType)
+		case "availability-zone":
+			field = aws.StringValue(r.AvailabilityZone)
+		case "state":
+			field = aws.StringValue(r.State)
+		case "tenancy":
+			field = aws.StringValue(r.Tenancy)
+		case "instance-platform":
+			field = aws.StringValue(r.InstancePlatform)
+		case "instance-match-criteria":
+			field = aws.StringValue(r.InstanceMatchCriteria)
+		case "owner-id":
+			field = aws.StringValue(r.OwnerId)
+		default:
+			return false
+		}
+		if !filterutil.MatchesAny(values, field) {
+			return false
+		}
+	}
+	return true
+}

--- a/spinifex/gateway/ec2/capacityreservation/capacityreservation_test.go
+++ b/spinifex/gateway/ec2/capacityreservation/capacityreservation_test.go
@@ -1,0 +1,320 @@
+package gateway_ec2_capacityreservation
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAccountID = "123456789012"
+
+// validCreateInput is a request that passes static validation, so census-driven
+// paths can be exercised by varying only the cluster's responses.
+func validCreateInput() *ec2.CreateCapacityReservationInput {
+	return &ec2.CreateCapacityReservationInput{
+		InstanceType:     aws.String("t3.micro"),
+		InstanceCount:    aws.Int64(2),
+		AvailabilityZone: aws.String("az-1"),
+		InstancePlatform: aws.String("Linux/UNIX"),
+	}
+}
+
+// answerNodeStatus replies to spinifex.node.status with the given snapshots,
+// letting a test stand up a synthetic census without a real daemon.
+func answerNodeStatus(t *testing.T, nc *nats.Conn, nodes []types.NodeStatusResponse) {
+	t.Helper()
+	sub, err := nc.Subscribe("spinifex.node.status", func(msg *nats.Msg) {
+		for _, n := range nodes {
+			data, _ := json.Marshal(n)
+			_ = nc.Publish(msg.Reply, data)
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+}
+
+// Create — static validation
+
+func TestValidateCreateCapacityReservationInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ec2.CreateCapacityReservationInput)
+		wantErr string
+	}{
+		{"valid", func(*ec2.CreateCapacityReservationInput) {}, ""},
+		{"nil instance type", func(in *ec2.CreateCapacityReservationInput) { in.InstanceType = nil }, awserrors.ErrorInvalidParameterValue},
+		{"empty instance type", func(in *ec2.CreateCapacityReservationInput) { in.InstanceType = aws.String("") }, awserrors.ErrorInvalidParameterValue},
+		{"zero count", func(in *ec2.CreateCapacityReservationInput) { in.InstanceCount = aws.Int64(0) }, awserrors.ErrorInvalidParameterValue},
+		{"negative count", func(in *ec2.CreateCapacityReservationInput) { in.InstanceCount = aws.Int64(-1) }, awserrors.ErrorInvalidParameterValue},
+		{"missing az", func(in *ec2.CreateCapacityReservationInput) { in.AvailabilityZone = nil }, awserrors.ErrorInvalidParameterValue},
+		{"az id set", func(in *ec2.CreateCapacityReservationInput) { in.AvailabilityZoneId = aws.String("azid-1") }, awserrors.ErrorInvalidParameterValue},
+		{"end date set", func(in *ec2.CreateCapacityReservationInput) { in.EndDate = aws.Time(time.Now()) }, awserrors.ErrorInvalidParameterValue},
+		{"limited end date type", func(in *ec2.CreateCapacityReservationInput) { in.EndDateType = aws.String(ec2.EndDateTypeLimited) }, awserrors.ErrorInvalidParameterValue},
+		{"unlimited end date type ok", func(in *ec2.CreateCapacityReservationInput) { in.EndDateType = aws.String(ec2.EndDateTypeUnlimited) }, ""},
+		{"non-default tenancy", func(in *ec2.CreateCapacityReservationInput) { in.Tenancy = aws.String("dedicated") }, awserrors.ErrorInvalidParameterValue},
+		{"default tenancy ok", func(in *ec2.CreateCapacityReservationInput) {
+			in.Tenancy = aws.String(ec2.CapacityReservationTenancyDefault)
+		}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := validCreateInput()
+			tt.mutate(in)
+			err := ValidateCreateCapacityReservationInput(in)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestValidateCreateCapacityReservationInput_Nil(t *testing.T) {
+	assert.EqualError(t, ValidateCreateCapacityReservationInput(nil), awserrors.ErrorInvalidParameterValue)
+}
+
+// DryRun short-circuits after validation, before any cluster round-trip.
+func TestCreateCapacityReservation_DryRun(t *testing.T) {
+	in := validCreateInput()
+	in.DryRun = aws.Bool(true)
+	_, err := CreateCapacityReservation(in, nil, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorDryRunOperation)
+}
+
+func TestCreateCapacityReservation_NilNATS(t *testing.T) {
+	_, err := CreateCapacityReservation(validCreateInput(), nil, 1, testAccountID)
+	assert.ErrorIs(t, err, utils.ErrClusterUnavailable)
+}
+
+// Create — census-driven paths
+
+func TestCreateCapacityReservation_UnknownAZ(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	answerNodeStatus(t, nc, []types.NodeStatusResponse{
+		{Node: "node-a", AZ: "az-2", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 4}}},
+	})
+	_, err := CreateCapacityReservation(validCreateInput(), nc, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInvalidAvailabilityZone)
+}
+
+func TestCreateCapacityReservation_UnknownType(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	answerNodeStatus(t, nc, []types.NodeStatusResponse{
+		{Node: "node-a", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.small", Available: 4}}},
+	})
+	_, err := CreateCapacityReservation(validCreateInput(), nc, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInvalidInstanceType)
+}
+
+func TestCreateCapacityReservation_InsufficientCapacity(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	answerNodeStatus(t, nc, []types.NodeStatusResponse{
+		{Node: "node-a", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 1}}},
+	})
+	_, err := CreateCapacityReservation(validCreateInput(), nc, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInsufficientInstanceCapacity)
+}
+
+func TestCreateCapacityReservation_Success(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	answerNodeStatus(t, nc, []types.NodeStatusResponse{
+		{Node: "node-a", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 4}}},
+	})
+
+	created := &ec2.CapacityReservation{
+		CapacityReservationId: aws.String("cr-0123456789abcdef0"),
+		OwnerId:               aws.String(testAccountID),
+		InstanceType:          aws.String("t3.micro"),
+		AvailabilityZone:      aws.String("az-1"),
+		TotalInstanceCount:    aws.Int64(2),
+		State:                 aws.String(ec2.CapacityReservationStateActive),
+	}
+	sub, err := nc.Subscribe("ec2.CreateCapacityReservation.node-a", func(msg *nats.Msg) {
+		data, _ := json.Marshal(created)
+		_ = msg.Respond(data)
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	out, err := CreateCapacityReservation(validCreateInput(), nc, 1, testAccountID)
+	require.NoError(t, err)
+	require.NotNil(t, out.CapacityReservation)
+	assert.Equal(t, "cr-0123456789abcdef0", aws.StringValue(out.CapacityReservation.CapacityReservationId))
+}
+
+// Create propagates the pinned daemon's error verbatim (e.g. a lost fit re-check).
+func TestCreateCapacityReservation_DaemonRejection(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	answerNodeStatus(t, nc, []types.NodeStatusResponse{
+		{Node: "node-a", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 4}}},
+	})
+	sub, err := nc.Subscribe("ec2.CreateCapacityReservation.node-a", func(msg *nats.Msg) {
+		_ = msg.Respond(utils.GenerateErrorPayload(awserrors.ErrorInsufficientInstanceCapacity))
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	_, err = CreateCapacityReservation(validCreateInput(), nc, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInsufficientInstanceCapacity)
+}
+
+// Describe — filtering
+
+func reservation(id, instanceType, az string) *ec2.CapacityReservation {
+	return &ec2.CapacityReservation{
+		CapacityReservationId: aws.String(id),
+		InstanceType:          aws.String(instanceType),
+		AvailabilityZone:      aws.String(az),
+		State:                 aws.String(ec2.CapacityReservationStateActive),
+		Tenancy:               aws.String(ec2.CapacityReservationTenancyDefault),
+		OwnerId:               aws.String(testAccountID),
+	}
+}
+
+func TestFilterReservations_ByID(t *testing.T) {
+	all := []*ec2.CapacityReservation{
+		reservation("cr-1", "t3.micro", "az-1"),
+		reservation("cr-2", "t3.small", "az-1"),
+	}
+	got := filterReservations(all, []string{"cr-2"}, nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, "cr-2", aws.StringValue(got[0].CapacityReservationId))
+}
+
+func TestFilterReservations_ByFilter(t *testing.T) {
+	all := []*ec2.CapacityReservation{
+		reservation("cr-1", "t3.micro", "az-1"),
+		reservation("cr-2", "t3.small", "az-2"),
+	}
+	got := filterReservations(all, nil, map[string][]string{"availability-zone": {"az-2"}})
+	require.Len(t, got, 1)
+	assert.Equal(t, "cr-2", aws.StringValue(got[0].CapacityReservationId))
+}
+
+func TestFilterReservations_IDAndFilterAreANDed(t *testing.T) {
+	all := []*ec2.CapacityReservation{
+		reservation("cr-1", "t3.micro", "az-1"),
+		reservation("cr-2", "t3.small", "az-2"),
+	}
+	got := filterReservations(all, []string{"cr-1"}, map[string][]string{"availability-zone": {"az-2"}})
+	assert.Empty(t, got)
+}
+
+func TestFilterReservations_TagFilterNeverMatches(t *testing.T) {
+	all := []*ec2.CapacityReservation{reservation("cr-1", "t3.micro", "az-1")}
+	got := filterReservations(all, nil, map[string][]string{"tag:env": {"prod"}})
+	assert.Empty(t, got)
+}
+
+func TestFilterReservations_Empty(t *testing.T) {
+	assert.Empty(t, filterReservations(nil, nil, nil))
+}
+
+func TestDescribeCapacityReservations_InvalidFilter(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	input := &ec2.DescribeCapacityReservationsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("bogus"), Values: aws.StringSlice([]string{"x"})}},
+	}
+	_, err := DescribeCapacityReservations(input, nc, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInvalidParameterValue)
+}
+
+func TestDescribeCapacityReservations_NilNATS(t *testing.T) {
+	_, err := DescribeCapacityReservations(&ec2.DescribeCapacityReservationsInput{}, nil, 1, testAccountID)
+	assert.ErrorIs(t, err, utils.ErrClusterUnavailable)
+}
+
+// Describe merges reservations across nodes and applies filters to the union.
+func TestDescribeCapacityReservations_MergesAndFilters(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	node1 := ec2.DescribeCapacityReservationsOutput{CapacityReservations: []*ec2.CapacityReservation{reservation("cr-1", "t3.micro", "az-1")}}
+	node2 := ec2.DescribeCapacityReservationsOutput{CapacityReservations: []*ec2.CapacityReservation{reservation("cr-2", "t3.small", "az-2")}}
+	sub, err := nc.Subscribe("ec2.DescribeCapacityReservations", func(msg *nats.Msg) {
+		for _, o := range []ec2.DescribeCapacityReservationsOutput{node1, node2} {
+			data, _ := json.Marshal(o)
+			_ = nc.Publish(msg.Reply, data)
+		}
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	out, err := DescribeCapacityReservations(&ec2.DescribeCapacityReservationsInput{}, nc, 2, testAccountID)
+	require.NoError(t, err)
+	assert.Len(t, out.CapacityReservations, 2)
+
+	filtered, err := DescribeCapacityReservations(&ec2.DescribeCapacityReservationsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("instance-type"), Values: aws.StringSlice([]string{"t3.small"})}},
+	}, nc, 2, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, filtered.CapacityReservations, 1)
+	assert.Equal(t, "cr-2", aws.StringValue(filtered.CapacityReservations[0].CapacityReservationId))
+}
+
+// Cancel
+
+func TestCancelCapacityReservation_NilInput(t *testing.T) {
+	_, err := CancelCapacityReservation(nil, nil, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInvalidParameterValue)
+}
+
+func TestCancelCapacityReservation_MissingID(t *testing.T) {
+	_, err := CancelCapacityReservation(&ec2.CancelCapacityReservationInput{}, nil, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorMissingParameter)
+}
+
+func TestCancelCapacityReservation_Malformed(t *testing.T) {
+	_, err := CancelCapacityReservation(&ec2.CancelCapacityReservationInput{
+		CapacityReservationId: aws.String("bogus-id"),
+	}, nil, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInvalidCapacityReservationIdMalformed)
+}
+
+func TestCancelCapacityReservation_DryRun(t *testing.T) {
+	_, err := CancelCapacityReservation(&ec2.CancelCapacityReservationInput{
+		CapacityReservationId: aws.String("cr-0123456789abcdef0"),
+		DryRun:                aws.Bool(true),
+	}, nil, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorDryRunOperation)
+}
+
+func TestCancelCapacityReservation_NotFound(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	sub, err := nc.Subscribe("ec2.CancelCapacityReservation", func(msg *nats.Msg) {
+		data, _ := json.Marshal(&ec2.CancelCapacityReservationOutput{Return: aws.Bool(false)})
+		_ = msg.Respond(data)
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	_, err = CancelCapacityReservation(&ec2.CancelCapacityReservationInput{
+		CapacityReservationId: aws.String("cr-0123456789abcdef0"),
+	}, nc, 1, testAccountID)
+	assert.EqualError(t, err, awserrors.ErrorInvalidCapacityReservationIdNotFound)
+}
+
+func TestCancelCapacityReservation_Found(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	sub, err := nc.Subscribe("ec2.CancelCapacityReservation", func(msg *nats.Msg) {
+		data, _ := json.Marshal(&ec2.CancelCapacityReservationOutput{Return: aws.Bool(true)})
+		_ = msg.Respond(data)
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	out, err := CancelCapacityReservation(&ec2.CancelCapacityReservationInput{
+		CapacityReservationId: aws.String("cr-0123456789abcdef0"),
+	}, nc, 1, testAccountID)
+	require.NoError(t, err)
+	assert.True(t, aws.BoolValue(out.Return))
+}

--- a/spinifex/gateway/ec2/capacityreservation/fanout.go
+++ b/spinifex/gateway/ec2/capacityreservation/fanout.go
@@ -1,0 +1,112 @@
+package gateway_ec2_capacityreservation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/nats-io/nats.go"
+)
+
+// censusTimeout bounds the census-complete node-status fan-out. Unlike the
+// latency-optimised queryNodeCapacity (which narrows to +200ms after the first
+// reply), we wait for every expected node or this full deadline so that a "no
+// node fits" answer is trustworthy rather than a race against a slow daemon.
+const censusTimeout = 3 * time.Second
+
+// nodeCensus is one node's capacity snapshot from spinifex.node.status: its id,
+// availability zone, and per-instance-type available count.
+type nodeCensus struct {
+	NodeID    string
+	AZ        string
+	Available map[string]int
+}
+
+// collectCensus fans out spinifex.node.status and returns one entry per distinct
+// node that responds, stopping once expectedNodes nodes have answered or
+// censusTimeout elapses. It deliberately does not narrow the deadline after the
+// first reply, trading latency for a complete cluster picture.
+func collectCensus(natsConn *nats.Conn, expectedNodes int) ([]nodeCensus, error) {
+	if expectedNodes < 1 {
+		expectedNodes = 1
+	}
+
+	inbox := nats.NewInbox()
+	sub, err := natsConn.SubscribeSync(inbox)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create inbox: %w", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+
+	pubMsg := nats.NewMsg("spinifex.node.status")
+	pubMsg.Reply = inbox
+	pubMsg.Data = []byte("{}")
+	if err := natsConn.PublishMsg(pubMsg); err != nil {
+		return nil, fmt.Errorf("failed to publish node status request: %w", err)
+	}
+
+	deadline := time.Now().Add(censusTimeout)
+	seen := make(map[string]struct{})
+	var census []nodeCensus
+
+	for len(seen) < expectedNodes {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		msg, err := sub.NextMsg(remaining)
+		if err != nil {
+			if errors.Is(err, nats.ErrTimeout) {
+				break
+			}
+			slog.Debug("collectCensus: error receiving message", "err", err)
+			break
+		}
+
+		var status types.NodeStatusResponse
+		if err := json.Unmarshal(msg.Data, &status); err != nil {
+			slog.Debug("collectCensus: failed to unmarshal response", "err", err)
+			continue
+		}
+		if status.Node == "" {
+			continue
+		}
+		if _, dup := seen[status.Node]; dup {
+			continue
+		}
+		seen[status.Node] = struct{}{}
+
+		avail := make(map[string]int, len(status.InstanceTypes))
+		for _, c := range status.InstanceTypes {
+			avail[c.Name] = c.Available
+		}
+		census = append(census, nodeCensus{NodeID: status.Node, AZ: status.AZ, Available: avail})
+	}
+
+	return census, nil
+}
+
+// selectNode returns the id of the in-AZ node with the most available capacity
+// for instanceType that can fit count instances, or "" if none qualifies. Ties
+// are broken by the lowest node id for deterministic placement.
+func selectNode(census []nodeCensus, az, instanceType string, count int) string {
+	best := ""
+	bestAvail := -1
+	for _, n := range census {
+		if n.AZ != az {
+			continue
+		}
+		avail := n.Available[instanceType]
+		if avail < count {
+			continue
+		}
+		if avail > bestAvail || (avail == bestAvail && n.NodeID < best) {
+			best = n.NodeID
+			bestAvail = avail
+		}
+	}
+	return best
+}

--- a/spinifex/gateway/ec2/capacityreservation/fanout.go
+++ b/spinifex/gateway/ec2/capacityreservation/fanout.go
@@ -13,9 +13,8 @@ import (
 )
 
 // censusTimeout bounds the census-complete node-status fan-out. Unlike the
-// latency-optimised queryNodeCapacity (which narrows to +200ms after the first
-// reply), we wait for every expected node or this full deadline so that a "no
-// node fits" answer is trustworthy rather than a race against a slow daemon.
+// latency-optimised queryNodeCapacity (which narrows after the first reply), we wait
+// for every expected node or this full deadline so a "no node fits" answer is trustworthy.
 const censusTimeout = 3 * time.Second
 
 // nodeCensus is one node's capacity snapshot from spinifex.node.status: its id,
@@ -27,9 +26,8 @@ type nodeCensus struct {
 }
 
 // collectCensus fans out spinifex.node.status and returns one entry per distinct
-// node that responds, stopping once expectedNodes nodes have answered or
-// censusTimeout elapses. It deliberately does not narrow the deadline after the
-// first reply, trading latency for a complete cluster picture.
+// node that responds, stopping once expectedNodes answer or censusTimeout elapses.
+// It does not narrow the deadline after the first reply, trading latency for completeness.
 func collectCensus(natsConn *nats.Conn, expectedNodes int) ([]nodeCensus, error) {
 	if natsConn == nil || !natsConn.IsConnected() {
 		return nil, utils.ErrClusterUnavailable
@@ -127,9 +125,8 @@ func azInCensus(census []nodeCensus, az string) bool {
 }
 
 // typeInCensus reports whether instanceType is in any node's catalog. Known types
-// appear in node status even at zero available count, so an absent key means the
-// type is unsupported (or GPU, which is excluded from schedulable capacity) and is
-// rejected as InvalidInstanceType.
+// appear in node status even at zero available count, so an absent key means the type
+// is unsupported (or GPU, excluded from schedulable capacity) — rejected as InvalidInstanceType.
 func typeInCensus(census []nodeCensus, instanceType string) bool {
 	for _, n := range census {
 		if _, ok := n.Available[instanceType]; ok {
@@ -140,10 +137,8 @@ func typeInCensus(census []nodeCensus, instanceType string) bool {
 }
 
 // fanoutCollect publishes payload to subject and gathers every node's reply,
-// stopping once expectedNodes have answered or censusTimeout elapses. Per-node
-// error payloads and malformed replies are skipped. Unlike NATSScatterGather
-// (first success wins) it returns all successful responses so a Describe can merge
-// them and a broadcast Cancel can inspect every ack.
+// stopping once expectedNodes answer or censusTimeout elapses. Error and malformed
+// replies are skipped; all successful responses are returned for the caller to merge.
 func fanoutCollect[Out any](natsConn *nats.Conn, subject string, payload []byte, expectedNodes int, accountID string) ([]Out, error) {
 	if natsConn == nil || !natsConn.IsConnected() {
 		return nil, utils.ErrClusterUnavailable

--- a/spinifex/gateway/ec2/capacityreservation/fanout.go
+++ b/spinifex/gateway/ec2/capacityreservation/fanout.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 )
 
@@ -30,6 +31,9 @@ type nodeCensus struct {
 // censusTimeout elapses. It deliberately does not narrow the deadline after the
 // first reply, trading latency for a complete cluster picture.
 func collectCensus(natsConn *nats.Conn, expectedNodes int) ([]nodeCensus, error) {
+	if natsConn == nil || !natsConn.IsConnected() {
+		return nil, utils.ErrClusterUnavailable
+	}
 	if expectedNodes < 1 {
 		expectedNodes = 1
 	}
@@ -109,4 +113,86 @@ func selectNode(census []nodeCensus, az, instanceType string, count int) string 
 		}
 	}
 	return best
+}
+
+// azInCensus reports whether any node in the census lives in az. A requested AZ
+// that no node reports is treated as unknown (InvalidAvailabilityZone).
+func azInCensus(census []nodeCensus, az string) bool {
+	for _, n := range census {
+		if n.AZ == az {
+			return true
+		}
+	}
+	return false
+}
+
+// typeInCensus reports whether instanceType is in any node's catalog. Known types
+// appear in node status even at zero available count, so an absent key means the
+// type is unsupported (or GPU, which is excluded from schedulable capacity) and is
+// rejected as InvalidInstanceType.
+func typeInCensus(census []nodeCensus, instanceType string) bool {
+	for _, n := range census {
+		if _, ok := n.Available[instanceType]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// fanoutCollect publishes payload to subject and gathers every node's reply,
+// stopping once expectedNodes have answered or censusTimeout elapses. Per-node
+// error payloads and malformed replies are skipped. Unlike NATSScatterGather
+// (first success wins) it returns all successful responses so a Describe can merge
+// them and a broadcast Cancel can inspect every ack.
+func fanoutCollect[Out any](natsConn *nats.Conn, subject string, payload []byte, expectedNodes int, accountID string) ([]Out, error) {
+	if natsConn == nil || !natsConn.IsConnected() {
+		return nil, utils.ErrClusterUnavailable
+	}
+	if expectedNodes < 1 {
+		expectedNodes = 1
+	}
+
+	inbox := nats.NewInbox()
+	sub, err := natsConn.SubscribeSync(inbox)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create inbox: %w", err)
+	}
+	defer func() { _ = sub.Unsubscribe() }()
+
+	pubMsg := nats.NewMsg(subject)
+	pubMsg.Reply = inbox
+	pubMsg.Data = payload
+	pubMsg.Header.Set(utils.AccountIDHeader, accountID)
+	if err := natsConn.PublishMsg(pubMsg); err != nil {
+		return nil, fmt.Errorf("failed to publish %s: %w", subject, err)
+	}
+
+	deadline := time.Now().Add(censusTimeout)
+	var out []Out
+	for received := 0; received < expectedNodes; received++ {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		msg, err := sub.NextMsg(remaining)
+		if err != nil {
+			if errors.Is(err, nats.ErrTimeout) {
+				break
+			}
+			slog.Debug("fanoutCollect: error receiving message", "subject", subject, "err", err)
+			break
+		}
+		if _, perr := utils.ValidateErrorPayload(msg.Data); perr != nil {
+			slog.Debug("fanoutCollect: skipping error response", "subject", subject)
+			continue
+		}
+		var o Out
+		if err := json.Unmarshal(msg.Data, &o); err != nil {
+			slog.Debug("fanoutCollect: failed to unmarshal response", "subject", subject, "err", err)
+			continue
+		}
+		out = append(out, o)
+	}
+
+	return out, nil
 }

--- a/spinifex/gateway/ec2/capacityreservation/fanout_test.go
+++ b/spinifex/gateway/ec2/capacityreservation/fanout_test.go
@@ -1,0 +1,114 @@
+package gateway_ec2_capacityreservation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func censusFixture() []nodeCensus {
+	return []nodeCensus{
+		{NodeID: "node-a", AZ: "az-1", Available: map[string]int{"t3.micro": 4, "t3.small": 2}},
+		{NodeID: "node-b", AZ: "az-1", Available: map[string]int{"t3.micro": 8}},
+		{NodeID: "node-c", AZ: "az-2", Available: map[string]int{"t3.micro": 16}},
+		{NodeID: "node-d", AZ: "az-1", Available: map[string]int{"t3.micro": 1}},
+	}
+}
+
+// selectNode picks the highest-available node within the requested AZ.
+func TestSelectNode_HighestAvailableInAZ(t *testing.T) {
+	assert.Equal(t, "node-b", selectNode(censusFixture(), "az-1", "t3.micro", 2))
+}
+
+// Nodes outside the requested AZ are never considered.
+func TestSelectNode_ExcludesOtherAZ(t *testing.T) {
+	assert.Equal(t, "node-c", selectNode(censusFixture(), "az-2", "t3.micro", 10))
+}
+
+// A node qualifies only if it can fit the whole instance count.
+func TestSelectNode_InsufficientCapacity(t *testing.T) {
+	assert.Equal(t, "node-b", selectNode(censusFixture(), "az-1", "t3.micro", 5))
+	assert.Empty(t, selectNode(censusFixture(), "az-1", "t3.micro", 9))
+}
+
+// Unknown type, unknown AZ, or empty census all yield no selection.
+func TestSelectNode_NoEligibleNode(t *testing.T) {
+	assert.Empty(t, selectNode(censusFixture(), "az-1", "g5.xlarge", 1))
+	assert.Empty(t, selectNode(censusFixture(), "az-9", "t3.micro", 1))
+	assert.Empty(t, selectNode(nil, "az-1", "t3.micro", 1))
+}
+
+// Equal-capacity nodes break ties by lowest node id for deterministic placement.
+func TestSelectNode_TieBrokenByLowestNodeID(t *testing.T) {
+	census := []nodeCensus{
+		{NodeID: "node-z", AZ: "az-1", Available: map[string]int{"t3.micro": 4}},
+		{NodeID: "node-a", AZ: "az-1", Available: map[string]int{"t3.micro": 4}},
+	}
+	assert.Equal(t, "node-a", selectNode(census, "az-1", "t3.micro", 1))
+}
+
+// collectCensus captures one entry per distinct node with its AZ and per-type
+// available counts, completing as soon as expectedNodes have answered.
+func TestCollectCensus_CapturesDistinctNodes(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+
+	sub, err := nc.Subscribe("spinifex.node.status", func(msg *nats.Msg) {
+		responses := []types.NodeStatusResponse{
+			{Node: "node-1", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 4}}},
+			{Node: "node-2", AZ: "az-2", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 2}}},
+		}
+		for _, r := range responses {
+			data, _ := json.Marshal(r)
+			_ = nc.Publish(msg.Reply, data)
+		}
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	census, err := collectCensus(nc, 2)
+	require.NoError(t, err)
+	require.Len(t, census, 2)
+
+	byNode := make(map[string]nodeCensus, len(census))
+	for _, c := range census {
+		byNode[c.NodeID] = c
+	}
+	assert.Equal(t, "az-1", byNode["node-1"].AZ)
+	assert.Equal(t, 4, byNode["node-1"].Available["t3.micro"])
+	assert.Equal(t, "az-2", byNode["node-2"].AZ)
+	assert.Equal(t, 2, byNode["node-2"].Available["t3.micro"])
+}
+
+// A node that answers more than once is recorded only once; the first reply wins.
+func TestCollectCensus_DedupsRepeatNodes(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+
+	sub, err := nc.Subscribe("spinifex.node.status", func(msg *nats.Msg) {
+		responses := []types.NodeStatusResponse{
+			{Node: "node-1", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 4}}},
+			{Node: "node-1", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 99}}},
+			{Node: "node-2", AZ: "az-1", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.micro", Available: 2}}},
+		}
+		for _, r := range responses {
+			data, _ := json.Marshal(r)
+			_ = nc.Publish(msg.Reply, data)
+		}
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	census, err := collectCensus(nc, 2)
+	require.NoError(t, err)
+	require.Len(t, census, 2)
+
+	byNode := make(map[string]nodeCensus, len(census))
+	for _, c := range census {
+		byNode[c.NodeID] = c
+	}
+	assert.Equal(t, 4, byNode["node-1"].Available["t3.micro"], "first reply wins, duplicate ignored")
+}


### PR DESCRIPTION
## Summary

Adds a minimal, AWS-compatible implementation of EC2 **On-Demand Capacity Reservations** to Spinifex. `CreateCapacityReservation` pins `InstanceCount` instances of a type to one node in an AZ and **subtracts that compute from the node's schedulable pool** (a dedicated `reservedCR*` term, like the host reserve), so the capacity is held out of the general launch path. `DescribeCapacityReservations` lists them; `CancelCapacityReservation` releases the carve-out.

Scope is deliberately small: **carve-out only**, **in-memory only** (reservations are lost on daemon restart — accepted). Launching *into* a reservation is a Phase 2 follow-up. 