### PR TITLE
feat: EKS apiserver anonymous-auth=false (CIS hardening)

### DIFF
--- a/scripts/images/eks-node/mulga-eks-state-report.sh
+++ b/scripts/images/eks-node/mulga-eks-state-report.sh
@@ -36,7 +36,9 @@ KUBECONFIG=${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml}
 export KUBECONFIG
 
 publish_report() {
-    if curl -sk --max-time 3 https://127.0.0.1:6443/healthz | grep -q '^ok$'; then
+    # Probe /healthz through the node's admin kubeconfig (apiserver runs
+    # anonymous-auth=false, CIS): an unauthenticated curl would return 401.
+    if kubectl get --raw='/healthz' 2>/dev/null | grep -q '^ok$'; then
         health=ok
         # Count Ready nodes only — k3s retains terminated workers as NotReady
         # until manually pruned, so a raw node count never drops on scale-down.

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -430,7 +430,9 @@ func buildK3sUserData(in K3sServerInput) string {
 
 	// First server uses cluster-init (embedded etcd); join servers set `server: <first>` + token.
 	// etcd-expose-metrics: surfaces etcd fsync/commit latency on 127.0.0.1:2381/metrics.
-	// anonymous-auth=true: reconciler probes /healthz unauthenticated to gate ACTIVE; RBAC limits exposure.
+	// anonymous-auth=false (CIS): cluster health rides the authenticated NATS
+	// state-report (probes /healthz via the node's admin kubeconfig), not an
+	// unauthenticated apiserver probe; the NLB target group uses a TCP health check.
 	// traefik+servicelb+local-storage are always disabled for AWS LB Controller parity.
 	var configLines []string
 	if in.ServerURL == "" {
@@ -486,7 +488,7 @@ func buildK3sUserData(in K3sServerInput) string {
 		"  - service-account-signing-key-file="+k3sOIDCSigningKeyPath,
 		"  - service-account-issuer="+in.OIDCIssuer,
 		"  - api-audiences=sts.amazonaws.com",
-		"  - anonymous-auth=true",
+		"  - anonymous-auth=false",
 		"  - authentication-token-webhook-config-file="+k3sTokenWebhookKubeconfigPath,
 		"  - authentication-token-webhook-cache-ttl=5m",
 		// v1: default v1beta1 rejects authentication.k8s.io/v1 TokenReview response (401).


### PR DESCRIPTION
## Summary
Flip the k3s server apiserver to `anonymous-auth=false` (CIS hardening, mulga-siv-231.5).

The only consumer of the anonymous path was the `mulga-eks-state-report` `/healthz` probe. It now probes through the node's admin kubeconfig (`kubectl get --raw=/healthz`); an unauthenticated curl would return 401.

## Why nothing else breaks
- **NLB target group** uses a TCP health check on 6443, not an HTTP `/healthz` probe.
- **Host-side reconciler** rides the authenticated NATS state-report (the host can't reach the VPC-bound apiserver directly), not an anonymous probe.
- `k3s-first-boot.sh` already used an authenticated `kubectl get --raw=/readyz`.

## Changes
- `spinifex/handlers/eks/k3s_server_vm.go`: `anonymous-auth=true` → `false` + comment.
- `scripts/images/eks-node/mulga-eks-state-report.sh`: anonymous curl `/healthz` → authenticated `kubectl get --raw=/healthz`.

## Testing
`make preflight` passes.

## Acceptance
apiserver runs `anonymous-auth=false`; cluster still reaches ACTIVE; reconciler health signal unaffected.