### PR TITLE
feat(ecr): rotate JWT signing keys with previous-key retention

### DIFF
--- a/spinifex/gateway/ecrauth/rotator.go
+++ b/spinifex/gateway/ecrauth/rotator.go
@@ -1,0 +1,154 @@
+package gateway_ecrauth
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// Rotation defaults (ecr-v1 Q3): rotate the active signing key every 30 days,
+// keep the previous 2 keys for at least 24h (well past the 12h token TTL) so
+// in-flight tokens stay verifiable, then prune.
+const (
+	DefaultRotateAfter           = 30 * 24 * time.Hour
+	DefaultRetainFor             = 24 * time.Hour
+	DefaultRetainCount           = 2
+	DefaultRotationCheckInterval = time.Hour
+)
+
+// rotationParams holds the rotation/retention policy.
+type rotationParams struct {
+	rotateAfter time.Duration
+	retainFor   time.Duration
+	retainCount int
+}
+
+// planRotation decides, from the current key metadata, whether to mint a new
+// active key and which rotated-out keys to prune. It is pure so the policy is
+// exhaustively unit-testable; rotateOnce wires KV I/O around it.
+//
+// The active key is the newest. A mint is due once the active key is older than
+// rotateAfter. A previous key is pruned once the active key has stood for
+// retainFor (its tokens have expired) or the key ranks beyond retainCount among
+// the previous keys. The active key is never pruned: when a mint is due it
+// becomes the previous key next cycle and is retained until the fresh key ages
+// past retainFor.
+func planRotation(metas []keyMeta, now time.Time, p rotationParams) (mint bool, prune []string) {
+	if len(metas) == 0 {
+		return true, nil
+	}
+	sorted := append([]keyMeta(nil), metas...)
+	sort.Slice(sorted, func(i, j int) bool { return newerKey(sorted[i], sorted[j]) })
+
+	active := sorted[0]
+	activeAge := now.Sub(active.created)
+	mint = activeAge >= p.rotateAfter
+
+	for rank, m := range sorted[1:] {
+		if activeAge >= p.retainFor || rank >= p.retainCount {
+			prune = append(prune, m.kid)
+		}
+	}
+	return mint, prune
+}
+
+// Rotator periodically rotates and prunes the ECR signing keys, pushing the new
+// active key + verification set into the live Issuer and Verifier. It mirrors
+// the LifecycleSweeper pattern: a Run loop bound to the process lifetime. It is
+// safe to run on every awsgw instance — mint and delete on the shared KV bucket
+// converge, and a delete of an already-gone key is a no-op.
+type Rotator struct {
+	kv        nats.KeyValue
+	masterKey []byte
+	issuer    *Issuer
+	verifier  *Verifier
+	params    rotationParams
+	interval  time.Duration
+	now       func() time.Time
+}
+
+// NewRotator opens the signing-key bucket and builds a rotator that keeps issuer
+// and verifier current. replicas matches the cluster size for first-run bucket
+// creation.
+func NewRotator(js nats.JetStreamContext, masterKey []byte, replicas int, issuer *Issuer, verifier *Verifier) (*Rotator, error) {
+	kv, err := openSigningBucket(js, masterKey, replicas)
+	if err != nil {
+		return nil, err
+	}
+	return &Rotator{
+		kv:        kv,
+		masterKey: masterKey,
+		issuer:    issuer,
+		verifier:  verifier,
+		params: rotationParams{
+			rotateAfter: DefaultRotateAfter,
+			retainFor:   DefaultRetainFor,
+			retainCount: DefaultRetainCount,
+		},
+		interval: DefaultRotationCheckInterval,
+		now:      func() time.Time { return time.Now().UTC() },
+	}, nil
+}
+
+// Run rotates on every tick until ctx is cancelled. Blocks until then.
+func (r *Rotator) Run(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	slog.Info("ECR signing-key rotator started", "interval", r.interval, "rotateAfter", r.params.rotateAfter)
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("ECR signing-key rotator stopped")
+			return
+		case <-ticker.C:
+			r.rotateOnce(r.now())
+		}
+	}
+}
+
+// rotateOnce runs one rotation/prune cycle and refreshes the issuer/verifier.
+// Errors are logged and skipped so a transient KV fault never crashes the loop.
+func (r *Rotator) rotateOnce(now time.Time) {
+	_, _, metas, err := reloadKeys(r.kv, r.masterKey)
+	if err != nil {
+		slog.Warn("ECR signing-key rotation: load keys failed", "err", err)
+		return
+	}
+
+	mint, prune := planRotation(metas, now, r.params)
+	if mint {
+		newKey, err := generateSigningKey(r.kv, r.masterKey)
+		if err != nil {
+			slog.Warn("ECR signing-key rotation: mint failed", "err", err)
+			return
+		}
+		slog.Info("ECR signing-key rotated", "kid", newKey.Kid)
+	}
+	for _, kid := range prune {
+		if err := deleteSigningKey(r.kv, kid); err != nil {
+			slog.Warn("ECR signing-key rotation: prune failed", "kid", kid, "err", err)
+			continue
+		}
+		slog.Info("ECR signing-key pruned", "kid", kid)
+	}
+
+	r.refresh()
+}
+
+// refresh reloads the canonical key set and installs it on the issuer/verifier.
+func (r *Rotator) refresh() {
+	active, verify, _, err := reloadKeys(r.kv, r.masterKey)
+	if err != nil {
+		slog.Warn("ECR signing-key rotation: refresh failed", "err", err)
+		return
+	}
+	if active == nil {
+		return
+	}
+	r.issuer.SetActiveKey(active)
+	r.verifier.SetKeys(verify)
+}

--- a/spinifex/gateway/ecrauth/rotator_test.go
+++ b/spinifex/gateway/ecrauth/rotator_test.go
@@ -1,0 +1,216 @@
+package gateway_ecrauth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testRotationParams() rotationParams {
+	return rotationParams{rotateAfter: 30 * 24 * time.Hour, retainFor: 24 * time.Hour, retainCount: 2}
+}
+
+func TestPlanRotation(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	p := testRotationParams()
+
+	mk := func(kid string, ageHours int) keyMeta {
+		return keyMeta{kid: kid, created: now.Add(-time.Duration(ageHours) * time.Hour)}
+	}
+
+	t.Run("empty bucket mints", func(t *testing.T) {
+		mint, prune := planRotation(nil, now, p)
+		assert.True(t, mint)
+		assert.Empty(t, prune)
+	})
+
+	t.Run("single young key holds", func(t *testing.T) {
+		mint, prune := planRotation([]keyMeta{mk("a", 1)}, now, p)
+		assert.False(t, mint)
+		assert.Empty(t, prune)
+	})
+
+	t.Run("single aged key mints, nothing to prune", func(t *testing.T) {
+		mint, prune := planRotation([]keyMeta{mk("a", 31*24)}, now, p)
+		assert.True(t, mint)
+		assert.Empty(t, prune)
+	})
+
+	t.Run("previous key within retention is kept", func(t *testing.T) {
+		// active 5h old (< retainFor), one previous: still verifiable.
+		metas := []keyMeta{mk("new", 5), mk("old", 40*24)}
+		mint, prune := planRotation(metas, now, p)
+		assert.False(t, mint)
+		assert.Empty(t, prune)
+	})
+
+	t.Run("previous key past retention is pruned", func(t *testing.T) {
+		// active 25h old (>= retainFor): the previous key's tokens have expired.
+		metas := []keyMeta{mk("new", 25), mk("old", 40*24)}
+		mint, prune := planRotation(metas, now, p)
+		assert.False(t, mint)
+		assert.Equal(t, []string{"old"}, prune)
+	})
+
+	t.Run("retainCount caps previous keys within window", func(t *testing.T) {
+		// active 1h old (< retainFor) but three previous keys: keep newest 2.
+		metas := []keyMeta{mk("active", 1), mk("p1", 2), mk("p2", 3), mk("p3", 4)}
+		mint, prune := planRotation(metas, now, p)
+		assert.False(t, mint)
+		assert.Equal(t, []string{"p3"}, prune)
+	})
+
+	t.Run("mint due prunes stale previous, keeps active", func(t *testing.T) {
+		// active is itself due for rotation (31d) and has an ancient previous.
+		metas := []keyMeta{mk("active", 31*24), mk("ancient", 60*24)}
+		mint, prune := planRotation(metas, now, p)
+		assert.True(t, mint)
+		assert.Equal(t, []string{"ancient"}, prune) // active retained for next cycle
+	})
+}
+
+// TestRotateOnce_MintsAndSwaps drives a cycle with rotateAfter=0 so a mint is
+// always due: a new active key is minted, installed on the issuer, and accepted
+// by the verifier, while the prior key stays verifiable.
+func TestRotateOnce_MintsAndSwaps(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	key, verify, err := LoadOrCreateSigningKey(js, testMasterKey, 1)
+	require.NoError(t, err)
+
+	issuer := NewIssuer(key, testAudience)
+	verifier := NewVerifier(verify, testAudience)
+	kv, err := openSigningBucket(js, testMasterKey, 1)
+	require.NoError(t, err)
+
+	// Token minted under the original key before rotation.
+	oldTok, _, err := issuer.Mint(samplePrincipal())
+	require.NoError(t, err)
+
+	r := &Rotator{
+		kv: kv, masterKey: testMasterKey, issuer: issuer, verifier: verifier,
+		params: rotationParams{rotateAfter: 0, retainFor: time.Hour, retainCount: 2},
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+	r.rotateOnce(time.Now().UTC())
+
+	// A new active key took over.
+	assert.NotEqual(t, key.Kid, issuer.ActiveKid(), "issuer should sign with the rotated key")
+
+	// Both old and new tokens verify (previous key retained).
+	_, err = verifier.Verify(oldTok)
+	require.NoError(t, err, "token from the previous key must still verify")
+	newTok, _, err := issuer.Mint(samplePrincipal())
+	require.NoError(t, err)
+	_, err = verifier.Verify(newTok)
+	require.NoError(t, err, "token from the rotated key must verify")
+
+	_, _, metas, err := reloadKeys(kv, testMasterKey)
+	require.NoError(t, err)
+	assert.Len(t, metas, 2, "previous key retained alongside the new active key")
+}
+
+// TestRotateOnce_PrunesExpiredKey seeds a second key, then runs a cycle with
+// retainFor=0 (and no mint) so the older key is pruned and dropped from the
+// verifier.
+func TestRotateOnce_PrunesExpiredKey(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	first, verify, err := LoadOrCreateSigningKey(js, testMasterKey, 1)
+	require.NoError(t, err)
+	kv, err := openSigningBucket(js, testMasterKey, 1)
+	require.NoError(t, err)
+	second, err := generateSigningKey(kv, testMasterKey)
+	require.NoError(t, err)
+	require.NotEqual(t, first.Kid, second.Kid)
+
+	issuer := NewIssuer(first, testAudience)
+	verifier := NewVerifier(verify, testAudience)
+
+	r := &Rotator{
+		kv: kv, masterKey: testMasterKey, issuer: issuer, verifier: verifier,
+		params: rotationParams{rotateAfter: 1000 * time.Hour, retainFor: 0, retainCount: 2},
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+	r.rotateOnce(time.Now().UTC())
+
+	active, _, metas, err := reloadKeys(kv, testMasterKey)
+	require.NoError(t, err)
+	require.Len(t, metas, 1, "the older key should be pruned")
+	assert.Equal(t, second.Kid, active.Kid, "newest key remains active")
+	assert.Equal(t, second.Kid, issuer.ActiveKid())
+}
+
+// TestRotator_RunRotatesThenStops drives the scheduler loop on a fast interval
+// with rotateAfter=0 so it mints on the first tick, then cancels: the active key
+// changes and Run returns.
+func TestRotator_RunRotatesThenStops(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	key, verify, err := LoadOrCreateSigningKey(js, testMasterKey, 1)
+	require.NoError(t, err)
+	issuer := NewIssuer(key, testAudience)
+	verifier := NewVerifier(verify, testAudience)
+	kv, err := openSigningBucket(js, testMasterKey, 1)
+	require.NoError(t, err)
+
+	r := &Rotator{
+		kv: kv, masterKey: testMasterKey, issuer: issuer, verifier: verifier,
+		params:   rotationParams{rotateAfter: 0, retainFor: time.Hour, retainCount: 2},
+		interval: time.Millisecond,
+		now:      func() time.Time { return time.Now().UTC() },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() { r.Run(ctx); close(stopped) }()
+
+	require.Eventually(t, func() bool { return issuer.ActiveKid() != key.Kid },
+		2*time.Second, 5*time.Millisecond, "rotator should mint a new active key")
+
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// TestIssuerVerifier_ConcurrentSwap exercises the hot-swap under -race: Mint and
+// Verify run while SetActiveKey/SetKeys rotate the key set.
+func TestIssuerVerifier_ConcurrentSwap(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	k1, v1, err := LoadOrCreateSigningKey(js, testMasterKey, 1)
+	require.NoError(t, err)
+	kv, err := openSigningBucket(js, testMasterKey, 1)
+	require.NoError(t, err)
+	k2, err := generateSigningKey(kv, testMasterKey)
+	require.NoError(t, err)
+	_, v2, _, err := reloadKeys(kv, testMasterKey)
+	require.NoError(t, err)
+
+	issuer := NewIssuer(k1, testAudience)
+	verifier := NewVerifier(v1, testAudience)
+
+	done := make(chan struct{})
+	go func() {
+		for range 200 {
+			tok, _, mErr := issuer.Mint(samplePrincipal())
+			if mErr == nil {
+				_, _ = verifier.Verify(tok)
+			}
+		}
+		close(done)
+	}()
+	for i := range 200 {
+		if i%2 == 0 {
+			issuer.SetActiveKey(k2)
+			verifier.SetKeys(v2)
+		} else {
+			issuer.SetActiveKey(k1)
+			verifier.SetKeys(v1)
+		}
+	}
+	<-done
+}

--- a/spinifex/gateway/ecrauth/signingkey.go
+++ b/spinifex/gateway/ecrauth/signingkey.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/nats-io/nats.go"
@@ -40,6 +41,23 @@ type SigningKey struct {
 
 func signingKeyName(kid string) string { return signingKeyPrefix + kid }
 
+// keyMeta is a stored signing key's id and KV creation time. created is assigned
+// by the JetStream server, so every node orders keys identically — the rotator
+// uses it to pick the active (newest) key and to drive retention pruning.
+type keyMeta struct {
+	kid     string
+	created time.Time
+}
+
+// newerKey reports whether a should win over b as the active key: later created
+// wins, ties broken by lexically-greater kid for cross-node determinism.
+func newerKey(a, b keyMeta) bool {
+	if !a.created.Equal(b.created) {
+		return a.created.After(b.created)
+	}
+	return a.kid > b.kid
+}
+
 // kidFor derives the key id from a public key as base64url(sha256(SPKI DER)).
 func kidFor(pub *ecdsa.PublicKey) (string, error) {
 	der, err := x509.MarshalPKIXPublicKey(pub)
@@ -53,48 +71,17 @@ func kidFor(pub *ecdsa.PublicKey) (string, error) {
 // LoadOrCreateSigningKey opens (or creates) the awsgw-keys KV bucket, loads
 // every stored signing key into the kid->public-key verification set, and
 // returns the active signing key. On first run it generates and persists one.
-// The active key is the lexically-greatest kid so all nodes converge on the
-// same signer without coordination.
+// The active key is the newest by KV creation time (ties broken by kid), so all
+// nodes converge on the same signer and a freshly rotated key takes over.
 func LoadOrCreateSigningKey(js nats.JetStreamContext, masterKey []byte, replicas int) (*SigningKey, map[string]*ecdsa.PublicKey, error) {
-	if js == nil {
-		return nil, nil, errors.New("ecrauth: nil JetStream context")
-	}
-	if len(masterKey) == 0 {
-		return nil, nil, errors.New("ecrauth: empty master key")
-	}
-
-	kv, err := js.CreateKeyValue(&nats.KeyValueConfig{
-		Bucket:   SigningBucket,
-		History:  signingKeyHistory,
-		Replicas: replicas,
-	})
+	kv, err := openSigningBucket(js, masterKey, replicas)
 	if err != nil {
-		if kv, err = js.KeyValue(SigningBucket); err != nil {
-			return nil, nil, fmt.Errorf("open %s bucket: %w", SigningBucket, err)
-		}
+		return nil, nil, err
 	}
-
-	keys, err := kv.Keys()
-	if err != nil && !errors.Is(err, nats.ErrNoKeysFound) {
-		return nil, nil, fmt.Errorf("list signing keys: %w", err)
+	active, verify, _, err := reloadKeys(kv, masterKey)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	verify := make(map[string]*ecdsa.PublicKey)
-	var active *SigningKey
-	for _, name := range keys {
-		if !strings.HasPrefix(name, signingKeyPrefix) {
-			continue
-		}
-		sk, err := loadSigningKey(kv, name, masterKey)
-		if err != nil {
-			return nil, nil, err
-		}
-		verify[sk.Kid] = &sk.priv.PublicKey
-		if active == nil || sk.Kid > active.Kid {
-			active = sk
-		}
-	}
-
 	if active == nil {
 		active, err = generateSigningKey(kv, masterKey)
 		if err != nil {
@@ -105,22 +92,82 @@ func LoadOrCreateSigningKey(js nats.JetStreamContext, masterKey []byte, replicas
 	return active, verify, nil
 }
 
-// loadSigningKey decrypts and parses one stored signing key. The kid is the
-// KV key suffix; the stored bytes are the AES-256-GCM-encrypted PKCS#8 PEM.
-func loadSigningKey(kv nats.KeyValue, name string, masterKey []byte) (*SigningKey, error) {
-	entry, err := kv.Get(name)
-	if err != nil {
-		return nil, fmt.Errorf("kv get %s: %w", name, err)
+// openSigningBucket validates inputs and returns the awsgw-keys KV handle,
+// creating the cluster-replicated bucket on first use.
+func openSigningBucket(js nats.JetStreamContext, masterKey []byte, replicas int) (nats.KeyValue, error) {
+	if js == nil {
+		return nil, errors.New("ecrauth: nil JetStream context")
 	}
-	pemStr, err := handlers_iam.DecryptSecret(string(entry.Value()), masterKey)
+	if len(masterKey) == 0 {
+		return nil, errors.New("ecrauth: empty master key")
+	}
+	kv, err := js.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket:   SigningBucket,
+		History:  signingKeyHistory,
+		Replicas: replicas,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("decrypt signing key %s: %w", name, err)
+		if kv, err = js.KeyValue(SigningBucket); err != nil {
+			return nil, fmt.Errorf("open %s bucket: %w", SigningBucket, err)
+		}
+	}
+	return kv, nil
+}
+
+// reloadKeys reads every stored signing key, returning the verify set, each
+// key's metadata, and the active (newest) decrypted key. active is nil for an
+// empty bucket. Used by both startup and the rotation scheduler.
+func reloadKeys(kv nats.KeyValue, masterKey []byte) (active *SigningKey, verify map[string]*ecdsa.PublicKey, metas []keyMeta, err error) {
+	names, err := kv.Keys()
+	if err != nil && !errors.Is(err, nats.ErrNoKeysFound) {
+		return nil, nil, nil, fmt.Errorf("list signing keys: %w", err)
+	}
+
+	verify = make(map[string]*ecdsa.PublicKey)
+	var activeMeta keyMeta
+	for _, name := range names {
+		if !strings.HasPrefix(name, signingKeyPrefix) {
+			continue
+		}
+		entry, err := kv.Get(name)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("kv get %s: %w", name, err)
+		}
+		sk, err := decodeSigningKey(strings.TrimPrefix(name, signingKeyPrefix), entry.Value(), masterKey)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		verify[sk.Kid] = &sk.priv.PublicKey
+		m := keyMeta{kid: sk.Kid, created: entry.Created()}
+		metas = append(metas, m)
+		if active == nil || newerKey(m, activeMeta) {
+			active, activeMeta = sk, m
+		}
+	}
+	return active, verify, metas, nil
+}
+
+// deleteSigningKey removes a rotated-out key from the bucket once its retention
+// window has elapsed.
+func deleteSigningKey(kv nats.KeyValue, kid string) error {
+	if err := kv.Delete(signingKeyName(kid)); err != nil {
+		return fmt.Errorf("kv delete %s: %w", signingKeyName(kid), err)
+	}
+	return nil
+}
+
+// decodeSigningKey decrypts and parses one stored signing key's encrypted PKCS#8
+// PEM bytes into a SigningKey under kid.
+func decodeSigningKey(kid string, ciphertext []byte, masterKey []byte) (*SigningKey, error) {
+	pemStr, err := handlers_iam.DecryptSecret(string(ciphertext), masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt signing key %s: %w", kid, err)
 	}
 	priv, err := parseECPrivateKeyPEM(pemStr)
 	if err != nil {
 		return nil, err
 	}
-	return &SigningKey{Kid: strings.TrimPrefix(name, signingKeyPrefix), priv: priv}, nil
+	return &SigningKey{Kid: kid, priv: priv}, nil
 }
 
 // generateSigningKey creates a fresh ES256 key, persists the encrypted PEM under

--- a/spinifex/gateway/ecrauth/token.go
+++ b/spinifex/gateway/ecrauth/token.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -39,7 +40,10 @@ type Principal struct {
 }
 
 // Issuer mints ES256 ECR tokens bound to an audience (ecr.{region}.{suffix}).
+// The active signing key is swapped under mu by the rotation scheduler while
+// Mint runs concurrently.
 type Issuer struct {
+	mu       sync.RWMutex
 	key      *SigningKey
 	audience string
 	ttl      time.Duration
@@ -50,10 +54,31 @@ func NewIssuer(key *SigningKey, audience string) *Issuer {
 	return &Issuer{key: key, audience: audience, ttl: DefaultTokenTTL}
 }
 
+// SetActiveKey swaps the signing key used by subsequent Mint calls. The rotator
+// calls it after minting a fresh key.
+func (i *Issuer) SetActiveKey(key *SigningKey) {
+	i.mu.Lock()
+	i.key = key
+	i.mu.Unlock()
+}
+
+// ActiveKid returns the kid of the current signing key, or "" if none.
+func (i *Issuer) ActiveKid() string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	if i.key == nil {
+		return ""
+	}
+	return i.key.Kid
+}
+
 // Mint returns a signed ES256 JWT for p and its expiry. The kid header lets any
 // verifier resolve the public key from the shared signing-key set.
 func (i *Issuer) Mint(p Principal) (token string, expiresAt time.Time, err error) {
-	if i.key == nil {
+	i.mu.RLock()
+	key := i.key
+	i.mu.RUnlock()
+	if key == nil {
 		return "", time.Time{}, errors.New("ecrauth: issuer has no signing key")
 	}
 	if p.AccountID == "" {
@@ -75,8 +100,8 @@ func (i *Issuer) Mint(p Principal) (token string, expiresAt time.Time, err error
 		AccessKeyID:   p.AccessKeyID,
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-	tok.Header["kid"] = i.key.Kid
-	signed, err := tok.SignedString(i.key.priv)
+	tok.Header["kid"] = key.Kid
+	signed, err := tok.SignedString(key.priv)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("sign ECR token: %w", err)
 	}
@@ -84,8 +109,10 @@ func (i *Issuer) Mint(p Principal) (token string, expiresAt time.Time, err error
 }
 
 // Verifier validates ECR tokens against the shared kid->public-key set and a
-// fixed expected audience.
+// fixed expected audience. The key set is swapped under mu by the rotation
+// scheduler while Verify runs concurrently.
 type Verifier struct {
+	mu       sync.RWMutex
 	keys     map[string]*ecdsa.PublicKey
 	audience string
 }
@@ -93,6 +120,22 @@ type Verifier struct {
 // NewVerifier returns a Verifier over keys for the expected audience.
 func NewVerifier(keys map[string]*ecdsa.PublicKey, audience string) *Verifier {
 	return &Verifier{keys: keys, audience: audience}
+}
+
+// SetKeys swaps the kid->public-key verification set. The rotator calls it after
+// each cycle so a newly minted key is accepted and pruned keys are dropped.
+func (v *Verifier) SetKeys(keys map[string]*ecdsa.PublicKey) {
+	v.mu.Lock()
+	v.keys = keys
+	v.mu.Unlock()
+}
+
+// publicKey resolves a kid under the read lock.
+func (v *Verifier) publicKey(kid string) (*ecdsa.PublicKey, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	pub, ok := v.keys[kid]
+	return pub, ok
 }
 
 // Verify parses and validates raw: ES256, unexpired, known kid, matching iss and
@@ -105,7 +148,7 @@ func (v *Verifier) Verify(raw string) (*Claims, error) {
 	)
 	_, err := parser.ParseWithClaims(raw, claims, func(t *jwt.Token) (any, error) {
 		kid, _ := t.Header["kid"].(string)
-		pub, ok := v.keys[kid]
+		pub, ok := v.publicKey(kid)
 		if !ok {
 			return nil, fmt.Errorf("unknown kid %q", kid)
 		}

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -251,6 +251,15 @@ func launchService(config *config.ClusterConfig) error {
 		ECRTokenVerifier: gateway_ecrauth.NewVerifier(verifyKeys, ecrAudience),
 	}
 
+	// Rotate the ECR signing key on a 30-day cadence, retaining the previous keys
+	// until their tokens expire. The rotator keeps the issuer/verifier current as
+	// keys roll. Bound to the same lifetime context as the STS janitor.
+	keyRotator, err := gateway_ecrauth.NewRotator(js, masterKey, len(config.Nodes), gw.ECRTokenIssuer, gw.ECRTokenVerifier)
+	if err != nil {
+		return fmt.Errorf("ECR auth bridge: signing-key rotator: %w", err)
+	}
+	go keyRotator.Run(janitorCtx)
+
 	if throttleCfg.Enabled {
 		gw.Throttler = ratelimit.New(throttleCfg)
 		defer gw.Throttler.Stop()


### PR DESCRIPTION
## Summary
The ECR auth bridge minted ES256 tokens from a signing key created once and never rotated. This adds a background rotator per ecr-v1 **Q3**: mint a fresh key every 30 days, retain the previous keys for 24h (past the 12h token TTL) so in-flight tokens stay verifiable, then prune.

## Key design points
- **Active selection changed**: was lexically-greatest `kid`, but `kid = base64url(sha256(SPKI))` is a content hash — a minted key would not reliably become active, so rotation would be a no-op. Active is now the **newest by KV `Created()`** (server-assigned → all nodes converge; a minted key takes over). Tie-broken by kid.
- **Hot-swappable Issuer/Verifier**: `Mint`/`Verify` now read the key set under an `RWMutex`; the rotator calls `SetActiveKey`/`SetKeys` after each cycle. Race-tested.
- **Pure planner**: `planRotation(metas, now, params) -> (mint, prune)` holds the policy for exhaustive unit testing; `rotateOnce` wires KV I/O around it.
- Wired into awsgw startup alongside the STS janitor / lifecycle sweeper (`go rotator.Run(janitorCtx)`).

## Testing
- `TestPlanRotation` table (not-due, due, retention holding vs elapsed, retainCount cap, mint-due prune).
- `TestRotateOnce_MintsAndSwaps` / `_PrunesExpiredKey` (JetStream): mint → issuer swaps → both old+new tokens verify; expired key pruned + dropped from verifier.
- `TestRotator_RunRotatesThenStops` (scheduler loop + cancel).
- `TestIssuerVerifier_ConcurrentSwap` under `-race`.
- `make preflight` green; diff coverage 63.2%.
- Live env19: ECR e2e suite (exercises mint/verify through docker/crane/skopeo) — pending in this session.

Bead: mulga-siv-366