### PR TITLE
fix: re-assert boot-volume in-use state on daemon-restart reconnect (siv-464)

### DIFF
--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -160,17 +160,7 @@ func (m *Manager) launch(instance *VM) error {
 	}
 
 	// Mark boot volumes as "in-use" now that instance is confirmed running.
-	if m.deps.VolumeStateUpdater != nil {
-		instance.EBSRequests.Mu.Lock()
-		for _, ebsReq := range instance.EBSRequests.Requests {
-			if ebsReq.Boot {
-				if err := m.deps.VolumeStateUpdater.UpdateVolumeState(ebsReq.Name, "in-use", instance.ID, ""); err != nil {
-					slog.Error("Failed to update volume state to in-use", "volumeId", ebsReq.Name, "err", err)
-				}
-			}
-		}
-		instance.EBSRequests.Mu.Unlock()
-	}
+	m.markBootVolumesInUse(instance)
 
 	if m.deps.Hooks.OnInstanceUp != nil {
 		// Launch path: per-instance subscribe failures are logged and the
@@ -184,6 +174,26 @@ func (m *Manager) launch(instance *VM) error {
 	}
 
 	return nil
+}
+
+// markBootVolumesInUse re-asserts "in-use" status for an instance's boot
+// volumes once it is confirmed running. Used by the launch path and the
+// daemon-restart reconnect path so both keep volume state consistent with a
+// running instance. Errors are logged, not fatal.
+func (m *Manager) markBootVolumesInUse(instance *VM) {
+	if m.deps.VolumeStateUpdater == nil {
+		return
+	}
+	instance.EBSRequests.Mu.Lock()
+	defer instance.EBSRequests.Mu.Unlock()
+	for _, ebsReq := range instance.EBSRequests.Requests {
+		if !ebsReq.Boot {
+			continue
+		}
+		if err := m.deps.VolumeStateUpdater.UpdateVolumeState(ebsReq.Name, "in-use", instance.ID, ""); err != nil {
+			slog.Error("Failed to update volume state to in-use", "volumeId", ebsReq.Name, "err", err)
+		}
+	}
 }
 
 const (

--- a/spinifex/vm/restore.go
+++ b/spinifex/vm/restore.go
@@ -318,6 +318,10 @@ func (m *Manager) reconnectInstance(instance *VM) error {
 
 	instance.Status = StateRunning
 
+	// Re-assert boot-volume in-use state; a daemon restart otherwise leaves the
+	// root volume "available" while the instance runs (split-brain, siv-464).
+	m.markBootVolumesInUse(instance)
+
 	if err := m.writeRunningState(); err != nil {
 		return fmt.Errorf("failed to persist reconnected instance state: %w", err)
 	}

--- a/spinifex/vm/restore_test.go
+++ b/spinifex/vm/restore_test.go
@@ -885,6 +885,35 @@ func TestReconnectInstance(t *testing.T) {
 		assert.NotNil(t, saved["i-no-hook"], "the reconnected instance must appear in the persisted snapshot")
 	})
 
+	t.Run("reconnect re-asserts boot-volume in-use, skips non-boot", func(t *testing.T) {
+		stateUpdater := &fakeVolumeStateUpdater{}
+		m := NewManager()
+		m.SetDeps(Deps{
+			NodeID:             "test-node",
+			StateStore:         newFakeStateStore(),
+			VolumeStateUpdater: stateUpdater,
+		})
+
+		orig := attachQMPForReconnect
+		t.Cleanup(func() { attachQMPForReconnect = orig })
+		attachQMPForReconnect = func(_ *Manager, v *VM) error { fakeAttachQMP(t, v); return nil }
+
+		instance := &VM{ID: "i-reconnect-vol", Status: StatePending}
+		instance.EBSRequests.Requests = []types.EBSRequest{
+			{Name: "vol-root", Boot: true},
+			{Name: "vol-data", Boot: false},
+		}
+		m.Insert(instance)
+
+		require.NoError(t, m.reconnectInstance(instance))
+
+		calls := stateUpdater.snapshot()
+		require.Len(t, calls, 1,
+			"reconnect must re-assert exactly the boot volume — a daemon restart otherwise leaves the root volume 'available' while the VM runs (siv-464)")
+		assert.Equal(t, volumeStateUpdate{VolumeID: "vol-root", State: "in-use", InstanceID: "i-reconnect-vol"}, calls[0],
+			"the boot volume must be marked in-use under the running instance; non-boot volumes are owned by their own attach flow")
+	})
+
 	t.Run("AttachQMP succeeds, OnInstanceUp errors: QMP closed and nil'd", func(t *testing.T) {
 		m := NewManager()
 		hookErr := errors.New("nats subscribe failed")


### PR DESCRIPTION
## Problem
After a spinifex daemon restart, `restore.go reconnectInstance` reconnects to a surviving QEMU and re-asserts the **instance** running state, but never re-asserts the **boot volume** in-use state. Result: `describe-instances` shows the VM running while `describe-volumes` shows its root volume `available` — a split-brain that makes `start-instances` attempt to double-launch a live QEMU (`Instance is already running pid=...`).

Sibling of siv-462 (which fixed the matching unmount gate so the boot volume isn't wrongly flipped to `available` on stop/crash).

## Fix
- Extract the launch path's boot-volume promotion (`lifecycle.go`) into a shared `markBootVolumesInUse` helper.
- Call it from `reconnectInstance` after the instance is set to `StateRunning`, so launch and recovery keep volume state consistent.

## Test
- New `TestReconnectInstance` subtest: a reconnect with a Boot + non-Boot EBSRequest marks exactly the boot volume `in-use` and leaves the non-boot volume to its own attach flow.
- `make preflight` green (lint 0, govulncheck 0, race ok, diff coverage 68.9%).