### PR TITLE
feat(eni): hot-plug reconciler + orphan sweep + e2e (Sprint 3d/3e)

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1493,6 +1493,9 @@ func (d *Daemon) startCluster() error {
 	// alarms — it never deletes volume data.
 	if d.jsManager != nil {
 		reapers := []vm.Reaper{d.vmMgr.NewTerminatedTeardownReaper()}
+		if eniRec := d.newENIReconciler(); eniRec != nil {
+			reapers = append(reapers, eniRec)
+		}
 		if d.volumeService != nil {
 			reapers = append(reapers, d.volumeService.NewVolumeLeakReaper(d.leakedVolumeInstances))
 		}

--- a/spinifex/daemon/daemon_handlers_eni.go
+++ b/spinifex/daemon/daemon_handlers_eni.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -52,6 +53,7 @@ func (d *Daemon) handleAttachNetworkInterface(msg *nats.Msg, command types.EC2In
 	}
 	if err := d.vpcService.UpdateENI(accountID, eniID, func(r *handlers_ec2_vpc.ENIRecord) {
 		r.AttachmentStatus = "attaching"
+		r.AttachmentStateAt = time.Now()
 		r.LastAttachError = ""
 	}); err != nil {
 		slog.Warn("AttachNetworkInterface: failed to mark attaching state",
@@ -78,6 +80,7 @@ func (d *Daemon) handleAttachNetworkInterface(msg *nats.Msg, command types.EC2In
 	if err := d.vpcService.UpdateENI(accountID, eniID, func(r *handlers_ec2_vpc.ENIRecord) {
 		r.AttachmentStatus = "attached"
 		r.HotPlugSlot = res.Slot
+		r.AttachmentStateAt = time.Now()
 	}); err != nil {
 		slog.Warn("AttachNetworkInterface: failed to mark attached state",
 			"eniId", eniID, "err", err)
@@ -128,6 +131,7 @@ func (d *Daemon) handleDetachNetworkInterface(msg *nats.Msg, command types.EC2In
 
 	if err := d.vpcService.UpdateENI(accountID, record.NetworkInterfaceId, func(r *handlers_ec2_vpc.ENIRecord) {
 		r.AttachmentStatus = "detaching"
+		r.AttachmentStateAt = time.Now()
 		r.DetachInFlight = true
 		r.DetachForce = force
 	}); err != nil {
@@ -154,6 +158,7 @@ func (d *Daemon) handleDetachNetworkInterface(msg *nats.Msg, command types.EC2In
 		r.HotPlugSlot = 0
 		r.DetachInFlight = false
 		r.DetachForce = false
+		r.AttachmentStateAt = time.Now()
 	})
 
 	publishENIHotplugEvent(d.natsConn, "vpc.eni-hotplug.detached", instance.ID, map[string]any{

--- a/spinifex/daemon/eni_reconciler.go
+++ b/spinifex/daemon/eni_reconciler.go
@@ -1,0 +1,227 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+)
+
+// eniStaleThreshold is the minimum age of an AttachmentStatus transition before
+// the reconciler will resolve it. Shorter than this and a live attach/detach
+// handler may still be mid-pipeline; the pipeline budget is ~5s, so 30s leaves
+// generous headroom while still healing a crashed daemon promptly.
+const eniStaleThreshold = 30 * time.Second
+
+// eniReconciler converges hot-plug ENI state (KV ↔ in-memory slot map ↔ guest
+// query-pci) for this node's running instances and reaps orphan devices/slots.
+// It is a node-local vm.Reaper run by the GarbageCollector backstop.
+type eniReconciler struct {
+	vmMgr *vm.Manager
+	vpc   *handlers_ec2_vpc.VPCServiceImpl
+	stale time.Duration
+}
+
+var _ vm.Reaper = (*eniReconciler)(nil)
+
+// newENIReconciler builds the reconciler over the daemon's VM manager and VPC
+// service. Returns nil when either dependency is absent so the caller can skip
+// wiring it on a node without a control plane.
+func (d *Daemon) newENIReconciler() *eniReconciler {
+	if d.vmMgr == nil || d.vpcService == nil {
+		return nil
+	}
+	return &eniReconciler{vmMgr: d.vmMgr, vpc: d.vpcService, stale: eniStaleThreshold}
+}
+
+func (r *eniReconciler) Class() string         { return "eni-hotplug" }
+func (r *eniReconciler) Scope() vm.ReaperScope { return vm.ScopeNodeLocal }
+
+// Sweep walks this node's running instances and converges each one's ENI
+// hot-plug state. Per-instance failures are logged and skipped so one bad QMP
+// socket does not stall the whole sweep.
+func (r *eniReconciler) Sweep(ctx context.Context) (int, error) {
+	reaped := 0
+	for _, instance := range r.vmMgr.Snapshot() {
+		if ctx.Err() != nil {
+			return reaped, ctx.Err()
+		}
+		if r.vmMgr.Status(instance) != vm.StateRunning || instance.AccountID == "" {
+			continue
+		}
+		reaped += r.reconcileInstance(instance)
+	}
+	return reaped, nil
+}
+
+// reconcileInstance applies the resolution matrix to a single instance.
+func (r *eniReconciler) reconcileInstance(instance *vm.VM) int {
+	live, err := r.vmMgr.ListLiveENIDevices(instance)
+	if err != nil {
+		slog.Warn("eni-reconciler: query-pci failed, skipping instance",
+			"instanceId", instance.ID, "err", err)
+		return 0
+	}
+
+	enis, err := r.vpc.ListInstanceENIs(instance.AccountID, instance.ID)
+	if err != nil {
+		slog.Warn("eni-reconciler: ListInstanceENIs failed, skipping instance",
+			"instanceId", instance.ID, "err", err)
+		return 0
+	}
+
+	reaped := 0
+	claimedSlots := make(map[int]bool)
+	knownENIs := make(map[string]bool)
+
+	for i := range enis {
+		rec := &enis[i]
+		knownENIs[rec.NetworkInterfaceId] = true
+		slot := r.slotFor(instance, rec)
+		if slot > 0 {
+			claimedSlots[slot] = true
+		}
+		if r.reconcileENI(instance, rec, slot, live) {
+			reaped++
+		}
+	}
+
+	reaped += r.sweepOrphanDevices(instance, live, claimedSlots)
+	reaped += r.sweepOrphanSlots(instance, knownENIs)
+	return reaped
+}
+
+// slotFor resolves the PCIe slot for a record: the persisted HotPlugSlot, or
+// the in-memory map when a crash interrupted the attach before HotPlugSlot was
+// written.
+func (r *eniReconciler) slotFor(instance *vm.VM, rec *handlers_ec2_vpc.ENIRecord) int {
+	if rec.HotPlugSlot > 0 {
+		return rec.HotPlugSlot
+	}
+	return r.vmMgr.ENISlotForReconcile(instance, rec.NetworkInterfaceId)
+}
+
+// reconcileENI applies matrix rows 1–6 for one ENI record. Returns true when it
+// reaped (mutated state toward convergence).
+func (r *eniReconciler) reconcileENI(instance *vm.VM, rec *handlers_ec2_vpc.ENIRecord, slot int, live map[int]string) bool {
+	present := slot > 0 && live[slot] != ""
+	acct := instance.AccountID
+	eniID := rec.NetworkInterfaceId
+
+	switch {
+	// Rows 5/6: detach in flight — only act once stale so we never race a
+	// live detach handler.
+	case rec.DetachInFlight || rec.AttachmentStatus == "detaching":
+		if !r.isStale(rec) {
+			return false
+		}
+		if present {
+			slog.Info("eni-reconciler: replaying interrupted detach", "instanceId", instance.ID, "eniId", eniID, "slot", slot)
+			if err := r.vmMgr.HotUnplugENI(instance, eniID, rec.DetachForce); err != nil {
+				slog.Warn("eni-reconciler: detach replay failed", "instanceId", instance.ID, "eniId", eniID, "err", err)
+			}
+		}
+		r.finalizeDetached(instance, acct, eniID)
+		return true
+
+	// Row 3/4: attach interrupted — finish if the device made it, else roll back.
+	case rec.AttachmentStatus == "attaching":
+		if !r.isStale(rec) {
+			return false
+		}
+		if present {
+			slog.Info("eni-reconciler: completing interrupted attach", "instanceId", instance.ID, "eniId", eniID, "slot", slot)
+			r.vmMgr.AdoptENISlot(instance, eniID, slot)
+			r.markAttached(acct, eniID, slot)
+		} else {
+			slog.Info("eni-reconciler: rolling back interrupted attach", "instanceId", instance.ID, "eniId", eniID)
+			r.finalizeDetached(instance, acct, eniID)
+		}
+		return true
+
+	// Row 1: steady attached, device present — re-adopt the slot if the
+	// in-memory map was lost across restart. Not a reap.
+	case present:
+		r.vmMgr.AdoptENISlot(instance, eniID, slot)
+		return false
+
+	// Row 2: KV says attached but the guest lost the device — converge to detached.
+	case rec.AttachmentStatus == "attached" || rec.HotPlugSlot > 0:
+		slog.Info("eni-reconciler: KV attached but device absent, detaching", "instanceId", instance.ID, "eniId", eniID, "slot", slot)
+		r.finalizeDetached(instance, acct, eniID)
+		return true
+
+	default:
+		return false
+	}
+}
+
+// sweepOrphanDevices removes live hot-plug devices whose slot no KV record
+// claims (row 7) — a crashed attach that reached QMP but never wrote KV.
+func (r *eniReconciler) sweepOrphanDevices(instance *vm.VM, live map[int]string, claimed map[int]bool) int {
+	reaped := 0
+	for slot := range live {
+		if claimed[slot] {
+			continue
+		}
+		slog.Info("eni-reconciler: removing orphan hot-plug device", "instanceId", instance.ID, "slot", slot)
+		if err := r.vmMgr.RemoveENIDeviceBySlot(instance, slot); err != nil {
+			slog.Warn("eni-reconciler: orphan device removal failed", "instanceId", instance.ID, "slot", slot, "err", err)
+			continue
+		}
+		reaped++
+	}
+	return reaped
+}
+
+// sweepOrphanSlots releases in-memory slot entries whose ENI has no live KV
+// attachment (row 8) — a detach that cleaned KV but not the slot map.
+func (r *eniReconciler) sweepOrphanSlots(instance *vm.VM, knownENIs map[string]bool) int {
+	reaped := 0
+	for _, eniID := range r.vmMgr.ENISlotMapKeys(instance) {
+		if knownENIs[eniID] {
+			continue
+		}
+		slog.Info("eni-reconciler: releasing orphan slot entry", "instanceId", instance.ID, "eniId", eniID)
+		r.vmMgr.ReleaseENISlot(instance, eniID)
+		reaped++
+	}
+	return reaped
+}
+
+// finalizeDetached drives KV + slot + tap to the detached terminal state. Each
+// step is idempotent so a re-run after a partial failure converges.
+func (r *eniReconciler) finalizeDetached(instance *vm.VM, accountID, eniID string) {
+	if err := r.vpc.DetachENI(accountID, eniID); err != nil {
+		slog.Warn("eni-reconciler: KV detach failed", "eniId", eniID, "err", err)
+	}
+	_ = r.vpc.UpdateENI(accountID, eniID, func(rec *handlers_ec2_vpc.ENIRecord) {
+		rec.AttachmentStatus = ""
+		rec.HotPlugSlot = 0
+		rec.DetachInFlight = false
+		rec.DetachForce = false
+		rec.AttachmentStateAt = time.Now()
+	})
+	r.vmMgr.ReleaseENISlot(instance, eniID)
+	r.vmMgr.CleanupENITap(instance, eniID)
+}
+
+// markAttached promotes a record to the attached terminal state.
+func (r *eniReconciler) markAttached(accountID, eniID string, slot int) {
+	_ = r.vpc.UpdateENI(accountID, eniID, func(rec *handlers_ec2_vpc.ENIRecord) {
+		rec.AttachmentStatus = "attached"
+		rec.HotPlugSlot = slot
+		rec.AttachmentStateAt = time.Now()
+	})
+}
+
+func (r *eniReconciler) isStale(rec *handlers_ec2_vpc.ENIRecord) bool {
+	// A zero timestamp pre-dates the field (Sprint 3d) — treat as stale so
+	// records stuck before the upgrade still converge.
+	if rec.AttachmentStateAt.IsZero() {
+		return true
+	}
+	return time.Since(rec.AttachmentStateAt) >= r.stale
+}

--- a/spinifex/daemon/eni_reconciler_test.go
+++ b/spinifex/daemon/eni_reconciler_test.go
@@ -1,0 +1,177 @@
+package daemon
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reconcilerFixture extends the shared ENI hot-plug fixture with the VM's
+// AccountID set (the reconciler skips account-less legacy VMs) and a built
+// reconciler whose staleness threshold the test can drive.
+func newReconcilerFixture(t *testing.T) (*eniHotPlugFixture, *eniReconciler) {
+	t.Helper()
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+	r := f.daemon.newENIReconciler()
+	require.NotNil(t, r)
+	return f, r
+}
+
+// seedAttached marks the fixture ENI attached to the VM in KV with the given
+// transition state, then optionally materializes the guest device + in-memory
+// slot so the reconciler observes a "present" device.
+func seedAttached(t *testing.T, f *eniHotPlugFixture, status string, slot int, age time.Duration, detachInFlight, force, seedDevice bool) {
+	t.Helper()
+	_, err := f.daemon.vpcService.AttachENI(testAccountID, f.eniID, f.vmInst.ID, int64(slot))
+	require.NoError(t, err)
+	require.NoError(t, f.daemon.vpcService.UpdateENI(testAccountID, f.eniID, func(r *handlers_ec2_vpc.ENIRecord) {
+		r.AttachmentStatus = status
+		r.HotPlugSlot = slot
+		r.DetachInFlight = detachInFlight
+		r.DetachForce = force
+		r.AttachmentStateAt = time.Now().Add(-age)
+	}))
+	if seedDevice {
+		require.NoError(t, f.stub.DeviceAdd(map[string]any{"id": "net-eni-" + strconv.Itoa(slot)}))
+		require.NoError(t, f.stub.NetdevAdd(map[string]any{"id": "hostnet-eni-" + strconv.Itoa(slot)}))
+		f.daemon.vmMgr.AdoptENISlot(f.vmInst, f.eniID, slot)
+	}
+}
+
+func eniStatus(t *testing.T, f *eniHotPlugFixture) handlers_ec2_vpc.ENIRecord {
+	t.Helper()
+	rec, err := f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.NoError(t, err)
+	return rec
+}
+
+// Row 1: steady attached, device present, in-memory slot lost across restart →
+// reconciler re-adopts the slot, reaps nothing, KV unchanged.
+func TestENIReconciler_AttachedPresent_ReadoptsSlot(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	seedAttached(t, f, "attached", 1, time.Minute, false, false, true)
+	f.daemon.vmMgr.ReleaseENISlot(f.vmInst, f.eniID) // simulate slot map lost on restart
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, reaped)
+	assert.Equal(t, "attached", eniStatus(t, f).AttachmentStatus)
+	assert.Equal(t, 1, f.daemon.vmMgr.ENISlotForReconcile(f.vmInst, f.eniID))
+}
+
+// Row 2: KV attached but the guest no longer exposes the device → detach.
+func TestENIReconciler_AttachedAbsent_Detaches(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	seedAttached(t, f, "attached", 1, time.Minute, false, false, false)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	rec := eniStatus(t, f)
+	assert.Equal(t, "available", rec.Status)
+	assert.Empty(t, rec.AttachmentStatus)
+	assert.Equal(t, 0, rec.HotPlugSlot)
+}
+
+// Row 3: attach interrupted, device made it → finish to attached.
+func TestENIReconciler_AttachingPresent_Completes(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	seedAttached(t, f, "attaching", 1, time.Minute, false, false, true)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	assert.Equal(t, "attached", eniStatus(t, f).AttachmentStatus)
+}
+
+// Row 4: attach interrupted before the device materialized → roll back.
+func TestENIReconciler_AttachingAbsent_RollsBack(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	seedAttached(t, f, "attaching", 1, time.Minute, false, false, false)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	assert.Equal(t, "available", eniStatus(t, f).Status)
+}
+
+// Row 5: detach interrupted, device still present → replay hot-unplug.
+func TestENIReconciler_DetachingPresent_ReplaysUnplug(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	seedAttached(t, f, "detaching", 1, time.Minute, true, false, true)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	assert.False(t, f.stub.HasDevice("net-eni-1"), "device should be removed")
+	rec := eniStatus(t, f)
+	assert.Equal(t, "available", rec.Status)
+	assert.False(t, rec.DetachInFlight)
+}
+
+// Row 6: detach interrupted after the device was already gone → finalize KV.
+func TestENIReconciler_DetachingAbsent_Finalizes(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	seedAttached(t, f, "detaching", 1, time.Minute, true, false, false)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	rec := eniStatus(t, f)
+	assert.Equal(t, "available", rec.Status)
+	assert.False(t, rec.DetachInFlight)
+}
+
+// Row 7: a live hot-plug device no KV record claims → removed as an orphan.
+func TestENIReconciler_OrphanDevice_Removed(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	require.NoError(t, f.stub.DeviceAdd(map[string]any{"id": "net-eni-2"}))
+	require.NoError(t, f.stub.NetdevAdd(map[string]any{"id": "hostnet-eni-2"}))
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	assert.False(t, f.stub.HasDevice("net-eni-2"), "orphan device should be removed")
+}
+
+// Row 8: an in-memory slot entry whose KV attachment is gone → slot released.
+func TestENIReconciler_OrphanSlot_Released(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	f.daemon.vmMgr.AdoptENISlot(f.vmInst, "eni-ghost", 3)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	assert.Equal(t, 0, f.daemon.vmMgr.ENISlotForReconcile(f.vmInst, "eni-ghost"))
+}
+
+// Staleness gate: a fresh attaching transition is left untouched so the
+// reconciler never races a live attach handler.
+func TestENIReconciler_FreshAttaching_NotTouched(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	seedAttached(t, f, "attaching", 1, time.Second, false, false, false)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, reaped)
+	assert.Equal(t, "attaching", eniStatus(t, f).AttachmentStatus)
+}
+
+// A stopped or account-less VM is skipped entirely.
+func TestENIReconciler_SkipsNonRunning(t *testing.T) {
+	f, r := newReconcilerFixture(t)
+	f.vmInst.Status = vm.StateStopped
+	seedAttached(t, f, "attached", 1, time.Minute, false, false, false)
+
+	reaped, err := r.Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, reaped)
+	assert.Equal(t, "attached", eniStatus(t, f).AttachmentStatus)
+}

--- a/spinifex/handlers/ec2/vpc/eni.go
+++ b/spinifex/handlers/ec2/vpc/eni.go
@@ -60,6 +60,10 @@ type ENIRecord struct {
 	// DetachForce records the force flag from the in-flight detach call so
 	// the reconciler can replay with the original semantics.
 	DetachForce bool `json:"detach_force,omitempty"`
+	// AttachmentStateAt timestamps the most recent AttachmentStatus
+	// transition. The reconciler ages transitions against this so it never
+	// rolls back a record a live attach/detach handler is mid-pipeline on.
+	AttachmentStateAt time.Time `json:"attachment_state_at,omitzero"`
 }
 
 // eniIsLiveAttachment reports whether the ENI record is a live attachment to
@@ -591,6 +595,38 @@ func (s *VPCServiceImpl) UpdateENI(accountID, eniId string, fn func(*ENIRecord))
 		return errors.New(awserrors.ErrorServerInternal)
 	}
 	return nil
+}
+
+// ListInstanceENIs returns every ENIRecord in accountID currently attached to
+// instanceID. Used by the hot-plug reconciler to converge a node's instances
+// against KV on restart.
+func (s *VPCServiceImpl) ListInstanceENIs(accountID, instanceID string) ([]ENIRecord, error) {
+	keys, err := s.eniKV.Keys()
+	if err != nil {
+		if errors.Is(err, nats.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, errors.New(awserrors.ErrorServerInternal)
+	}
+	prefix := accountID + "."
+	var out []ENIRecord
+	for _, key := range keys {
+		if key == utils.VersionKey || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		entry, err := s.eniKV.Get(key)
+		if err != nil {
+			continue
+		}
+		var record ENIRecord
+		if err := json.Unmarshal(entry.Value(), &record); err != nil {
+			continue
+		}
+		if record.InstanceId == instanceID {
+			out = append(out, record)
+		}
+	}
+	return out, nil
 }
 
 // FindENIByAttachment scans the ENI bucket for the record with the given

--- a/spinifex/vm/eni_hotplug.go
+++ b/spinifex/vm/eni_hotplug.go
@@ -73,10 +73,10 @@ func (m *Manager) HotPlugENI(instance *VM, eniID, mac string) (HotPlugENIResult,
 	instance.ENIRequests.AttachedByENIID[eniID] = slot
 
 	dc := newDeviceController(instance)
-	netdevID := fmt.Sprintf("hostnet-eni-%d", slot)
-	deviceID := fmt.Sprintf("net-eni-%d", slot)
+	netdevID := eniNetdevID(slot)
+	deviceID := eniDeviceID(slot)
 	tapName := TapDeviceName(eniID)
-	busID := fmt.Sprintf("hotplug-eni%d", slot)
+	busID := eniBusID(slot)
 
 	// Step 1: tap device + OVS port on br-int (carries OVN iface-id binding).
 	if err := m.setupENITap(instance.ID, eniID, mac); err != nil {
@@ -149,8 +149,8 @@ func (m *Manager) HotUnplugENI(instance *VM, eniID string, force bool) error {
 	}
 
 	dc := newDeviceController(instance)
-	netdevID := fmt.Sprintf("hostnet-eni-%d", slot)
-	deviceID := fmt.Sprintf("net-eni-%d", slot)
+	netdevID := eniNetdevID(slot)
+	deviceID := eniDeviceID(slot)
 	tapName := TapDeviceName(eniID)
 
 	// Step 1: device_del (guest driver release request).

--- a/spinifex/vm/eni_reconcile.go
+++ b/spinifex/vm/eni_reconcile.go
@@ -1,0 +1,164 @@
+package vm
+
+import (
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+)
+
+// eni hot-plug QEMU object IDs, derived from the PCIe root-port slot. The
+// reconciler and the attach/detach pipelines must agree on these formats so
+// query-pci qdev IDs round-trip to a slot.
+func eniNetdevID(slot int) string { return fmt.Sprintf("hostnet-eni-%d", slot) }
+func eniDeviceID(slot int) string { return fmt.Sprintf("net-eni-%d", slot) }
+func eniBusID(slot int) string    { return fmt.Sprintf("hotplug-eni%d", slot) }
+
+// eniSlotFromDeviceID parses a "net-eni-{slot}" qdev ID back to its slot.
+// ok is false for any device that is not a hot-plug ENI.
+func eniSlotFromDeviceID(qdevID string) (slot int, ok bool) {
+	const prefix = "net-eni-"
+	if !strings.HasPrefix(qdevID, prefix) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(qdevID[len(prefix):])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// ListLiveENIDevices returns slot → qdev ID for every hot-plug ENI device the
+// guest currently exposes via query-pci. Boot-time and non-ENI devices are
+// excluded. Returns an error if QMP is unavailable so the reconciler can skip
+// the instance rather than treat an empty list as "no devices".
+func (m *Manager) ListLiveENIDevices(instance *VM) (map[int]string, error) {
+	if instance == nil || instance.QMPClient == nil {
+		return nil, fmt.Errorf("%w: instance %v", ErrQMPUnavailable, instanceID(instance))
+	}
+	dc := newDeviceController(instance)
+	devs, err := dc.QueryPCI()
+	if err != nil {
+		return nil, fmt.Errorf("query-pci: %w", err)
+	}
+	out := make(map[int]string)
+	for _, d := range devs {
+		if slot, ok := eniSlotFromDeviceID(d.QDevID); ok {
+			out[slot] = d.QDevID
+		}
+	}
+	return out, nil
+}
+
+// AdoptENISlot repopulates the in-memory slot map for an ENI the reconciler
+// found live (post-restart re-adoption). Idempotent: a slot already mapped to
+// eniID is left as-is, and the slot is removed from the free-list at most once.
+func (m *Manager) AdoptENISlot(instance *VM, eniID string, slot int) {
+	if instance == nil {
+		return
+	}
+	instance.ENIRequests.Mu.Lock()
+	defer instance.ENIRequests.Mu.Unlock()
+	if instance.ENIRequests.AttachedByENIID == nil {
+		instance.ENIRequests.AttachedByENIID = make(map[string]int)
+	}
+	if cur, ok := instance.ENIRequests.AttachedByENIID[eniID]; ok && cur == slot {
+		return
+	}
+	instance.ENIRequests.AttachedByENIID[eniID] = slot
+	filtered := instance.ENIRequests.AvailableSlots[:0]
+	for _, s := range instance.ENIRequests.AvailableSlots {
+		if s != slot {
+			filtered = append(filtered, s)
+		}
+	}
+	instance.ENIRequests.AvailableSlots = filtered
+}
+
+// ReleaseENISlot drops eniID from the slot map and returns its slot to the
+// free-list. Idempotent: releasing an unknown ENI is a no-op.
+func (m *Manager) ReleaseENISlot(instance *VM, eniID string) {
+	if instance == nil {
+		return
+	}
+	instance.ENIRequests.Mu.Lock()
+	defer instance.ENIRequests.Mu.Unlock()
+	slot, ok := instance.ENIRequests.AttachedByENIID[eniID]
+	if !ok {
+		return
+	}
+	delete(instance.ENIRequests.AttachedByENIID, eniID)
+	instance.ENIRequests.AvailableSlots = append(instance.ENIRequests.AvailableSlots, slot)
+}
+
+// RemoveENIDeviceBySlot tears down the QEMU device + netdev for a hot-plug slot
+// the reconciler found orphaned (live device, no KV attachment). Best-effort:
+// netdev_del failure is logged, not returned, so the slot still frees. The
+// caller releases the slot and cleans the tap (when an eniID is known).
+func (m *Manager) RemoveENIDeviceBySlot(instance *VM, slot int) error {
+	if instance == nil {
+		return ErrInstanceNotFound
+	}
+	if instance.QMPClient == nil {
+		return fmt.Errorf("%w: instance %s", ErrQMPUnavailable, instance.ID)
+	}
+	dc := newDeviceController(instance)
+	deviceID := eniDeviceID(slot)
+	netdevID := eniNetdevID(slot)
+	if err := dc.DeviceDel(deviceID); err != nil {
+		return fmt.Errorf("device_del %s: %w", deviceID, err)
+	}
+	if err := waitForPCIDevice(dc, deviceID, false); err != nil {
+		slog.Warn("RemoveENIDeviceBySlot: device removal not observed",
+			"instanceId", instance.ID, "slot", slot, "err", err)
+	}
+	if err := dc.NetdevDel(netdevID); err != nil {
+		slog.Warn("RemoveENIDeviceBySlot: netdev_del failed",
+			"instanceId", instance.ID, "slot", slot, "err", err)
+	}
+	return nil
+}
+
+// ENISlotForReconcile returns the in-memory slot for eniID, or 0 when the slot
+// map does not know it. Used to recover the slot of an attach interrupted
+// before HotPlugSlot was persisted to KV.
+func (m *Manager) ENISlotForReconcile(instance *VM, eniID string) int {
+	if instance == nil {
+		return 0
+	}
+	instance.ENIRequests.Mu.Lock()
+	defer instance.ENIRequests.Mu.Unlock()
+	return instance.ENIRequests.AttachedByENIID[eniID]
+}
+
+// ENISlotMapKeys returns a snapshot of the ENI IDs in the in-memory slot map.
+// The reconciler uses it to find slot entries whose KV attachment is gone.
+func (m *Manager) ENISlotMapKeys(instance *VM) []string {
+	if instance == nil {
+		return nil
+	}
+	instance.ENIRequests.Mu.Lock()
+	defer instance.ENIRequests.Mu.Unlock()
+	out := make([]string, 0, len(instance.ENIRequests.AttachedByENIID))
+	for eniID := range instance.ENIRequests.AttachedByENIID {
+		out = append(out, eniID)
+	}
+	return out
+}
+
+// CleanupENITap removes the tap + OVS port for an ENI. Exported wrapper over
+// the pipeline's idempotent cleanup so the reconciler can drop tap state when
+// finalizing a detached/rolled-back ENI.
+func (m *Manager) CleanupENITap(instance *VM, eniID string) {
+	if instance == nil {
+		return
+	}
+	m.cleanupENITap(instance.ID, eniID, TapDeviceName(eniID))
+}
+
+func instanceID(instance *VM) string {
+	if instance == nil {
+		return "<nil>"
+	}
+	return instance.ID
+}

--- a/spinifex/vm/eni_reconcile_test.go
+++ b/spinifex/vm/eni_reconcile_test.go
@@ -1,0 +1,218 @@
+package vm
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/qmp"
+	"github.com/mulgadc/spinifex/spinifex/types"
+)
+
+func TestENISlotFromDeviceID(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantSlot int
+		wantOK   bool
+	}{
+		{"net-eni-1", 1, true},
+		{"net-eni-12", 12, true},
+		{"net-eni-0", 0, false},     // slot 0 is the non-hotplug sentinel
+		{"net-eni-x", 0, false},     // non-numeric
+		{"net-eni-", 0, false},      // empty index
+		{"virtio-net-0", 0, false},  // wrong prefix
+		{"hostnet-eni-1", 0, false}, // netdev, not device
+		{"", 0, false},
+	}
+	for _, tt := range tests {
+		slot, ok := eniSlotFromDeviceID(tt.in)
+		if slot != tt.wantSlot || ok != tt.wantOK {
+			t.Errorf("eniSlotFromDeviceID(%q) = (%d, %v), want (%d, %v)", tt.in, slot, ok, tt.wantSlot, tt.wantOK)
+		}
+	}
+}
+
+func TestENIObjectIDFormats(t *testing.T) {
+	if got := eniDeviceID(3); got != "net-eni-3" {
+		t.Errorf("eniDeviceID(3) = %q", got)
+	}
+	if got := eniNetdevID(3); got != "hostnet-eni-3" {
+		t.Errorf("eniNetdevID(3) = %q", got)
+	}
+	if got := eniBusID(3); got != "hotplug-eni3" {
+		t.Errorf("eniBusID(3) = %q", got)
+	}
+}
+
+func TestAdoptENISlot(t *testing.T) {
+	_, v, _ := newHotPlugTestVM(t, 4)
+
+	m := &Manager{}
+	m.AdoptENISlot(v, "eni-a", 2)
+	if got := v.ENIRequests.AttachedByENIID["eni-a"]; got != 2 {
+		t.Fatalf("AttachedByENIID[eni-a] = %d, want 2", got)
+	}
+	if slices.Contains(v.ENIRequests.AvailableSlots, 2) {
+		t.Errorf("slot 2 still in free-list after adopt: %v", v.ENIRequests.AvailableSlots)
+	}
+
+	// Idempotent: re-adopting the same slot leaves the free-list unchanged.
+	before := slices.Clone(v.ENIRequests.AvailableSlots)
+	m.AdoptENISlot(v, "eni-a", 2)
+	if !slices.Equal(before, v.ENIRequests.AvailableSlots) {
+		t.Errorf("re-adopt mutated free-list: %v -> %v", before, v.ENIRequests.AvailableSlots)
+	}
+
+	// Nil instance is a no-op (no panic).
+	m.AdoptENISlot(nil, "eni-x", 1)
+}
+
+func TestAdoptENISlot_NilMap(t *testing.T) {
+	v := &VM{ENIRequests: types.ENIRequests{AvailableSlots: []int{1}}}
+	m := &Manager{}
+	m.AdoptENISlot(v, "eni-a", 1)
+	if got := v.ENIRequests.AttachedByENIID["eni-a"]; got != 1 {
+		t.Fatalf("AttachedByENIID[eni-a] = %d, want 1", got)
+	}
+}
+
+func TestReleaseENISlot(t *testing.T) {
+	_, v, _ := newHotPlugTestVM(t, 4)
+	m := &Manager{}
+	m.AdoptENISlot(v, "eni-a", 2)
+
+	m.ReleaseENISlot(v, "eni-a")
+	if _, ok := v.ENIRequests.AttachedByENIID["eni-a"]; ok {
+		t.Errorf("eni-a still mapped after release")
+	}
+	if !slices.Contains(v.ENIRequests.AvailableSlots, 2) {
+		t.Errorf("slot 2 not returned to free-list: %v", v.ENIRequests.AvailableSlots)
+	}
+
+	// Releasing an unknown ENI is a no-op.
+	before := slices.Clone(v.ENIRequests.AvailableSlots)
+	m.ReleaseENISlot(v, "eni-unknown")
+	if !slices.Equal(before, v.ENIRequests.AvailableSlots) {
+		t.Errorf("release of unknown ENI mutated free-list")
+	}
+	m.ReleaseENISlot(nil, "eni-x") // no panic
+}
+
+func TestENISlotForReconcileAndMapKeys(t *testing.T) {
+	_, v, _ := newHotPlugTestVM(t, 4)
+	m := &Manager{}
+	m.AdoptENISlot(v, "eni-a", 1)
+	m.AdoptENISlot(v, "eni-b", 2)
+
+	if got := m.ENISlotForReconcile(v, "eni-a"); got != 1 {
+		t.Errorf("ENISlotForReconcile(eni-a) = %d, want 1", got)
+	}
+	if got := m.ENISlotForReconcile(v, "eni-missing"); got != 0 {
+		t.Errorf("ENISlotForReconcile(eni-missing) = %d, want 0", got)
+	}
+	if got := m.ENISlotForReconcile(nil, "eni-a"); got != 0 {
+		t.Errorf("ENISlotForReconcile(nil) = %d, want 0", got)
+	}
+
+	keys := m.ENISlotMapKeys(v)
+	slices.Sort(keys)
+	if !slices.Equal(keys, []string{"eni-a", "eni-b"}) {
+		t.Errorf("ENISlotMapKeys = %v, want [eni-a eni-b]", keys)
+	}
+	if got := m.ENISlotMapKeys(nil); got != nil {
+		t.Errorf("ENISlotMapKeys(nil) = %v, want nil", got)
+	}
+}
+
+func TestListLiveENIDevices(t *testing.T) {
+	mgr, v, stub := newHotPlugTestVM(t, 4)
+	// Two ENI hot-plug devices + one unrelated device.
+	mustAdd(t, stub, "net-eni-1")
+	mustAdd(t, stub, "net-eni-3")
+	mustAdd(t, stub, "virtio-blk-0")
+
+	live, err := mgr.ListLiveENIDevices(v)
+	if err != nil {
+		t.Fatalf("ListLiveENIDevices: %v", err)
+	}
+	if len(live) != 2 || live[1] != "net-eni-1" || live[3] != "net-eni-3" {
+		t.Errorf("live = %v, want {1:net-eni-1, 3:net-eni-3}", live)
+	}
+}
+
+func TestListLiveENIDevices_NoQMP(t *testing.T) {
+	mgr := NewManagerWithDeps(Deps{})
+	v := &VM{ID: "i-noqmp"}
+	if _, err := mgr.ListLiveENIDevices(v); err == nil {
+		t.Fatalf("expected error for nil QMPClient")
+	}
+}
+
+func TestRemoveENIDeviceBySlot(t *testing.T) {
+	mgr, v, stub := newHotPlugTestVM(t, 4)
+	mustAdd(t, stub, "net-eni-2")
+	if err := stub.NetdevAdd(map[string]any{"id": "hostnet-eni-2"}); err != nil {
+		t.Fatalf("seed netdev: %v", err)
+	}
+
+	if err := mgr.RemoveENIDeviceBySlot(v, 2); err != nil {
+		t.Fatalf("RemoveENIDeviceBySlot: %v", err)
+	}
+	if stub.HasDevice("net-eni-2") {
+		t.Errorf("device net-eni-2 still present after removal")
+	}
+	if stub.HasNetdev("hostnet-eni-2") {
+		t.Errorf("netdev hostnet-eni-2 still present after removal")
+	}
+}
+
+func TestRemoveENIDeviceBySlot_NoQMP(t *testing.T) {
+	mgr := NewManagerWithDeps(Deps{})
+	v := &VM{ID: "i-noqmp"}
+	if err := mgr.RemoveENIDeviceBySlot(v, 1); err == nil {
+		t.Fatalf("expected error for nil QMPClient")
+	}
+	if err := mgr.RemoveENIDeviceBySlot(nil, 1); err == nil {
+		t.Fatalf("expected error for nil instance")
+	}
+}
+
+func TestRemoveENIDeviceBySlot_DeviceDelFails(t *testing.T) {
+	mgr, v, stub := newHotPlugTestVM(t, 4)
+	// No device seeded → stub device_del returns "not found".
+	if err := mgr.RemoveENIDeviceBySlot(v, 9); err == nil {
+		t.Fatalf("expected device_del error for absent device")
+	}
+	_ = stub
+}
+
+func TestCleanupENITap(t *testing.T) {
+	_, v, _, plumber := newHotPlugTestVMWithPlumber(t, 4)
+	mgr := NewManagerWithDeps(Deps{NetworkPlumber: plumber})
+	mgr.Insert(v)
+
+	mgr.CleanupENITap(v, "eni-a")
+	want := TapDeviceName("eni-a")
+	if len(plumber.cleanupCalls) != 1 || plumber.cleanupCalls[0] != want {
+		t.Errorf("cleanupCalls = %v, want [%s]", plumber.cleanupCalls, want)
+	}
+	mgr.CleanupENITap(nil, "eni-x") // no panic
+}
+
+func TestInstanceIDHelper(t *testing.T) {
+	if got := instanceID(nil); got != "<nil>" {
+		t.Errorf("instanceID(nil) = %q, want <nil>", got)
+	}
+	if got := instanceID(&VM{ID: "i-1"}); got != "i-1" {
+		t.Errorf("instanceID(i-1) = %q", got)
+	}
+}
+
+func mustAdd(t *testing.T, stub *StubDeviceController, id string) {
+	t.Helper()
+	if err := stub.DeviceAdd(map[string]any{"id": id}); err != nil {
+		t.Fatalf("seed device %s: %v", id, err)
+	}
+}
+
+// keep qmp import used when QMPClient literal is needed in future cases.
+var _ = qmp.QMPClient{}

--- a/tests/e2e/single/eni_reconcile_test.go
+++ b/tests/e2e/single/eni_reconcile_test.go
@@ -1,0 +1,193 @@
+//go:build e2e
+
+package single
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+	"github.com/stretchr/testify/require"
+)
+
+// runENIHotplugReconcile proves the Sprint 3d hot-plug reconciler end to end:
+// attach a secondary ENI, restart spinifex-daemon (the guest QEMU survives via
+// KillMode=process), then assert the ENI stays attached and is still fully
+// manageable — DescribeNetworkInterfaces reports in-use, the guest NIC is still
+// present, and a detach succeeds. The detach is the load-bearing assertion: the
+// hot-attach mutates the in-memory PCIe slot map, which may not have been
+// persisted before the restart, so without the reconciler re-adopting the slot
+// the detach would fail InvalidAttachmentID.NotFound. OVN-gated; restores the
+// singleton (detach + delete) before returning.
+func runENIHotplugReconcile(t *testing.T, fix *Fixture) {
+	harness.Phase(t, "Single — ENI Hot-Plug Reconciler Convergence (OVN)")
+	harness.SkipIfNoOVN(t)
+	requireSSHHealthy(t)
+
+	c := fix.AWS
+	inst, _ := needInstance(t, fix)
+	instanceID := aws.StringValue(inst.InstanceId)
+	_, keyPath := needKeyPair(t, fix)
+
+	def := harness.EnsureDefaultVPC(t, fix.Harness)
+	require.NotEmpty(t, def.SubnetID, "default subnet ID required")
+	require.NotEmpty(t, def.SGID, "default SG ID required")
+	harness.AuthorizeSSHIngress(t, c, def.SGID)
+
+	host, port := harness.InstancePublicSSHHost(t, inst)
+	waitForSSHReady(t, host, port, keyPath)
+	tgt := harness.SSHTarget{User: "ec2-user", Host: host, Port: port, KeyPath: keyPath}
+
+	before := guestMACSet(t, tgt)
+
+	// --- Attach a secondary ENI -------------------------------------------
+	harness.Step(t, "create-network-interface subnet=%s", def.SubnetID)
+	// e2e:allow-create — the secondary ENI is the subject under test.
+	cniOut, err := c.EC2.CreateNetworkInterface(&ec2.CreateNetworkInterfaceInput{
+		SubnetId:    aws.String(def.SubnetID),
+		Groups:      []*string{aws.String(def.SGID)},
+		Description: aws.String("e2e-eni-reconcile"),
+	})
+	require.NoError(t, err, "create-network-interface")
+	require.NotNil(t, cniOut.NetworkInterface, "create-network-interface returned nil ENI")
+	eniID := aws.StringValue(cniOut.NetworkInterface.NetworkInterfaceId)
+	eniMAC := strings.ToLower(aws.StringValue(cniOut.NetworkInterface.MacAddress))
+	require.NotEmpty(t, eniID, "ENI NetworkInterfaceId empty")
+	require.NotEmpty(t, eniMAC, "ENI MacAddress empty")
+	harness.Detail(t, "eni", eniID, "eni_mac", eniMAC)
+
+	t.Cleanup(func() {
+		if _, derr := c.EC2.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: aws.String(eniID),
+		}); derr != nil && !harness.ErrorCodeIs(derr, "InvalidNetworkInterfaceID.NotFound") {
+			t.Logf("WARNING: cleanup delete ENI %s: %v", eniID, derr)
+		}
+	})
+
+	harness.Step(t, "attach-network-interface %s -> %s device-index=1", eniID, instanceID)
+	attachOut, err := c.EC2.AttachNetworkInterface(&ec2.AttachNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniID),
+		InstanceId:         aws.String(instanceID),
+		DeviceIndex:        aws.Int64(1),
+	})
+	require.NoError(t, err, "attach-network-interface")
+	attachmentID := aws.StringValue(attachOut.AttachmentId)
+	require.NotEmpty(t, attachmentID, "AttachmentId empty")
+	detached := false
+	t.Cleanup(func() {
+		if detached {
+			return
+		}
+		if _, derr := c.EC2.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
+			AttachmentId: aws.String(attachmentID),
+		}); derr != nil && !harness.ErrorCodeIs(derr, "InvalidAttachmentID.NotFound") {
+			t.Logf("WARNING: cleanup detach ENI %s: %v", eniID, derr)
+		}
+		_ = waitForENIStatusSoft(c, eniID, "available", 2*time.Minute)
+	})
+
+	waitForENIAttached(t, c, eniID, instanceID)
+	require.NotContains(t, before, eniMAC, "ENI MAC present before attach — cannot prove a fresh hotplug")
+	harness.Step(t, "assert guest NIC with MAC %s appears", eniMAC)
+	harness.EventuallyErr(t, func() error {
+		if _, ok := guestMACSet(t, tgt)[eniMAC]; ok {
+			return nil
+		}
+		return fmt.Errorf("ENI MAC %s not yet visible in guest", eniMAC)
+	}, 90*time.Second, 3*time.Second)
+
+	// --- Restart the daemon; the guest must survive ------------------------
+	harness.Step(t, "restart spinifex-daemon (guest QEMU survives)")
+	restartSpinifexDaemon(t)
+	waitForControlPlaneReady(t, c, instanceID)
+
+	// --- Post-restart: ENI still attached + guest NIC intact --------------
+	harness.Step(t, "assert ENI %s still attached after restart", eniID)
+	waitForENIAttached(t, c, eniID, instanceID)
+	require.Contains(t, guestMACSet(t, tgt), eniMAC,
+		"guest NIC for MAC %s vanished across daemon restart — QEMU should survive", eniMAC)
+
+	// --- Detach: succeeds only if the reconciler re-adopted the slot ------
+	harness.Step(t, "detach-network-interface %s (proves slot re-adoption)", attachmentID)
+	detachAfterReconcile(t, c, attachmentID)
+	waitForENIStatus(t, c, eniID, "available")
+	detached = true
+
+	harness.Step(t, "verify guest NIC for MAC %s disappears", eniMAC)
+	if !guestNICDropped(t, tgt, eniMAC, 45*time.Second) {
+		t.Logf("WARN: guest NIC for MAC %s still present after detach (udev lag?)", eniMAC)
+	}
+
+	harness.Step(t, "delete-network-interface %s", eniID)
+	_, err = c.EC2.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(eniID),
+	})
+	require.NoError(t, err, "delete-network-interface")
+}
+
+// restartSpinifexDaemon restarts the host spinifex-daemon unit. The single-node
+// suite runs on the host with passwordless sudo (same precedent as harness diag
+// capture), so a local systemctl restart reaches the daemon without SSH.
+func restartSpinifexDaemon(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("sudo", "-n", "systemctl", "restart", "spinifex-daemon").CombinedOutput()
+	require.NoErrorf(t, err, "restart spinifex-daemon: %s", strings.TrimSpace(string(out)))
+}
+
+// waitForControlPlaneReady polls DescribeInstances until the daemon has
+// reconnected after a restart and serves the singleton again.
+func waitForControlPlaneReady(t *testing.T, c *harness.AWSClient, instanceID string) {
+	t.Helper()
+	harness.EventuallyErr(t, func() error {
+		out, err := c.EC2.DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(instanceID)},
+		})
+		if err != nil {
+			return fmt.Errorf("describe-instances after restart: %w", err)
+		}
+		if len(out.Reservations) == 0 || len(out.Reservations[0].Instances) == 0 {
+			return fmt.Errorf("instance %s not yet visible after restart", instanceID)
+		}
+		return nil
+	}, 90*time.Second, 3*time.Second)
+}
+
+// detachAfterReconcile issues the detach, retrying while the reconciler's
+// startup sweep is still re-adopting the slot. InvalidAttachmentID.NotFound is
+// the symptom of an un-adopted slot and is safe to retry (no state changed);
+// any other error is fatal.
+func detachAfterReconcile(t *testing.T, c *harness.AWSClient, attachmentID string) {
+	t.Helper()
+	harness.EventuallyErr(t, func() error {
+		_, err := c.EC2.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{
+			AttachmentId: aws.String(attachmentID),
+		})
+		if err == nil {
+			return nil
+		}
+		if harness.ErrorCodeIs(err, "InvalidAttachmentID.NotFound") {
+			return fmt.Errorf("slot not yet re-adopted by reconciler: %w", err)
+		}
+		t.Fatalf("detach-network-interface %s: %v", attachmentID, err)
+		return nil
+	}, 60*time.Second, 3*time.Second)
+}
+
+// guestNICDropped polls briefly for the guest NIC carrying mac to disappear.
+// Soft: virtio-net unplug + udev cleanup can lag the control-plane detach.
+func guestNICDropped(t *testing.T, tgt harness.SSHTarget, mac string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, ok := guestMACSet(t, tgt)[mac]; !ok {
+			return true
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}

--- a/tests/e2e/single/tests_test.go
+++ b/tests/e2e/single/tests_test.go
@@ -123,6 +123,14 @@ func TestENIHotplug(t *testing.T) {
 	runENIHotplug(t, requireSingleNodeFixture(t))
 }
 
+// TestENIHotplugReconcile attaches a secondary ENI, restarts spinifex-daemon,
+// and asserts the hot-plug reconciler keeps the ENI attached + manageable
+// (detach succeeds) across the restart. Runs after TestENIHotplug so the
+// singleton is known running + SSH-healthy.
+func TestENIHotplugReconcile(t *testing.T) {
+	runENIHotplugReconcile(t, requireSingleNodeFixture(t))
+}
+
 func TestVolumeLifecycle(t *testing.T) {
 	runVolumeLifecycle(t, requireSingleNodeFixture(t))
 }


### PR DESCRIPTION
## Summary

ENI hot-plug **reconciler** that converges attach/detach state across a daemon
restart or crash, plus an orphan sweep for QMP devices and PCIe slots with no
live KV attachment. Runs as a node-local `vm.Reaper` inside the existing
`GarbageCollector` backstop (reuses `vm/gc.go`, no new loop). Sprints 3d + 3e.

Plan: `docs/development/feature/eni-hotplug-3d-reconciler.md`
Beads: `mulga-cs-enihotplug-3d` (GH #80), `mulga-cs-enihotplug-3e` (GH #86).

## Changes

**3d — reconciler**
- `daemon/eni_reconciler.go` (new): `eniReconciler` implements `vm.Reaper`
  (`Class() "eni-hotplug"`, `Scope() ScopeNodeLocal`). Sweep walks running
  instances, applies the 8-row resolution matrix per ENI + orphan device.
- `vm/eni_reconcile.go` (new): `ListLiveENIDevices` (query-pci filtered),
  `AdoptENISlot` / `ReleaseENISlot` (slot-map under lock), `RemoveENIDeviceBySlot`,
  `CleanupENITap`, plus stable `net-eni-{slot}` / `hostnet-eni-{slot}` ID helpers.
- `handlers/ec2/vpc/eni.go`: `AttachmentStateAt` timestamp + `ListInstanceENIs`.
- `daemon/daemon_handlers_eni.go`: stamp `AttachmentStateAt` on transitions so
  the 30s staleness gate can age them (reconciler never races a live handler).
- `daemon/daemon.go`: wire reconciler into the reapers slice.

**3e — e2e**
- `tests/e2e/single/eni_reconcile_test.go` (new): attach ENI → restart
  spinifex-daemon (guest QEMU survives, KillMode=process) → assert ENI still
  attached + detach succeeds. The post-restart detach is the load-bearing
  assertion: it passes only if the startup sweep re-adopted the in-memory slot
  map from KV.

## Resolution matrix (idempotent, staleness-gated)

| # | KV status | actual | Action |
|---|---|---|---|
| 1 | attached | present | re-adopt slot post-restart |
| 2 | attached | absent | converge to detached |
| 3 | attaching (stale) | present | finish attach |
| 4 | attaching (stale) | absent | roll back |
| 5 | detaching (stale) | present | replay unplug |
| 6 | detaching (stale) | absent | finalize |
| 7 | orphan device | — | hot-unplug by slot + release |
| 8 | orphan slot-map entry | — | release slot |

## Testing

- `make preflight` green — diff coverage 78.6% (threshold 60%), lint/vet/race/vuln clean.
- Unit + race: 8 matrix rows + staleness gate + scope guard all pass.
- **Live e2e on dev box** (deployed branch, OVN, real Ubuntu VM):
  - `TestENIHotplug` PASS (61.9s)
  - `TestENIHotplugReconcile` PASS (21.7s) — daemon-restart slot re-adoption proven.