### PR TITLE
fix: alpine image ssh

### DIFF
--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -42,6 +42,10 @@ const cloudInitUserDataTemplate = `#cloud-config
 users:
   - name: {{.Username}}
     shell: /bin/sh
+{{- if .AlpineUnlockPasswd}}
+    lock_passwd: false
+    hashed_passwd: "*"
+{{- end}}
     groups:
       - {{.SudoGroup}}
     sudo: "ALL=(ALL) NOPASSWD:ALL"
@@ -208,6 +212,11 @@ type CloudInitData struct {
 	// Empty on non-Alpine or non-VPC instances.
 	AlpineWriteFiles string
 	AlpineRunCmd     string
+	// AlpineUnlockPasswd renders the user with a disabled-but-unlocked password
+	// (lock_passwd: false, hashed_passwd: "*"). Alpine's sshd is built without
+	// PAM and rejects any login for a locked ("!") account; "*" keeps password
+	// auth disabled while letting pubkey auth through.
+	AlpineUnlockPasswd bool
 }
 
 // buildRHELCloudInit produces the cloud-init write_files (NM keyfiles) and
@@ -1846,14 +1855,15 @@ func (s *InstanceServiceImpl) createCloudInitISO(input *ec2.RunInstancesInput, i
 	}
 
 	userData := CloudInitData{
-		Username:       "ec2-user",
-		SSHKey:         string(sshKey),
-		Hostname:       hostname,
-		CACertPEM:      caCertPEM,
-		DistroFamily:   distroFamily,
-		SudoGroup:      sudoGroup,
-		RHELWriteFiles: rhelWriteFiles,
-		RHELRunCmd:     rhelRunCmd,
+		Username:           "ec2-user",
+		SSHKey:             string(sshKey),
+		Hostname:           hostname,
+		CACertPEM:          caCertPEM,
+		DistroFamily:       distroFamily,
+		SudoGroup:          sudoGroup,
+		RHELWriteFiles:     rhelWriteFiles,
+		RHELRunCmd:         rhelRunCmd,
+		AlpineUnlockPasswd: distroFamily == "alpine",
 	}
 
 	// Decode and classify user-data from RunInstances (base64-encoded).

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -550,6 +550,32 @@ func TestCloudInitTemplate_FamilyBranching(t *testing.T) {
 		assert.Contains(t, out, "nmcli, connection, up, vpc0")
 	})
 
+	t.Run("alpine family: user rendered unlocked with disabled password", func(t *testing.T) {
+		var buf bytes.Buffer
+		tmpl := template.Must(template.New("c").Parse(cloudInitUserDataTemplate))
+		require.NoError(t, tmpl.Execute(&buf, CloudInitData{
+			Username: "ec2-user", SSHKey: "ssh-rsa AAA", Hostname: "spinifex-vm-alpine",
+			DistroFamily: "alpine", SudoGroup: "sudo", AlpineUnlockPasswd: true,
+		}))
+		out := buf.String()
+		// Alpine's no-PAM sshd denies a locked ("!") account; "*" keeps password
+		// auth disabled while letting pubkey auth through.
+		assert.Contains(t, out, "lock_passwd: false")
+		assert.Contains(t, out, `hashed_passwd: "*"`)
+	})
+
+	t.Run("non-alpine family: no password unlock lines", func(t *testing.T) {
+		var buf bytes.Buffer
+		tmpl := template.Must(template.New("c").Parse(cloudInitUserDataTemplate))
+		require.NoError(t, tmpl.Execute(&buf, CloudInitData{
+			Username: "ec2-user", SSHKey: "ssh-rsa AAA", Hostname: "spinifex-vm-deb",
+			DistroFamily: "debian", SudoGroup: "sudo",
+		}))
+		out := buf.String()
+		assert.NotContains(t, out, "lock_passwd")
+		assert.NotContains(t, out, "hashed_passwd")
+	})
+
 	t.Run("rhel + user script: both blocks merged under single write_files/runcmd", func(t *testing.T) {
 		var buf bytes.Buffer
 		tmpl := template.Must(template.New("c").Parse(cloudInitUserDataTemplate))


### PR DESCRIPTION
Alpine's sshd is built without PAM and rejects any login for a locked ("!") account; "*" keeps password auth disabled while letting pubkey auth through.