### PR TITLE
feat: ECS STOPPED task GC (leader sweep, 1h retention)

### DIFF
--- a/spinifex/handlers/ecs/scheduler.go
+++ b/spinifex/handlers/ecs/scheduler.go
@@ -22,6 +22,12 @@ const (
 	reconcileInterval   = 10 * time.Second
 	heartbeatTimeout    = 90 * time.Second
 	stoppedReasonReaped = "ContainerInstance disconnected"
+
+	// sweepInterval is how often the leader prunes stale STOPPED task records;
+	// stoppedTaskRetention keeps a just-stopped task describable (DescribeTasks /
+	// UI exit reason) before it is dropped, matching AWS's ~1h STOPPED window.
+	sweepInterval        = 60 * time.Second
+	stoppedTaskRetention = 1 * time.Hour
 )
 
 // Scheduler is the per-daemon ECS control loop. A single leader (elected via the
@@ -49,9 +55,11 @@ func (sc *Scheduler) Run(ctx context.Context) {
 	leaseTicker := time.NewTicker(leaseRefresh)
 	reaperTicker := time.NewTicker(reaperInterval)
 	reconcileTicker := time.NewTicker(reconcileInterval)
+	sweepTicker := time.NewTicker(sweepInterval)
 	defer leaseTicker.Stop()
 	defer reaperTicker.Stop()
 	defer reconcileTicker.Stop()
+	defer sweepTicker.Stop()
 
 	sc.evaluateLeadership(ctx)
 	for {
@@ -68,6 +76,10 @@ func (sc *Scheduler) Run(ctx context.Context) {
 		case <-reconcileTicker.C:
 			if sc.isLeader() {
 				sc.svc.reconcileAllServices()
+			}
+		case <-sweepTicker.C:
+			if sc.isLeader() {
+				sc.sweepStoppedTasks()
 			}
 		}
 	}

--- a/spinifex/handlers/ecs/tasks_gc.go
+++ b/spinifex/handlers/ecs/tasks_gc.go
@@ -1,0 +1,70 @@
+package handlers_ecs
+
+import (
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// sweepStoppedTasks prunes stale STOPPED task records across every ECS account
+// bucket. Leader-only (scheduler is the single KV writer); runs on the sweep
+// tick. Mirrors reap()'s bucket walk.
+func (sc *Scheduler) sweepStoppedTasks() {
+	js, err := sc.nc.JetStream()
+	if err != nil {
+		return
+	}
+	now := time.Now().UTC()
+	for bucket := range js.KeyValueStoreNames() {
+		if _, ok := accountIDFromBucket(bucket); !ok {
+			continue
+		}
+		kv, err := js.KeyValue(bucket)
+		if err != nil {
+			continue
+		}
+		pruned, serr := sc.svc.sweepStoppedBucket(kv, now, stoppedTaskRetention)
+		if serr != nil {
+			slog.Error("ECS sweep: bucket failed", "bucket", bucket, "err", serr)
+			continue
+		}
+		if pruned > 0 {
+			slog.Info("ECS sweep: pruned stale STOPPED tasks", "bucket", bucket, "count", pruned)
+		}
+	}
+}
+
+// sweepStoppedBucket deletes task records that have been STOPPED longer than
+// retention. A task missing its StoppedAt timestamp is never pruned (defensive:
+// it would otherwise look infinitely old). Returns the number deleted.
+func (s *Service) sweepStoppedBucket(kv nats.KeyValue, now time.Time, retention time.Duration) (int, error) {
+	keys, err := keysWithPrefix(kv, "clusters/")
+	if err != nil {
+		return 0, err
+	}
+	pruned := 0
+	for _, k := range keys {
+		if !strings.Contains(k, "/tasks/") {
+			continue
+		}
+		var task TaskRecord
+		found, gerr := getJSON(kv, k, &task)
+		if gerr != nil || !found {
+			continue
+		}
+		if task.LastStatus != TaskStatusStopped || task.StoppedAt.IsZero() {
+			continue
+		}
+		if now.Sub(task.StoppedAt) <= retention {
+			continue
+		}
+		if derr := kv.Delete(k); derr != nil {
+			slog.Warn("ECS sweep: delete failed", "key", k, "err", derr)
+			continue
+		}
+		pruned++
+	}
+	return pruned, nil
+}

--- a/spinifex/handlers/ecs/tasks_gc_test.go
+++ b/spinifex/handlers/ecs/tasks_gc_test.go
@@ -1,0 +1,42 @@
+package handlers_ecs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSweepStoppedBucket_PrunesOnlyStale(t *testing.T) {
+	svc, _, kv := serviceTestRig(t)
+	now := time.Now().UTC()
+
+	put := func(id, status string, stoppedAt time.Time) {
+		rec := TaskRecord{
+			TaskID: id, Cluster: "web", ARN: TaskARN(testRegion, testAccountID, "web", id),
+			LastStatus: status, DesiredStatus: status, StoppedAt: stoppedAt,
+		}
+		require.NoError(t, putJSON(kv, TaskKey("web", id), &rec))
+	}
+
+	put("stale", TaskStatusStopped, now.Add(-2*time.Hour))   // older than retention -> prune
+	put("fresh", TaskStatusStopped, now.Add(-5*time.Minute)) // within retention -> keep
+	put("running", TaskStatusRunning, time.Time{})           // not stopped -> keep
+	put("nostamp", TaskStatusStopped, time.Time{})           // STOPPED but no timestamp -> keep (defensive)
+
+	pruned, err := svc.sweepStoppedBucket(kv, now, time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, pruned)
+
+	exists := func(id string) bool {
+		var rec TaskRecord
+		found, gerr := getJSON(kv, TaskKey("web", id), &rec)
+		require.NoError(t, gerr)
+		return found
+	}
+	assert.False(t, exists("stale"), "stale STOPPED task should be pruned")
+	assert.True(t, exists("fresh"), "recently STOPPED task should survive")
+	assert.True(t, exists("running"), "RUNNING task should survive")
+	assert.True(t, exists("nostamp"), "STOPPED task with no StoppedAt should survive")
+}


### PR DESCRIPTION
## Summary

Prunes stale STOPPED task records from the per-account KV. Previously nothing deleted a task record once it reached STOPPED, so `ListTasks` enumerated every task a cluster had ever run and the KV grew unbounded on a long-lived cluster.

Bead: `mulga-siv-450` (epic `mulga-cs-ecs`, GH #65). Plan: `docs/development/feature/ecs-stopped-task-gc.md`.

## Change

- Adds a **leader-gated sweep tick** to the scheduler cron (`sweepInterval = 60s`), alongside the existing reaper (30s) and reconcile (10s) — single-writer, no new machinery.
- `sweepStoppedTasks` walks every ECS account bucket (mirrors `reap()`); `sweepStoppedBucket` deletes task records where `LastStatus == STOPPED` and `now - StoppedAt > stoppedTaskRetention (1h)`.
- Retention keeps a just-stopped task **describable** (DescribeTasks / UI exit reason) for the window, matching AWS's ~1h STOPPED behaviour.
- A record missing its `StoppedAt` is **never pruned** (defensive — would otherwise read as infinitely old).

## Testing

- New `tasks_gc_test.go` against real JetStream KV: stale STOPPED pruned; recently-STOPPED, RUNNING, and zero-`StoppedAt` all survive; prune count asserted.
- `make preflight` green (vet, race, lint, govulncheck, coverage 68.5%).
- Live time-gated verification (1h window) not run — would require a test-only short retention; prune logic is proven against real KV and the tick reuses the already-live reaper bucket-walk.