### PR TITLE
feat: ECR background lifecycle expiry sweep

### DIFF
--- a/spinifex/gateway/ecr/lifecycle_sweep.go
+++ b/spinifex/gateway/ecr/lifecycle_sweep.go
@@ -1,0 +1,185 @@
+package gateway_ecr
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/handlers/ecr"
+)
+
+// DefaultLifecycleSweepInterval is the period between lifecycle expiry cycles.
+const DefaultLifecycleSweepInterval = time.Hour
+
+// LifecycleSweeper periodically applies each repository's stored lifecycle
+// policy: it evaluates the shared rule engine against the repo's current images
+// and deletes the expired set through the registry's GC reclaim path. It runs in
+// the gateway because only the gateway holds a Registry (object store + meta);
+// the daemon owns the KV but cannot reclaim predastore bytes.
+//
+// The sweep is idempotent and safe to run concurrently across awsgw instances:
+// a delete of an already-gone image is a no-op, and per-item errors are logged
+// and skipped so one bad repo never aborts the cycle.
+type LifecycleSweeper struct {
+	reg      *Registry
+	accounts func() ([]string, error)
+	interval time.Duration
+	now      func() time.Time
+}
+
+// NewLifecycleSweeper builds a sweeper over reg. accounts enumerates the account
+// IDs to sweep (typically ACTIVE IAM accounts). A zero interval falls back to the
+// default.
+func NewLifecycleSweeper(reg *Registry, accounts func() ([]string, error), interval time.Duration) *LifecycleSweeper {
+	if interval <= 0 {
+		interval = DefaultLifecycleSweepInterval
+	}
+	return &LifecycleSweeper{
+		reg:      reg,
+		accounts: accounts,
+		interval: interval,
+		now:      func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Run sweeps on every tick until ctx is cancelled. Blocks until then.
+func (s *LifecycleSweeper) Run(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	slog.Info("ECR lifecycle sweeper started", "interval", s.interval)
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("ECR lifecycle sweeper stopped")
+			return
+		case <-ticker.C:
+			s.sweepOnce(s.now())
+		}
+	}
+}
+
+// sweepOnce runs one cycle over every account/repo, returning the number of
+// images expired. Per-account and per-repo errors are logged and skipped.
+func (s *LifecycleSweeper) sweepOnce(now time.Time) int {
+	accounts, err := s.accounts()
+	if err != nil {
+		slog.Warn("ECR lifecycle sweep: list accounts failed", "err", err)
+		return 0
+	}
+
+	var deleted int
+	for _, account := range accounts {
+		repos, err := s.reg.Meta.ListRepos(account)
+		if err != nil {
+			if errors.Is(err, ecr.ErrNotFound) {
+				continue
+			}
+			slog.Warn("ECR lifecycle sweep: list repos failed", "account", account, "err", err)
+			continue
+		}
+		for _, repo := range repos {
+			deleted += s.sweepRepo(account, repo, now)
+		}
+	}
+	return deleted
+}
+
+// sweepRepo applies one repo's lifecycle policy. A repo with no policy is left
+// untouched. Returns the count of images expired in this repo.
+func (s *LifecycleSweeper) sweepRepo(account, repo string, now time.Time) int {
+	policy, err := s.reg.Meta.GetLifecyclePolicy(account, repo)
+	if err != nil {
+		if !errors.Is(err, ecr.ErrNotFound) {
+			slog.Warn("ECR lifecycle sweep: get policy failed", "account", account, "repo", repo, "err", err)
+		}
+		return 0
+	}
+	if len(policy) == 0 {
+		return 0
+	}
+
+	records, err := s.reg.ListImages(account, repo)
+	if err != nil {
+		if !errors.Is(err, ecr.ErrNotFound) {
+			slog.Warn("ECR lifecycle sweep: list images failed", "account", account, "repo", repo, "err", err)
+		}
+		return 0
+	}
+
+	images := make([]ecr.LifecycleImage, 0, len(records))
+	for _, rec := range records {
+		images = append(images, ecr.LifecycleImage{Digest: rec.Digest, Tags: rec.Tags, PushedAt: rec.PushedAt})
+	}
+
+	expiries, err := ecr.EvaluateLifecyclePolicy(policy, images, now)
+	if err != nil {
+		slog.Warn("ECR lifecycle sweep: evaluate policy failed", "account", account, "repo", repo, "err", err)
+		return 0
+	}
+	if len(expiries) == 0 {
+		return 0
+	}
+
+	// Optimistic-concurrency guard: re-read the current tag set immediately
+	// before deleting. If an image gained or changed tags since evaluation, a
+	// concurrent push/re-tag landed — skip it and let the next cycle re-evaluate
+	// the new state. The cross-repo blob mount guard is provided separately by
+	// reclaimManifest/referencedDigests.
+	fresh, err := s.reg.ListImages(account, repo)
+	if err != nil {
+		slog.Warn("ECR lifecycle sweep: re-list images failed", "account", account, "repo", repo, "err", err)
+		return 0
+	}
+	currentTags := make(map[string][]string, len(fresh))
+	present := make(map[string]bool, len(fresh))
+	for _, rec := range fresh {
+		currentTags[rec.Digest] = rec.Tags
+		present[rec.Digest] = true
+	}
+
+	var deleted int
+	for _, exp := range expiries {
+		if !present[exp.Digest] {
+			continue // already gone
+		}
+		if !sameTagSet(exp.Tags, currentTags[exp.Digest]) {
+			slog.Info("ECR lifecycle sweep: skipping image changed since evaluation",
+				"account", account, "repo", repo, "digest", exp.Digest)
+			continue
+		}
+		if _, err := s.reg.DeleteImage(account, repo, "", exp.Digest); err != nil {
+			if errors.Is(err, ErrImageNotFound) {
+				continue
+			}
+			slog.Warn("ECR lifecycle sweep: delete image failed",
+				"account", account, "repo", repo, "digest", exp.Digest, "err", err)
+			continue
+		}
+		slog.Info("ECR lifecycle sweep: expired image",
+			"account", account, "repo", repo, "digest", exp.Digest,
+			"tags", exp.Tags, "rulePriority", exp.RulePriority)
+		deleted++
+	}
+	return deleted
+}
+
+// sameTagSet reports whether two tag slices hold the same set of tags,
+// order-independent.
+func sameTagSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]int, len(a))
+	for _, t := range a {
+		seen[t]++
+	}
+	for _, t := range b {
+		if seen[t] == 0 {
+			return false
+		}
+		seen[t]--
+	}
+	return true
+}

--- a/spinifex/gateway/ecr/lifecycle_sweep_test.go
+++ b/spinifex/gateway/ecr/lifecycle_sweep_test.go
@@ -1,0 +1,139 @@
+package gateway_ecr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/handlers/ecr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sweepMediaType = "application/vnd.docker.distribution.manifest.v2+json"
+
+// seedTimedImage writes a repo + manifest meta (with a controllable pushedAt) + tags
+// directly into the registry's metadata, bypassing blob upload. Sufficient for
+// exercising selection + DeleteImage; predastore reclaim is best-effort.
+func seedTimedImage(t *testing.T, reg *Registry, account, repo, digest string, pushedAt time.Time, tags ...string) {
+	t.Helper()
+	require.NoError(t, reg.Meta.PutRepo(account, ecr.RepoMeta{Name: repo, CreatedAt: pushedAt}))
+	require.NoError(t, reg.Meta.PutManifestMeta(account, repo, ecr.ManifestMeta{
+		Digest: digest, MediaType: sweepMediaType, Size: 1, PushedAt: pushedAt,
+	}))
+	for _, tag := range tags {
+		require.NoError(t, reg.Meta.PutTag(account, repo, tag, digest))
+	}
+}
+
+func digestsOf(t *testing.T, reg *Registry, account, repo string) []string {
+	t.Helper()
+	records, err := reg.ListImages(account, repo)
+	require.NoError(t, err)
+	out := make([]string, 0, len(records))
+	for _, r := range records {
+		out = append(out, r.Digest)
+	}
+	return out
+}
+
+func newSweeper(reg *Registry, accounts ...string) *LifecycleSweeper {
+	return NewLifecycleSweeper(reg, func() ([]string, error) { return accounts, nil }, time.Hour)
+}
+
+func putPolicy(t *testing.T, reg *Registry, account, repo, policy string) {
+	t.Helper()
+	require.NoError(t, reg.Meta.PutLifecyclePolicy(account, repo, []byte(policy)))
+}
+
+const untaggedExpirePolicy = `{"rules":[{"rulePriority":1,"selection":{"tagStatus":"untagged","countType":"sinceImagePushed","countUnit":"days","countNumber":7},"action":{"type":"expire"}}]}`
+
+func TestSweepRepo_SinceImagePushed(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	repo := "team/app"
+	seedTimedImage(t, reg, testAccount, repo, "sha256:olduntagged", now.AddDate(0, 0, -10))
+	seedTimedImage(t, reg, testAccount, repo, "sha256:newuntagged", now.AddDate(0, 0, -2))
+	seedTimedImage(t, reg, testAccount, repo, "sha256:oldtagged", now.AddDate(0, 0, -10), "v1")
+	putPolicy(t, reg, testAccount, repo, untaggedExpirePolicy)
+
+	deleted := newSweeper(reg, testAccount).sweepRepo(testAccount, repo, now)
+	assert.Equal(t, 1, deleted)
+	assert.ElementsMatch(t, []string{"sha256:newuntagged", "sha256:oldtagged"},
+		digestsOf(t, reg, testAccount, repo))
+}
+
+func TestSweepRepo_ImageCountMoreThan(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	repo := "team/app"
+	seedTimedImage(t, reg, testAccount, repo, "sha256:a", now.AddDate(0, 0, -1), "a")
+	seedTimedImage(t, reg, testAccount, repo, "sha256:b", now.AddDate(0, 0, -2), "b")
+	seedTimedImage(t, reg, testAccount, repo, "sha256:c", now.AddDate(0, 0, -3), "c")
+	putPolicy(t, reg, testAccount, repo,
+		`{"rules":[{"rulePriority":1,"selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":1},"action":{"type":"expire"}}]}`)
+
+	deleted := newSweeper(reg, testAccount).sweepRepo(testAccount, repo, now)
+	assert.Equal(t, 2, deleted)
+	// Newest (a) kept; the two older expire.
+	assert.Equal(t, []string{"sha256:a"}, digestsOf(t, reg, testAccount, repo))
+}
+
+func TestSweepRepo_NoPolicy(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	repo := "team/app"
+	seedTimedImage(t, reg, testAccount, repo, "sha256:x", now.AddDate(0, 0, -100))
+
+	deleted := newSweeper(reg, testAccount).sweepRepo(testAccount, repo, now)
+	assert.Equal(t, 0, deleted)
+	assert.Len(t, digestsOf(t, reg, testAccount, repo), 1)
+}
+
+func TestSweepRepo_Idempotent(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	repo := "team/app"
+	seedTimedImage(t, reg, testAccount, repo, "sha256:olduntagged", now.AddDate(0, 0, -10))
+	seedTimedImage(t, reg, testAccount, repo, "sha256:newuntagged", now.AddDate(0, 0, -2))
+	putPolicy(t, reg, testAccount, repo, untaggedExpirePolicy)
+
+	s := newSweeper(reg, testAccount)
+	assert.Equal(t, 1, s.sweepRepo(testAccount, repo, now))
+	assert.Equal(t, 0, s.sweepRepo(testAccount, repo, now)) // nothing left to expire
+}
+
+func TestSweepOnce_MultiAccount(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	const acct2 = "000000000001"
+	policy := `{"rules":[{"rulePriority":1,"selection":{"tagStatus":"any","countType":"imageCountMoreThan","countNumber":1},"action":{"type":"expire"}}]}`
+
+	seedTimedImage(t, reg, testAccount, "team/app", "sha256:a1", now.AddDate(0, 0, -1), "n")
+	seedTimedImage(t, reg, testAccount, "team/app", "sha256:a2", now.AddDate(0, 0, -2), "o")
+	putPolicy(t, reg, testAccount, "team/app", policy)
+
+	seedTimedImage(t, reg, acct2, "team/web", "sha256:b1", now.AddDate(0, 0, -1), "n")
+	seedTimedImage(t, reg, acct2, "team/web", "sha256:b2", now.AddDate(0, 0, -2), "o")
+	putPolicy(t, reg, acct2, "team/web", policy)
+
+	deleted := newSweeper(reg, testAccount, acct2).sweepOnce(now)
+	assert.Equal(t, 2, deleted) // one per account
+	assert.Len(t, digestsOf(t, reg, testAccount, "team/app"), 1)
+	assert.Len(t, digestsOf(t, reg, acct2, "team/web"), 1)
+}
+
+func TestSweepOnce_AccountsError(t *testing.T) {
+	reg := newTestRegistry()
+	s := NewLifecycleSweeper(reg, func() ([]string, error) {
+		return nil, assert.AnError
+	}, time.Hour)
+	assert.Equal(t, 0, s.sweepOnce(time.Now().UTC()))
+}
+
+func TestSameTagSet(t *testing.T) {
+	assert.True(t, sameTagSet(nil, nil))
+	assert.True(t, sameTagSet([]string{"a", "b"}, []string{"b", "a"}))
+	assert.False(t, sameTagSet([]string{"a"}, []string{"a", "b"}))
+	assert.False(t, sameTagSet([]string{"a"}, []string{"b"}))
+	assert.False(t, sameTagSet(nil, []string{"a"}))
+}

--- a/spinifex/gateway/ecr/lifecycle_sweep_test.go
+++ b/spinifex/gateway/ecr/lifecycle_sweep_test.go
@@ -1,6 +1,8 @@
 package gateway_ecr
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -128,6 +130,80 @@ func TestSweepOnce_AccountsError(t *testing.T) {
 		return nil, assert.AnError
 	}, time.Hour)
 	assert.Equal(t, 0, s.sweepOnce(time.Now().UTC()))
+}
+
+func TestNewLifecycleSweeper_DefaultInterval(t *testing.T) {
+	reg := newTestRegistry()
+	s := NewLifecycleSweeper(reg, func() ([]string, error) { return nil, nil }, 0)
+	assert.Equal(t, DefaultLifecycleSweepInterval, s.interval)
+
+	s = NewLifecycleSweeper(reg, func() ([]string, error) { return nil, nil }, -5)
+	assert.Equal(t, DefaultLifecycleSweepInterval, s.interval)
+
+	s = NewLifecycleSweeper(reg, func() ([]string, error) { return nil, nil }, time.Minute)
+	assert.Equal(t, time.Minute, s.interval)
+}
+
+// TestSweeperRun drives the ticker loop: with a tiny interval and an expiring
+// image, the first tick must delete it; cancelling the context stops Run.
+func TestSweeperRun(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	repo := "team/app"
+	seedTimedImage(t, reg, testAccount, repo, "sha256:olduntagged", now.AddDate(0, 0, -10))
+	seedTimedImage(t, reg, testAccount, repo, "sha256:newuntagged", now.AddDate(0, 0, -2))
+	putPolicy(t, reg, testAccount, repo, untaggedExpirePolicy)
+
+	var swept atomic.Int64
+	s := NewLifecycleSweeper(reg, func() ([]string, error) {
+		swept.Add(1)
+		return []string{testAccount}, nil
+	}, time.Millisecond)
+	s.now = func() time.Time { return now }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(digestsOf(t, reg, testAccount, repo)) == 1
+	}, time.Second, 2*time.Millisecond, "expired image not swept")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+	assert.Positive(t, swept.Load())
+}
+
+// TestSweepRepo_InvalidStoredPolicy exercises the evaluate-error branch: a
+// malformed stored policy is logged and skipped, deleting nothing.
+func TestSweepRepo_InvalidStoredPolicy(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	repo := "team/app"
+	seedTimedImage(t, reg, testAccount, repo, "sha256:x", now.AddDate(0, 0, -100))
+	putPolicy(t, reg, testAccount, repo, "{not valid json")
+
+	deleted := newSweeper(reg, testAccount).sweepRepo(testAccount, repo, now)
+	assert.Equal(t, 0, deleted)
+	assert.Len(t, digestsOf(t, reg, testAccount, repo), 1)
+}
+
+// TestSweepRepo_PolicyWithoutRepo exercises the ListImages-not-found branch: a
+// policy stored for a repo with no manifests yields nothing to expire.
+func TestSweepRepo_PolicyWithoutRepo(t *testing.T) {
+	reg := newTestRegistry()
+	now := time.Now().UTC()
+	putPolicy(t, reg, testAccount, "ghost", untaggedExpirePolicy)
+
+	deleted := newSweeper(reg, testAccount).sweepRepo(testAccount, "ghost", now)
+	assert.Equal(t, 0, deleted)
 }
 
 func TestSameTagSet(t *testing.T) {

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -315,9 +315,14 @@ func initIAMService(natsConn *nats.Conn, masterKey []byte, clusterSize int) (*ha
 	}
 }
 
+// accountLister is the slice of IAMService the lifecycle sweeper needs.
+type accountLister interface {
+	ListAccounts() ([]*handlers_iam.Account, error)
+}
+
 // activeAccountIDs adapts IAMService.ListAccounts into the account-ID enumerator
 // the ECR lifecycle sweeper expects, including only ACTIVE accounts.
-func activeAccountIDs(iam handlers_iam.IAMService) func() ([]string, error) {
+func activeAccountIDs(iam accountLister) func() ([]string, error) {
 	return func() ([]string, error) {
 		accounts, err := iam.ListAccounts()
 		if err != nil {

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -212,6 +212,14 @@ func launchService(config *config.ClusterConfig) error {
 	)
 	ecrRegistry := gateway_ecr.NewRegistry(ecrStore, ecr.NewNATSMetaStore(natsConn), config.Bootstrap.AccountID)
 
+	// Lifecycle expiry sweep applies each repo's stored lifecycle policy and
+	// deletes the expired set via the registry GC path. It runs here (not the
+	// daemon) because only the gateway holds the object store. Bound to the same
+	// lifetime context as the STS janitor.
+	lifecycleSweeper := gateway_ecr.NewLifecycleSweeper(
+		ecrRegistry, activeAccountIDs(iamService), gateway_ecr.DefaultLifecycleSweepInterval)
+	go lifecycleSweeper.Run(janitorCtx)
+
 	// ECR auth bridge: load (or first-run create) the ES256 signing key from the
 	// cluster-replicated awsgw-keys KV bucket, then build the token issuer
 	// (GetAuthorizationToken) and verifier (/v2 Authorization).
@@ -304,6 +312,24 @@ func initIAMService(natsConn *nats.Conn, masterKey []byte, clusterSize int) (*ha
 		slog.Warn("IAM service not ready (waiting for JetStream cluster quorum)", "error", err, "attempt", attempt, "elapsed", elapsed.Round(time.Second), "retryIn", retryDelay)
 		time.Sleep(retryDelay)
 		retryDelay = min(retryDelay*2, 10*time.Second)
+	}
+}
+
+// activeAccountIDs adapts IAMService.ListAccounts into the account-ID enumerator
+// the ECR lifecycle sweeper expects, including only ACTIVE accounts.
+func activeAccountIDs(iam handlers_iam.IAMService) func() ([]string, error) {
+	return func() ([]string, error) {
+		accounts, err := iam.ListAccounts()
+		if err != nil {
+			return nil, err
+		}
+		ids := make([]string, 0, len(accounts))
+		for _, acct := range accounts {
+			if acct.Status == handlers_iam.AccountStatusActive {
+				ids = append(ids, acct.AccountID)
+			}
+		}
+		return ids, nil
 	}
 }
 

--- a/spinifex/services/awsgw/lifecycle_accounts_test.go
+++ b/spinifex/services/awsgw/lifecycle_accounts_test.go
@@ -1,0 +1,42 @@
+package awsgw
+
+import (
+	"testing"
+
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAccountLister struct {
+	accounts []*handlers_iam.Account
+	err      error
+}
+
+func (f *fakeAccountLister) ListAccounts() ([]*handlers_iam.Account, error) {
+	return f.accounts, f.err
+}
+
+func TestActiveAccountIDs_FiltersActive(t *testing.T) {
+	lister := &fakeAccountLister{accounts: []*handlers_iam.Account{
+		{AccountID: "000000000001", Status: handlers_iam.AccountStatusActive},
+		{AccountID: "000000000002", Status: "SUSPENDED"},
+		{AccountID: "000000000003", Status: handlers_iam.AccountStatusActive},
+	}}
+
+	ids, err := activeAccountIDs(lister)()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"000000000001", "000000000003"}, ids)
+}
+
+func TestActiveAccountIDs_Empty(t *testing.T) {
+	ids, err := activeAccountIDs(&fakeAccountLister{})()
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+func TestActiveAccountIDs_Error(t *testing.T) {
+	ids, err := activeAccountIDs(&fakeAccountLister{err: assert.AnError})()
+	require.Error(t, err)
+	assert.Nil(t, ids)
+}


### PR DESCRIPTION
## Summary

Wires automated image expiry on top of siv-373's lifecycle policy + evaluation engine. A gateway-side `LifecycleSweeper` periodically applies each repo's stored lifecycle policy and deletes the expired set via the existing GC reclaim path (`DeleteImage` → `reclaimManifest`).

- **Runs in the gateway, not the daemon** — only the gateway holds a `Registry` (predastore object store + `MetaStore`); the daemon owns the KV but cannot reclaim bytes. Launched on the STS janitor's lifetime context in `awsgw.go`, enumerating ACTIVE IAM accounts via `IAMService.ListAccounts`.
- **Per cycle:** accounts → `ListRepos` → per repo: `GetLifecyclePolicy` (skip if none) → `ListImages` → `EvaluateLifecyclePolicy` → delete expiries.
- **Optimistic-concurrency guard:** before deleting, re-read the current tag set and skip any image whose tags changed since evaluation (concurrent push/re-tag) — next cycle re-evaluates. Cross-repo blob *mount* safety is already provided by `reclaimManifest`/`referencedDigests` (skips blobs referenced by a live manifest anywhere in the account).
- **Resilient:** per-account/per-repo/per-item errors are logged and skipped; idempotent; safe to run concurrently across awsgw instances.

Default interval 1h (const, mirroring the STS janitor / imds token sweep).

## Testing

- `make preflight` green (tests, race, vet, lint, govulncheck).
- Unit tests over an in-memory `Registry`: `sinceImagePushed` cutoff, `imageCountMoreThan` keep-newest, no-policy untouched, idempotent re-run, multi-account `sweepOnce`, accounts-error tolerance, and the `sameTagSet` CAS comparison.

## Residual / out of scope

The delete primitive is not KV-revision-CAS guarded; the tag-set re-check narrows but does not fully close the scan→blob-delete TOCTOU. This window is shared by all delete paths (BatchDeleteImage, DeleteRepository), and best-effort blob reclaim only leaks bytes, never corrupts logical state. A KV-revision CAS on manifest/tag deletion is a separate hardening item.

## Live verification note

The sweep is a server-side hourly timer with no manual trigger, so a live env19 "drive" would need a 1h wait or a temporary short interval. The engine and `DeleteImage`/`reclaimManifest` paths are already env19-verified (siv-373 #393, GC #390); this PR's new logic (`sweepOnce`/`sweepRepo` + CAS guard) is covered by unit tests.