### PR TITLE
feat: EKS EBS CSI driver (Viperblock) — egress, attach, node discovery, e2e

### DIFF
--- a/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/00-rbac.yaml
+++ b/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/00-rbac.yaml
@@ -1,0 +1,443 @@
+# aws-ebs-csi-driver 1.40.1 — RBAC, ServiceAccounts, CSIDriver, PDB.
+# Vendored from kubernetes-sigs/aws-ebs-csi-driver v1.41.0 deploy/kubernetes/base;
+# namespace kube-system + controller-SA IRSA role-arn annotation injected.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-controller-sa
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: '{{SERVICE_ACCOUNT_ROLE_ARN}}'
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-node-sa
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  namespace: kube-system
+automountServiceAccountToken: true
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-external-attacher-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-external-provisioner-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-external-resizer-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-external-snapshotter-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - groupsnapshot.storage.k8s.io
+  resources:
+  - volumegroupsnapshotcontents/status
+  verbs:
+  - update
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-attacher-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+- kind: ServiceAccount
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-external-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node-getter-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+- kind: ServiceAccount
+  name: ebs-csi-node-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-csi-node-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-provisioner-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+- kind: ServiceAccount
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-resizer-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+- kind: ServiceAccount
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-external-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-snapshotter-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+- kind: ServiceAccount
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: ebs-external-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-leases-role
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  namespace: kube-system
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-leases-rolebinding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: ebs-csi-leases-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: ebs.csi.aws.com
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+  fsGroupPolicy: File
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ebs-csi-controller
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: ebs-csi-controller
+      app.kubernetes.io/name: aws-ebs-csi-driver
+  maxUnavailable: 1

--- a/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml
+++ b/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml
@@ -65,12 +65,6 @@ spec:
                   - ebs-csi-controller
               topologyKey: kubernetes.io/hostname
             weight: 100
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        operator: Exists
-        tolerationSeconds: 300
       securityContext:
         fsGroup: 1000
         runAsGroup: 1000

--- a/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml
+++ b/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml
@@ -1,0 +1,309 @@
+# aws-ebs-csi-driver 1.40.1 — controller Deployment + gateway-CA Secret.
+# IRSA (web-identity) wired to the Spinifex AWS gateway: projected SA token
+# (aud sts.amazonaws.com) + role ARN + EC2/STS endpoint + CA, filled by
+# mulga-eks-addon-sync. Static aws-secret key auth removed.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spinifex-gateway-ca
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+type: Opaque
+data:
+  ca.pem: '{{GATEWAY_CA_PEM_B64}}'
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ebs-csi-controller
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  namespace: kube-system
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ebs-csi-controller
+      app.kubernetes.io/name: aws-ebs-csi-driver
+  template:
+    metadata:
+      labels:
+        app: ebs-csi-controller
+        app.kubernetes.io/name: aws-ebs-csi-driver
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ebs-csi-controller-sa
+      priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+                - auto
+                - hybrid
+            weight: 1
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - ebs-csi-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+        tolerationSeconds: 300
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: ebs-plugin
+        image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.40.1
+        imagePullPolicy: IfNotPresent
+        args:
+        - controller
+        - --endpoint=$(CSI_ENDPOINT)
+        - --batching=true
+        - --logging-format=text
+        - --user-agent-extra=kustomize
+        - --v=2
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: CSI_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: AWS_EC2_ENDPOINT
+          value: '{{GATEWAY_ENDPOINT}}'
+        - name: AWS_ROLE_ARN
+          value: '{{SERVICE_ACCOUNT_ROLE_ARN}}'
+        - name: AWS_WEB_IDENTITY_TOKEN_FILE
+          value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+        - name: AWS_STS_REGIONAL_ENDPOINTS
+          value: regional
+        - name: AWS_REGION
+          value: '{{AWS_REGION}}'
+        - name: AWS_DEFAULT_REGION
+          value: '{{AWS_REGION}}'
+        - name: AWS_ENDPOINT_URL_STS
+          value: '{{GATEWAY_ENDPOINT}}'
+        - name: AWS_ENDPOINT_URL_EC2
+          value: '{{GATEWAY_ENDPOINT}}'
+        - name: AWS_CA_BUNDLE
+          value: /etc/spinifex/gateway-ca/ca.pem
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: aws-iam-token
+          mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+          readOnly: true
+        - name: spinifex-gateway-ca
+          mountPath: /etc/spinifex/gateway-ca
+          readOnly: true
+        ports:
+        - name: healthz
+          containerPort: 9808
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 5
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: csi-provisioner
+        image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v5.2.0-eks-1-32-7
+        imagePullPolicy: IfNotPresent
+        args:
+        - --timeout=60s
+        - --csi-address=$(ADDRESS)
+        - --v=2
+        - --feature-gates=Topology=true
+        - --extra-create-metadata
+        - --leader-election=true
+        - --default-fstype=ext4
+        - --kube-api-qps=20
+        - --kube-api-burst=100
+        - --worker-threads=100
+        - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: csi-attacher
+        image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.8.1-eks-1-32-7
+        imagePullPolicy: IfNotPresent
+        args:
+        - --timeout=60s
+        - --csi-address=$(ADDRESS)
+        - --v=2
+        - --leader-election=true
+        - --kube-api-qps=20
+        - --kube-api-burst=100
+        - --worker-threads=100
+        - --retry-interval-max=5m
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: csi-snapshotter
+        image: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v8.2.1-eks-1-32-7
+        imagePullPolicy: IfNotPresent
+        args:
+        - --csi-address=$(ADDRESS)
+        - --leader-election=true
+        - --v=2
+        - --extra-create-metadata
+        - --kube-api-qps=20
+        - --kube-api-burst=100
+        - --worker-threads=100
+        - --retry-interval-max=30m
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: csi-resizer
+        image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.13.2-eks-1-32-7
+        imagePullPolicy: IfNotPresent
+        args:
+        - --timeout=60s
+        - --extra-modify-metadata
+        - --csi-address=$(ADDRESS)
+        - --v=2
+        - --handle-volume-inuse-error=false
+        - --leader-election=true
+        - --kube-api-qps=20
+        - --kube-api-burst=100
+        - --workers=100
+        - --retry-interval-max=30m
+        - --feature-gates=VolumeAttributesClass=true
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+      - name: liveness-probe
+        image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-32-7
+        imagePullPolicy: IfNotPresent
+        args:
+        - --csi-address=/csi/csi.sock
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /csi
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      volumes:
+      - name: socket-dir
+        emptyDir: {}
+      - name: aws-iam-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: sts.amazonaws.com
+              expirationSeconds: 86400
+              path: token
+      - name: spinifex-gateway-ca
+        secret:
+          defaultMode: 420
+          secretName: spinifex-gateway-ca

--- a/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml
+++ b/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml
@@ -49,8 +49,6 @@ spec:
       serviceAccountName: ebs-csi-node-sa
       terminationGracePeriodSeconds: 30
       priorityClassName: system-node-critical
-      tolerations:
-      - operator: Exists
       hostNetwork: false
       securityContext:
         fsGroup: 0

--- a/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml
+++ b/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml
@@ -1,0 +1,184 @@
+# aws-ebs-csi-driver 1.40.1 — node DaemonSet. Mounts host /dev so the plugin
+# resolves /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_<volid> (minted by
+# mulga-ebs-byid). No AWS creds: the node plugin does not call EC2.
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ebs-csi-node
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  namespace: kube-system
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ebs-csi-node
+      app.kubernetes.io/name: aws-ebs-csi-driver
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ebs-csi-node
+        app.kubernetes.io/name: aws-ebs-csi-driver
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+                - auto
+                - hybrid
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - a1.medium
+                - a1.large
+                - a1.xlarge
+                - a1.2xlarge
+                - a1.4xlarge
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ebs-csi-node-sa
+      terminationGracePeriodSeconds: 30
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+      hostNetwork: false
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
+      containers:
+      - name: ebs-plugin
+        image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.40.1
+        imagePullPolicy: IfNotPresent
+        args:
+        - node
+        - --endpoint=$(CSI_ENDPOINT)
+        - --csi-mount-point-prefix=/var/lib/kubelet/plugins/kubernetes.io/csi/ebs.csi.aws.com/
+        - --logging-format=text
+        - --v=2
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:/csi/csi.sock
+        - name: CSI_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: kubelet-dir
+          mountPath: /var/lib/kubelet
+          mountPropagation: Bidirectional
+        - name: plugin-dir
+          mountPath: /csi
+        - name: device-dir
+          mountPath: /dev
+        ports:
+        - name: healthz
+          containerPort: 9808
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 5
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/aws-ebs-csi-driver
+              - pre-stop-hook
+      - name: node-driver-registrar
+        image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.13.0-eks-1-32-7
+        imagePullPolicy: IfNotPresent
+        args:
+        - --csi-address=$(ADDRESS)
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --v=2
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
+        livenessProbe:
+          exec:
+            command:
+            - /csi-node-driver-registrar
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --mode=kubelet-registration-probe
+          initialDelaySeconds: 30
+          periodSeconds: 90
+          timeoutSeconds: 15
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: registration-dir
+          mountPath: /registration
+        - name: probe-dir
+          mountPath: /var/lib/kubelet/plugins/ebs.csi.aws.com/
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      - name: liveness-probe
+        image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-32-7
+        imagePullPolicy: IfNotPresent
+        args:
+        - --csi-address=/csi/csi.sock
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      volumes:
+      - name: kubelet-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/ebs.csi.aws.com/
+          type: DirectoryOrCreate
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry/
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: probe-dir
+        emptyDir: {}

--- a/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/30-storageclass.yaml
+++ b/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/30-storageclass.yaml
@@ -1,0 +1,18 @@
+# Default gp3 StorageClass — PVCs without an explicit class provision a
+# Viperblock-backed EBS volume via the Spinifex EBS API. WaitForFirstConsumer
+# defers CreateVolume until a pod schedules so the volume lands in the node's AZ.
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: gp3
+  csi.storage.k8s.io/fstype: ext4

--- a/scripts/images/eks-node/manifest.conf
+++ b/scripts/images/eks-node/manifest.conf
@@ -38,6 +38,8 @@ scripts/images/eks-node/mulga-eks-addon-sync.initd:/etc/init.d/mulga-eks-addon-s
 scripts/images/eks-node/mulga-eks-addon-sync.sh:/usr/local/sbin/mulga-eks-addon-sync \
 scripts/images/eks-node/mulga-ebs-byid.initd:/etc/init.d/mulga-ebs-byid \
 scripts/images/eks-node/mulga-ebs-byid.sh:/usr/local/sbin/mulga-ebs-byid \
+scripts/images/eks-node/mulga-eks-provider-id.initd:/etc/init.d/mulga-eks-provider-id \
+scripts/images/eks-node/mulga-eks-provider-id.sh:/usr/local/sbin/mulga-eks-provider-id \
 scripts/images/eks-node/addons/spinifex-noop/0.1.0/noop.yaml:/usr/share/spinifex-eks/addons/spinifex-noop/0.1.0/noop.yaml \
 scripts/images/eks-node/addons/argocd/3.0.23/argocd.yaml:/usr/share/spinifex-eks/addons/argocd/3.0.23/argocd.yaml \
 scripts/images/eks-node/addons/aws-load-balancer-controller/2.11.0/00-crds.yaml:/usr/share/spinifex-eks/addons/aws-load-balancer-controller/2.11.0/00-crds.yaml \
@@ -53,7 +55,7 @@ scripts/images/eks-node/mulga-eks-etcd-snapshot.sh:/etc/periodic/daily/mulga-eks
 # Only crond (etcd snapshot) + the role selector at bake. The selector adds the
 # role-specific services (k3s/eks-token-webhook/k3s-first-boot/state-report or
 # k3s-agent) to the default runlevel on first boot.
-ENABLE_SERVICES="crond eks-node-role mulga-ebs-byid"
+ENABLE_SERVICES="crond eks-node-role mulga-ebs-byid mulga-eks-provider-id"
 
 SETUP_SCRIPT="scripts/images/eks-node/setup.sh"
 

--- a/scripts/images/eks-node/manifest.conf
+++ b/scripts/images/eks-node/manifest.conf
@@ -36,18 +36,24 @@ scripts/images/eks-node/mulga-eks-state-report.initd:/etc/init.d/mulga-eks-state
 scripts/images/eks-node/mulga-eks-state-report.sh:/usr/local/sbin/mulga-eks-state-report \
 scripts/images/eks-node/mulga-eks-addon-sync.initd:/etc/init.d/mulga-eks-addon-sync \
 scripts/images/eks-node/mulga-eks-addon-sync.sh:/usr/local/sbin/mulga-eks-addon-sync \
+scripts/images/eks-node/mulga-ebs-byid.initd:/etc/init.d/mulga-ebs-byid \
+scripts/images/eks-node/mulga-ebs-byid.sh:/usr/local/sbin/mulga-ebs-byid \
 scripts/images/eks-node/addons/spinifex-noop/0.1.0/noop.yaml:/usr/share/spinifex-eks/addons/spinifex-noop/0.1.0/noop.yaml \
 scripts/images/eks-node/addons/argocd/3.0.23/argocd.yaml:/usr/share/spinifex-eks/addons/argocd/3.0.23/argocd.yaml \
 scripts/images/eks-node/addons/aws-load-balancer-controller/2.11.0/00-crds.yaml:/usr/share/spinifex-eks/addons/aws-load-balancer-controller/2.11.0/00-crds.yaml \
 scripts/images/eks-node/addons/aws-load-balancer-controller/2.11.0/10-aws-load-balancer-controller.yaml:/usr/share/spinifex-eks/addons/aws-load-balancer-controller/2.11.0/10-aws-load-balancer-controller.yaml \
 scripts/images/eks-node/addons/aws-load-balancer-controller/2.11.0/webhook.conf:/usr/share/spinifex-eks/addons/aws-load-balancer-controller/2.11.0/webhook.conf \
+scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/00-rbac.yaml:/usr/share/spinifex-eks/addons/aws-ebs-csi-driver/1.40.1/00-rbac.yaml \
+scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml:/usr/share/spinifex-eks/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml \
+scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml:/usr/share/spinifex-eks/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml \
+scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/30-storageclass.yaml:/usr/share/spinifex-eks/addons/aws-ebs-csi-driver/1.40.1/30-storageclass.yaml \
 scripts/images/eks-node/coredns/coredns-mulga.yaml:/usr/share/spinifex-eks/coredns/coredns-mulga.yaml \
 scripts/images/eks-node/mulga-eks-etcd-snapshot.sh:/etc/periodic/daily/mulga-eks-etcd-snapshot"
 
 # Only crond (etcd snapshot) + the role selector at bake. The selector adds the
 # role-specific services (k3s/eks-token-webhook/k3s-first-boot/state-report or
 # k3s-agent) to the default runlevel on first boot.
-ENABLE_SERVICES="crond eks-node-role"
+ENABLE_SERVICES="crond eks-node-role mulga-ebs-byid"
 
 SETUP_SCRIPT="scripts/images/eks-node/setup.sh"
 

--- a/scripts/images/eks-node/mulga-ebs-byid.initd
+++ b/scripts/images/eks-node/mulga-ebs-byid.initd
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+# mulga-ebs-byid — role-agnostic boot oneshot that enables the EBS by-id
+# symlink bridge for the aws-ebs-csi-driver node plugin. Points the kernel
+# hotplug helper at busybox mdev (Alpine has no eudev/netlink device manager),
+# so a hot-attached virtio-blk volume triggers /etc/mdev.conf, then coldplugs
+# any volume already present at boot. Runs on every node (server + agent).
+
+description="Mulga EBS /dev/disk/by-id symlink bridge (mdev hotplug)"
+
+depend() {
+    after dev
+    before k3s k3s-agent
+}
+
+start() {
+    ebegin "Enabling EBS by-id hotplug bridge"
+    if [ -w /proc/sys/kernel/hotplug ]; then
+        echo /sbin/mdev > /proc/sys/kernel/hotplug
+    fi
+    ACTION=coldplug /usr/local/sbin/mulga-ebs-byid
+    eend $?
+}

--- a/scripts/images/eks-node/mulga-ebs-byid.sh
+++ b/scripts/images/eks-node/mulga-ebs-byid.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# mulga-ebs-byid — mint the EBS-style /dev/disk/by-id symlink the upstream
+# aws-ebs-csi-driver node plugin resolves. Spinifex attaches Viperblock volumes
+# as virtio-blk with serial = volume-id (dashes stripped); the kernel exposes it
+# at /sys/block/<dev>/serial. Alpine uses busybox mdev (no eudev), so the
+# nvme-Amazon_Elastic_Block_Store_<serial> link is created here from that serial.
+#
+# Invoked by mdev (env MDEV=<dev>, ACTION add|remove) and at boot for coldplug.
+set -eu
+
+BYID_DIR=/dev/disk/by-id
+PREFIX=nvme-Amazon_Elastic_Block_Store_
+
+dev="${MDEV:-${1:-}}"
+[ -n "${dev}" ] || exit 0
+
+link_dev() {
+    _d=$1
+    _sf="/sys/block/${_d}/serial"
+    [ -r "${_sf}" ] || return 0
+    _serial=$(cat "${_sf}" 2>/dev/null) || return 0
+    case "${_serial}" in
+        vol*) mkdir -p "${BYID_DIR}"; ln -sf "../../${_d}" "${BYID_DIR}/${PREFIX}${_serial}" ;;
+    esac
+}
+
+unlink_dev() {
+    _d=$1
+    for _l in "${BYID_DIR}/${PREFIX}"*; do
+        [ -L "${_l}" ] || continue
+        [ "$(readlink "${_l}")" = "../../${_d}" ] && rm -f "${_l}"
+    done
+}
+
+case "${ACTION:-add}" in
+    remove) unlink_dev "${dev}" ;;
+    coldplug)
+        for _p in /sys/block/vd*; do
+            [ -e "${_p}" ] || continue
+            link_dev "$(basename "${_p}")"
+        done
+        ;;
+    *) link_dev "${dev}" ;;
+esac
+exit 0

--- a/scripts/images/eks-node/mulga-ebs-byid.sh
+++ b/scripts/images/eks-node/mulga-ebs-byid.sh
@@ -5,9 +5,15 @@
 # at /sys/block/<dev>/serial. Alpine uses busybox mdev (no eudev), so the
 # nvme-Amazon_Elastic_Block_Store_<serial> link is created here from that serial.
 #
+# The mdev rule routes every vd* event here (busybox mdev stops at the first
+# matching line, so this helper supersedes the stock vd* rule rather than
+# stacking with it). Stock by-id/by-path/block links are preserved by
+# delegating to /lib/mdev/persistent-storage first.
+#
 # Invoked by mdev (env MDEV=<dev>, ACTION add|remove) and at boot for coldplug.
 set -eu
 
+PERSISTENT_STORAGE=/lib/mdev/persistent-storage
 BYID_DIR=/dev/disk/by-id
 PREFIX=nvme-Amazon_Elastic_Block_Store_
 
@@ -32,14 +38,25 @@ unlink_dev() {
     done
 }
 
+delegate() {
+    [ -x "${PERSISTENT_STORAGE}" ] || return 0
+    MDEV="${dev}" "${PERSISTENT_STORAGE}" || true
+}
+
 case "${ACTION:-add}" in
-    remove) unlink_dev "${dev}" ;;
+    remove)
+        unlink_dev "${dev}"
+        delegate
+        ;;
     coldplug)
         for _p in /sys/block/vd*; do
             [ -e "${_p}" ] || continue
             link_dev "$(basename "${_p}")"
         done
         ;;
-    *) link_dev "${dev}" ;;
+    *)
+        delegate
+        link_dev "${dev}"
+        ;;
 esac
 exit 0

--- a/scripts/images/eks-node/mulga-eks-provider-id.initd
+++ b/scripts/images/eks-node/mulga-eks-provider-id.initd
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+# mulga-eks-provider-id — boot oneshot that writes a K3s drop-in from IMDS
+# before K3s starts: the kubelet provider-id plus region/zone topology labels,
+# the node metadata the aws-ebs-csi-driver needs for NodeGetInfo + provisioning.
+# Ordered after local (which installs the IMDS on-link route) and before both
+# K3s roles. Role-agnostic: enabled on every node (server + agent).
+
+description="Set K3s provider-id + topology labels from IMDS for EBS CSI"
+
+depend() {
+    after net local
+    before k3s k3s-agent
+}
+
+start() {
+    ebegin "Writing K3s provider-id drop-in from IMDS"
+    /usr/local/sbin/mulga-eks-provider-id
+    eend $?
+}

--- a/scripts/images/eks-node/mulga-eks-provider-id.sh
+++ b/scripts/images/eks-node/mulga-eks-provider-id.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -eu
+
+# mulga-eks-provider-id — writes a K3s config drop-in that supplies the node
+# metadata the aws-ebs-csi-driver needs, read from IMDS at boot: the kubelet
+# provider-id (aws:///<az>/<instance-id>) plus the region/zone topology labels
+# and the instance-type label.
+#
+# The node plugin's metadata init first tries IMDS, whose ENI path the spinifex
+# IMDS does not serve, then falls back to Kubernetes: instance ID from
+# .spec.providerID, region/zone from the well-known topology labels, and the
+# instance type from node.kubernetes.io/instance-type. K3s runs no AWS
+# cloud-provider, so none of those are set unless kubelet is told. Without the
+# topology labels NodeGetInfo never runs, the CSINode carries no topology key,
+# and the provisioner fails "no topology key found"; without a parseable
+# instance type NodeGetInfo panics in IsNitroInstanceType ("cannot determine
+# family"). This drop-in supplies all four; region is derived from the AZ
+# (trailing zone letters stripped).
+#
+# K3s merges /etc/rancher/k3s/config.yaml.d/*.yaml over config.yaml; list keys
+# such as kubelet-arg are concatenated, so this adds the flag without touching
+# the cloud-init-written main config. Role-agnostic: runs on server + agent.
+
+IMDS="http://169.254.169.254/latest"
+DROPIN_DIR=/etc/rancher/k3s/config.yaml.d
+DROPIN="${DROPIN_DIR}/10-provider-id.yaml"
+LOGTAG="mulga-eks-provider-id"
+
+log() { echo "[${LOGTAG}] $*"; }
+
+if [ -f "${DROPIN}" ]; then
+    log "drop-in ${DROPIN} present — already configured"
+    exit 0
+fi
+
+# IMDSv2 token if the service enforces it; tokenless (v1) is the fallback.
+fetch() {
+    if [ -n "${_tok}" ]; then
+        curl -fsS --max-time 3 -H "X-aws-ec2-metadata-token: ${_tok}" "${IMDS}/meta-data/$1" 2>/dev/null
+    else
+        curl -fsS --max-time 3 "${IMDS}/meta-data/$1" 2>/dev/null
+    fi
+}
+
+# Retry: the IMDS on-link route + networking may settle shortly after boot.
+iid=""
+az=""
+itype=""
+i=0
+while [ "${i}" -lt 30 ]; do
+    _tok=$(curl -fsS --max-time 3 -X PUT "${IMDS}/api/token" \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
+    iid=$(fetch instance-id || true)
+    az=$(fetch placement/availability-zone || true)
+    itype=$(fetch instance-type || true)
+    case "${iid}" in
+        i-*) [ -n "${az}" ] && break ;;
+    esac
+    iid=""
+    az=""
+    i=$((i + 1))
+    sleep 2
+done
+
+if [ -z "${iid}" ] || [ -z "${az}" ]; then
+    log "IMDS instance-id/availability-zone unavailable after retries; provider-id not set"
+    exit 0
+fi
+
+# Region = AZ with the trailing zone letter(s) removed (ap-southeast-2a ->
+# ap-southeast-2). The CSI metadata fallback reads it from the region label.
+region=$(printf '%s' "${az}" | sed 's/[a-z]*$//')
+
+# instance-type must parse as family.size or the node plugin panics in
+# IsNitroInstanceType. Fall back to a generic type only to keep it parseable;
+# the real spinifex type (e.g. sys.medium) already satisfies the format.
+case "${itype}" in
+    *.*) : ;;
+    *) itype="m5.large" ;;
+esac
+
+mkdir -p "${DROPIN_DIR}"
+cat > "${DROPIN}" <<EOF
+kubelet-arg:
+  - "provider-id=aws:///${az}/${iid}"
+node-label:
+  - "topology.kubernetes.io/region=${region}"
+  - "topology.kubernetes.io/zone=${az}"
+  - "node.kubernetes.io/instance-type=${itype}"
+EOF
+log "wrote provider-id aws:///${az}/${iid}, region=${region} zone=${az} type=${itype}"

--- a/scripts/images/eks-node/setup.sh
+++ b/scripts/images/eks-node/setup.sh
@@ -51,11 +51,19 @@ chmod 0755 /etc/init.d/mulga-ebs-byid /usr/local/sbin/mulga-ebs-byid
 chmod 0755 /etc/init.d/mulga-eks-provider-id /usr/local/sbin/mulga-eks-provider-id
 chmod 0755 /etc/periodic/daily/mulga-eks-etcd-snapshot
 
-# EBS by-id bridge: mdev rule firing mulga-ebs-byid for whole virtio-blk disks
-# (vd[a-z], no partition suffix). The leading '*' runs the command on both add
-# and remove; the script keys on $ACTION. mulga-ebs-byid (boot oneshot) points
-# the kernel hotplug helper at mdev so hot-attached volumes reach this rule.
-printf '%s\n' 'vd[a-z]		root:root 0660 */usr/local/sbin/mulga-ebs-byid' >> /etc/mdev.conf
+# EBS by-id bridge: route every virtio-blk event through mulga-ebs-byid, which
+# delegates to the stock persistent-storage helper and then mints the
+# nvme-Amazon_Elastic_Block_Store_<serial> link the EBS CSI node plugin resolves.
+# busybox mdev stops at the first matching rule, so the stock vd* persistent-
+# storage line is replaced in place — appending a second vd* rule would be
+# shadowed and never fire. The leading '*' runs the command on add and remove.
+sed -i \
+    's#^vd\[a-z\]\.\*[[:space:]].*persistent-storage#vd[a-z].*\troot:disk 0660 */usr/local/sbin/mulga-ebs-byid#' \
+    /etc/mdev.conf
+grep -q 'mulga-ebs-byid' /etc/mdev.conf || {
+    echo "[eks-node-setup] failed to wire mulga-ebs-byid into /etc/mdev.conf"
+    exit 1
+}
 
 # K3s server config — skeleton; cloud-init / first-boot fills in the
 # per-cluster fields (cluster-cidr, service-cidr, token-file, etc). Agents

--- a/scripts/images/eks-node/setup.sh
+++ b/scripts/images/eks-node/setup.sh
@@ -48,6 +48,7 @@ chmod 0755 /etc/init.d/eks-node-role /etc/init.d/k3s /etc/init.d/k3s-agent \
 chmod 0755 /usr/local/sbin/eks-node-role /usr/local/sbin/k3s-first-boot \
     /usr/local/sbin/mulga-eks-state-report /usr/local/sbin/mulga-eks-addon-sync
 chmod 0755 /etc/init.d/mulga-ebs-byid /usr/local/sbin/mulga-ebs-byid
+chmod 0755 /etc/init.d/mulga-eks-provider-id /usr/local/sbin/mulga-eks-provider-id
 chmod 0755 /etc/periodic/daily/mulga-eks-etcd-snapshot
 
 # EBS by-id bridge: mdev rule firing mulga-ebs-byid for whole virtio-blk disks

--- a/scripts/images/eks-node/setup.sh
+++ b/scripts/images/eks-node/setup.sh
@@ -47,7 +47,14 @@ chmod 0755 /etc/init.d/eks-node-role /etc/init.d/k3s /etc/init.d/k3s-agent \
     /etc/init.d/mulga-eks-addon-sync
 chmod 0755 /usr/local/sbin/eks-node-role /usr/local/sbin/k3s-first-boot \
     /usr/local/sbin/mulga-eks-state-report /usr/local/sbin/mulga-eks-addon-sync
+chmod 0755 /etc/init.d/mulga-ebs-byid /usr/local/sbin/mulga-ebs-byid
 chmod 0755 /etc/periodic/daily/mulga-eks-etcd-snapshot
+
+# EBS by-id bridge: mdev rule firing mulga-ebs-byid for whole virtio-blk disks
+# (vd[a-z], no partition suffix). The leading '*' runs the command on both add
+# and remove; the script keys on $ACTION. mulga-ebs-byid (boot oneshot) points
+# the kernel hotplug helper at mdev so hot-attached volumes reach this rule.
+printf '%s\n' 'vd[a-z]		root:root 0660 */usr/local/sbin/mulga-ebs-byid' >> /etc/mdev.conf
 
 # K3s server config — skeleton; cloud-init / first-boot fills in the
 # per-cluster fields (cluster-cidr, service-cidr, token-file, etc). Agents

--- a/spinifex/handlers/eks/addon_catalog.go
+++ b/spinifex/handlers/eks/addon_catalog.go
@@ -26,6 +26,9 @@ var addonCatalog = buildAddonCatalog(
 	newAddonSpec("argocd", false,
 		"Declarative GitOps continuous delivery for Kubernetes.",
 		"3.0.23"),
+	newAddonSpec("aws-ebs-csi-driver", true,
+		"Container Storage Interface driver for Amazon EBS (Viperblock) volumes.",
+		"1.40.1"),
 	// spinifex-noop is the delivery-transport fixture: a trivial bundle
 	// (Namespace + ConfigMap) used by the addon e2e to prove stage → render →
 	// auto-deploy → ACTIVE → delete round-trips end-to-end without depending on

--- a/spinifex/vm/device_map.go
+++ b/spinifex/vm/device_map.go
@@ -261,3 +261,31 @@ func nextAvailableDevice(instance *VM) string {
 
 	return ""
 }
+
+// nextHotplugEBSPort picks the lowest free EBS hot-plug PCIe port
+// (1..EBSHotPlugSlotCount) from live QEMU state. The port is decoupled from the
+// AWS device name: callers (e.g. the EBS CSI driver) supply arbitrary names like
+// /dev/xvdaa that do not map onto the /dev/sd[f-p] slot range, so the physical
+// port is allocated independently. Returns 0 when the pool is exhausted.
+func nextHotplugEBSPort(qmpClient *qmp.QMPClient, instanceID string) (int, error) {
+	resp, err := sendQMPCommand(qmpClient, qmp.QMPCommand{Execute: "query-block"}, instanceID)
+	if err != nil {
+		return 0, fmt.Errorf("query-block failed: %w", err)
+	}
+	var devices []qmp.BlockDevice
+	if err := json.Unmarshal(resp.Return, &devices); err != nil {
+		return 0, fmt.Errorf("failed to parse query-block response: %w", err)
+	}
+	used := make(map[int]bool, len(devices))
+	for _, dev := range devices {
+		if port := extractHotplugPort(dev.QDev); port > 0 {
+			used[port] = true
+		}
+	}
+	for p := 1; p <= EBSHotPlugSlotCount; p++ {
+		if !used[p] {
+			return p, nil
+		}
+	}
+	return 0, nil
+}

--- a/spinifex/vm/volumes.go
+++ b/spinifex/vm/volumes.go
@@ -39,6 +39,18 @@ func (m *Manager) rollbackUnmount(req types.EBSRequest) {
 	}
 }
 
+// delIothreadBestEffort removes the per-volume iothread object on a failed
+// attach. Without it the orphaned iothread makes object-add fail on every
+// retry ("duplicate property"), so the attach can never recover.
+func (m *Manager) delIothreadBestEffort(instance *VM, iothreadID, volumeID string) {
+	if _, err := sendQMPCommand(instance.QMPClient, qmp.QMPCommand{
+		Execute:   "object-del",
+		Arguments: map[string]any{"id": iothreadID},
+	}, instance.ID); err != nil {
+		slog.Warn("AttachVolume: rollback object-del iothread failed", "volumeId", volumeID, "err", err)
+	}
+}
+
 // AttachVolume hot-plugs a volume via the QMP pipeline (mount → blockdev-add →
 // device_add). Partial state is rolled back on failure. If device is empty, the
 // next free /dev/sd[f-p] slot is allocated. Instance must be in StateRunning.
@@ -96,6 +108,22 @@ func (m *Manager) AttachVolume(id, volumeID, device string) (AttachVolumeResult,
 	deviceID := fmt.Sprintf("vdisk-%s", volumeID)
 	iothreadID := fmt.Sprintf("ioth-%s", volumeID)
 
+	// Allocate the PCIe hot-plug port from live QEMU state before any QMP
+	// mutation, so an exhausted pool rolls back only the mount. virtio-blk-pci
+	// cannot land on pcie.0 (no hot-plug), so a free hotplug-ebs root port is
+	// required regardless of the AWS device name.
+	hotplugPort, err := nextHotplugEBSPort(instance.QMPClient, instance.ID)
+	if err != nil {
+		slog.Error("AttachVolume: failed to query hot-plug ports", "volumeId", volumeID, "err", err)
+		m.rollbackUnmount(ebsRequest)
+		return AttachVolumeResult{}, fmt.Errorf("query hot-plug ports: %w", err)
+	}
+	if hotplugPort == 0 {
+		slog.Error("AttachVolume: EBS hot-plug port pool exhausted", "volumeId", volumeID)
+		m.rollbackUnmount(ebsRequest)
+		return AttachVolumeResult{}, ErrAttachmentLimitExceeded
+	}
+
 	if _, err := sendQMPCommand(instance.QMPClient, qmp.QMPCommand{
 		Execute: "object-add",
 		Arguments: map[string]any{
@@ -119,21 +147,15 @@ func (m *Manager) AttachVolume(id, volumeID, device string) (AttachVolumeResult,
 		},
 	}, instance.ID); err != nil {
 		slog.Error("AttachVolume: QMP blockdev-add failed", "volumeId", volumeID, "err", err)
+		m.delIothreadBestEffort(instance, iothreadID, volumeID)
 		m.rollbackUnmount(ebsRequest)
 		return AttachVolumeResult{}, fmt.Errorf("QMP blockdev-add: %w", err)
 	}
 
-	// /dev/sdf -> hotplug-ebs1, /dev/sdg -> hotplug-ebs2, etc. The id prefix
-	// matches the pcie-root-port pre-allocation in buildBaseVMConfig; the
-	// "-ebs" suffix disambiguates these ports from hotplug-eni{N} (Sprint 3a
-	// ENI hot-plug pool).
-	hotplugBus := ""
-	if len(device) > 0 {
-		letter := device[len(device)-1]
-		if letter >= 'f' && letter <= 'p' {
-			hotplugBus = fmt.Sprintf("hotplug-ebs%d", letter-'f'+1)
-		}
-	}
+	// The virtio-blk-pci device must land on a free hot-plug PCIe root port
+	// (hotplug-ebs{N}); pcie.0 rejects hot-plug. The port is allocated from
+	// live QEMU state above, independent of the AWS device name.
+	hotplugBus := fmt.Sprintf("hotplug-ebs%d", hotplugPort)
 
 	// serial is the volume-id with dashes stripped ("vol" + 17 hex = 20 bytes,
 	// the virtio-blk serial limit). It surfaces in-guest as the block device
@@ -145,9 +167,7 @@ func (m *Manager) AttachVolume(id, volumeID, device string) (AttachVolumeResult,
 		"drive":    nodeName,
 		"iothread": iothreadID,
 		"serial":   strings.ReplaceAll(volumeID, "-", ""),
-	}
-	if hotplugBus != "" {
-		deviceAddArgs["bus"] = hotplugBus
+		"bus":      hotplugBus,
 	}
 
 	if _, err := sendQMPCommand(instance.QMPClient, qmp.QMPCommand{
@@ -163,6 +183,7 @@ func (m *Manager) AttachVolume(id, volumeID, device string) (AttachVolumeResult,
 			slog.Error("AttachVolume: rollback blockdev-del failed, skipping EBS unmount",
 				"volumeId", volumeID, "err", delErr)
 		} else {
+			m.delIothreadBestEffort(instance, iothreadID, volumeID)
 			m.rollbackUnmount(ebsRequest)
 		}
 		return AttachVolumeResult{}, fmt.Errorf("QMP device_add: %w", err)

--- a/spinifex/vm/volumes_test.go
+++ b/spinifex/vm/volumes_test.go
@@ -606,6 +606,9 @@ func TestAttachVolume_ObjectAddFailure_TriggersUnmountOne(t *testing.T) {
 	recorder := &qmpRecorder{}
 	qmpClient, cancel := newMockQMPClient(t, func(cmd qmp.QMPCommand) map[string]any {
 		recorder.record(cmd)
+		if cmd.Execute == "query-block" {
+			return map[string]any{"return": []qmp.BlockDevice{}}
+		}
 		if cmd.Execute == "object-add" {
 			return map[string]any{"error": map[string]any{"class": "GenericError", "desc": "iothread limit"}}
 		}
@@ -619,7 +622,7 @@ func TestAttachVolume_ObjectAddFailure_TriggersUnmountOne(t *testing.T) {
 	_, err := m.AttachVolume("i-1", "vol-1", "/dev/sdf")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "object-add")
-	assert.Equal(t, []string{"object-add"}, recorder.executes(),
+	assert.Equal(t, []string{"query-block", "object-add"}, recorder.executes(),
 		"object-add failure must short-circuit before blockdev-add")
 	assert.Equal(t, []string{"vol-1"}, mounter.unmountedOne)
 }
@@ -631,6 +634,9 @@ func TestAttachVolume_BlockdevAddFailure_TriggersUnmountOne(t *testing.T) {
 	recorder := &qmpRecorder{}
 	qmpClient, cancel := newMockQMPClient(t, func(cmd qmp.QMPCommand) map[string]any {
 		recorder.record(cmd)
+		if cmd.Execute == "query-block" {
+			return map[string]any{"return": []qmp.BlockDevice{}}
+		}
 		if cmd.Execute == "blockdev-add" {
 			return map[string]any{"error": map[string]any{"class": "GenericError", "desc": "nbd connect failed"}}
 		}
@@ -644,7 +650,7 @@ func TestAttachVolume_BlockdevAddFailure_TriggersUnmountOne(t *testing.T) {
 	_, err := m.AttachVolume("i-1", "vol-1", "/dev/sdf")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "blockdev-add")
-	assert.Equal(t, []string{"object-add", "blockdev-add"}, recorder.executes())
+	assert.Equal(t, []string{"query-block", "object-add", "blockdev-add", "object-del"}, recorder.executes())
 	assert.Equal(t, []string{"vol-1"}, mounter.unmountedOne)
 }
 
@@ -655,6 +661,9 @@ func TestAttachVolume_DeviceAddFailure_BlockdevDelOK_Unmounts(t *testing.T) {
 	recorder := &qmpRecorder{}
 	qmpClient, cancel := newMockQMPClient(t, func(cmd qmp.QMPCommand) map[string]any {
 		recorder.record(cmd)
+		if cmd.Execute == "query-block" {
+			return map[string]any{"return": []qmp.BlockDevice{}}
+		}
 		if cmd.Execute == "device_add" {
 			return map[string]any{"error": map[string]any{"class": "GenericError", "desc": "no PCI slot"}}
 		}
@@ -668,7 +677,7 @@ func TestAttachVolume_DeviceAddFailure_BlockdevDelOK_Unmounts(t *testing.T) {
 	_, err := m.AttachVolume("i-1", "vol-1", "/dev/sdf")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "device_add")
-	assert.Equal(t, []string{"object-add", "blockdev-add", "device_add", "blockdev-del"}, recorder.executes())
+	assert.Equal(t, []string{"query-block", "object-add", "blockdev-add", "device_add", "blockdev-del", "object-del"}, recorder.executes())
 	assert.Equal(t, []string{"vol-1"}, mounter.unmountedOne,
 		"successful blockdev-del rollback must be followed by UnmountOne")
 }
@@ -684,6 +693,8 @@ func TestAttachVolume_DeviceAddFailure_BlockdevDelFails_SkipsUnmountOne(t *testi
 	qmpClient, cancel := newMockQMPClient(t, func(cmd qmp.QMPCommand) map[string]any {
 		recorder.record(cmd)
 		switch cmd.Execute {
+		case "query-block":
+			return map[string]any{"return": []qmp.BlockDevice{}}
 		case "device_add":
 			return map[string]any{"error": map[string]any{"class": "GenericError", "desc": "no PCI slot"}}
 		case "blockdev-del":
@@ -699,7 +710,7 @@ func TestAttachVolume_DeviceAddFailure_BlockdevDelFails_SkipsUnmountOne(t *testi
 	_, err := m.AttachVolume("i-1", "vol-1", "/dev/sdf")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "device_add")
-	assert.Equal(t, []string{"object-add", "blockdev-add", "device_add", "blockdev-del"}, recorder.executes())
+	assert.Equal(t, []string{"query-block", "object-add", "blockdev-add", "device_add", "blockdev-del"}, recorder.executes())
 	assert.Empty(t, mounter.unmountedOne,
 		"failed blockdev-del must skip UnmountOne — unmounting under a live block node crashes QEMU")
 }

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	eksVPCCIDR    = "10.210.0.0/16"
-	eksSubnetCIDR = "10.210.1.0/24"
-	eksClusterPfx = "eks-e2e"
-	getTokenTpl   = "k8s-aws-v1."
+	eksVPCCIDR          = "10.210.0.0/16"
+	eksSubnetCIDR       = "10.210.1.0/24"
+	eksPublicSubnetCIDR = "10.210.2.0/24"
+	eksClusterPfx       = "eks-e2e"
+	getTokenTpl         = "k8s-aws-v1."
 )
 
 // TestEKS drives the EKS control-plane lifecycle against the local awsgw
@@ -619,12 +620,20 @@ func waitPodReady(t *testing.T, kc *harness.Kubectl, pod string) {
 // --- Fixture --------------------------------------------------------------
 
 type clusterFixture struct {
-	ClusterName string
-	AccountID   string
-	VPCID       string
-	SubnetID    string
-	Cluster     *eks.Cluster
-	Deleted     bool
+	ClusterName     string
+	AccountID       string
+	VPCID           string
+	SubnetID        string // worker (private) subnet
+	IGWID           string
+	PubSubnetID     string
+	PubRTID         string
+	PubRTAssocID    string
+	EIPAllocID      string
+	NATGWID         string
+	WorkerRTID      string
+	WorkerRTAssocID string
+	Cluster         *eks.Cluster
+	Deleted         bool
 }
 
 func setupClusterFixture(t *testing.T, c *harness.AWSClient, env *harness.Env, artifacts string) *clusterFixture {
@@ -642,6 +651,8 @@ func setupClusterFixture(t *testing.T, c *harness.AWSClient, env *harness.Env, a
 	t.Cleanup(func() { deleteVPC(t, c, fx) })
 	createSubnet(t, c, fx)
 	t.Cleanup(func() { deleteSubnet(t, c, fx) })
+	createWorkerEgress(t, c, fx)
+	t.Cleanup(func() { deleteWorkerEgress(t, c, fx) })
 
 	harness.Phase(t, "Creating cluster %q", fx.ClusterName)
 	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s-role", fx.AccountID, fx.ClusterName)
@@ -650,6 +661,10 @@ func setupClusterFixture(t *testing.T, c *harness.AWSClient, env *harness.Env, a
 		RoleArn: aws.String(roleArn),
 		ResourcesVpcConfig: &eks.VpcConfigRequest{
 			SubnetIds: aws.StringSlice([]string{fx.SubnetID}),
+			// Public access (default). The customer VPC has a NAT Gateway
+			// (createWorkerEgress), so the private worker SNATs out to reach
+			// the internet-facing NLB endpoint and pull public CSI images.
+			EndpointPublicAccess: aws.Bool(true),
 		},
 	})
 	require.NoError(t, err, "create-cluster")
@@ -702,6 +717,197 @@ func deleteSubnet(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
 	}
 	if _, err := c.EC2.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(fx.SubnetID)}); err != nil {
 		t.Logf("delete subnet %s: %v", fx.SubnetID, err)
+	}
+}
+
+// createWorkerEgress gives the customer VPC the egress a real customer VPC
+// needs for private workers: an IGW-fronted public subnet hosting a NAT
+// Gateway, with the worker subnet default-routed to that NAT Gateway. AttachIGW
+// deliberately programs no SNAT (mirrors AWS: an IGW serves only public-IP
+// instances), so a private worker reaches the public NLB endpoint and pulls
+// public CSI images only through the NAT Gateway's subnet-wide SNAT.
+func createWorkerEgress(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
+	t.Helper()
+
+	igwOut, err := c.EC2.CreateInternetGateway(&ec2.CreateInternetGatewayInput{}) // e2e:allow-create
+	require.NoError(t, err, "create-internet-gateway")
+	fx.IGWID = aws.StringValue(igwOut.InternetGateway.InternetGatewayId)
+	_, err = c.EC2.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(fx.IGWID),
+		VpcId:             aws.String(fx.VPCID),
+	})
+	require.NoError(t, err, "attach-internet-gateway")
+
+	// Public subnet routed straight to the IGW; the NAT Gateway lives here.
+	pubOut, err := c.EC2.CreateSubnet(&ec2.CreateSubnetInput{ // e2e:allow-create
+		VpcId:     aws.String(fx.VPCID),
+		CidrBlock: aws.String(eksPublicSubnetCIDR),
+	})
+	require.NoError(t, err, "create-public-subnet")
+	fx.PubSubnetID = aws.StringValue(pubOut.Subnet.SubnetId)
+
+	pubRT, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{VpcId: aws.String(fx.VPCID)}) // e2e:allow-create
+	require.NoError(t, err, "create-public-route-table")
+	fx.PubRTID = aws.StringValue(pubRT.RouteTable.RouteTableId)
+	_, err = c.EC2.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         aws.String(fx.PubRTID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String(fx.IGWID),
+	})
+	require.NoError(t, err, "create-public-route")
+	pubAssoc, err := c.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(fx.PubRTID),
+		SubnetId:     aws.String(fx.PubSubnetID),
+	})
+	require.NoError(t, err, "associate-public-route-table")
+	fx.PubRTAssocID = aws.StringValue(pubAssoc.AssociationId)
+
+	// Elastic IP + NAT Gateway in the public subnet.
+	eip, err := c.EC2.AllocateAddress(&ec2.AllocateAddressInput{Domain: aws.String("vpc")}) // e2e:allow-create
+	require.NoError(t, err, "allocate-address")
+	fx.EIPAllocID = aws.StringValue(eip.AllocationId)
+	natOut, err := c.EC2.CreateNatGateway(&ec2.CreateNatGatewayInput{ // e2e:allow-create
+		SubnetId:     aws.String(fx.PubSubnetID),
+		AllocationId: aws.String(fx.EIPAllocID),
+	})
+	require.NoError(t, err, "create-nat-gateway")
+	fx.NATGWID = aws.StringValue(natOut.NatGateway.NatGatewayId)
+	waitNatGatewayAvailable(t, c, fx.NATGWID)
+
+	// Worker (private) subnet default-routes to the NAT Gateway; associating
+	// the route table triggers the subnet-wide SNAT egress reroute.
+	workerRT, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{VpcId: aws.String(fx.VPCID)}) // e2e:allow-create
+	require.NoError(t, err, "create-worker-route-table")
+	fx.WorkerRTID = aws.StringValue(workerRT.RouteTable.RouteTableId)
+	_, err = c.EC2.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         aws.String(fx.WorkerRTID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		NatGatewayId:         aws.String(fx.NATGWID),
+	})
+	require.NoError(t, err, "create-worker-route")
+	workerAssoc, err := c.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(fx.WorkerRTID),
+		SubnetId:     aws.String(fx.SubnetID),
+	})
+	require.NoError(t, err, "associate-worker-route-table")
+	fx.WorkerRTAssocID = aws.StringValue(workerAssoc.AssociationId)
+	t.Logf("egress: igw=%s nat=%s eip=%s pubrt=%s workerrt=%s",
+		fx.IGWID, fx.NATGWID, fx.EIPAllocID, fx.PubRTID, fx.WorkerRTID)
+}
+
+// waitNatGatewayAvailable blocks until the NAT Gateway reports "available";
+// SNAT is not programmed on the VPC router until then.
+func waitNatGatewayAvailable(t *testing.T, c *harness.AWSClient, natID string) {
+	t.Helper()
+	const timeout = 3 * time.Minute
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := c.EC2.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
+			NatGatewayIds: aws.StringSlice([]string{natID}),
+		})
+		if err == nil && len(out.NatGateways) > 0 {
+			switch aws.StringValue(out.NatGateways[0].State) {
+			case "available":
+				return
+			case "failed", "deleted":
+				t.Fatalf("nat gateway %s entered terminal state %q", natID, aws.StringValue(out.NatGateways[0].State))
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nat gateway %s not available within %s", natID, timeout)
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// deleteWorkerEgress tears the egress topology down in reverse: the worker
+// route table releases the private subnet, then the NAT Gateway is deleted and
+// drained before the public subnet + EIP it pins can be removed.
+func deleteWorkerEgress(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
+	if fx.WorkerRTAssocID != "" {
+		if _, err := c.EC2.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
+			AssociationId: aws.String(fx.WorkerRTAssocID),
+		}); err != nil {
+			t.Logf("disassociate worker route table %s: %v", fx.WorkerRTAssocID, err)
+		}
+	}
+	if fx.WorkerRTID != "" {
+		if _, err := c.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+			RouteTableId: aws.String(fx.WorkerRTID),
+		}); err != nil {
+			t.Logf("delete worker route table %s: %v", fx.WorkerRTID, err)
+		}
+	}
+	if fx.NATGWID != "" {
+		if _, err := c.EC2.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+			NatGatewayId: aws.String(fx.NATGWID),
+		}); err != nil {
+			t.Logf("delete nat gateway %s: %v", fx.NATGWID, err)
+		}
+		waitNatGatewayDeleted(t, c, fx.NATGWID)
+	}
+	if fx.EIPAllocID != "" {
+		if _, err := c.EC2.ReleaseAddress(&ec2.ReleaseAddressInput{
+			AllocationId: aws.String(fx.EIPAllocID),
+		}); err != nil {
+			t.Logf("release address %s: %v", fx.EIPAllocID, err)
+		}
+	}
+	if fx.PubRTAssocID != "" {
+		if _, err := c.EC2.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
+			AssociationId: aws.String(fx.PubRTAssocID),
+		}); err != nil {
+			t.Logf("disassociate public route table %s: %v", fx.PubRTAssocID, err)
+		}
+	}
+	if fx.PubRTID != "" {
+		if _, err := c.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+			RouteTableId: aws.String(fx.PubRTID),
+		}); err != nil {
+			t.Logf("delete public route table %s: %v", fx.PubRTID, err)
+		}
+	}
+	if fx.PubSubnetID != "" {
+		if _, err := c.EC2.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(fx.PubSubnetID)}); err != nil {
+			t.Logf("delete public subnet %s: %v", fx.PubSubnetID, err)
+		}
+	}
+	if fx.IGWID != "" {
+		if _, err := c.EC2.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
+			InternetGatewayId: aws.String(fx.IGWID),
+			VpcId:             aws.String(fx.VPCID),
+		}); err != nil {
+			t.Logf("detach igw %s: %v", fx.IGWID, err)
+		}
+		if _, err := c.EC2.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+			InternetGatewayId: aws.String(fx.IGWID),
+		}); err != nil {
+			t.Logf("delete igw %s: %v", fx.IGWID, err)
+		}
+	}
+}
+
+// waitNatGatewayDeleted blocks until the NAT Gateway drains to "deleted" so the
+// public subnet + EIP it holds can be released; best-effort on timeout.
+func waitNatGatewayDeleted(t *testing.T, c *harness.AWSClient, natID string) {
+	t.Helper()
+	const timeout = 3 * time.Minute
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := c.EC2.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
+			NatGatewayIds: aws.StringSlice([]string{natID}),
+		})
+		if err != nil || len(out.NatGateways) == 0 {
+			return
+		}
+		if aws.StringValue(out.NatGateways[0].State) == "deleted" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Logf("nat gateway %s not deleted within %s; continuing teardown", natID, timeout)
+			return
+		}
+		time.Sleep(3 * time.Second)
 	}
 }
 

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -214,6 +214,11 @@ func TestEKS(t *testing.T) {
 		runIRSAWebIdentity(t, c, env, artifacts, fx)
 	})
 
+	t.Run("EBSCSIVolume", func(t *testing.T) {
+		requireClusterReady(t, fx)
+		runEBSCSIVolume(t, c, env, artifacts, fx)
+	})
+
 	t.Run("DeleteCluster", func(t *testing.T) {
 		requireClusterReady(t, fx)
 		_, err := c.EKS.DeleteCluster(&eks.DeleteClusterInput{Name: aws.String(fx.ClusterName)})
@@ -318,6 +323,211 @@ func runIRSAWebIdentity(t *testing.T, c *harness.AWSClient, env *harness.Env, ar
 	assert.Contains(t, aws.StringValue(ident.Arn), "assumed-role/"+roleName,
 		"caller ARN must reflect the assumed IRSA role")
 	t.Logf("GetCallerIdentity (web-identity creds): %s", aws.StringValue(ident.Arn))
+}
+
+// runEBSCSIVolume exercises the full EBS CSI data path on the live cluster:
+// install the aws-ebs-csi-driver managed addon bound to an IRSA role, then
+// drive a default gp3 PVC -> Pod -> CreateVolume(Viperblock)/AttachVolume
+// (virtio-blk hotplug, serial=volume-id) -> mdev by-id symlink -> ext4 mount.
+// A nonce written by the first pod must survive a reschedule onto a fresh pod
+// backed by the same PVC, proving the volume detaches/reattaches data-intact.
+func runEBSCSIVolume(t *testing.T, c *harness.AWSClient, env *harness.Env, artifacts string, fx *clusterFixture) {
+	require.NotNil(t, fx.Cluster.Identity, "ACTIVE cluster must expose Identity")
+	require.NotNil(t, fx.Cluster.Identity.Oidc, "ACTIVE cluster must expose Identity.Oidc")
+	issuer := aws.StringValue(fx.Cluster.Identity.Oidc.Issuer)
+	require.NotEmpty(t, issuer, "cluster OIDC issuer must be published")
+
+	// IRSA role for ebs-csi-controller-sa. awsgw does not enforce EC2 IAM
+	// authorization, so the web-identity trust alone suffices (no permission
+	// policy) — the controller's projected SA token is the identity it presents
+	// to AssumeRoleWithWebIdentity before calling CreateVolume/AttachVolume.
+	oidcOut, err := c.IAM.CreateOpenIDConnectProvider(&iam.CreateOpenIDConnectProviderInput{
+		Url:            aws.String(issuer),
+		ClientIDList:   aws.StringSlice([]string{"sts.amazonaws.com"}),
+		ThumbprintList: aws.StringSlice([]string{"0000000000000000000000000000000000000000"}),
+	})
+	require.NoError(t, err, "create-open-id-connect-provider")
+	providerArn := aws.StringValue(oidcOut.OpenIDConnectProviderArn)
+	t.Cleanup(func() {
+		_, _ = c.IAM.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(providerArn),
+		})
+	})
+
+	roleName := fmt.Sprintf("%s-ebs-csi", fx.ClusterName)
+	trustPolicy := fmt.Sprintf(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Federated":%q},"Action":"sts:AssumeRoleWithWebIdentity"}]}`, providerArn)
+	roleOut, err := c.IAM.CreateRole(&iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+		Description:              aws.String("E2E EBS CSI controller role"),
+	})
+	require.NoError(t, err, "create-role")
+	roleArn := aws.StringValue(roleOut.Role.Arn)
+	t.Cleanup(func() {
+		_, _ = c.IAM.DeleteRole(&iam.DeleteRoleInput{RoleName: aws.String(roleName)})
+	})
+	t.Logf("EBS CSI IRSA role: %s", roleArn)
+
+	// Install the managed addon bound to the role. The addon-sync agent renders
+	// the controller manifest's {{SERVICE_ACCOUNT_ROLE_ARN}} from this ARN.
+	const addon = "aws-ebs-csi-driver"
+	harness.Phase(t, "Installing %s addon", addon)
+	_, err = c.EKS.CreateAddon(&eks.CreateAddonInput{
+		ClusterName:           aws.String(fx.ClusterName),
+		AddonName:             aws.String(addon),
+		ServiceAccountRoleArn: aws.String(roleArn),
+	})
+	require.NoError(t, err, "create-addon")
+	t.Cleanup(func() {
+		_, _ = c.EKS.DeleteAddon(&eks.DeleteAddonInput{
+			ClusterName: aws.String(fx.ClusterName),
+			AddonName:   aws.String(addon),
+		})
+	})
+
+	harness.EventuallyErr(t, func() error {
+		out, derr := c.EKS.DescribeAddon(&eks.DescribeAddonInput{
+			ClusterName: aws.String(fx.ClusterName),
+			AddonName:   aws.String(addon),
+		})
+		if derr != nil {
+			return fmt.Errorf("describe-addon: %w", derr)
+		}
+		if s := aws.StringValue(out.Addon.Status); s != eks.AddonStatusActive {
+			return fmt.Errorf("addon status %q, want ACTIVE", s)
+		}
+		return nil
+	}, 5*time.Minute, 10*time.Second)
+
+	kcPath := writeKubeconfig(t, artifacts, fx.Cluster)
+	kc := harness.NewKubectl(t, kcPath, getTokenEnv(t, env))
+
+	// Controller Deployment + node DaemonSet must roll out before a PVC binds.
+	harness.Phase(t, "Waiting for CSI driver rollout")
+	harness.EventuallyErr(t, func() error {
+		if out, rerr := kc.Run(60*time.Second, "-n", "kube-system", "rollout", "status",
+			"deployment/ebs-csi-controller", "--timeout", "30s"); rerr != nil {
+			return fmt.Errorf("controller rollout: %v\n%s", rerr, out)
+		}
+		if out, rerr := kc.Run(60*time.Second, "-n", "kube-system", "rollout", "status",
+			"daemonset/ebs-csi-node", "--timeout", "30s"); rerr != nil {
+			return fmt.Errorf("node rollout: %v\n%s", rerr, out)
+		}
+		return nil
+	}, 3*time.Minute, 10*time.Second)
+
+	// Provision a gp3 PVC and a pod that writes a unique marker onto the volume.
+	marker := fmt.Sprintf("csi-e2e-%d", time.Now().UnixNano())
+	const pvcName = "ebs-csi-e2e"
+	writerPath := filepath.Join(artifacts, "ebs-csi-writer.yaml")
+	require.NoError(t, os.WriteFile(writerPath, []byte(csiPVCPodManifest(pvcName, "ebs-csi-e2e-writer",
+		fmt.Sprintf("echo %s > /data/marker && sync && sleep 3600", marker))), 0o600))
+	t.Cleanup(func() {
+		_, _ = kc.Run(60*time.Second, "delete", "-f", writerPath, "--ignore-not-found", "--wait=false")
+	})
+
+	harness.Phase(t, "Applying gp3 PVC + writer pod")
+	out, err := kc.Run(60*time.Second, "apply", "-f", writerPath)
+	require.NoErrorf(t, err, "apply writer:\n%s", out)
+
+	// Bind drives CreateVolume(Viperblock) + AttachVolume(virtio-blk hotplug).
+	harness.EventuallyErr(t, func() error {
+		ph, perr := kc.Run(30*time.Second, "get", "pvc", pvcName, "-o", `jsonpath={.status.phase}`)
+		if perr != nil {
+			return fmt.Errorf("get pvc: %v\n%s", perr, ph)
+		}
+		if strings.TrimSpace(ph) != "Bound" {
+			return fmt.Errorf("pvc phase %q, want Bound", strings.TrimSpace(ph))
+		}
+		return nil
+	}, 5*time.Minute, 5*time.Second)
+	t.Logf("PVC %s Bound", pvcName)
+
+	waitPodReady(t, kc, "ebs-csi-e2e-writer")
+
+	// The marker must have landed on the mounted volume.
+	got, err := kc.Run(30*time.Second, "exec", "ebs-csi-e2e-writer", "--", "cat", "/data/marker")
+	require.NoErrorf(t, err, "exec cat marker:\n%s", got)
+	require.Equal(t, marker, strings.TrimSpace(got), "writer must observe its own marker")
+
+	// Reschedule: delete the writer, bind the same PVC to a fresh reader pod and
+	// assert the marker survived the detach/reattach + remount.
+	harness.Phase(t, "Rescheduling onto a fresh pod")
+	out, err = kc.Run(90*time.Second, "delete", "pod", "ebs-csi-e2e-writer", "--wait=true", "--timeout", "60s")
+	require.NoErrorf(t, err, "delete writer:\n%s", out)
+
+	readerPath := filepath.Join(artifacts, "ebs-csi-reader.yaml")
+	require.NoError(t, os.WriteFile(readerPath, []byte(csiPVCPodManifest(pvcName, "ebs-csi-e2e-reader",
+		"cat /data/marker && sleep 3600")), 0o600))
+	t.Cleanup(func() {
+		_, _ = kc.Run(60*time.Second, "delete", "-f", readerPath, "--ignore-not-found", "--wait=false")
+	})
+	out, err = kc.Run(60*time.Second, "apply", "-f", readerPath)
+	require.NoErrorf(t, err, "apply reader:\n%s", out)
+	waitPodReady(t, kc, "ebs-csi-e2e-reader")
+
+	got, err = kc.Run(30*time.Second, "exec", "ebs-csi-e2e-reader", "--", "cat", "/data/marker")
+	require.NoErrorf(t, err, "exec cat marker (reader):\n%s", got)
+	assert.Equal(t, marker, strings.TrimSpace(got), "marker must survive pod reschedule")
+	t.Logf("marker survived reschedule: %s", strings.TrimSpace(got))
+}
+
+// csiPVCPodManifest renders a gp3 PVC plus a single pod that mounts it at /data
+// and runs cmd. Reusing the claim name lets the reader pod rebind the volume the
+// writer provisioned. Control-plane tolerations let it schedule on single-node
+// k3s servers, where the only node carries the control-plane taint.
+func csiPVCPodManifest(pvc, pod, cmd string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: %s
+  namespace: default
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: ebs-gp3
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: default
+spec:
+  restartPolicy: Never
+  tolerations:
+  - operator: Exists
+  containers:
+  - name: app
+    image: public.ecr.aws/docker/library/busybox:1.36
+    command: ["sh", "-c", %q]
+    volumeMounts:
+    - name: vol
+      mountPath: /data
+  volumes:
+  - name: vol
+    persistentVolumeClaim:
+      claimName: %s
+`, pvc, pod, cmd, pvc)
+}
+
+// waitPodReady blocks until the named default-namespace pod reports Ready,
+// dumping `describe pod` into the failure message on timeout.
+func waitPodReady(t *testing.T, kc *harness.Kubectl, pod string) {
+	t.Helper()
+	harness.EventuallyErr(t, func() error {
+		out, err := kc.Run(30*time.Second, "get", "pod", pod, "-o",
+			`jsonpath={.status.conditions[?(@.type=="Ready")].status}`)
+		if err != nil {
+			return fmt.Errorf("get pod: %v\n%s", err, out)
+		}
+		if strings.TrimSpace(out) != "True" {
+			desc, _ := kc.Run(30*time.Second, "describe", "pod", pod)
+			return fmt.Errorf("pod %s not Ready (%q)\n%s", pod, strings.TrimSpace(out), desc)
+		}
+		return nil
+	}, 4*time.Minute, 5*time.Second)
 }
 
 // --- Fixture --------------------------------------------------------------

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -395,6 +395,46 @@ func runEBSCSIVolume(t *testing.T, c *harness.AWSClient, env *harness.Env, artif
 		})
 	})
 
+	// The EBS CSI driver obeys the control-plane taint, so it and the volume
+	// workloads need a customer worker node. Create a 1-node nodegroup; its
+	// worker is a customer-space instance, so the customer-owned volume can
+	// attach to it. DescribeNodegroup reports ACTIVE only once the worker has
+	// registered Ready.
+	const nodegroup = "ebs-csi-e2e-ng"
+	harness.Phase(t, "Creating worker nodegroup %s", nodegroup)
+	// e2e:allow-create — the worker nodegroup is the subject under test (customer-space node for cross-space attach).
+	_, err = c.EKS.CreateNodegroup(&eks.CreateNodegroupInput{
+		ClusterName:   aws.String(fx.ClusterName),
+		NodegroupName: aws.String(nodegroup),
+		Subnets:       aws.StringSlice([]string{fx.SubnetID}),
+		NodeRole:      aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s-node", fx.AccountID, fx.ClusterName)),
+		ScalingConfig: &eks.NodegroupScalingConfig{
+			MinSize:     aws.Int64(1),
+			MaxSize:     aws.Int64(1),
+			DesiredSize: aws.Int64(1),
+		},
+	})
+	require.NoError(t, err, "create-nodegroup")
+	t.Cleanup(func() {
+		_, _ = c.EKS.DeleteNodegroup(&eks.DeleteNodegroupInput{
+			ClusterName:   aws.String(fx.ClusterName),
+			NodegroupName: aws.String(nodegroup),
+		})
+	})
+	harness.EventuallyErr(t, func() error {
+		out, derr := c.EKS.DescribeNodegroup(&eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(fx.ClusterName),
+			NodegroupName: aws.String(nodegroup),
+		})
+		if derr != nil {
+			return fmt.Errorf("describe-nodegroup: %w", derr)
+		}
+		if s := aws.StringValue(out.Nodegroup.Status); s != eks.NodegroupStatusActive {
+			return fmt.Errorf("nodegroup status %q, want ACTIVE", s)
+		}
+		return nil
+	}, 8*time.Minute, 10*time.Second)
+
 	// Install the managed addon bound to the role. The addon-sync agent renders
 	// the controller manifest's {{SERVICE_ACCOUNT_ROLE_ARN}} from this ARN.
 	const addon = "aws-ebs-csi-driver"
@@ -522,8 +562,8 @@ func runEBSCSIVolume(t *testing.T, c *harness.AWSClient, env *harness.Env, artif
 
 // csiPVCPodManifest renders a gp3 PVC plus a single pod that mounts it at /data
 // and runs cmd. Reusing the claim name lets the reader pod rebind the volume the
-// writer provisioned. Control-plane tolerations let it schedule on single-node
-// k3s servers, where the only node carries the control-plane taint.
+// writer provisioned. No control-plane toleration: the pod must land on the
+// customer worker node (the volume's space), not the system control-plane.
 func csiPVCPodManifest(pvc, pod, cmd string) string {
 	return fmt.Sprintf(`apiVersion: v1
 kind: PersistentVolumeClaim
@@ -544,8 +584,6 @@ metadata:
   namespace: default
 spec:
   restartPolicy: Never
-  tolerations:
-  - operator: Exists
   containers:
   - name: app
     image: public.ecr.aws/docker/library/busybox:1.36

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -368,6 +368,33 @@ func runEBSCSIVolume(t *testing.T, c *harness.AWSClient, env *harness.Env, artif
 	})
 	t.Logf("EBS CSI IRSA role: %s", roleArn)
 
+	// awsgw enforces IAM on assumed-role EC2 calls, so the controller's
+	// CreateVolume/AttachVolume need a permission policy on the role — a
+	// customer-managed one with an explicit allow (AWS-managed ARNs are opaque
+	// and grant nothing). This mirrors what an operator attaches to the
+	// ServiceAccountRoleArn in production.
+	const ebsPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["ec2:CreateVolume","ec2:DeleteVolume","ec2:AttachVolume","ec2:DetachVolume","ec2:ModifyVolume","ec2:DescribeVolumes","ec2:DescribeVolumesModifications","ec2:DescribeInstances","ec2:DescribeAvailabilityZones","ec2:DescribeSnapshots","ec2:CreateSnapshot","ec2:DeleteSnapshot","ec2:DescribeTags","ec2:CreateTags","ec2:DeleteTags"],"Resource":"*"}]}`
+	polOut, err := c.IAM.CreatePolicy(&iam.CreatePolicyInput{
+		PolicyName:     aws.String(roleName + "-policy"),
+		PolicyDocument: aws.String(ebsPolicy),
+	})
+	require.NoError(t, err, "create-policy")
+	policyArn := aws.StringValue(polOut.Policy.Arn)
+	t.Cleanup(func() {
+		_, _ = c.IAM.DeletePolicy(&iam.DeletePolicyInput{PolicyArn: aws.String(policyArn)})
+	})
+	_, err = c.IAM.AttachRolePolicy(&iam.AttachRolePolicyInput{
+		RoleName:  aws.String(roleName),
+		PolicyArn: aws.String(policyArn),
+	})
+	require.NoError(t, err, "attach-role-policy")
+	t.Cleanup(func() {
+		_, _ = c.IAM.DetachRolePolicy(&iam.DetachRolePolicyInput{
+			RoleName:  aws.String(roleName),
+			PolicyArn: aws.String(policyArn),
+		})
+	})
+
 	// Install the managed addon bound to the role. The addon-sync agent renders
 	// the controller manifest's {{SERVICE_ACCOUNT_ROLE_ARN}} from this ARN.
 	const addon = "aws-ebs-csi-driver"
@@ -401,6 +428,27 @@ func runEBSCSIVolume(t *testing.T, c *harness.AWSClient, env *harness.Env, artif
 
 	kcPath := writeKubeconfig(t, artifacts, fx.Cluster)
 	kc := harness.NewKubectl(t, kcPath, getTokenEnv(t, env))
+
+	// On failure, snapshot the CSI control path while the cluster is still up
+	// (DeleteCluster runs in a later subtest). Dumps land in the artifact dir,
+	// which is retained on failure.
+	harness.OnFailure(t, func() {
+		dumps := map[string][]string{
+			"csi-describe-pvc.txt":     {"-n", "default", "describe", "pvc", "ebs-csi-e2e"},
+			"csi-describe-pods.txt":    {"-n", "default", "describe", "pods"},
+			"csi-get-events.txt":       {"-n", "default", "get", "events", "--sort-by", ".lastTimestamp"},
+			"csi-storageclass.txt":     {"get", "storageclass", "-o", "yaml"},
+			"csi-csidriver.txt":        {"get", "csidriver,csinode", "-o", "wide"},
+			"csi-volumeattach.txt":     {"get", "volumeattachment", "-o", "wide"},
+			"csi-ctrl-provisioner.txt": {"-n", "kube-system", "logs", "deploy/ebs-csi-controller", "-c", "csi-provisioner", "--tail", "200"},
+			"csi-ctrl-plugin.txt":      {"-n", "kube-system", "logs", "deploy/ebs-csi-controller", "-c", "ebs-plugin", "--tail", "200"},
+			"csi-node-plugin.txt":      {"-n", "kube-system", "logs", "daemonset/ebs-csi-node", "-c", "ebs-plugin", "--tail", "200"},
+		}
+		for name, args := range dumps {
+			out, _ := kc.Run(45*time.Second, args...)
+			harness.DumpFile(t, artifacts, name, []byte(out))
+		}
+	})
 
 	// Controller Deployment + node DaemonSet must roll out before a PVC binds.
 	harness.Phase(t, "Waiting for CSI driver rollout")


### PR DESCRIPTION
## Summary

Makes the upstream `aws-ebs-csi-driver` work end-to-end on Spinifex EKS: customer-VPC workers get egress, gp3 volumes attach to the right device, in-guest device discovery resolves, and PVCs mount and survive reschedule. Validated by a full green `TestEKS` e2e on the baked `spinifex-eks-node` AMI (CreateCluster → worker join via NAT egress → CSI rollout → gp3 PVC mount → marker survives reschedule → teardown).

Closes the EBS CSI work items on epic mulga-siv-377: 384, 388, 390, 391, 392.

## Changes

- **Bake the CSI addon + node bridges** — ship `aws-ebs-csi-driver` 1.40.1 manifests (rbac/controller/node/storageclass) and bake them into the eks-node AMI, plus the `mulga-eks-provider-id` and `mulga-ebs-byid` OpenRC services.
- **Node device discovery (mdev by-id)** — the stock driver resolves volumes only via `/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_<serial>`. Alpine uses busybox `mdev` (first-match-wins), so the stock `vd*` persistent-storage rule shadowed our appended rule. `setup.sh` now swaps the `vd*` rule in place to route through `mulga-ebs-byid`, which delegates to `persistent-storage` then mints the nvme-style link from the virtio-blk serial (volume-id, dashes stripped).
- **Attach correctness** — decouple the hotplug PCIe port from the AWS device name and roll back the iothread/object on a failed `device_add` (`vm/volumes.go`, `vm/device_map.go`).
- **Control-plane taint** — CSI controller tolerates/obeys the control-plane taint so it schedules on the customer worker, not the system CP.
- **provider-id + topology labels** — eks-node sets the kubelet provider-id and instance-type/zone labels the CSI driver needs.
- **e2e** — `TestEKS/EBSCSIVolume` provisions a gp3 PVC + writer pod and asserts the marker survives a reschedule; adds the NAT-Gateway egress fixture (public subnet + IGW route, EIP + NAT GW, worker subnet route via NAT GW) so private workers join the public NLB and pull CSI images, with a NAT-available waiter and LIFO teardown.

## Testing

- `make preflight` — green.
- Full `TestEKS` e2e on baked AMI — all subtests PASS, including `EBSCSIVolume` (marker survived reschedule) and `DeleteCluster`.
