### PR TITLE
feat: IAM inline role policies (Put/Get/DeleteRolePolicy + real ListRolePolicies)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -665,9 +665,6 @@ jobs:
             echo "=== systemctl is-active spinifex-* ==="
             ssh "${SSH_OPTS[@]}" "$VM" 'for s in spinifex-nats spinifex-predastore spinifex-awsgw spinifex-vpcd spinifex-daemon; do printf "%-22s %s\n" "$s" "$(systemctl is-active $s 2>&1)"; done'
             echo
-            echo "=== which spx + version ==="
-            ssh "${SSH_OPTS[@]}" "$VM" 'which spx; spx --version 2>&1 || true'
-            echo
             echo "=== spx get nodes (direct ssh, tf-user) ==="
             ssh "${SSH_OPTS[@]}" "$VM" 'spx get nodes --timeout 5s 2>&1; echo "exit=$?"'
             echo

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -528,8 +528,10 @@ bypasses policy evaluation entirely.
 | `attach-role-policy` | `--role-name`, `--policy-arn` | — | **DONE** |
 | `detach-role-policy` | `--role-name`, `--policy-arn` | — | **DONE** |
 | `list-attached-role-policies` | `--role-name`, `--path-prefix` | `--max-items`, `--marker` | **DONE** |
-| `list-role-policies` | `--role-name` | `--max-items`, `--marker` | **DONE** (gateway stub — inline policies unsupported, always returns empty) |
-| `get-role-policy` / `put-role-policy` / `delete-role-policy` | — | inline role policies | **NOT STARTED** |
+| `list-role-policies` | `--role-name` | `--max-items`, `--marker` | **DONE** |
+| `put-role-policy` | `--role-name`, `--policy-name`, `--policy-document` | — | **DONE** |
+| `get-role-policy` | `--role-name`, `--policy-name` | — | **DONE** (document returned as raw JSON, not URL-encoded) |
+| `delete-role-policy` | `--role-name`, `--policy-name` | — | **DONE** |
 
 ### IAM — Instance Profiles
 

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -144,6 +144,18 @@ func (m *mockIAMService) DetachRolePolicy(_ string, _ *iam.DetachRolePolicyInput
 func (m *mockIAMService) ListAttachedRolePolicies(_ string, _ *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
 	return nil, nil
 }
+func (m *mockIAMService) PutRolePolicy(_ string, _ *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	return nil, nil
+}
+func (m *mockIAMService) GetRolePolicy(_ string, _ *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
+	return nil, nil
+}
+func (m *mockIAMService) DeleteRolePolicy(_ string, _ *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	return nil, nil
+}
+func (m *mockIAMService) ListRolePolicies(_ string, _ *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	return nil, nil
+}
 func (m *mockIAMService) CreateInstanceProfile(_ string, _ *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
 	return nil, nil
 }

--- a/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
+++ b/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
@@ -124,6 +124,18 @@ func (f *fakeIAMService) DetachRolePolicy(string, *iam.DetachRolePolicyInput) (*
 func (f *fakeIAMService) ListAttachedRolePolicies(string, *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
 	return &iam.ListAttachedRolePoliciesOutput{}, nil
 }
+func (f *fakeIAMService) PutRolePolicy(string, *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	return &iam.PutRolePolicyOutput{}, nil
+}
+func (f *fakeIAMService) GetRolePolicy(string, *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
+	return &iam.GetRolePolicyOutput{}, nil
+}
+func (f *fakeIAMService) DeleteRolePolicy(string, *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	return &iam.DeleteRolePolicyOutput{}, nil
+}
+func (f *fakeIAMService) ListRolePolicies(string, *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	return &iam.ListRolePoliciesOutput{}, nil
+}
 func (f *fakeIAMService) CreateInstanceProfile(string, *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
 	return &iam.CreateInstanceProfileOutput{}, nil
 }

--- a/spinifex/gateway/iam.go
+++ b/spinifex/gateway/iam.go
@@ -124,6 +124,15 @@ var iamActions = map[string]IAMHandler{
 	"DetachRolePolicy": iamHandler(func(accountID string, input *iam.DetachRolePolicyInput, gw *GatewayConfig) (any, error) {
 		return gateway_iam.DetachRolePolicy(accountID, input, gw.IAMService)
 	}),
+	"PutRolePolicy": iamHandler(func(accountID string, input *iam.PutRolePolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.PutRolePolicy(accountID, input, gw.IAMService)
+	}),
+	"GetRolePolicy": iamHandler(func(accountID string, input *iam.GetRolePolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.GetRolePolicy(accountID, input, gw.IAMService)
+	}),
+	"DeleteRolePolicy": iamHandler(func(accountID string, input *iam.DeleteRolePolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.DeleteRolePolicy(accountID, input, gw.IAMService)
+	}),
 	"ListAttachedRolePolicies": iamHandler(func(accountID string, input *iam.ListAttachedRolePoliciesInput, gw *GatewayConfig) (any, error) {
 		return gateway_iam.ListAttachedRolePolicies(accountID, input, gw.IAMService)
 	}),

--- a/spinifex/gateway/iam/handler_test.go
+++ b/spinifex/gateway/iam/handler_test.go
@@ -135,6 +135,18 @@ func (s *stubIAMService) DetachRolePolicy(_ string, _ *iam.DetachRolePolicyInput
 func (s *stubIAMService) ListAttachedRolePolicies(_ string, _ *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
 	return &iam.ListAttachedRolePoliciesOutput{}, nil
 }
+func (s *stubIAMService) PutRolePolicy(_ string, _ *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	return &iam.PutRolePolicyOutput{}, nil
+}
+func (s *stubIAMService) GetRolePolicy(_ string, _ *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
+	return &iam.GetRolePolicyOutput{}, nil
+}
+func (s *stubIAMService) DeleteRolePolicy(_ string, _ *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	return &iam.DeleteRolePolicyOutput{}, nil
+}
+func (s *stubIAMService) ListRolePolicies(_ string, _ *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	return &iam.ListRolePoliciesOutput{}, nil
+}
 func (s *stubIAMService) CreateInstanceProfile(_ string, _ *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
 	return &iam.CreateInstanceProfileOutput{}, nil
 }

--- a/spinifex/gateway/iam/role.go
+++ b/spinifex/gateway/iam/role.go
@@ -80,14 +80,42 @@ func ListAttachedRolePolicies(accountID string, input *iam.ListAttachedRolePolic
 	return svc.ListAttachedRolePolicies(accountID, input)
 }
 
-// ListRolePolicies lists inline role policies. Spinifex only ever attaches
-// managed policies (AttachRolePolicy), never inline, so this always returns an
-// empty list — enough to satisfy the AWS provider's aws_iam_role read-back.
+func PutRolePolicy(accountID string, input *iam.PutRolePolicyInput, svc handlers_iam.IAMService) (*iam.PutRolePolicyOutput, error) {
+	if input.RoleName == nil || *input.RoleName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyName == nil || *input.PolicyName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyDocument == nil || *input.PolicyDocument == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.PutRolePolicy(accountID, input)
+}
+
+func GetRolePolicy(accountID string, input *iam.GetRolePolicyInput, svc handlers_iam.IAMService) (*iam.GetRolePolicyOutput, error) {
+	if input.RoleName == nil || *input.RoleName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyName == nil || *input.PolicyName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.GetRolePolicy(accountID, input)
+}
+
+func DeleteRolePolicy(accountID string, input *iam.DeleteRolePolicyInput, svc handlers_iam.IAMService) (*iam.DeleteRolePolicyOutput, error) {
+	if input.RoleName == nil || *input.RoleName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyName == nil || *input.PolicyName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.DeleteRolePolicy(accountID, input)
+}
+
 func ListRolePolicies(accountID string, input *iam.ListRolePoliciesInput, svc handlers_iam.IAMService) (*iam.ListRolePoliciesOutput, error) {
 	if input.RoleName == nil || *input.RoleName == "" {
 		return nil, errors.New(awserrors.ErrorMissingParameter)
 	}
-	return &iam.ListRolePoliciesOutput{
-		PolicyNames: []*string{},
-	}, nil
+	return svc.ListRolePolicies(accountID, input)
 }

--- a/spinifex/gateway/iam/role_test.go
+++ b/spinifex/gateway/iam/role_test.go
@@ -219,3 +219,109 @@ func TestListAttachedRolePolicies(t *testing.T) {
 		})
 	}
 }
+
+const validInlineDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ec2:DescribeInstances","Resource":"*"}]}`
+
+func TestPutRolePolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.PutRolePolicyInput
+		wantErr string
+	}{
+		{"nil RoleName", &iam.PutRolePolicyInput{PolicyName: aws.String("p"), PolicyDocument: aws.String(validInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"empty RoleName", &iam.PutRolePolicyInput{RoleName: aws.String(""), PolicyName: aws.String("p"), PolicyDocument: aws.String(validInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"nil PolicyName", &iam.PutRolePolicyInput{RoleName: aws.String("r"), PolicyDocument: aws.String(validInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"empty PolicyName", &iam.PutRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String(""), PolicyDocument: aws.String(validInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"nil PolicyDocument", &iam.PutRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"empty PolicyDocument", &iam.PutRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String("p"), PolicyDocument: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.PutRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String("p"), PolicyDocument: aws.String(validInlineDoc)}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PutRolePolicy(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetRolePolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.GetRolePolicyInput
+		wantErr string
+	}{
+		{"nil RoleName", &iam.GetRolePolicyInput{PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"empty RoleName", &iam.GetRolePolicyInput{RoleName: aws.String(""), PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"nil PolicyName", &iam.GetRolePolicyInput{RoleName: aws.String("r")}, awserrors.ErrorMissingParameter},
+		{"empty PolicyName", &iam.GetRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.GetRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String("p")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := GetRolePolicy(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDeleteRolePolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.DeleteRolePolicyInput
+		wantErr string
+	}{
+		{"nil RoleName", &iam.DeleteRolePolicyInput{PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"empty RoleName", &iam.DeleteRolePolicyInput{RoleName: aws.String(""), PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"nil PolicyName", &iam.DeleteRolePolicyInput{RoleName: aws.String("r")}, awserrors.ErrorMissingParameter},
+		{"empty PolicyName", &iam.DeleteRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.DeleteRolePolicyInput{RoleName: aws.String("r"), PolicyName: aws.String("p")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DeleteRolePolicy(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListRolePolicies(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.ListRolePoliciesInput
+		wantErr string
+	}{
+		{"nil RoleName", &iam.ListRolePoliciesInput{}, awserrors.ErrorMissingParameter},
+		{"empty RoleName", &iam.ListRolePoliciesInput{RoleName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.ListRolePoliciesInput{RoleName: aws.String("r")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListRolePolicies(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/spinifex/gateway/iam_request_test.go
+++ b/spinifex/gateway/iam_request_test.go
@@ -169,6 +169,18 @@ func (m *flexMockIAMService) DetachRolePolicy(_ string, _ *iam.DetachRolePolicyI
 func (m *flexMockIAMService) ListAttachedRolePolicies(_ string, _ *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
 	return &iam.ListAttachedRolePoliciesOutput{}, nil
 }
+func (m *flexMockIAMService) PutRolePolicy(_ string, _ *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	return &iam.PutRolePolicyOutput{}, nil
+}
+func (m *flexMockIAMService) GetRolePolicy(_ string, _ *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
+	return &iam.GetRolePolicyOutput{}, nil
+}
+func (m *flexMockIAMService) DeleteRolePolicy(_ string, _ *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	return &iam.DeleteRolePolicyOutput{}, nil
+}
+func (m *flexMockIAMService) ListRolePolicies(_ string, _ *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	return &iam.ListRolePoliciesOutput{}, nil
+}
 func (m *flexMockIAMService) CreateInstanceProfile(_ string, _ *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
 	return &iam.CreateInstanceProfileOutput{}, nil
 }

--- a/spinifex/gateway/sts/handler_test.go
+++ b/spinifex/gateway/sts/handler_test.go
@@ -169,6 +169,18 @@ func (s *stubIAMService) DetachRolePolicy(string, *iam.DetachRolePolicyInput) (*
 func (s *stubIAMService) ListAttachedRolePolicies(string, *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
 	panic("unexpected ListAttachedRolePolicies call")
 }
+func (s *stubIAMService) PutRolePolicy(string, *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	panic("unexpected PutRolePolicy call")
+}
+func (s *stubIAMService) GetRolePolicy(string, *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
+	panic("unexpected GetRolePolicy call")
+}
+func (s *stubIAMService) DeleteRolePolicy(string, *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	panic("unexpected DeleteRolePolicy call")
+}
+func (s *stubIAMService) ListRolePolicies(string, *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	panic("unexpected ListRolePolicies call")
+}
 func (s *stubIAMService) CreateInstanceProfile(string, *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
 	panic("unexpected CreateInstanceProfile call")
 }

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -328,6 +328,105 @@ func (s *IAMServiceImpl) ListAttachedRolePolicies(accountID string, input *iam.L
 	}, nil
 }
 
+// PutRolePolicy embeds an inline policy document in a role, keyed by PolicyName.
+// Idempotent upsert: a same-name policy is overwritten, mirroring AWS.
+func (s *IAMServiceImpl) PutRolePolicy(accountID string, input *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	roleName := *input.RoleName
+	policyName := *input.PolicyName
+	policyDoc := *input.PolicyDocument
+
+	if err := validatePolicyName(policyName); err != nil {
+		return nil, errors.New(awserrors.ErrorIAMInvalidInput)
+	}
+	if _, err := ValidatePolicyDocument(policyDoc); err != nil {
+		return nil, errors.New(awserrors.ErrorIAMMalformedPolicyDocument)
+	}
+
+	err := s.updateRoleCAS(accountID, roleName, func(role *Role) (bool, error) {
+		if role.InlinePolicies == nil {
+			role.InlinePolicies = map[string]string{}
+		}
+		role.InlinePolicies[policyName] = policyDoc
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("IAM inline policy put on role", "accountID", accountID, "roleName", roleName, "policyName", policyName)
+	return &iam.PutRolePolicyOutput{}, nil
+}
+
+// GetRolePolicy returns a role's inline policy document by name.
+// Returns the document as a raw JSON string, matching how GetRole returns
+// AssumeRolePolicyDocument; AWS URL-encodes it, we follow the in-repo convention.
+func (s *IAMServiceImpl) GetRolePolicy(accountID string, input *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
+	roleName := *input.RoleName
+	policyName := *input.PolicyName
+
+	role, err := s.getRole(accountID, roleName)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, ok := role.InlinePolicies[policyName]
+	if !ok {
+		return nil, errors.New(awserrors.ErrorIAMNoSuchEntity)
+	}
+
+	return &iam.GetRolePolicyOutput{
+		RoleName:       aws.String(roleName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(doc),
+	}, nil
+}
+
+// DeleteRolePolicy removes a role's inline policy by name. A missing name yields
+// NoSuchEntity, matching AWS.
+func (s *IAMServiceImpl) DeleteRolePolicy(accountID string, input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	roleName := *input.RoleName
+	policyName := *input.PolicyName
+
+	err := s.updateRoleCAS(accountID, roleName, func(role *Role) (bool, error) {
+		if _, ok := role.InlinePolicies[policyName]; !ok {
+			return false, errors.New(awserrors.ErrorIAMNoSuchEntity)
+		}
+		delete(role.InlinePolicies, policyName)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("IAM inline policy deleted from role", "accountID", accountID, "roleName", roleName, "policyName", policyName)
+	return &iam.DeleteRolePolicyOutput{}, nil
+}
+
+// ListRolePolicies returns the names of a role's inline policies, sorted for
+// deterministic output. Pagination is not implemented: IsTruncated is always false.
+func (s *IAMServiceImpl) ListRolePolicies(accountID string, input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	role, err := s.getRole(accountID, *input.RoleName)
+	if err != nil {
+		return nil, err
+	}
+
+	rawNames := make([]string, 0, len(role.InlinePolicies))
+	for name := range role.InlinePolicies {
+		rawNames = append(rawNames, name)
+	}
+	slices.Sort(rawNames)
+
+	names := make([]*string, 0, len(rawNames))
+	for _, name := range rawNames {
+		names = append(names, aws.String(name))
+	}
+
+	return &iam.ListRolePoliciesOutput{
+		PolicyNames: names,
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
 // GetRolePolicies resolves the managed policy documents attached to a role.
 // Used by the gateway for policy evaluation. Fails closed: any unresolvable
 // policy returns an error so the caller denies access rather than using a partial set.

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -172,6 +172,10 @@ func (s *IAMServiceImpl) DeleteRole(accountID string, input *iam.DeleteRoleInput
 		return nil, errors.New(awserrors.ErrorIAMDeleteConflict)
 	}
 
+	if len(role.InlinePolicies) > 0 {
+		return nil, errors.New(awserrors.ErrorIAMDeleteConflict)
+	}
+
 	profiles, err := s.findInstanceProfilesForRole(accountID, roleName)
 	if err != nil {
 		return nil, fmt.Errorf("check role instance profiles: %w", err)
@@ -445,6 +449,14 @@ func (s *IAMServiceImpl) GetRolePolicies(accountID, roleName string) ([]PolicyDo
 		if include {
 			docs = append(docs, doc)
 		}
+	}
+
+	for name, raw := range role.InlinePolicies {
+		doc, err := ValidatePolicyDocument(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse inline policy %s: %w", name, err) // fail closed
+		}
+		docs = append(docs, *doc)
 	}
 
 	return docs, nil

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -431,7 +431,7 @@ func (s *IAMServiceImpl) ListRolePolicies(accountID string, input *iam.ListRoleP
 	}, nil
 }
 
-// GetRolePolicies resolves the managed policy documents attached to a role.
+// GetRolePolicies resolves the managed and inline policy documents for a role.
 // Used by the gateway for policy evaluation. Fails closed: any unresolvable
 // policy returns an error so the caller denies access rather than using a partial set.
 func (s *IAMServiceImpl) GetRolePolicies(accountID, roleName string) ([]PolicyDocument, error) {
@@ -452,11 +452,11 @@ func (s *IAMServiceImpl) GetRolePolicies(accountID, roleName string) ([]PolicyDo
 	}
 
 	for name, raw := range role.InlinePolicies {
-		doc, err := ValidatePolicyDocument(raw)
-		if err != nil {
+		var doc PolicyDocument
+		if err := json.Unmarshal([]byte(raw), &doc); err != nil {
 			return nil, fmt.Errorf("parse inline policy %s: %w", name, err) // fail closed
 		}
-		docs = append(docs, *doc)
+		docs = append(docs, doc)
 	}
 
 	return docs, nil

--- a/spinifex/handlers/iam/roles_test.go
+++ b/spinifex/handlers/iam/roles_test.go
@@ -775,6 +775,333 @@ func policiesGrant(docs []PolicyDocument, action string) bool {
 }
 
 // ============================================================================
+// Inline Role Policy Tests (Put / Get / Delete / List)
+// ============================================================================
+
+// inlineDenyDocument returns a valid inline policy document that denies an action.
+func inlineDenyDocument() string {
+	return `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"s3:DeleteObject","Resource":"*"}]}`
+}
+
+func TestPutRolePolicy_RoundTrip(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "inline-role")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("inline-role"),
+		PolicyName:     aws.String("AllowDescribe"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	out, err := svc.GetRolePolicy(testAccountID, &iam.GetRolePolicyInput{
+		RoleName:   aws.String("inline-role"),
+		PolicyName: aws.String("AllowDescribe"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inline-role", *out.RoleName)
+	assert.Equal(t, "AllowDescribe", *out.PolicyName)
+	assert.Equal(t, validPolicyDocument(), *out.PolicyDocument)
+}
+
+func TestPutRolePolicy_IdempotentOverwrite(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "overwrite-role")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("overwrite-role"),
+		PolicyName:     aws.String("Policy"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("overwrite-role"),
+		PolicyName:     aws.String("Policy"),
+		PolicyDocument: aws.String(inlineDenyDocument()),
+	})
+	require.NoError(t, err)
+
+	out, err := svc.GetRolePolicy(testAccountID, &iam.GetRolePolicyInput{
+		RoleName:   aws.String("overwrite-role"),
+		PolicyName: aws.String("Policy"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, inlineDenyDocument(), *out.PolicyDocument)
+
+	list, err := svc.ListRolePolicies(testAccountID, &iam.ListRolePoliciesInput{
+		RoleName: aws.String("overwrite-role"),
+	})
+	require.NoError(t, err)
+	assert.Len(t, list.PolicyNames, 1, "overwrite must not duplicate the name")
+}
+
+func TestPutRolePolicy_InvalidName(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "badname-role")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("badname-role"),
+		PolicyName:     aws.String("bad name"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMInvalidInput)
+}
+
+func TestPutRolePolicy_MalformedDocument(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "malformed-role")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("malformed-role"),
+		PolicyName:     aws.String("Bad"),
+		PolicyDocument: aws.String(`{not valid json`),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMMalformedPolicyDocument)
+}
+
+func TestPutRolePolicy_OversizedDocument(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "oversized-role")
+
+	huge := strings.Repeat("a", maxPolicyDocumentSize+1)
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("oversized-role"),
+		PolicyName:     aws.String("Huge"),
+		PolicyDocument: aws.String(huge),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMMalformedPolicyDocument)
+}
+
+func TestPutRolePolicy_RoleNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("ghost"),
+		PolicyName:     aws.String("Policy"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestGetRolePolicy_UnknownName(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "get-unknown")
+
+	_, err := svc.GetRolePolicy(testAccountID, &iam.GetRolePolicyInput{
+		RoleName:   aws.String("get-unknown"),
+		PolicyName: aws.String("missing"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestGetRolePolicy_RoleNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.GetRolePolicy(testAccountID, &iam.GetRolePolicyInput{
+		RoleName:   aws.String("ghost"),
+		PolicyName: aws.String("Policy"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestListRolePolicies_Sorted(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "list-role")
+
+	for _, name := range []string{"Charlie", "Alpha", "Bravo"} {
+		_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+			RoleName:       aws.String("list-role"),
+			PolicyName:     aws.String(name),
+			PolicyDocument: aws.String(validPolicyDocument()),
+		})
+		require.NoError(t, err)
+	}
+
+	out, err := svc.ListRolePolicies(testAccountID, &iam.ListRolePoliciesInput{
+		RoleName: aws.String("list-role"),
+	})
+	require.NoError(t, err)
+	require.False(t, *out.IsTruncated)
+	got := make([]string, 0, len(out.PolicyNames))
+	for _, n := range out.PolicyNames {
+		got = append(got, *n)
+	}
+	assert.Equal(t, []string{"Alpha", "Bravo", "Charlie"}, got)
+}
+
+func TestListRolePolicies_Empty(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "empty-inline")
+
+	out, err := svc.ListRolePolicies(testAccountID, &iam.ListRolePoliciesInput{
+		RoleName: aws.String("empty-inline"),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, out.PolicyNames)
+	assert.Len(t, out.PolicyNames, 0)
+	assert.False(t, *out.IsTruncated)
+}
+
+func TestListRolePolicies_RoleNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.ListRolePolicies(testAccountID, &iam.ListRolePoliciesInput{
+		RoleName: aws.String("ghost"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestDeleteRolePolicy(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "del-inline")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("del-inline"),
+		PolicyName:     aws.String("Doomed"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteRolePolicy(testAccountID, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String("del-inline"),
+		PolicyName: aws.String("Doomed"),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.GetRolePolicy(testAccountID, &iam.GetRolePolicyInput{
+		RoleName:   aws.String("del-inline"),
+		PolicyName: aws.String("Doomed"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+
+	list, err := svc.ListRolePolicies(testAccountID, &iam.ListRolePoliciesInput{
+		RoleName: aws.String("del-inline"),
+	})
+	require.NoError(t, err)
+	assert.Len(t, list.PolicyNames, 0)
+}
+
+func TestDeleteRolePolicy_DoubleDelete(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "double-del")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("double-del"),
+		PolicyName:     aws.String("Once"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteRolePolicy(testAccountID, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String("double-del"),
+		PolicyName: aws.String("Once"),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteRolePolicy(testAccountID, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String("double-del"),
+		PolicyName: aws.String("Once"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestDeleteRolePolicy_RoleNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.DeleteRolePolicy(testAccountID, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String("ghost"),
+		PolicyName: aws.String("Policy"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestDeleteRole_WithInlinePolicy(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "inline-conflict")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("inline-conflict"),
+		PolicyName:     aws.String("Blocker"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteRole(testAccountID, &iam.DeleteRoleInput{
+		RoleName: aws.String("inline-conflict"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMDeleteConflict)
+
+	// Succeeds once the inline policy is removed.
+	_, err = svc.DeleteRolePolicy(testAccountID, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String("inline-conflict"),
+		PolicyName: aws.String("Blocker"),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteRole(testAccountID, &iam.DeleteRoleInput{
+		RoleName: aws.String("inline-conflict"),
+	})
+	require.NoError(t, err)
+}
+
+// TestGetRolePolicies_Inline proves the enforcement resolver walks inline
+// policies, not just managed attachments, so an inline statement is evaluated.
+func TestGetRolePolicies_Inline(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestRole(t, svc, "inline-eval")
+
+	_, err := svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("inline-eval"),
+		PolicyName:     aws.String("InlineAllow"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	docs, err := svc.GetRolePolicies(testAccountID, "inline-eval")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.True(t, policiesGrant(docs, "ec2:DescribeInstances"))
+}
+
+// TestGetRolePolicies_ManagedAndInline proves managed and inline documents both
+// surface from the resolver in one combined set.
+func TestGetRolePolicies_ManagedAndInline(t *testing.T) {
+	svc := setupTestIAMService(t)
+	role := createTestRole(t, svc, "combined-eval")
+	policy := createTestPolicy(t, svc, "ManagedAllow")
+
+	_, err := svc.AttachRolePolicy(testAccountID, &iam.AttachRolePolicyInput{
+		RoleName:  role.RoleName,
+		PolicyArn: policy.Arn,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.PutRolePolicy(testAccountID, &iam.PutRolePolicyInput{
+		RoleName:       aws.String("combined-eval"),
+		PolicyName:     aws.String("InlineDeny"),
+		PolicyDocument: aws.String(inlineDenyDocument()),
+	})
+	require.NoError(t, err)
+
+	docs, err := svc.GetRolePolicies(testAccountID, "combined-eval")
+	require.NoError(t, err)
+	require.Len(t, docs, 2)
+	assert.True(t, policiesGrant(docs, "ec2:DescribeInstances"), "managed Allow surfaced")
+}
+
+// ============================================================================
 // Account Scoping
 // ============================================================================
 

--- a/spinifex/handlers/iam/service.go
+++ b/spinifex/handlers/iam/service.go
@@ -76,8 +76,8 @@ type IAMService interface {
 	// Policy evaluation (internal — used by gateway enforcement)
 	GetUserPolicies(accountID, userName string) ([]PolicyDocument, error)
 	// GetRolePolicies resolves an assumed-role session's permission policies for
-	// gateway enforcement. Managed policies only; inline policies are not yet
-	// supported.
+	// gateway enforcement. Resolves both managed attachments and embedded inline
+	// policies.
 	GetRolePolicies(accountID, roleName string) ([]PolicyDocument, error)
 
 	// Auth (internal — used by SigV4 middleware and bootstrap, not exposed via gateway)

--- a/spinifex/handlers/iam/service.go
+++ b/spinifex/handlers/iam/service.go
@@ -39,10 +39,14 @@ type IAMService interface {
 	UpdateRole(accountID string, input *iam.UpdateRoleInput) (*iam.UpdateRoleOutput, error)
 	UpdateAssumeRolePolicy(accountID string, input *iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error)
 
-	// Role policy attachment — account-scoped
+	// Role policies — managed + inline — account-scoped
 	AttachRolePolicy(accountID string, input *iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error)
 	DetachRolePolicy(accountID string, input *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error)
 	ListAttachedRolePolicies(accountID string, input *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error)
+	PutRolePolicy(accountID string, input *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error)
+	GetRolePolicy(accountID string, input *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error)
+	DeleteRolePolicy(accountID string, input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error)
+	ListRolePolicies(accountID string, input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error)
 
 	// Instance profile CRUD — account-scoped
 	CreateInstanceProfile(accountID string, input *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error)

--- a/spinifex/handlers/iam/types.go
+++ b/spinifex/handlers/iam/types.go
@@ -74,17 +74,18 @@ type Statement struct {
 // Role is an assumable IAM identity stored in JetStream KV.
 // AssumeRolePolicyDocument is stored opaque; parsed for shape validation only.
 type Role struct {
-	RoleName                 string   `json:"role_name"`
-	RoleID                   string   `json:"role_id"`
-	AccountID                string   `json:"account_id"`
-	ARN                      string   `json:"arn"`
-	Path                     string   `json:"path"`
-	Description              string   `json:"description,omitempty"`
-	AssumeRolePolicyDocument string   `json:"assume_role_policy_document"`
-	MaxSessionDuration       int64    `json:"max_session_duration,omitempty"`
-	CreatedAt                string   `json:"created_at"`
-	AttachedPolicies         []string `json:"attached_policies"` // policy ARNs
-	Tags                     []Tag    `json:"tags"`
+	RoleName                 string            `json:"role_name"`
+	RoleID                   string            `json:"role_id"`
+	AccountID                string            `json:"account_id"`
+	ARN                      string            `json:"arn"`
+	Path                     string            `json:"path"`
+	Description              string            `json:"description,omitempty"`
+	AssumeRolePolicyDocument string            `json:"assume_role_policy_document"`
+	MaxSessionDuration       int64             `json:"max_session_duration,omitempty"`
+	CreatedAt                string            `json:"created_at"`
+	AttachedPolicies         []string          `json:"attached_policies"`         // policy ARNs
+	InlinePolicies           map[string]string `json:"inline_policies,omitempty"` // policyName → document JSON
+	Tags                     []Tag             `json:"tags"`
 }
 
 // InstanceProfile is a container for at most one Role, attachable to EC2 instances.


### PR DESCRIPTION
## Summary

Add the inline role-policy operations to spinifex's IAM surface — `PutRolePolicy`, `GetRolePolicy`, `DeleteRolePolicy` — and replace the hardcoded-empty `ListRolePolicies` stub with a real implementation. Inline policies are policy documents embedded directly in a role (keyed by `PolicyName`), complementing the existing managed attachment path (`AttachRolePolicy`).

These are the operations the AWS Terraform provider and CLI expect for `aws_iam_role_policy` and the inline `inline_policy` block.

## Changes

- `handlers/iam/types.go`: `InlinePolicies map[string]string` on `Role` (`omitempty`, so existing serialised roles are byte-identical until first write).
- `handlers/iam/service.go`: four interface methods in the role-policy block.
- `handlers/iam/roles.go`: CRUD impls via the existing `updateRoleCAS` path (idempotent upsert; missing name/role → `NoSuchEntity`; sorted `ListRolePolicies` with `IsTruncated=false`). `DeleteRole` gains an inline-policy `DeleteConflict` check. `GetRolePolicies` (the assumed-role enforcement resolver) now also walks inline documents, failing closed on a parse error.
- `gateway/iam/role.go`: `Put`/`Get`/`DeleteRolePolicy` param-guard wrappers; `ListRolePolicies` rewritten to delegate to the service.
- `gateway/iam.go`: route the three new actions.