### PR TITLE
fix: force-terminate stopped+wedged EKS workers on teardown (siv-475)

### DIFF
--- a/spinifex/daemon/eks_worker_launch.go
+++ b/spinifex/daemon/eks_worker_launch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ec2_instance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/instance"
 	handlers_eks "github.com/mulgadc/spinifex/spinifex/handlers/eks"
 	spxtypes "github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -96,8 +97,14 @@ func (d *Daemon) terminateWorkerInstance(instanceID, accountID string) error {
 		}
 	}
 	if errors.Is(err, nats.ErrNoResponders) {
-		slog.Debug("TerminateWorkerInstances: no owner for instance, already gone", "instanceId", instanceID)
-		return nil
+		// No live ec2.cmd owner: the worker is stopped — its per-instance
+		// subscription is torn down at stop, including a stopped+wedged VM whose
+		// volume remount broke. Fall back to the ec2.terminate queue group, which
+		// runs TerminateStoppedInstance against shared KV (deleting the worker's
+		// volumes, IP, and ENI) so the ENI cannot pin the customer subnet/VPC
+		// undeletable. Without this a DeleteCluster wedges in DELETING on
+		// DependencyViolation until the operator manually terminates the node.
+		return d.terminateStoppedWorker(instanceID, accountID)
 	}
 	if err != nil {
 		return err
@@ -109,5 +116,38 @@ func (d *Daemon) terminateWorkerInstance(instanceID, accountID string) error {
 		}
 		return errors.New(*errPayload.Code)
 	}
+	return nil
+}
+
+// terminateStoppedWorker tears down a worker that has no live ec2.cmd owner via
+// the ec2.terminate queue group, mirroring the gateway TerminateInstances
+// fallback. Any worker daemon services it from shared KV, so a stopped (incl.
+// stopped+wedged) worker is reaped regardless of which node ran the teardown. A
+// NotFound payload — or no responder at all — means the instance is already
+// gone, which a retried teardown treats as idempotent success.
+func (d *Daemon) terminateStoppedWorker(instanceID, accountID string) error {
+	req, err := json.Marshal(handlers_ec2_instance.TerminateStoppedInstanceInput{InstanceID: instanceID})
+	if err != nil {
+		return fmt.Errorf("marshal stopped-terminate request: %w", err)
+	}
+	reqMsg := nats.NewMsg("ec2.terminate")
+	reqMsg.Data = req
+	reqMsg.Header.Set(utils.AccountIDHeader, accountID)
+	msg, err := d.natsConn.RequestMsg(reqMsg, 30*time.Second)
+	if errors.Is(err, nats.ErrNoResponders) {
+		slog.Debug("TerminateWorkerInstances: no ec2.terminate responder, instance already gone", "instanceId", instanceID)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("ec2.terminate stopped worker %s: %w", instanceID, err)
+	}
+	if errPayload, parseErr := utils.ValidateErrorPayload(msg.Data); parseErr != nil {
+		if *errPayload.Code == awserrors.ErrorInvalidInstanceIDNotFound {
+			slog.Debug("TerminateWorkerInstances: stopped worker already gone, idempotent", "instanceId", instanceID)
+			return nil
+		}
+		return errors.New(*errPayload.Code)
+	}
+	slog.Info("TerminateWorkerInstances: terminated stopped worker via ec2.terminate", "instanceId", instanceID)
 	return nil
 }

--- a/spinifex/daemon/eks_worker_launch_test.go
+++ b/spinifex/daemon/eks_worker_launch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ec2_instance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/instance"
 	spxtypes "github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
@@ -93,6 +94,73 @@ func TestTerminateWorkerInstances_OwnerErrorSurfaces(t *testing.T) {
 	t.Cleanup(func() { _ = sub.Unsubscribe() })
 
 	err = d.TerminateWorkerInstances([]string{"i-protected"}, "111122223333")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorOperationNotPermitted)
+}
+
+// A stopped worker has no ec2.cmd.<id> owner (its per-instance subscription is
+// torn down at stop). The terminate must fall back to the ec2.terminate queue
+// group so TerminateStoppedInstance reaps the worker from shared KV — otherwise
+// a stopped+wedged node's ENI pins the customer subnet/VPC undeletable and
+// DeleteCluster wedges in DELETING (mulga-siv-475).
+func TestTerminateWorkerInstances_StoppedFallbackToEC2Terminate(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	d := &Daemon{natsConn: nc}
+
+	gotID := make(chan string, 1)
+	sub, err := nc.Subscribe("ec2.terminate", func(msg *nats.Msg) {
+		var req handlers_ec2_instance.TerminateStoppedInstanceInput
+		_ = json.Unmarshal(msg.Data, &req)
+		gotID <- req.InstanceID
+		_ = msg.Respond([]byte(`{"status":"terminated"}`))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	require.NoError(t, d.TerminateWorkerInstances([]string{"i-stopped"}, "111122223333"))
+
+	select {
+	case id := <-gotID:
+		assert.Equal(t, "i-stopped", id, "stopped worker must be reaped via ec2.terminate")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected stopped worker terminate routed to ec2.terminate")
+	}
+}
+
+// A NotFound payload from the ec2.terminate fallback (worker already drained) is
+// idempotent success, not a teardown failure.
+func TestTerminateWorkerInstances_StoppedFallbackNotFoundIdempotent(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	d := &Daemon{natsConn: nc}
+
+	sub, err := nc.Subscribe("ec2.terminate", func(msg *nats.Msg) {
+		_ = msg.Respond(utils.GenerateErrorPayload(awserrors.ErrorInvalidInstanceIDNotFound))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	require.NoError(t, d.TerminateWorkerInstances([]string{"i-drained"}, "111122223333"))
+}
+
+// A non-NotFound error from the ec2.terminate fallback must surface so the
+// teardown backstop retries rather than orphaning the worker (and its ENI).
+func TestTerminateWorkerInstances_StoppedFallbackErrorSurfaces(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	d := &Daemon{natsConn: nc}
+
+	sub, err := nc.Subscribe("ec2.terminate", func(msg *nats.Msg) {
+		_ = msg.Respond(utils.GenerateErrorPayload(awserrors.ErrorOperationNotPermitted))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	err = d.TerminateWorkerInstances([]string{"i-protected-stopped"}, "111122223333")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), awserrors.ErrorOperationNotPermitted)
 }


### PR DESCRIPTION
## Problem

`DeleteCluster` / `DeleteNodegroup` on env19 stalled indefinitely tearing down worker nodes that were **stopped and wedged** (volume remount broken). It never reaped them; a manual `aws ec2 terminate-instances` unblocked it.

Root cause: `TerminateWorkerInstances` routes each terminate to the worker's owning node via the per-instance topic `ec2.cmd.<id>`. That subscription is torn down when a VM transitions to stopped (`onInstanceDownHook`), so a stopped worker has **no responder** and the request returns `nats.ErrNoResponders`. The old code treated that as "already gone" and returned `nil` — but the worker was still in shared KV with its volumes, public IP, and ENI intact. The nodegroup record was deleted while the ENI kept pinning the customer subnet/VPC, so the later subnet/VPC teardown failed with `DependencyViolation` and the cluster wedged in `DELETING`.

The gateway `TerminateInstances` path (what manual `terminate-instances` hits) already handles this: on `ErrNoResponders` it falls back to the `ec2.terminate` queue group → `TerminateStoppedInstance` (tears down a stopped VM from shared KV, no running QEMU needed). The worker path just lacked the same fallback.

## Fix

- `terminateWorkerInstance`: on `ErrNoResponders`, call the new `terminateStoppedWorker` instead of returning `nil`.
- `terminateStoppedWorker`: publish `TerminateStoppedInstanceInput` to the `ec2.terminate` queue group (mirrors the gateway fallback). Any worker daemon services it from shared KV. `NotFound` — or no responder at all — is idempotent success; any other error payload surfaces so the teardown backstop retries.

## Scope note

This PR is **Part 1** of siv-475 (the bead's primary: force-terminate wedged stopped nodes). **Part 2** — reaping the AWS LoadBalancer Controller's orphan `k8s-toc-*` ALBs and `k8s-traffic-toc-*` SGs by ownership tag in `purgeClusterInfra` — is a separate cross-subsystem feature (ELBv2/SG tag-reaping) and is split into a follow-up bead.

## Testing

- `make preflight` passes (lint, vet, race, vulncheck, coverage).
- New: stopped worker reaped via `ec2.terminate`; NotFound is idempotent; non-NotFound error surfaces.
- Existing `TestTerminateWorkerInstances_NotFoundIsIdempotent` still green (no responder on either topic → idempotent).