### PR TITLE
fix(ecr): negotiate manifest media type across all Accept headers

### DIFF
--- a/spinifex/gateway/ecr/registry.go
+++ b/spinifex/gateway/ecr/registry.go
@@ -516,7 +516,7 @@ func (reg *Registry) getManifest(w http.ResponseWriter, r *http.Request, name, r
 		WriteError(w, http.StatusNotFound, "MANIFEST_UNKNOWN", "manifest unknown")
 		return
 	}
-	if !acceptsType(r.Header.Get("Accept"), meta.MediaType) {
+	if !acceptsType(strings.Join(r.Header.Values("Accept"), ","), meta.MediaType) {
 		WriteError(w, http.StatusNotAcceptable, "MANIFEST_INVALID", "no acceptable manifest media type")
 		return
 	}

--- a/spinifex/gateway/ecr/registry_test.go
+++ b/spinifex/gateway/ecr/registry_test.go
@@ -208,6 +208,29 @@ func TestManifest_Get_AcceptMismatch(t *testing.T) {
 	assert.Equal(t, http.StatusNotAcceptable, w.Code)
 }
 
+// TestManifest_Get_MultipleAcceptHeaders reproduces skopeo, which sends each
+// acceptable manifest media type as its own Accept header line rather than one
+// comma-joined value. Negotiation must consider every line, not just the first.
+func TestManifest_Get_MultipleAcceptHeaders(t *testing.T) {
+	reg := newTestRegistry()
+	repo := "team/app"
+	cfg := pushBlob(t, reg, repo, []byte("c"))
+	manifest := fmt.Appendf(nil,
+		`{"mediaType":"%s","config":{"digest":"%s"},"layers":[]}`, mediaTypeDockerManifest, cfg)
+	do(reg, http.MethodPut, "/v2/"+repo+"/manifests/v1", manifest,
+		map[string]string{"Content-Type": mediaTypeDockerManifest})
+
+	r := httptest.NewRequest(http.MethodGet, "/v2/"+repo+"/manifests/v1", nil)
+	r.Header.Add("Accept", mediaTypeOCIIndex)
+	r.Header.Add("Accept", mediaTypeOCIManifest)
+	r.Header.Add("Accept", mediaTypeDockerManifest)
+	w := httptest.NewRecorder()
+	reg.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, manifest, w.Body.Bytes())
+}
+
 func TestManifest_Get_Unknown(t *testing.T) {
 	reg := newTestRegistry()
 	w := do(reg, http.MethodGet, "/v2/team/app/manifests/missing", nil, nil)


### PR DESCRIPTION
## Summary
`getManifest` negotiated the response manifest media type using `r.Header.Get("Accept")`, which returns only the **first** `Accept` header line. Clients that send each acceptable manifest media type as a separate `Accept` header — notably **skopeo** — never matched the stored type and received `406 MANIFEST_INVALID`. docker/crane send a single comma-joined `Accept` and were unaffected.

Fix: join all `Accept` header values before negotiation so the existing comma-split logic in `acceptsType` sees every offered type.

## Discovery
Found live on env19 during the ECR E2E suite (cs-ecr-2f) skopeo leg.

## Testing
- New `TestManifest_Get_MultipleAcceptHeaders` reproduces skopeo (three separate `Accept` lines) — fails before the fix (406), passes after (200 + bytes).
- `make preflight` green.
- Pending: re-run skopeo E2E leg live on env19 after deploy.

Bead: mulga-siv-389