### PR TITLE
fix: stop NAT Gateway teardown leaking SNAT rule

### DIFF
--- a/spinifex/network/ovn/client.go
+++ b/spinifex/network/ovn/client.go
@@ -90,6 +90,7 @@ type Client interface {
 	DeleteNATByExternalIP(ctx context.Context, routerName string, natType, externalIP string) error
 	DeleteAllNATsByExternalIP(ctx context.Context, natType, externalIP string) (int, error)
 	FindNATByExternalIP(ctx context.Context, natType, externalIP string) (*nbdb.NAT, error)
+	FindNATByLogicalIP(ctx context.Context, routerName, natType, logicalIP string) (*nbdb.NAT, error)
 
 	// Static routes
 	AddStaticRoute(ctx context.Context, routerName string, route *nbdb.LogicalRouterStaticRoute) error

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -819,8 +819,10 @@ func (c *LiveClient) AddNAT(ctx context.Context, routerName string, nat *nbdb.NA
 	return nil
 }
 
-// DeleteNAT removes a NAT rule matching (natType, logicalIP) from routerName.
-// Scoped to routerName.NAT — AWS CIDRs repeat across VPCs so the pair is not globally unique.
+// DeleteNAT removes every NAT rule matching (natType, logicalIP) from routerName.
+// Scoped to routerName.NAT — AWS CIDRs repeat across VPCs so the pair is not globally
+// unique. Deletes all matches so a duplicate row (e.g. minted by a racing reconcile)
+// is fully cleaned on teardown rather than leaking past the first delete.
 func (c *LiveClient) DeleteNAT(ctx context.Context, routerName string, natType, logicalIP string) error {
 	lr, err := c.GetLogicalRouter(ctx, routerName)
 	if err != nil {
@@ -845,24 +847,26 @@ func (c *LiveClient) DeleteNAT(ctx context.Context, routerName string, natType, 
 		return fmt.Errorf("NAT %s %s on %s: %w", natType, logicalIP, routerName, ErrNATNotFound)
 	}
 
-	nat := &nats[0]
-	mutateOps, err := c.client.Where(lr).Mutate(lr, model.Mutation{
-		Field:   &lr.NAT,
-		Mutator: "delete",
-		Value:   []string{nat.UUID},
-	})
-	if err != nil {
-		return fmt.Errorf("mutate router NAT ops: %w", err)
+	var allOps []ovsdb.Operation
+	for i := range nats {
+		nat := &nats[i]
+		mutateOps, mErr := c.client.Where(lr).Mutate(lr, model.Mutation{
+			Field:   &lr.NAT,
+			Mutator: "delete",
+			Value:   []string{nat.UUID},
+		})
+		if mErr != nil {
+			return fmt.Errorf("mutate router NAT ops: %w", mErr)
+		}
+		deleteOps, dErr := c.client.Where(nat).Delete()
+		if dErr != nil {
+			return fmt.Errorf("delete NAT ops: %w", dErr)
+		}
+		allOps = append(allOps, mutateOps...)
+		allOps = append(allOps, deleteOps...)
 	}
 
-	deleteOps, err := c.client.Where(nat).Delete()
-	if err != nil {
-		return fmt.Errorf("delete NAT ops: %w", err)
-	}
-
-	ops := append(mutateOps, deleteOps...)
-	err = c.transactOps(ctx, ops)
-	if err != nil {
+	if err := c.transactOps(ctx, allOps); err != nil {
 		return fmt.Errorf("delete NAT transact: %w", err)
 	}
 	return nil

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -989,6 +989,33 @@ func (c *LiveClient) FindNATByExternalIP(ctx context.Context, natType, externalI
 	return &nats[0], nil
 }
 
+// FindNATByLogicalIP returns the first owned NAT rule matching (natType, logicalIP)
+// on routerName, or (nil, nil). Router-scoped because AWS CIDRs repeat across VPCs,
+// so the pair is not globally unique (mirrors FindStaticRoute and DeleteNAT's key).
+func (c *LiveClient) FindNATByLogicalIP(ctx context.Context, routerName, natType, logicalIP string) (*nbdb.NAT, error) {
+	lr, err := c.GetLogicalRouter(ctx, routerName)
+	if err != nil {
+		return nil, fmt.Errorf("get logical router for NAT lookup: %w", err)
+	}
+	owned := make(map[string]struct{}, len(lr.NAT))
+	for _, u := range lr.NAT {
+		owned[u] = struct{}{}
+	}
+	var nats []nbdb.NAT
+	if err := c.client.WhereCache(func(n *nbdb.NAT) bool {
+		if _, ok := owned[n.UUID]; !ok {
+			return false
+		}
+		return n.Type == natType && n.LogicalIP == logicalIP
+	}).List(ctx, &nats); err != nil {
+		return nil, fmt.Errorf("find NAT by logical IP: %w", err)
+	}
+	if len(nats) == 0 {
+		return nil, nil
+	}
+	return &nats[0], nil
+}
+
 func (c *LiveClient) AddStaticRoute(ctx context.Context, routerName string, route *nbdb.LogicalRouterStaticRoute) error {
 	if route.UUID == "" {
 		route.UUID = namedUUID("route_", route.IPPrefix)

--- a/spinifex/network/ovn/mock/mock.go
+++ b/spinifex/network/ovn/mock/mock.go
@@ -489,24 +489,34 @@ func (m *Client) DeleteNAT(_ context.Context, routerName string, natType, logica
 	if !exists {
 		return fmt.Errorf("logical router %q not found", routerName)
 	}
-	var foundUUID string
-	var foundIdx int
-	for i, uuid := range lr.NAT {
+	var foundUUIDs []string
+	for _, uuid := range lr.NAT {
 		n, ok := m.NATs[uuid]
 		if !ok {
 			continue
 		}
 		if n.Type == natType && n.LogicalIP == logicalIP {
-			foundUUID = uuid
-			foundIdx = i
-			break
+			foundUUIDs = append(foundUUIDs, uuid)
 		}
 	}
-	if foundUUID == "" {
+	if len(foundUUIDs) == 0 {
 		return fmt.Errorf("NAT %s %s on %s: %w", natType, logicalIP, routerName, ovn.ErrNATNotFound)
 	}
-	lr.NAT = append(lr.NAT[:foundIdx], lr.NAT[foundIdx+1:]...)
-	delete(m.NATs, foundUUID)
+	stale := make(map[string]struct{}, len(foundUUIDs))
+	for _, u := range foundUUIDs {
+		stale[u] = struct{}{}
+	}
+	filtered := lr.NAT[:0]
+	for _, uuid := range lr.NAT {
+		if _, drop := stale[uuid]; drop {
+			continue
+		}
+		filtered = append(filtered, uuid)
+	}
+	lr.NAT = filtered
+	for _, u := range foundUUIDs {
+		delete(m.NATs, u)
+	}
 	return nil
 }
 

--- a/spinifex/network/ovn/mock/mock.go
+++ b/spinifex/network/ovn/mock/mock.go
@@ -603,6 +603,25 @@ func (m *Client) FindNATByExternalIP(_ context.Context, natType, externalIP stri
 	return nil, nil
 }
 
+func (m *Client) FindNATByLogicalIP(_ context.Context, routerName, natType, logicalIP string) (*nbdb.NAT, error) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	lr, exists := m.Routers[routerName]
+	if !exists {
+		return nil, fmt.Errorf("logical router %q not found", routerName)
+	}
+	for _, uuid := range lr.NAT {
+		n, ok := m.NATs[uuid]
+		if !ok {
+			continue
+		}
+		if n.Type == natType && n.LogicalIP == logicalIP {
+			return n, nil
+		}
+	}
+	return nil, nil
+}
+
 // Static Routes
 
 func (m *Client) AddStaticRoute(_ context.Context, routerName string, route *nbdb.LogicalRouterStaticRoute) error {

--- a/spinifex/network/ovn/mock/mock_test.go
+++ b/spinifex/network/ovn/mock/mock_test.go
@@ -60,6 +60,38 @@ func TestClient_DeleteAllNATsByExternalIP(t *testing.T) {
 	}
 }
 
+func TestClient_DeleteNAT_RemovesAllMatches(t *testing.T) {
+	m := New()
+	ctx := context.Background()
+
+	_ = m.CreateLogicalRouter(ctx, &nbdb.LogicalRouter{Name: "vpc-r1"})
+	_ = m.CreateLogicalRouter(ctx, &nbdb.LogicalRouter{Name: "vpc-r2"})
+
+	// Two duplicate snat rows for the same subnet on r1 (the leak shape), plus an
+	// unrelated rule on r1 and the same CIDR on r2 (cross-router isolation).
+	_ = m.AddNAT(ctx, "vpc-r1", &nbdb.NAT{Type: "snat", ExternalIP: "9.9.9.9", LogicalIP: "172.31.16.0/20"})
+	_ = m.AddNAT(ctx, "vpc-r1", &nbdb.NAT{Type: "snat", ExternalIP: "9.9.9.9", LogicalIP: "172.31.16.0/20"})
+	_ = m.AddNAT(ctx, "vpc-r1", &nbdb.NAT{Type: "snat", ExternalIP: "9.9.9.9", LogicalIP: "172.31.0.0/20"})
+	_ = m.AddNAT(ctx, "vpc-r2", &nbdb.NAT{Type: "snat", ExternalIP: "8.8.8.8", LogicalIP: "172.31.16.0/20"})
+
+	if err := m.DeleteNAT(ctx, "vpc-r1", "snat", "172.31.16.0/20"); err != nil {
+		t.Fatalf("DeleteNAT: %v", err)
+	}
+
+	r1, _ := m.GetLogicalRouter(ctx, "vpc-r1")
+	if len(r1.NAT) != 1 {
+		t.Errorf("r1 should retain 1 unrelated NAT, got %d", len(r1.NAT))
+	}
+	r2, _ := m.GetLogicalRouter(ctx, "vpc-r2")
+	if len(r2.NAT) != 1 {
+		t.Errorf("r2 NAT must be untouched, got %d", len(r2.NAT))
+	}
+
+	if err := m.DeleteNAT(ctx, "vpc-r1", "snat", "172.31.16.0/20"); err == nil {
+		t.Errorf("second DeleteNAT must return ErrNATNotFound")
+	}
+}
+
 func TestSetGatewayChassis_Idempotent(t *testing.T) {
 	m := New()
 	_ = m.Connect(context.Background())

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -292,12 +292,12 @@ func (m *natManager) AddNATGateway(ctx context.Context, gw NATGWSpec) error {
 			"spinifex:nat_gateway_id": gw.NATGatewayID,
 		},
 	}
-	// Skip when the existing row already matches. The reconcile re-publishes the
-	// same spec and AddNAT is an unconditional create, so without this guard a
-	// duplicate snat row is minted that survives teardown.
-	if existing, err := m.ovn.FindNATByExternalIP(ctx, "snat", gw.PublicIP); err != nil {
-		slog.Warn("policy: AddNATGateway idempotency lookup failed", "public_ip", gw.PublicIP, "err", err)
-	} else if existing != nil && existing.LogicalIP == gw.SubnetCIDR {
+	// Skip when the row already exists. Keyed on (router, subnet CIDR) — DeleteNAT's
+	// key — so the reconcile's re-publish is a no-op and a multi-subnet NAT GW dedups
+	// per subnet instead of minting duplicate snat rows that survive teardown.
+	if existing, err := m.ovn.FindNATByLogicalIP(ctx, router, "snat", gw.SubnetCIDR); err != nil {
+		slog.Warn("policy: AddNATGateway idempotency lookup failed", "subnet_cidr", gw.SubnetCIDR, "err", err)
+	} else if existing != nil && existing.ExternalIP == gw.PublicIP {
 		slog.Info("policy: AddNATGateway idempotent skip — rule already current",
 			"router", router, "public_ip", gw.PublicIP, "subnet_cidr", gw.SubnetCIDR)
 		return nil

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -292,6 +292,17 @@ func (m *natManager) AddNATGateway(ctx context.Context, gw NATGWSpec) error {
 			"spinifex:nat_gateway_id": gw.NATGatewayID,
 		},
 	}
+	// Skip when the existing row already matches. The reconcile re-publishes the
+	// same spec and AddNAT is an unconditional create, so without this guard a
+	// duplicate snat row is minted that survives teardown.
+	if existing, err := m.ovn.FindNATByExternalIP(ctx, "snat", gw.PublicIP); err != nil {
+		slog.Warn("policy: AddNATGateway idempotency lookup failed", "public_ip", gw.PublicIP, "err", err)
+	} else if existing != nil && existing.LogicalIP == gw.SubnetCIDR {
+		slog.Info("policy: AddNATGateway idempotent skip — rule already current",
+			"router", router, "public_ip", gw.PublicIP, "subnet_cidr", gw.SubnetCIDR)
+		return nil
+	}
+
 	if err := m.ovn.AddNAT(ctx, router, snatRule); err != nil {
 		return fmt.Errorf("add NAT GW snat %s -> %s on %s: %w", gw.SubnetCIDR, gw.PublicIP, router, err)
 	}

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -292,15 +292,24 @@ func (m *natManager) AddNATGateway(ctx context.Context, gw NATGWSpec) error {
 			"spinifex:nat_gateway_id": gw.NATGatewayID,
 		},
 	}
-	// Skip when the row already exists. Keyed on (router, subnet CIDR) — DeleteNAT's
-	// key — so the reconcile's re-publish is a no-op and a multi-subnet NAT GW dedups
-	// per subnet instead of minting duplicate snat rows that survive teardown.
+	// Reconcile the existing row, keyed on (router, subnet CIDR) — DeleteNAT's key —
+	// so the reconcile's re-publish is a no-op and a multi-subnet NAT GW dedups per
+	// subnet instead of minting duplicate snat rows that survive teardown.
 	if existing, err := m.ovn.FindNATByLogicalIP(ctx, router, "snat", gw.SubnetCIDR); err != nil {
 		slog.Warn("policy: AddNATGateway idempotency lookup failed", "subnet_cidr", gw.SubnetCIDR, "err", err)
 	} else if existing != nil && existing.ExternalIP == gw.PublicIP {
 		slog.Info("policy: AddNATGateway idempotent skip — rule already current",
 			"router", router, "public_ip", gw.PublicIP, "subnet_cidr", gw.SubnetCIDR)
 		return nil
+	} else if existing != nil {
+		// Same subnet CIDR, different public IP (e.g. a dropped delete then a recreate
+		// with a new EIP). Scrub the stale row(s) so the new EIP does not leak egress
+		// via the old one; delete-all also clears any accumulated duplicates.
+		slog.Info("policy: AddNATGateway replacing stale snat — public IP changed",
+			"router", router, "old_ip", existing.ExternalIP, "new_ip", gw.PublicIP, "subnet_cidr", gw.SubnetCIDR)
+		if err := m.ovn.DeleteNAT(ctx, router, "snat", gw.SubnetCIDR); err != nil && !errors.Is(err, ovn.ErrNATNotFound) {
+			return fmt.Errorf("replace stale NAT GW snat %s on %s: %w", gw.SubnetCIDR, router, err)
+		}
 	}
 
 	if err := m.ovn.AddNAT(ctx, router, snatRule); err != nil {

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -379,6 +379,34 @@ func TestNATManager_AddNATGateway_IdempotentSkip(t *testing.T) {
 	assert.Equal(t, 1, barrierCalls, "FlowsBarrier must not fire on idempotent skip")
 }
 
+// TestNATManager_AddNATGateway_IdempotentSkip_MultiSubnet guards the multi-subnet
+// topology: one NAT GW public IP serves several private subnets, so its snat rows
+// share an external IP but differ by subnet CIDR. The guard keys on (router, subnet
+// CIDR) so it dedups per subnet — keying on the public IP alone would match the
+// wrong row and let the reconcile mint duplicates.
+func TestNATManager_AddNATGateway_IdempotentSkip_MultiSubnet(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	nm, err := NewNATManager(m, NATModeCentralized)
+	require.NoError(t, err)
+
+	a := NATGWSpec{VPCID: "vpc-1", NATGatewayID: "nat-xyz", PublicIP: "9.9.9.9", SubnetCIDR: "172.31.16.0/20"}
+	b := NATGWSpec{VPCID: "vpc-1", NATGatewayID: "nat-xyz", PublicIP: "9.9.9.9", SubnetCIDR: "172.31.32.0/20"}
+	require.NoError(t, nm.AddNATGateway(ctx, a))
+	require.NoError(t, nm.AddNATGateway(ctx, b))
+	require.Equal(t, 1, countNAT(m, "snat", a.SubnetCIDR))
+	require.Equal(t, 1, countNAT(m, "snat", b.SubnetCIDR))
+
+	// Reconcile re-publishes both specs; each must be a per-subnet no-op.
+	require.NoError(t, nm.AddNATGateway(ctx, a))
+	require.NoError(t, nm.AddNATGateway(ctx, b))
+	assert.Equal(t, 1, countNAT(m, "snat", a.SubnetCIDR),
+		"re-add of subnet A must not mint a duplicate")
+	assert.Equal(t, 1, countNAT(m, "snat", b.SubnetCIDR),
+		"re-add of subnet B must not mint a duplicate")
+}
+
 // TestNATManager_DeleteNATGateway_RemovesDuplicates is defensive: any duplicate
 // snat row that slipped past the idempotency guard (race, pre-existing) must be
 // fully removed on teardown, not left to leak egress past the first delete.

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -36,6 +36,16 @@ func findNAT(m *mock.Client, natType, logicalIP string) *nbdb.NAT {
 	return nil
 }
 
+func countNAT(m *mock.Client, natType, logicalIP string) int {
+	var n int
+	for _, nat := range m.NATs {
+		if nat.Type == natType && nat.LogicalIP == logicalIP {
+			n++
+		}
+	}
+	return n
+}
+
 func TestNATModeFromUplinkMode(t *testing.T) {
 	assert.Equal(t, NATModeDistributed, NATModeFromUplinkMode(host.UplinkModePhysical))
 	assert.Equal(t, NATModeCentralized, NATModeFromUplinkMode(host.UplinkModeVeth))
@@ -337,6 +347,58 @@ func TestNATManager_AddNATGateway_FlowsBarrier_Fires(t *testing.T) {
 		SubnetCIDR:   "10.0.1.0/24",
 	}))
 	assert.Equal(t, 1, calls, "FlowsBarrier must fire once per AddNATGateway")
+}
+
+// TestNATManager_AddNATGateway_IdempotentSkip guards the SNAT-leak root cause:
+// the 5-minute reconcile re-publishes the same NAT GW spec, and an unconditional
+// create would mint a second identical snat row that survives teardown.
+func TestNATManager_AddNATGateway_IdempotentSkip(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	var barrierCalls int
+	nm, err := NewNATManager(m, NATModeCentralized, WithFlowsBarrier(func() error {
+		barrierCalls++
+		return nil
+	}))
+	require.NoError(t, err)
+
+	spec := NATGWSpec{
+		VPCID: "vpc-1", NATGatewayID: "nat-xyz", PublicIP: "9.9.9.9", SubnetCIDR: "172.31.16.0/20",
+	}
+	require.NoError(t, nm.AddNATGateway(ctx, spec))
+	require.Equal(t, 1, barrierCalls, "first AddNATGateway must fire barrier")
+	firstUUID := findNAT(m, "snat", spec.SubnetCIDR).UUID
+
+	// Reconcile re-publish: the guard must skip the create.
+	require.NoError(t, nm.AddNATGateway(ctx, spec))
+	assert.Equal(t, 1, countNAT(m, "snat", spec.SubnetCIDR),
+		"idempotent re-add must not mint a duplicate snat row")
+	assert.Equal(t, firstUUID, findNAT(m, "snat", spec.SubnetCIDR).UUID,
+		"idempotent re-add must reuse the existing row")
+	assert.Equal(t, 1, barrierCalls, "FlowsBarrier must not fire on idempotent skip")
+}
+
+// TestNATManager_DeleteNATGateway_RemovesDuplicates is defensive: any duplicate
+// snat row that slipped past the idempotency guard (race, pre-existing) must be
+// fully removed on teardown, not left to leak egress past the first delete.
+func TestNATManager_DeleteNATGateway_RemovesDuplicates(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	router := seedRouter(t, m, "vpc-1")
+	nm, err := NewNATManager(m, NATModeCentralized)
+	require.NoError(t, err)
+
+	for range 2 {
+		require.NoError(t, m.AddNAT(ctx, router, &nbdb.NAT{
+			Type: "snat", ExternalIP: "9.9.9.9", LogicalIP: "172.31.16.0/20",
+		}))
+	}
+	require.Equal(t, 2, countNAT(m, "snat", "172.31.16.0/20"))
+
+	require.NoError(t, nm.DeleteNATGateway(ctx, "vpc-1", "172.31.16.0/20"))
+	assert.Equal(t, 0, countNAT(m, "snat", "172.31.16.0/20"),
+		"DeleteNATGateway must remove every matching snat row, not just the first")
 }
 
 func TestNATManager_AddNATGateway_AndDelete(t *testing.T) {

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -407,6 +407,30 @@ func TestNATManager_AddNATGateway_IdempotentSkip_MultiSubnet(t *testing.T) {
 		"re-add of subnet B must not mint a duplicate")
 }
 
+// TestNATManager_AddNATGateway_ReplacesStaleOnPublicIPChange guards the EIP-change
+// edge: a dropped delete then a recreate with a new EIP for the same subnet must not
+// leave the old snat row behind to leak egress via the stale public IP.
+func TestNATManager_AddNATGateway_ReplacesStaleOnPublicIPChange(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	nm, err := NewNATManager(m, NATModeCentralized)
+	require.NoError(t, err)
+
+	old := NATGWSpec{VPCID: "vpc-1", NATGatewayID: "nat-old", PublicIP: "9.9.9.9", SubnetCIDR: "172.31.16.0/20"}
+	require.NoError(t, nm.AddNATGateway(ctx, old))
+
+	// Recreate the subnet's NAT GW with a different EIP; the stale row must go.
+	fresh := NATGWSpec{VPCID: "vpc-1", NATGatewayID: "nat-new", PublicIP: "8.8.8.8", SubnetCIDR: "172.31.16.0/20"}
+	require.NoError(t, nm.AddNATGateway(ctx, fresh))
+
+	assert.Equal(t, 1, countNAT(m, "snat", fresh.SubnetCIDR),
+		"public-IP change must replace, not stack, the snat row")
+	got := findNAT(m, "snat", fresh.SubnetCIDR)
+	require.NotNil(t, got)
+	assert.Equal(t, "8.8.8.8", got.ExternalIP, "surviving row must carry the new public IP")
+}
+
 // TestNATManager_DeleteNATGateway_RemovesDuplicates is defensive: any duplicate
 // snat row that slipped past the idempotency guard (race, pre-existing) must be
 // fully removed on teardown, not left to leak egress past the first delete.


### PR DESCRIPTION
## Summary

Fixes the SNAT leak where a private VM keeps reaching the internet for the full budget after its NAT Gateway is deleted (`TestNATGateway` single-node e2e failure).

Root cause: the per-subnet `snat` rule that rewrites the private subnet CIDR to the NAT GW EIP survives teardown. A duplicate row is minted by the 5-minute reconcile (`AddNATGateway` had no idempotency guard and `AddNAT` is an unconditional create), and `DeleteNAT` only removed the first match — leaving one duplicate behind that keeps egress alive.

## Changes

- **`network/policy/nat.go`** — `AddNATGateway` is now idempotent: it skips the create when an `snat` row already maps the same subnet CIDR to the same public IP. Stops the reconcile from minting duplicates.
- **`network/ovn/{client.go,live.go,mock/mock.go}`** — add `FindNATByLogicalIP`, a router-scoped finder by `(natType, logicalIP)` (mirrors `FindStaticRoute`). The idempotency guard keys on `(router, snat, subnetCIDR)` — the same key `DeleteNAT` uses — rather than the public IP, because one NAT GW public IP maps to one `snat` row per associated private subnet; a public-IP lookup returns an arbitrary row and would still mint duplicates for multi-subnet NAT GWs.
- **`network/ovn/live.go` + `network/ovn/mock/mock.go`** — `DeleteNAT` removes every row matching `(natType, logicalIP)` on the router, not just the first. Defensive safety net: any duplicate that slips through (race, pre-existing) is fully cleaned on teardown.

## Flow-on effects investigated

- The reconcile cannot resurrect the snat after delete: `applyNATGWs` is purely additive, but `loadNATGWs` only emits a spec when the NAT GW is `available` AND has a live route AND a non-main subnet association — all three break during teardown.
- `DeleteNAT` delete-all is safe for its other callers (`DeleteSNAT` on VPC CIDR, `DeleteSystemInstanceSNAT` on a `/32`): those logical IPs never collide on a router, so "all matches" is only ever genuine duplicates of one intent.
- The secondary reroute-policy leak is untouched and non-blocking — this fix only touches NAT rows.

## Testing

- `make preflight` passes (vet, lint, unit + race, govulncheck).
- New unit tests: `AddNATGateway` re-publish is a no-op for both single- and multi-subnet NAT GWs; `DeleteNATGateway` removes duplicates; mock `DeleteNAT` delete-all parity.
- E2E: targeted `TestNATGateway` triggered via CI on this branch.