### PR TITLE
feat(ebs): set EBS volume-id as virtio-blk serial on attach

### DIFF
--- a/spinifex/vm/volumes.go
+++ b/spinifex/vm/volumes.go
@@ -135,11 +135,16 @@ func (m *Manager) AttachVolume(id, volumeID, device string) (AttachVolumeResult,
 		}
 	}
 
+	// serial is the volume-id with dashes stripped ("vol" + 17 hex = 20 bytes,
+	// the virtio-blk serial limit). It surfaces in-guest as the block device
+	// serial so the EBS CSI node plugin can locate /dev/disk/by-id and match
+	// `lsblk -o SERIAL` against the volume-id.
 	deviceAddArgs := map[string]any{
 		"driver":   "virtio-blk-pci",
 		"id":       deviceID,
 		"drive":    nodeName,
 		"iothread": iothreadID,
+		"serial":   strings.ReplaceAll(volumeID, "-", ""),
 	}
 	if hotplugBus != "" {
 		deviceAddArgs["bus"] = hotplugBus


### PR DESCRIPTION
## Summary
Sets the EBS volume-id (dashes stripped) as the virtio-blk serial on QMP `device_add` in `vm/volumes.go` AttachVolume, so the volume-id surfaces in-guest as the block-device serial. This lets the upstream aws-ebs-csi-driver node plugin locate `/dev/disk/by-id/*` and match `lsblk -o SERIAL` against the volume-id for device discovery. Applies to the boot disk too.

`vol` + 17 hex = exactly 20 bytes = the virtio-blk serial limit, so real volume-ids are never truncated.

Epic: EKS EBS CSI driver (mulga-siv-377), gap#1 (mulga-siv-379), spike (mulga-siv-378).

## Verification (local Spinifex dev box)
Booted a Debian-13 guest with two scratch disks attached via the exact device line — `virtio-blk-pci,serial=vol68c1fb9a54f87cd7a` / `serial=vol2dfdddf4ac4a68d18`:

- `lsblk -o SERIAL` → `vol68c1fb9a54f87cd7a`, `vol2dfdddf4ac4a68d18` — full 20 bytes, no truncation, distinct.
- `/dev/disk/by-id/virtio-vol68c1fb9a54f87cd7a -> vda`, `/sys/block/vda/serial` matches.
- Upstream node-plugin probe `lsblk --noheadings --ascii --nodeps -o SERIAL /dev/vda` → `vol68c1fb9a54f87cd7a`.

## Testing
- `make preflight` ✅