### PR TITLE
fix: recover reaped container instances when the agent re-registers

### DIFF
--- a/spinifex/handlers/ecs/cluster_teardown.go
+++ b/spinifex/handlers/ecs/cluster_teardown.go
@@ -120,6 +120,7 @@ func (s *Service) UpdateContainerInstancesState(input *ecs.UpdateContainerInstan
 			continue
 		}
 		rec.Status = status
+		rec.Reaped = false
 		if perr := putJSON(kv, InstanceKey(cluster, id), &rec); perr != nil {
 			return nil, perr
 		}

--- a/spinifex/handlers/ecs/instance_recovery_test.go
+++ b/spinifex/handlers/ecs/instance_recovery_test.go
@@ -1,0 +1,87 @@
+package handlers_ecs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// reRegister drives the agent's heartbeat path: an idempotent
+// RegisterContainerInstance through the gateway handler.
+func reRegister(t *testing.T, svc *Service, cluster, id string) {
+	t.Helper()
+	_, err := svc.RegisterContainerInstance(&ecs.RegisterContainerInstanceInput{
+		Cluster:                  aws.String(cluster),
+		InstanceIdentityDocument: aws.String(id),
+	}, testAccountID)
+	require.NoError(t, err)
+}
+
+func instanceStatus(t *testing.T, svc *Service, cluster, id string) InstanceRecord {
+	t.Helper()
+	kv, err := svc.bucket(testAccountID)
+	require.NoError(t, err)
+	var rec InstanceRecord
+	found, err := getJSON(kv, InstanceKey(cluster, id), &rec)
+	require.NoError(t, err)
+	require.True(t, found)
+	return rec
+}
+
+// A reaper-drained (involuntary) instance returns to ACTIVE once its agent
+// re-registers, so a control-plane restart that briefly reaps live instances
+// self-heals instead of stranding them in DRAINING.
+func TestRegister_RestoresReapedInstanceToActive(t *testing.T) {
+	svc, nc := newTestService(t)
+	_, err := svc.CreateCluster(&ecs.CreateClusterInput{ClusterName: aws.String("web")}, testAccountID)
+	require.NoError(t, err)
+	registerInstance(t, svc, "web", "i-1", 1024, 2048)
+
+	kv, err := svc.bucket(testAccountID)
+	require.NoError(t, err)
+	rec := instanceStatus(t, svc, "web", "i-1")
+	rec.LastSeen = time.Now().UTC().Add(-2 * heartbeatTimeout)
+	require.NoError(t, putJSON(kv, InstanceKey("web", "i-1"), &rec))
+
+	NewScheduler(nc, svc, "test-holder").reapBucket(kv, testAccountID, time.Now().UTC())
+
+	reaped := instanceStatus(t, svc, "web", "i-1")
+	require.Equal(t, InstanceStatusDraining, reaped.Status)
+	require.True(t, reaped.Reaped)
+
+	reRegister(t, svc, "web", "i-1")
+
+	recovered := instanceStatus(t, svc, "web", "i-1")
+	assert.Equal(t, InstanceStatusActive, recovered.Status)
+	assert.False(t, recovered.Reaped)
+}
+
+// An operator UpdateContainerInstancesState=DRAINING is intentional and must
+// persist even though the live agent keeps re-registering.
+func TestRegister_DoesNotUndoOperatorDrain(t *testing.T) {
+	svc, _ := newTestService(t)
+	_, err := svc.CreateCluster(&ecs.CreateClusterInput{ClusterName: aws.String("web")}, testAccountID)
+	require.NoError(t, err)
+	registerInstance(t, svc, "web", "i-1", 1024, 2048)
+
+	arn := instanceStatus(t, svc, "web", "i-1").ARN
+	_, err = svc.UpdateContainerInstancesState(&ecs.UpdateContainerInstancesStateInput{
+		Cluster:            aws.String("web"),
+		ContainerInstances: []*string{aws.String(arn)},
+		Status:             aws.String(InstanceStatusDraining),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	drained := instanceStatus(t, svc, "web", "i-1")
+	require.Equal(t, InstanceStatusDraining, drained.Status)
+	require.False(t, drained.Reaped)
+
+	reRegister(t, svc, "web", "i-1")
+
+	after := instanceStatus(t, svc, "web", "i-1")
+	assert.Equal(t, InstanceStatusDraining, after.Status, "operator drain must survive agent re-register")
+}

--- a/spinifex/handlers/ecs/instances.go
+++ b/spinifex/handlers/ecs/instances.go
@@ -54,6 +54,13 @@ func (s *Service) RegisterContainerInstance(input *ecs.RegisterContainerInstance
 				r.TotalMemoryMiB = int(aws.Int64Value(res.IntegerValue))
 			}
 		}
+		// The agent heartbeats by re-registering. A re-register from a reaped
+		// (involuntarily drained) instance proves the agent is back, so restore
+		// it to ACTIVE. An operator drain (Reaped=false) is left untouched.
+		if r.Status == InstanceStatusDraining && r.Reaped {
+			r.Status = InstanceStatusActive
+			r.Reaped = false
+		}
 	})
 	if err != nil {
 		return nil, err

--- a/spinifex/handlers/ecs/records.go
+++ b/spinifex/handlers/ecs/records.go
@@ -149,6 +149,11 @@ type InstanceRecord struct {
 	PlacedTasks       []string  `json:"placedTasks,omitempty"`
 	RegisteredAt      time.Time `json:"registeredAt"`
 	LastSeen          time.Time `json:"lastSeen"`
+	// Reaped marks a DRAINING caused by the heartbeat reaper (involuntary), as
+	// opposed to an operator UpdateContainerInstancesState drain. A reaped
+	// instance is restored to ACTIVE when its agent re-registers; an operator
+	// drain persists.
+	Reaped bool `json:"reaped,omitempty"`
 }
 
 // ContainerState is a container's last-reported status within a task record.

--- a/spinifex/handlers/ecs/scheduler.go
+++ b/spinifex/handlers/ecs/scheduler.go
@@ -267,6 +267,7 @@ func (sc *Scheduler) reapBucket(kv nats.KeyValue, accountID string, now time.Tim
 		slog.Warn("ECS scheduler: reaping disconnected instance", "cluster", inst.Cluster, "instance", inst.InstanceID,
 			"lastSeen", inst.LastSeen.Format(time.RFC3339))
 		inst.Status = InstanceStatusDraining
+		inst.Reaped = true
 		if perr := putJSON(kv, k, &inst); perr != nil {
 			continue
 		}


### PR DESCRIPTION
## Problem

The ECS agent heartbeats by periodically re-registering through the gateway (`RegisterContainerInstance`). After a control-plane restart, the heartbeat reaper marks instances `DRAINING` for the missed-heartbeat window — but the re-register path only refreshed `LastSeen` and never restored `Status`. A reaped instance therefore stayed `DRAINING` forever even though its agent was healthy and re-registering every 30s.

## Fix

- Add a `Reaped` flag to `InstanceRecord`, set by the reaper when it involuntarily drains an instance.
- On `RegisterContainerInstance`, restore a reaped instance to `ACTIVE` and clear the flag.
- An operator `UpdateContainerInstancesState` drain clears `Reaped`, so an intentional drain is never undone by the live agent.

## Testing

- Unit (`-race`): reaped instance recovers to ACTIVE on re-register; operator drain persists across re-register.
- Live (local spinifex): ACTIVE instance, gateway stopped >90s → reaper drained it (`status=DRAINING`, `reaped=true`); agent re-registered on VM boot → recovered to `ACTIVE` (agentConnected true). Verified via on-disk KV and `describe-container-instances`.