### PR TITLE
fix: ECS ListTaskDefinitions honors Status filter (default ACTIVE)

### DIFF
--- a/spinifex/handlers/ecs/service.go
+++ b/spinifex/handlers/ecs/service.go
@@ -352,11 +352,17 @@ func (s *Service) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput,
 	return &ecs.DescribeTaskDefinitionOutput{TaskDefinition: rec.toAWS()}, nil
 }
 
-// ListTaskDefinitions returns all revision ARNs, optionally filtered by family.
+// ListTaskDefinitions returns revision ARNs, optionally filtered by family and
+// by status. Matching AWS, the status defaults to ACTIVE when unset, so
+// deregistered (INACTIVE) revisions drop off the default listing.
 func (s *Service) ListTaskDefinitions(input *ecs.ListTaskDefinitionsInput, accountID string) (*ecs.ListTaskDefinitionsOutput, error) {
 	kv, err := s.bucket(accountID)
 	if err != nil {
 		return nil, err
+	}
+	wantStatus := aws.StringValue(input.Status)
+	if wantStatus == "" {
+		wantStatus = TaskDefStatusActive
 	}
 	prefix := TaskDefFamiliesPrefix()
 	if fam := aws.StringValue(input.FamilyPrefix); fam != "" {
@@ -376,7 +382,7 @@ func (s *Service) ListTaskDefinitions(input *ecs.ListTaskDefinitionsInput, accou
 		if err != nil {
 			return nil, err
 		}
-		if found {
+		if found && rec.Status == wantStatus {
 			out.TaskDefinitionArns = append(out.TaskDefinitionArns, aws.String(rec.ARN))
 		}
 	}

--- a/spinifex/handlers/ecs/service_test.go
+++ b/spinifex/handlers/ecs/service_test.go
@@ -90,6 +90,38 @@ func TestService_RegisterTaskDefinition_RevisionBump(t *testing.T) {
 	assert.Len(t, list.TaskDefinitionArns, 2)
 }
 
+func TestService_ListTaskDefinitions_StatusFilter(t *testing.T) {
+	svc, _ := newTestService(t)
+	registerTaskDef(t, svc, "keep", 128, 256)
+	registerTaskDef(t, svc, "gone", 128, 256)
+
+	_, err := svc.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: aws.String("gone:1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	// Default (unset) status lists ACTIVE only; the deregistered revision drops.
+	active, err := svc.ListTaskDefinitions(&ecs.ListTaskDefinitionsInput{}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, active.TaskDefinitionArns, 1)
+	assert.Contains(t, aws.StringValue(active.TaskDefinitionArns[0]), "keep:1")
+
+	// Explicit ACTIVE matches the default.
+	activeExplicit, err := svc.ListTaskDefinitions(&ecs.ListTaskDefinitionsInput{
+		Status: aws.String(TaskDefStatusActive),
+	}, testAccountID)
+	require.NoError(t, err)
+	assert.Len(t, activeExplicit.TaskDefinitionArns, 1)
+
+	// INACTIVE returns only the deregistered revision.
+	inactive, err := svc.ListTaskDefinitions(&ecs.ListTaskDefinitionsInput{
+		Status: aws.String(TaskDefStatusInactive),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, inactive.TaskDefinitionArns, 1)
+	assert.Contains(t, aws.StringValue(inactive.TaskDefinitionArns[0]), "gone:1")
+}
+
 func TestService_RegisterTaskDefinition_NoFamily(t *testing.T) {
 	svc, _ := newTestService(t)
 	_, err := svc.RegisterTaskDefinition(&ecs.RegisterTaskDefinitionInput{}, testAccountID)


### PR DESCRIPTION
## Problem
`ListTaskDefinitions` appended every revision ARN regardless of `input.Status`. Deregistered (INACTIVE) task definitions stayed in the default (ACTIVE) listing, so the ECS console could never clear them — `--status ACTIVE` and `--status INACTIVE` returned the same set.

## Fix
Filter revisions by status, defaulting to ACTIVE when unset (AWS behavior). Deregistering a task definition now drops it from the default listing.

## Testing
- New `TestService_ListTaskDefinitions_StatusFilter`: register 2, deregister 1 → default + ACTIVE list the survivor, INACTIVE lists the deregistered one.
- `make preflight` passed.

Bead: mulga-siv-463