### PR TITLE
feat: EC2 Spot Instances v1 (mock SIRs over RunInstances)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -130,28 +130,9 @@ Operational commands for inspecting cluster state. These fan out NATS requests t
 | `monitor-instances` | — | `--instance-ids` | **NOT STARTED** |
 | `unmonitor-instances` | — | `--instance-ids` | **NOT STARTED** |
 
-`run-instances --iam-instance-profile` enforces `iam:PassRole` on the contained
-role ARN and rejects cross-account profile ARNs. Placement strategies: `spread`
-(1 per node, atomic CAS) and `cluster` (pin all to one node).
-
-`run-instances --capacity-reservation-specification` consumes a reserved slot on
-the node owning the targeted reservation (targeted-by-id only; `open`
-auto-matching is not supported). The combination with `--placement` (group) is
-rejected. `describe-instances` then reports the instance's `CapacityReservationId`.
-
-`modify-instance-metadata-options` is the only metadata-options mutator — AWS has
-no `get-instance-metadata-options` API, so the per-instance block is read through
-`describe-instances`. Only the hop limit is mutable; `--http-tokens optional` and
-the other posture-weakening values are refused with `UnsupportedOperation`, since
-the platform enforces IMDSv2 permanently. `run-instances --metadata-options` runs
-the same validation at launch.
-
 ### EC2 — Spot Instances
 
-Spot Instance Requests (SIRs) are a **mock** over the on-demand `run-instances`
-path: a request synchronously launches real VMs on the operator's own compute and
-is then reported `active`/`fulfilled`. There is no spot market — no bidding, price
-rejection, interruption, or reclamation, and instances are never reclaimed.
+Spot Instance Requests (SIRs) are a **mock** over the on-demand `run-instances` path: a request synchronously launches real VMs on the operator's own compute and is then reported `active`/`fulfilled`. There is no spot market — no bidding, price rejection, interruption, or reclamation, and instances are never reclaimed.
 
 | Command | Implemented Flags | Missing Flags | Status |
 |---------|-------------------|---------------|--------|
@@ -159,30 +140,9 @@ rejection, interruption, or reclamation, and instances are never reclaimed.
 | `describe-spot-instance-requests` | `--spot-instance-request-ids`, `--filters` (spot-instance-request-id, state, instance-id, launch.image-id, launch.instance-type, launch.key-name, type, launched-availability-zone, tag-key, tag:*) | `--max-results`, `--next-token`, `--dry-run` | **DONE** |
 | `cancel-spot-instance-requests` | `--spot-instance-request-ids` | `--dry-run` | **DONE** |
 
-`request-spot-instances` maps the single `--instance-count N` to
-`MinCount=MaxCount=N`, so fulfilment is **all-or-nothing**: on insufficient capacity
-the call returns `InsufficientInstanceCapacity` and **persists no SIRs**.
-`--client-token` is passed through to the on-demand idempotency path. The launched
-instances are plain on-demand VMs — v1 does **not** stamp `InstanceLifecycle=spot`
-or `SpotInstanceRequestId` on the instance; the instance↔request link lives only on
-the SIR (`SpotInstanceRequest.InstanceId`).
-
-`cancel-spot-instance-requests` flips the request to `cancelled`
-(`request-canceled-and-instance-running`) and **does not terminate** the instance —
-cancel ≠ terminate. Terminating the instance instead moves its SIR to `closed`
-(`instance-terminated-by-user`). Terminal (`cancelled`/`closed`) requests stay
-readable via `describe-spot-instance-requests` for **1 hour**, then auto-expire.
-
-`describe-spot-price-history` is **unsupported** (returns `InvalidAction`): on owned
-hardware there is no spot/on-demand price differential, so any synthetic price would
-be misleading rather than helpful.
+`describe-spot-price-history` is **unsupported** (returns `InvalidAction`): on owned hardware there is no spot/on-demand price differential, so any synthetic price would be misleading rather than helpful.
 
 ### EC2 — IAM Instance Profile Associations
-
-Stored as `vm.VM.IamInstanceProfileArn` + `IamInstanceProfileAssociationId`
-(one ARN per instance). Association IDs (`iip-assoc-`) are regenerated on every
-Associate/Replace and never reused. Auto-disassociated on terminate; preserved
-across stop/start.
 
 | Command | Implemented Flags | Missing Flags | Status |
 |---------|-------------------|---------------|--------|
@@ -214,9 +174,7 @@ across stop/start.
 | `reset-image-attribute` | `--image-id`, `--attribute description` | `--attribute launchPermission`, `--dry-run` | **DONE** |
 | `import-image` | — | `--disk-containers`, `--description`, `--architecture`, `--platform` | **NOT STARTED** |
 
-`copy-image` is metadata-only — no block copy. The new snapshot inherits the
-source `VolumeID`. `register-image`/`copy-image` accept `uefi-preferred` as
-input but treat it as `uefi` at launch.
+`copy-image` is metadata-only — no block copy. The new snapshot inherits the. source `VolumeID`.
 
 ### EC2 — Volumes (EBS)
 
@@ -259,8 +217,7 @@ input but treat it as `uefi` at launch.
 
 ### EC2 — Account Settings
 
-Persistence works (NATS JetStream KV) but stored values are not yet enforced
-by downstream services.
+Persistence works but stored values are not yet enforced by downstream services.
 
 | Command | Implemented Flags | Missing Flags | Status |
 |---------|-------------------|---------------|--------|
@@ -279,10 +236,7 @@ by downstream services.
 | `modify-instance-metadata-defaults` | — | `--http-tokens`, `--http-put-response-hop-limit`, `--http-endpoint`, `--instance-metadata-tags` | **NOT STARTED** |
 | `get-instance-metadata-defaults` | — | `--dry-run` | **NOT STARTED** |
 
-The account-level `modify-/get-instance-metadata-defaults` are blocked on an
-`aws-sdk-go` bump: the `InstanceMetadataDefaultsResponse` type is absent from the
-pinned v1.44.266 (these APIs landed ~March 2024), and the gateway's generic
-handler needs the typed input struct to route them.
+The account-level `modify-/get-instance-metadata-defaults` are blocked on an `aws-sdk-go` bump: the `InstanceMetadataDefaultsResponse` type is absent from our version (these APIs landed ~March 2024), and the gateway's generic handler needs the typed input struct to route them.
 
 ### EC2 — VPC Core
 
@@ -327,8 +281,7 @@ handler needs the typed input struct to route them.
 
 ### EC2 — Egress-Only Internet Gateway
 
-KV CRUD only — no OVN/OVS integration. EIGWs are stored but have no effect on
-network topology.
+KV CRUD only — no OVN/OVS integration. EIGWs are stored but have no effect on network topology.
 
 | Command | Implemented Flags | Missing Flags | Status |
 |---------|-------------------|---------------|--------|
@@ -656,7 +609,7 @@ curl -i http://169.254.169.254/latest/meta-data/instance-id
 | `/latest/meta-data/ami-id` | GET | launch `ImageId` | **DONE** |
 | `/latest/meta-data/ami-launch-index` | GET | Per-instance launch index (`0..n-1`), contiguous on partial failure | **DONE** |
 | `/latest/meta-data/reservation-id` | GET | `DescribeInstances` `Reservation.ReservationId` | **DONE** |
-| `/latest/meta-data/instance-life-cycle` | GET | `on-demand` (Spot not modelled) | **DONE** |
+| `/latest/meta-data/instance-life-cycle` | GET | `spot` for a spot-launched instance, else `on-demand`; defaults to `on-demand` on a resolution miss (never 404, the leaf is always advertised) | **DONE** |
 | `/latest/meta-data/local-ipv4` | GET | `ENIRecord.PrivateIpAddress` (== request source IP) | **DONE** |
 | `/latest/meta-data/public-ipv4` | GET | EIP, else instance public IP; empty body if none | **DONE** |
 | `/latest/meta-data/public-hostname` | GET | Mirrors `public-ipv4`; 404 when no public IP | **DONE** |
@@ -682,7 +635,7 @@ curl -i http://169.254.169.254/latest/meta-data/instance-id
 | `/latest/meta-data/block-device-mapping/...` | GET | `ami`/`root`/`ebsN`/`ephemeralN` device map | **NOT STARTED** (404) |
 | `/latest/meta-data/placement/{group-name,partition-number,availability-zone-id,host-id}` | GET | Placement extras beyond `availability-zone`/`region` | **NOT STARTED** (404) |
 | `/latest/meta-data/instance-action` | GET | `none` unless interruptible instances ship | **NOT STARTED** (404) |
-| `/latest/meta-data/spot/{instance-action,termination-time}` | GET | Only meaningful once Spot is modelled | **NOT STARTED** (404) |
+| `/latest/meta-data/spot/{instance-action,termination-time}` | GET | 404 is the faithful steady state for a never-interrupted spot instance ("no action scheduled"); a 200 body would trigger interruption handling in pollers (AWS Node Termination Handler / Karpenter). Not advertised in the `spot/` listing | **DONE** (404 by contract) |
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -572,7 +572,7 @@ bypasses policy evaluation entirely.
 | `get-federation-token` | — | `--name`, `--policy`, `--policy-arns`, `--duration-seconds`, `--tags` | **NOT STARTED** |
 | `decode-authorization-message` | — | `--encoded-message` | **NOT STARTED** |
 
-Trust policies stored on roles (`AssumeRolePolicyDocument`) reject `Condition`, `NotPrincipal`, `NotAction`, empty-string `Action` elements, and empty `Principal` blocks at write time (`MalformedPolicyDocument`) — v1 has no Condition evaluator so accepting them would silently allow.
+Trust policies (`AssumeRolePolicyDocument`) reject `NotPrincipal`, `NotAction`, empty-string `Action` elements, and empty `Principal` blocks at write time (`MalformedPolicyDocument`). `Condition` blocks are rejected except on `sts:AssumeRoleWithWebIdentity` with `StringEquals` (IRSA), which v1 evaluates at assume time (`{iss}:sub`, `{iss}:aud`); anything wider is rejected to avoid silent over-grant.
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -146,6 +146,37 @@ the other posture-weakening values are refused with `UnsupportedOperation`, sinc
 the platform enforces IMDSv2 permanently. `run-instances --metadata-options` runs
 the same validation at launch.
 
+### EC2 — Spot Instances
+
+Spot Instance Requests (SIRs) are a **mock** over the on-demand `run-instances`
+path: a request synchronously launches real VMs on the operator's own compute and
+is then reported `active`/`fulfilled`. There is no spot market — no bidding, price
+rejection, interruption, or reclamation, and instances are never reclaimed.
+
+| Command | Implemented Flags | Missing Flags | Status |
+|---------|-------------------|---------------|--------|
+| `request-spot-instances` | `--instance-count` (default 1), `--type` (`one-time`/`persistent` — stored, behaviour identical), `--spot-price` (echoed only), `--client-token`, `--launch-specification` (ImageId, InstanceType, KeyName, SubnetId, SecurityGroupIds, UserData, BlockDeviceMappings, IamInstanceProfile, Placement.GroupName, NetworkInterfaces), `--tag-specifications` (spot-instances-request) | `--valid-from`, `--valid-until`, `--launch-group`, `--availability-zone-group`, `--block-duration-minutes`, `--instance-interruption-behavior`, `--dry-run` | **DONE** (mock) |
+| `describe-spot-instance-requests` | `--spot-instance-request-ids`, `--filters` (spot-instance-request-id, state, instance-id, launch.image-id, launch.instance-type, launch.key-name, type, launched-availability-zone, tag-key, tag:*) | `--max-results`, `--next-token`, `--dry-run` | **DONE** |
+| `cancel-spot-instance-requests` | `--spot-instance-request-ids` | `--dry-run` | **DONE** |
+
+`request-spot-instances` maps the single `--instance-count N` to
+`MinCount=MaxCount=N`, so fulfilment is **all-or-nothing**: on insufficient capacity
+the call returns `InsufficientInstanceCapacity` and **persists no SIRs**.
+`--client-token` is passed through to the on-demand idempotency path. The launched
+instances are plain on-demand VMs — v1 does **not** stamp `InstanceLifecycle=spot`
+or `SpotInstanceRequestId` on the instance; the instance↔request link lives only on
+the SIR (`SpotInstanceRequest.InstanceId`).
+
+`cancel-spot-instance-requests` flips the request to `cancelled`
+(`request-canceled-and-instance-running`) and **does not terminate** the instance —
+cancel ≠ terminate. Terminating the instance instead moves its SIR to `closed`
+(`instance-terminated-by-user`). Terminal (`cancelled`/`closed`) requests stay
+readable via `describe-spot-instance-requests` for **1 hour**, then auto-expire.
+
+`describe-spot-price-history` is **unsupported** (returns `InvalidAction`): on owned
+hardware there is no spot/on-demand price differential, so any synthetic price would
+be misleading rather than helpful.
+
 ### EC2 — IAM Instance Profile Associations
 
 Stored as `vm.VM.IamInstanceProfileArn` + `IamInstanceProfileAssociationId`

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -45,6 +45,7 @@ import (
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	handlers_ec2_routetable "github.com/mulgadc/spinifex/spinifex/handlers/ec2/routetable"
 	handlers_ec2_snapshot "github.com/mulgadc/spinifex/spinifex/handlers/ec2/snapshot"
+	handlers_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/spotinstance"
 	handlers_ec2_tags "github.com/mulgadc/spinifex/spinifex/handlers/ec2/tags"
 	handlers_ec2_volume "github.com/mulgadc/spinifex/spinifex/handlers/ec2/volume"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
@@ -146,6 +147,7 @@ type Daemon struct {
 	eigwService           *handlers_ec2_eigw.EgressOnlyIGWServiceImpl
 	igwService            *handlers_ec2_igw.IGWServiceImpl
 	placementGroupService *handlers_ec2_placementgroup.PlacementGroupServiceImpl
+	spotInstanceService   *handlers_ec2_spotinstance.SpotInstanceServiceImpl
 	vpcService            *handlers_ec2_vpc.VPCServiceImpl
 	eipService            *handlers_ec2_eip.EIPServiceImpl
 	elbv2Service          *handlers_elbv2.ELBv2ServiceImpl
@@ -787,6 +789,9 @@ func (d *Daemon) subscribeAll() error {
 		{"ec2.RemoveInstanceFromPlacementGroup", d.handleEC2RemoveInstanceFromPlacementGroup, "spinifex-workers"},
 		{"ec2.ReserveClusterNode", d.handleEC2ReserveClusterNode, "spinifex-workers"},
 		{"ec2.FinalizeClusterInstances", d.handleEC2FinalizeClusterInstances, "spinifex-workers"},
+		{"ec2.PutSpotInstanceRequests", d.handleEC2PutSpotInstanceRequests, "spinifex-workers"},
+		{"ec2.DescribeSpotInstanceRequests", d.handleEC2DescribeSpotInstanceRequests, "spinifex-workers"},
+		{"ec2.CancelSpotInstanceRequests", d.handleEC2CancelSpotInstanceRequests, "spinifex-workers"},
 		// Capacity reservations: Create is node-targeted (gateway pins one node);
 		// Describe fans out and Cancel broadcasts, so both use plain Subscribe.
 		{fmt.Sprintf("ec2.CreateCapacityReservation.%s", d.node), d.handleEC2CreateCapacityReservation, ""},
@@ -1165,6 +1170,8 @@ func (d *Daemon) assertNoClusterServicesInitialised() error {
 		return errors.New("d.igwService must be nil before startCluster")
 	case d.placementGroupService != nil:
 		return errors.New("d.placementGroupService must be nil before startCluster")
+	case d.spotInstanceService != nil:
+		return errors.New("d.spotInstanceService must be nil before startCluster")
 	case d.vpcService != nil:
 		return errors.New("d.vpcService must be nil before startCluster")
 	case d.routeTableService != nil:
@@ -1274,6 +1281,13 @@ func (d *Daemon) startCluster() error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize placement group service: %w", err)
+	}
+
+	d.spotInstanceService, err = initServiceWithRetry("spot instance service", func() (*handlers_ec2_spotinstance.SpotInstanceServiceImpl, error) {
+		return handlers_ec2_spotinstance.NewSpotInstanceServiceImplWithNATS(d.config, d.natsConn)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize spot instance service: %w", err)
 	}
 
 	d.vpcService, err = initServiceWithRetry("VPC service", func() (*handlers_ec2_vpc.VPCServiceImpl, error) {

--- a/spinifex/daemon/daemon_handlers.go
+++ b/spinifex/daemon/daemon_handlers.go
@@ -115,6 +115,8 @@ func (d *Daemon) handleEC2Events(msg *nats.Msg) {
 		d.handleDetachNetworkInterface(msg, command, instance)
 	case command.Attributes.AssociateIamInstanceProfile:
 		d.handleAssociateIamInstanceProfile(msg, command, instance)
+	case command.Attributes.SetSpotLineage:
+		d.handleSetSpotLineage(msg, command)
 	case command.Attributes.StartInstance:
 		if err := d.instanceService.StartInstance(instance, command); err != nil {
 			respondWithError(msg, awserrors.ValidErrorCode(err.Error()))

--- a/spinifex/daemon/daemon_handlers_instance.go
+++ b/spinifex/daemon/daemon_handlers_instance.go
@@ -348,6 +348,15 @@ func (d *Daemon) handleEC2DescribeInstances(msg *nats.Msg) {
 					}
 				}
 
+				// Project spot lineage stamped by the post-launch write-back.
+				// Both empty for on-demand, so the fields stay absent there.
+				if instance.InstanceLifecycle != "" {
+					instanceCopy.InstanceLifecycle = aws.String(instance.InstanceLifecycle)
+				}
+				if instance.SpotInstanceRequestId != "" {
+					instanceCopy.SpotInstanceRequestId = aws.String(instance.SpotInstanceRequestId)
+				}
+
 				// Apply filters against the fully-built instance copy
 				if len(parsedFilters) > 0 && !instanceMatchesFilters(instance, &instanceCopy, parsedFilters) {
 					continue

--- a/spinifex/daemon/daemon_handlers_instance_test.go
+++ b/spinifex/daemon/daemon_handlers_instance_test.go
@@ -674,3 +674,77 @@ func TestHandleEC2DescribeInstances_NoCapacityReservationEcho(t *testing.T) {
 	assert.Empty(t, aws.StringValue(got.CapacityReservationId))
 	assert.Nil(t, got.CapacityReservationSpecification)
 }
+
+// A spot-launched instance projects InstanceLifecycle + SpotInstanceRequestId.
+func TestHandleEC2DescribeInstances_SpotLineageEcho(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	reservation := &ec2.Reservation{}
+	reservation.SetReservationId("r-spot-echo")
+	reservation.SetOwnerId(testAccountID)
+	instance := &ec2.Instance{}
+	instance.SetInstanceId("i-spot-echo")
+	instance.SetInstanceType("t3.micro")
+
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:                    "i-spot-echo",
+		Status:                vm.StateRunning,
+		AccountID:             testAccountID,
+		InstanceLifecycle:     ec2.InstanceLifecycleTypeSpot,
+		SpotInstanceRequestId: "sir-0123456789abcdef0",
+		Reservation:           reservation,
+		Instance:              instance,
+	})
+
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstances", daemon.handleEC2DescribeInstances)
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	reqData, _ := json.Marshal(&ec2.DescribeInstancesInput{})
+	reply, err := natsRequest(daemon.natsConn, "ec2.DescribeInstances", reqData, 5*time.Second)
+	require.NoError(t, err)
+	var out ec2.DescribeInstancesOutput
+	require.NoError(t, json.Unmarshal(reply.Data, &out))
+	require.Len(t, out.Reservations, 1)
+	require.Len(t, out.Reservations[0].Instances, 1)
+
+	got := out.Reservations[0].Instances[0]
+	assert.Equal(t, ec2.InstanceLifecycleTypeSpot, aws.StringValue(got.InstanceLifecycle))
+	assert.Equal(t, "sir-0123456789abcdef0", aws.StringValue(got.SpotInstanceRequestId))
+}
+
+// An on-demand instance reports no spot-lineage fields.
+func TestHandleEC2DescribeInstances_NoSpotLineageEcho(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	reservation := &ec2.Reservation{}
+	reservation.SetReservationId("r-ondemand")
+	reservation.SetOwnerId(testAccountID)
+	instance := &ec2.Instance{}
+	instance.SetInstanceId("i-ondemand")
+	instance.SetInstanceType("t3.micro")
+
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:          "i-ondemand",
+		Status:      vm.StateRunning,
+		AccountID:   testAccountID,
+		Reservation: reservation,
+		Instance:    instance,
+	})
+
+	sub, err := daemon.natsConn.Subscribe("ec2.DescribeInstances", daemon.handleEC2DescribeInstances)
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	reqData, _ := json.Marshal(&ec2.DescribeInstancesInput{})
+	reply, err := natsRequest(daemon.natsConn, "ec2.DescribeInstances", reqData, 5*time.Second)
+	require.NoError(t, err)
+	var out ec2.DescribeInstancesOutput
+	require.NoError(t, json.Unmarshal(reply.Data, &out))
+	require.Len(t, out.Reservations, 1)
+	require.Len(t, out.Reservations[0].Instances, 1)
+
+	got := out.Reservations[0].Instances[0]
+	assert.Empty(t, aws.StringValue(got.InstanceLifecycle))
+	assert.Empty(t, aws.StringValue(got.SpotInstanceRequestId))
+}

--- a/spinifex/daemon/daemon_handlers_spotinstance.go
+++ b/spinifex/daemon/daemon_handlers_spotinstance.go
@@ -1,6 +1,14 @@
 package daemon
 
-import "github.com/nats-io/nats.go"
+import (
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go"
+)
 
 func (d *Daemon) handleEC2PutSpotInstanceRequests(msg *nats.Msg) {
 	handleNATSRequest(msg, d.spotInstanceService.PutSpotInstanceRequests)
@@ -12,4 +20,33 @@ func (d *Daemon) handleEC2DescribeSpotInstanceRequests(msg *nats.Msg) {
 
 func (d *Daemon) handleEC2CancelSpotInstanceRequests(msg *nats.Msg) {
 	handleNATSRequest(msg, d.spotInstanceService.CancelSpotInstanceRequests)
+}
+
+// handleSetSpotLineage stamps the spot lineage (InstanceLifecycle=spot +
+// SpotInstanceRequestId) onto a launched VM. Dispatched from handleEC2Events,
+// which already verified ownership; the SIR id is the only datum on the wire as
+// the lifecycle is always spot for this command.
+func (d *Daemon) handleSetSpotLineage(msg *nats.Msg, command types.EC2InstanceCommand) {
+	if command.SpotLineageData == nil {
+		respondWithError(msg, awserrors.ErrorMissingParameter)
+		return
+	}
+
+	found, err := d.vmMgr.UpdateAndPersist(command.ID, func(v *vm.VM) bool {
+		v.InstanceLifecycle = ec2.InstanceLifecycleTypeSpot
+		v.SpotInstanceRequestId = command.SpotLineageData.SpotInstanceRequestId
+		return true
+	})
+	if err != nil {
+		respondWithError(msg, awserrors.ValidErrorCode(err.Error()))
+		return
+	}
+	if !found {
+		respondWithError(msg, awserrors.ErrorInvalidInstanceIDNotFound)
+		return
+	}
+
+	if err := msg.Respond([]byte(`{}`)); err != nil {
+		slog.Error("Failed to respond to NATS request", "err", err)
+	}
 }

--- a/spinifex/daemon/daemon_handlers_spotinstance.go
+++ b/spinifex/daemon/daemon_handlers_spotinstance.go
@@ -1,0 +1,15 @@
+package daemon
+
+import "github.com/nats-io/nats.go"
+
+func (d *Daemon) handleEC2PutSpotInstanceRequests(msg *nats.Msg) {
+	handleNATSRequest(msg, d.spotInstanceService.PutSpotInstanceRequests)
+}
+
+func (d *Daemon) handleEC2DescribeSpotInstanceRequests(msg *nats.Msg) {
+	handleNATSRequest(msg, d.spotInstanceService.DescribeSpotInstanceRequests)
+}
+
+func (d *Daemon) handleEC2CancelSpotInstanceRequests(msg *nats.Msg) {
+	handleNATSRequest(msg, d.spotInstanceService.CancelSpotInstanceRequests)
+}

--- a/spinifex/daemon/daemon_handlers_spotinstance_test.go
+++ b/spinifex/daemon/daemon_handlers_spotinstance_test.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// handleSetSpotLineage stamps InstanceLifecycle=spot + the SIR id onto the VM,
+// dispatched through handleEC2Events on ec2.cmd.{id} after the ownership check.
+func TestHandleSetSpotLineage_Stamps(t *testing.T) {
+	d := createTestDaemon(t, sharedNATSURL)
+
+	d.vmMgr.Insert(&vm.VM{
+		ID:        "i-spot-stamp",
+		Status:    vm.StateRunning,
+		AccountID: testAccountID,
+		Instance:  &ec2.Instance{InstanceId: aws.String("i-spot-stamp")},
+	})
+
+	command := types.EC2InstanceCommand{
+		ID:              "i-spot-stamp",
+		Attributes:      types.EC2CommandAttributes{SetSpotLineage: true},
+		SpotLineageData: &types.SpotLineageData{SpotInstanceRequestId: "sir-abc123"},
+	}
+	body, _ := json.Marshal(command)
+	reply := requestHandler(t, d.natsConn, "ec2.cmd.i-spot-stamp", d.handleEC2Events, testAccountID, body)
+	assert.JSONEq(t, `{}`, string(reply.Data))
+
+	got, ok := d.vmMgr.Get("i-spot-stamp")
+	require.True(t, ok)
+	assert.Equal(t, ec2.InstanceLifecycleTypeSpot, got.InstanceLifecycle)
+	assert.Equal(t, "sir-abc123", got.SpotInstanceRequestId)
+}
+
+// Missing SpotLineageData is rejected with MissingParameter and leaves the VM unmarked.
+func TestHandleSetSpotLineage_RejectsMissingData(t *testing.T) {
+	d := createTestDaemon(t, sharedNATSURL)
+
+	d.vmMgr.Insert(&vm.VM{
+		ID:        "i-spot-nodata",
+		Status:    vm.StateRunning,
+		AccountID: testAccountID,
+		Instance:  &ec2.Instance{InstanceId: aws.String("i-spot-nodata")},
+	})
+
+	command := types.EC2InstanceCommand{
+		ID:         "i-spot-nodata",
+		Attributes: types.EC2CommandAttributes{SetSpotLineage: true},
+	}
+	body, _ := json.Marshal(command)
+	reply := requestHandler(t, d.natsConn, "ec2.cmd.i-spot-nodata", d.handleEC2Events, testAccountID, body)
+	assert.Equal(t, awserrors.ErrorMissingParameter, decodeError(t, reply.Data)["Code"])
+
+	got, ok := d.vmMgr.Get("i-spot-nodata")
+	require.True(t, ok)
+	assert.Empty(t, got.InstanceLifecycle)
+	assert.Empty(t, got.SpotInstanceRequestId)
+}

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -41,6 +41,7 @@ import (
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	handlers_ec2_routetable "github.com/mulgadc/spinifex/spinifex/handlers/ec2/routetable"
 	handlers_ec2_snapshot "github.com/mulgadc/spinifex/spinifex/handlers/ec2/snapshot"
+	handlers_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/spotinstance"
 	handlers_ec2_volume "github.com/mulgadc/spinifex/spinifex/handlers/ec2/volume"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	handlers_elbv2 "github.com/mulgadc/spinifex/spinifex/handlers/elbv2"
@@ -4251,6 +4252,7 @@ func TestAssertNoClusterServicesInitialised_PerField(t *testing.T) {
 		{name: "eigwService", set: func(d *Daemon) { d.eigwService = &handlers_ec2_eigw.EgressOnlyIGWServiceImpl{} }, wantMsg: "eigwService"},
 		{name: "igwService", set: func(d *Daemon) { d.igwService = &handlers_ec2_igw.IGWServiceImpl{} }, wantMsg: "igwService"},
 		{name: "placementGroupService", set: func(d *Daemon) { d.placementGroupService = &handlers_ec2_placementgroup.PlacementGroupServiceImpl{} }, wantMsg: "placementGroupService"},
+		{name: "spotInstanceService", set: func(d *Daemon) { d.spotInstanceService = &handlers_ec2_spotinstance.SpotInstanceServiceImpl{} }, wantMsg: "spotInstanceService"},
 		{name: "vpcService", set: func(d *Daemon) { d.vpcService = &handlers_ec2_vpc.VPCServiceImpl{} }, wantMsg: "vpcService"},
 		{name: "routeTableService", set: func(d *Daemon) { d.routeTableService = &handlers_ec2_routetable.RouteTableServiceImpl{} }, wantMsg: "routeTableService"},
 		{name: "natGatewayService", set: func(d *Daemon) { d.natGatewayService = &handlers_ec2_natgw.NatGatewayServiceImpl{} }, wantMsg: "natGatewayService"},

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -710,6 +710,22 @@ func (a *instanceCleanerAdapter) RemoveFromPlacementGroup(instance *vm.VM) error
 	return nil
 }
 
+// RemoveFromSpotRequest closes the Spot Instance Request fulfilled by this
+// instance, if any. The VM carries no spot marker, so the service scans the
+// active bucket by instance ID; a non-spot instance is a cheap no-op. No-op
+// when the spot instance service is not configured.
+func (a *instanceCleanerAdapter) RemoveFromSpotRequest(instance *vm.VM) error {
+	if a.d.spotInstanceService == nil {
+		return nil
+	}
+	if err := a.d.spotInstanceService.CloseForInstance(instance.ID, instance.AccountID); err != nil {
+		slog.Error("Failed to close spot request for instance",
+			"instanceId", instance.ID, "err", err)
+		return err
+	}
+	return nil
+}
+
 // ReleaseGPU unbinds the instance's GPU from vfio-pci and rebinds to its
 // original host driver. No-op for instances without a GPU allocation or
 // when GPU passthrough is disabled.

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -354,6 +354,17 @@ func TestReleaseGPU_ManagerError_LogsWarning(t *testing.T) {
 	a.ReleaseGPU(instance)
 }
 
+// --- RemoveFromSpotRequest ---
+
+// RemoveFromSpotRequest is a no-op when the spot instance service is not
+// configured. The service-present path is just a delegation to the spot
+// service's CloseForInstance, which is covered by the service's own tests.
+func TestRemoveFromSpotRequest_NoService_NoOp(t *testing.T) {
+	d := &Daemon{}
+	a := newInstanceCleanerAdapter(d)
+	require.NoError(t, a.RemoveFromSpotRequest(&vm.VM{ID: "i-x", AccountID: "111111111111"}))
+}
+
 // TestBuildVMManagerDeps_WiresBeforeInstanceRelaunch guards the single line
 // in buildVMManagerDeps that routes the recovery hook to
 // refreshSystemInstanceState. Dropping it would surface only in cell-18.

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -347,7 +347,7 @@ var ec2Actions = map[string]EC2Handler{
 		passRoleCheck := func(roleARN string) error {
 			return gw.checkPolicyResource(r, "iam", "PassRole", roleARN)
 		}
-		return gateway_ec2_spotinstance.RequestSpotInstances(input, gw.NATSConn, gw.IAMService, accountID, gw.AZ, passRoleCheck, gw.ExpectedNodes)
+		return gateway_ec2_spotinstance.RequestSpotInstances(input, gw.NATSConn, gw.IAMService, accountID, gw.AZ, passRoleCheck, gw.Quota, gw.ExpectedNodes)
 	}),
 	"DescribeSpotInstanceRequests": ec2Handler(func(input *ec2.DescribeSpotInstanceRequestsInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_spotinstance.DescribeSpotInstanceRequests(input, gw.NATSConn, accountID)

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -23,6 +23,7 @@ import (
 	gateway_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/gateway/ec2/placementgroup"
 	gateway_ec2_routetable "github.com/mulgadc/spinifex/spinifex/gateway/ec2/routetable"
 	gateway_ec2_snapshot "github.com/mulgadc/spinifex/spinifex/gateway/ec2/snapshot"
+	gateway_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/gateway/ec2/spotinstance"
 	gateway_ec2_tags "github.com/mulgadc/spinifex/spinifex/gateway/ec2/tags"
 	gateway_ec2_volume "github.com/mulgadc/spinifex/spinifex/gateway/ec2/volume"
 	gateway_ec2_vpc "github.com/mulgadc/spinifex/spinifex/gateway/ec2/vpc"
@@ -341,6 +342,18 @@ var ec2Actions = map[string]EC2Handler{
 	}),
 	"CancelCapacityReservation": ec2Handler(func(input *ec2.CancelCapacityReservationInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_capacityreservation.CancelCapacityReservation(input, gw.NATSConn, gw.ExpectedNodes, accountID)
+	}),
+	"RequestSpotInstances": ec2HandlerWithReq(func(input *ec2.RequestSpotInstancesInput, gw *GatewayConfig, accountID string, r *http.Request) (any, error) {
+		passRoleCheck := func(roleARN string) error {
+			return gw.checkPolicyResource(r, "iam", "PassRole", roleARN)
+		}
+		return gateway_ec2_spotinstance.RequestSpotInstances(input, gw.NATSConn, gw.IAMService, accountID, gw.AZ, passRoleCheck, gw.ExpectedNodes)
+	}),
+	"DescribeSpotInstanceRequests": ec2Handler(func(input *ec2.DescribeSpotInstanceRequestsInput, gw *GatewayConfig, accountID string) (any, error) {
+		return gateway_ec2_spotinstance.DescribeSpotInstanceRequests(input, gw.NATSConn, accountID)
+	}),
+	"CancelSpotInstanceRequests": ec2Handler(func(input *ec2.CancelSpotInstanceRequestsInput, gw *GatewayConfig, accountID string) (any, error) {
+		return gateway_ec2_spotinstance.CancelSpotInstanceRequests(input, gw.NATSConn, accountID)
 	}),
 	"CreateVpc": ec2Handler(func(input *ec2.CreateVpcInput, gw *GatewayConfig, accountID string) (any, error) {
 		if err := gw.Quota.EnforceVPCs(gw.NATSConn, accountID, 1); err != nil {

--- a/spinifex/gateway/ec2/spotinstance/CancelSpotInstanceRequests.go
+++ b/spinifex/gateway/ec2/spotinstance/CancelSpotInstanceRequests.go
@@ -1,0 +1,22 @@
+package gateway_ec2_spotinstance
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	handlers_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/spotinstance"
+	"github.com/nats-io/nats.go"
+)
+
+// CancelSpotInstanceRequests handles the EC2 CancelSpotInstanceRequests API call.
+// It is a thin pass-through to the daemon spot service, which moves matching active
+// requests to the terminal bucket as cancelled. The instances keep running.
+func CancelSpotInstanceRequests(input *ec2.CancelSpotInstanceRequestsInput, natsConn *nats.Conn, accountID string) (ec2.CancelSpotInstanceRequestsOutput, error) {
+	var output ec2.CancelSpotInstanceRequestsOutput
+
+	svc := handlers_ec2_spotinstance.NewNATSSpotInstanceService(natsConn)
+	result, err := svc.CancelSpotInstanceRequests(input, accountID)
+	if err != nil {
+		return output, err
+	}
+
+	return *result, nil
+}

--- a/spinifex/gateway/ec2/spotinstance/DescribeSpotInstanceRequests.go
+++ b/spinifex/gateway/ec2/spotinstance/DescribeSpotInstanceRequests.go
@@ -1,0 +1,22 @@
+package gateway_ec2_spotinstance
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	handlers_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/spotinstance"
+	"github.com/nats-io/nats.go"
+)
+
+// DescribeSpotInstanceRequests handles the EC2 DescribeSpotInstanceRequests API
+// call. It is a thin pass-through to the daemon spot service, which reads both the
+// active and terminal buckets, merges, and applies the requested filters.
+func DescribeSpotInstanceRequests(input *ec2.DescribeSpotInstanceRequestsInput, natsConn *nats.Conn, accountID string) (ec2.DescribeSpotInstanceRequestsOutput, error) {
+	var output ec2.DescribeSpotInstanceRequestsOutput
+
+	svc := handlers_ec2_spotinstance.NewNATSSpotInstanceService(natsConn)
+	result, err := svc.DescribeSpotInstanceRequests(input, accountID)
+	if err != nil {
+		return output, err
+	}
+
+	return *result, nil
+}

--- a/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
+++ b/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
@@ -103,12 +103,20 @@ func RequestSpotInstances(input *ec2.RequestSpotInstancesInput, natsConn *nats.C
 		return output, err
 	}
 
-	// Stamp spot lineage back onto each launched VM (best-effort): the VMs run
-	// and the SIRs persist regardless, so a write-back miss only drops the
-	// instance-side projection, never the request.
-	stampSpotLineage(natsConn, requests, accountID)
-
 	output.SpotInstanceRequests = requests
+
+	// Stamp spot lineage onto each launched VM in the background: it is
+	// best-effort (a miss only drops the projection, never the request), so it
+	// must not block the response.
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("RequestSpotInstances: spot lineage write-back panic", "panic", r)
+			}
+		}()
+		stampSpotLineage(natsConn, requests, accountID)
+	}()
+
 	return output, nil
 }
 

--- a/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
+++ b/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
@@ -103,6 +103,11 @@ func RequestSpotInstances(input *ec2.RequestSpotInstancesInput, natsConn *nats.C
 		return output, err
 	}
 
+	// Stamp spot lineage back onto each launched VM (best-effort): the VMs run
+	// and the SIRs persist regardless, so a write-back miss only drops the
+	// instance-side projection, never the request.
+	stampSpotLineage(natsConn, requests, accountID)
+
 	output.SpotInstanceRequests = requests
 	return output, nil
 }

--- a/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
+++ b/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
@@ -1,0 +1,202 @@
+// Package gateway_ec2_spotinstance provides the gateway-side orchestration for
+// AWS-compatible Spot Instance Requests. Fulfilment is a mock over the existing
+// on-demand RunInstances path: a request synchronously launches real VMs and is
+// then reported as active/fulfilled. There is no bidding, interruption, or
+// reclamation.
+package gateway_ec2_spotinstance
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	gateway_ec2_instance "github.com/mulgadc/spinifex/spinifex/gateway/ec2/instance"
+	handlers_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/spotinstance"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// ValidateRequestSpotInstancesInput enforces the required launch specification
+// fields and the few constrained scalar parameters. Defaults (InstanceCount 1,
+// Type one-time) are applied later and are not validation failures when absent.
+func ValidateRequestSpotInstancesInput(input *ec2.RequestSpotInstancesInput) error {
+	if input == nil {
+		return errors.New(awserrors.ErrorMissingParameter)
+	}
+
+	spec := input.LaunchSpecification
+	if spec == nil {
+		return errors.New(awserrors.ErrorMissingParameter)
+	}
+
+	if aws.StringValue(spec.ImageId) == "" {
+		return errors.New(awserrors.ErrorMissingParameter)
+	}
+	if !strings.HasPrefix(aws.StringValue(spec.ImageId), "ami-") {
+		return errors.New(awserrors.ErrorInvalidAMIIDMalformed)
+	}
+	if aws.StringValue(spec.InstanceType) == "" {
+		return errors.New(awserrors.ErrorMissingParameter)
+	}
+	if aws.StringValue(spec.KeyName) == "" {
+		return errors.New(awserrors.ErrorMissingParameter)
+	}
+
+	if input.InstanceCount != nil && *input.InstanceCount < 1 {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	switch aws.StringValue(input.Type) {
+	case "", ec2.SpotInstanceTypeOneTime, ec2.SpotInstanceTypePersistent:
+	default:
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	return nil
+}
+
+// RequestSpotInstances validates the request, launches real VMs via the shared
+// on-demand RunInstances path (all-or-nothing: MinCount=MaxCount=InstanceCount,
+// ClientToken passed through), then builds and persists one active/fulfilled
+// SpotInstanceRequest per launched instance. On a launch failure (including
+// InsufficientInstanceCapacity) it returns the error and persists nothing.
+func RequestSpotInstances(input *ec2.RequestSpotInstancesInput, natsConn *nats.Conn, iamSvc handlers_iam.IAMService, accountID, az string, passRoleCheck gateway_ec2_instance.PassRoleChecker, expectedNodes int) (ec2.RequestSpotInstancesOutput, error) {
+	var output ec2.RequestSpotInstancesOutput
+
+	if err := ValidateRequestSpotInstancesInput(input); err != nil {
+		return output, err
+	}
+
+	count := spotInstanceCount(input)
+	runInput := runInputFromLaunchSpec(input, count)
+
+	// RunInstances normalises runInput in place (e.g. instance profile to ARN),
+	// so the launch spec echoed back is built from runInput afterwards.
+	reservation, err := gateway_ec2_instance.RunInstances(runInput, natsConn, iamSvc, accountID, passRoleCheck, nil, expectedNodes)
+	if err != nil {
+		return output, err
+	}
+
+	requests := buildSpotRequests(input, runInput, reservation.Instances, az)
+
+	svc := handlers_ec2_spotinstance.NewNATSSpotInstanceService(natsConn)
+	if _, err := svc.PutSpotInstanceRequests(&handlers_ec2_spotinstance.PutSpotRequestsInput{Requests: requests}, accountID); err != nil {
+		slog.Error("RequestSpotInstances: VMs launched but SIR persist failed", "count", count, "accountID", accountID, "err", err)
+		return output, err
+	}
+
+	output.SpotInstanceRequests = requests
+	return output, nil
+}
+
+// spotInstanceCount returns the requested instance count, defaulting to 1.
+func spotInstanceCount(input *ec2.RequestSpotInstancesInput) int64 {
+	if input.InstanceCount != nil && *input.InstanceCount >= 1 {
+		return *input.InstanceCount
+	}
+	return 1
+}
+
+// runInputFromLaunchSpec translates a spot launch specification into a
+// RunInstancesInput. MinCount=MaxCount=count maps the single spot InstanceCount
+// to all-or-nothing fulfilment, and ClientToken is passed through for idempotency.
+func runInputFromLaunchSpec(input *ec2.RequestSpotInstancesInput, count int64) *ec2.RunInstancesInput {
+	spec := input.LaunchSpecification
+	runInput := &ec2.RunInstancesInput{
+		MinCount:            aws.Int64(count),
+		MaxCount:            aws.Int64(count),
+		ImageId:             spec.ImageId,
+		InstanceType:        spec.InstanceType,
+		KeyName:             spec.KeyName,
+		SubnetId:            spec.SubnetId,
+		SecurityGroupIds:    spec.SecurityGroupIds,
+		UserData:            spec.UserData,
+		BlockDeviceMappings: spec.BlockDeviceMappings,
+		IamInstanceProfile:  spec.IamInstanceProfile,
+		NetworkInterfaces:   spec.NetworkInterfaces,
+		ClientToken:         input.ClientToken,
+	}
+	if spec.Placement != nil && aws.StringValue(spec.Placement.GroupName) != "" {
+		runInput.Placement = &ec2.Placement{GroupName: spec.Placement.GroupName}
+	}
+	return runInput
+}
+
+// launchSpecFromRunInput builds the SpotInstanceRequest launch specification
+// echoed in Describe responses from the resolved RunInstancesInput. The launch
+// input carries security groups as IDs; the read-side spec carries GroupIdentifiers.
+func launchSpecFromRunInput(runInput *ec2.RunInstancesInput) *ec2.LaunchSpecification {
+	spec := &ec2.LaunchSpecification{
+		ImageId:             runInput.ImageId,
+		InstanceType:        runInput.InstanceType,
+		KeyName:             runInput.KeyName,
+		SubnetId:            runInput.SubnetId,
+		UserData:            runInput.UserData,
+		BlockDeviceMappings: runInput.BlockDeviceMappings,
+		IamInstanceProfile:  runInput.IamInstanceProfile,
+		NetworkInterfaces:   runInput.NetworkInterfaces,
+	}
+	for _, sgID := range runInput.SecurityGroupIds {
+		spec.SecurityGroups = append(spec.SecurityGroups, &ec2.GroupIdentifier{GroupId: sgID})
+	}
+	if runInput.Placement != nil && aws.StringValue(runInput.Placement.GroupName) != "" {
+		spec.Placement = &ec2.SpotPlacement{GroupName: runInput.Placement.GroupName}
+	}
+	return spec
+}
+
+// buildSpotRequests constructs one active/fulfilled SpotInstanceRequest per
+// launched instance, mapping instances to requests by order. Creation-time tags
+// come from the spot-instances-request TagSpecification.
+func buildSpotRequests(input *ec2.RequestSpotInstancesInput, runInput *ec2.RunInstancesInput, instances []*ec2.Instance, az string) []*ec2.SpotInstanceRequest {
+	count := spotInstanceCount(input)
+
+	spotType := aws.StringValue(input.Type)
+	if spotType == "" {
+		spotType = ec2.SpotInstanceTypeOneTime
+	}
+
+	tags := utils.MapToEC2Tags(utils.ExtractTags(input.TagSpecifications, ec2.ResourceTypeSpotInstancesRequest))
+	launchSpec := launchSpecFromRunInput(runInput)
+	now := time.Now().UTC()
+
+	requests := make([]*ec2.SpotInstanceRequest, 0, count)
+	for range count {
+		req := &ec2.SpotInstanceRequest{
+			SpotInstanceRequestId:    aws.String(utils.GenerateResourceID("sir")),
+			State:                    aws.String(ec2.SpotInstanceStateActive),
+			Type:                     aws.String(spotType),
+			ProductDescription:       aws.String(ec2.RIProductDescriptionLinuxUnix),
+			LaunchedAvailabilityZone: aws.String(az),
+			CreateTime:               aws.Time(now),
+			LaunchSpecification:      launchSpec,
+			Tags:                     tags,
+			Status: &ec2.SpotInstanceStatus{
+				Code:       aws.String(handlers_ec2_spotinstance.SpotStatusCodeFulfilled),
+				Message:    aws.String("Your Spot request is fulfilled."),
+				UpdateTime: aws.Time(now),
+			},
+		}
+		if input.SpotPrice != nil {
+			req.SpotPrice = input.SpotPrice
+		}
+		requests = append(requests, req)
+	}
+
+	// Map launched instances to requests by order. All-or-nothing fulfilment
+	// makes len(instances) == count on success; the guard tolerates any short read.
+	for i, inst := range instances {
+		if i >= len(requests) {
+			break
+		}
+		if inst != nil {
+			requests[i].InstanceId = inst.InstanceId
+		}
+	}
+	return requests
+}

--- a/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
+++ b/spinifex/gateway/ec2/spotinstance/RequestSpotInstances.go
@@ -17,6 +17,7 @@ import (
 	gateway_ec2_instance "github.com/mulgadc/spinifex/spinifex/gateway/ec2/instance"
 	handlers_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/spotinstance"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	handlers_quota "github.com/mulgadc/spinifex/spinifex/handlers/quota"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 )
@@ -62,10 +63,10 @@ func ValidateRequestSpotInstancesInput(input *ec2.RequestSpotInstancesInput) err
 
 // RequestSpotInstances validates the request, launches real VMs via the shared
 // on-demand RunInstances path (all-or-nothing: MinCount=MaxCount=InstanceCount,
-// ClientToken passed through), then builds and persists one active/fulfilled
-// SpotInstanceRequest per launched instance. On a launch failure (including
-// InsufficientInstanceCapacity) it returns the error and persists nothing.
-func RequestSpotInstances(input *ec2.RequestSpotInstancesInput, natsConn *nats.Conn, iamSvc handlers_iam.IAMService, accountID, az string, passRoleCheck gateway_ec2_instance.PassRoleChecker, expectedNodes int) (ec2.RequestSpotInstancesOutput, error) {
+// ClientToken passed through, same vCPU quota gate), then builds and persists one
+// active/fulfilled SpotInstanceRequest per launched instance. On a launch failure
+// (including InsufficientInstanceCapacity) it returns the error and persists nothing.
+func RequestSpotInstances(input *ec2.RequestSpotInstancesInput, natsConn *nats.Conn, iamSvc handlers_iam.IAMService, accountID, az string, passRoleCheck gateway_ec2_instance.PassRoleChecker, quota *handlers_quota.Service, expectedNodes int) (ec2.RequestSpotInstancesOutput, error) {
 	var output ec2.RequestSpotInstancesOutput
 
 	if err := ValidateRequestSpotInstancesInput(input); err != nil {
@@ -75,11 +76,23 @@ func RequestSpotInstances(input *ec2.RequestSpotInstancesInput, natsConn *nats.C
 	count := spotInstanceCount(input)
 	runInput := runInputFromLaunchSpec(input, count)
 
+	// Gate on the per-account vCPU cap exactly like the on-demand path; spot
+	// launches are real VMs and must not slip past the quota.
+	launchQuotaCheck := func() error {
+		return quota.EnforceLaunch(accountID, aws.StringValue(runInput.InstanceType), int(count))
+	}
+
 	// RunInstances normalises runInput in place (e.g. instance profile to ARN),
 	// so the launch spec echoed back is built from runInput afterwards.
-	reservation, err := gateway_ec2_instance.RunInstances(runInput, natsConn, iamSvc, accountID, passRoleCheck, nil, expectedNodes)
+	reservation, err := gateway_ec2_instance.RunInstances(runInput, natsConn, iamSvc, accountID, passRoleCheck, launchQuotaCheck, expectedNodes)
 	if err != nil {
 		return output, err
+	}
+
+	// Charge the actual launched vCPUs; a counter write failure is drift for
+	// reconcile to correct, so it must not fail the already-successful launch.
+	if err := quota.ChargeLaunch(accountID, &reservation); err != nil {
+		slog.Warn("RequestSpotInstances: vcpu quota charge failed, reconcile will correct", "account", accountID, "err", err)
 	}
 
 	requests := buildSpotRequests(input, runInput, reservation.Instances, az)

--- a/spinifex/gateway/ec2/spotinstance/RequestSpotInstances_test.go
+++ b/spinifex/gateway/ec2/spotinstance/RequestSpotInstances_test.go
@@ -1,0 +1,231 @@
+package gateway_ec2_spotinstance
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_ec2_spotinstance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/spotinstance"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validLaunchSpec() *ec2.RequestSpotLaunchSpecification {
+	return &ec2.RequestSpotLaunchSpecification{
+		ImageId:          aws.String("ami-0abcdef1234567890"),
+		InstanceType:     aws.String("t2.micro"),
+		KeyName:          aws.String("my-key-pair"),
+		SubnetId:         aws.String("subnet-6e7f829e"),
+		SecurityGroupIds: []*string{aws.String("sg-0123456789abcdef0")},
+	}
+}
+
+func TestValidateRequestSpotInstancesInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *ec2.RequestSpotInstancesInput
+		want  error
+	}{
+		{
+			name:  "Valid",
+			input: &ec2.RequestSpotInstancesInput{LaunchSpecification: validLaunchSpec()},
+			want:  nil,
+		},
+		{
+			name:  "NilInput",
+			input: nil,
+			want:  errors.New(awserrors.ErrorMissingParameter),
+		},
+		{
+			name:  "MissingLaunchSpecification",
+			input: &ec2.RequestSpotInstancesInput{},
+			want:  errors.New(awserrors.ErrorMissingParameter),
+		},
+		{
+			name: "MissingImageId",
+			input: &ec2.RequestSpotInstancesInput{LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
+				InstanceType: aws.String("t2.micro"),
+				KeyName:      aws.String("my-key-pair"),
+			}},
+			want: errors.New(awserrors.ErrorMissingParameter),
+		},
+		{
+			name: "MalformedImageId",
+			input: &ec2.RequestSpotInstancesInput{LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
+				ImageId:      aws.String("invalid-name-here"),
+				InstanceType: aws.String("t2.micro"),
+				KeyName:      aws.String("my-key-pair"),
+			}},
+			want: errors.New(awserrors.ErrorInvalidAMIIDMalformed),
+		},
+		{
+			name: "MissingInstanceType",
+			input: &ec2.RequestSpotInstancesInput{LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
+				ImageId: aws.String("ami-0abcdef1234567890"),
+				KeyName: aws.String("my-key-pair"),
+			}},
+			want: errors.New(awserrors.ErrorMissingParameter),
+		},
+		{
+			name: "MissingKeyName",
+			input: &ec2.RequestSpotInstancesInput{LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
+				ImageId:      aws.String("ami-0abcdef1234567890"),
+				InstanceType: aws.String("t2.micro"),
+			}},
+			want: errors.New(awserrors.ErrorMissingParameter),
+		},
+		{
+			name: "InstanceCountZero",
+			input: &ec2.RequestSpotInstancesInput{
+				LaunchSpecification: validLaunchSpec(),
+				InstanceCount:       aws.Int64(0),
+			},
+			want: errors.New(awserrors.ErrorInvalidParameterValue),
+		},
+		{
+			name: "InstanceCountNegative",
+			input: &ec2.RequestSpotInstancesInput{
+				LaunchSpecification: validLaunchSpec(),
+				InstanceCount:       aws.Int64(-1),
+			},
+			want: errors.New(awserrors.ErrorInvalidParameterValue),
+		},
+		{
+			name: "InvalidType",
+			input: &ec2.RequestSpotInstancesInput{
+				LaunchSpecification: validLaunchSpec(),
+				Type:                aws.String("spot-block"),
+			},
+			want: errors.New(awserrors.ErrorInvalidParameterValue),
+		},
+		{
+			name: "PersistentTypeAccepted",
+			input: &ec2.RequestSpotInstancesInput{
+				LaunchSpecification: validLaunchSpec(),
+				Type:                aws.String(ec2.SpotInstanceTypePersistent),
+			},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, ValidateRequestSpotInstancesInput(test.input))
+		})
+	}
+}
+
+func TestSpotInstanceCountDefaultsToOne(t *testing.T) {
+	assert.Equal(t, int64(1), spotInstanceCount(&ec2.RequestSpotInstancesInput{}))
+	assert.Equal(t, int64(3), spotInstanceCount(&ec2.RequestSpotInstancesInput{InstanceCount: aws.Int64(3)}))
+}
+
+func TestRunInputFromLaunchSpec_CountAndClientToken(t *testing.T) {
+	input := &ec2.RequestSpotInstancesInput{
+		LaunchSpecification: validLaunchSpec(),
+		ClientToken:         aws.String("idem-token-123"),
+	}
+
+	runInput := runInputFromLaunchSpec(input, 4)
+
+	require.NotNil(t, runInput.MinCount)
+	require.NotNil(t, runInput.MaxCount)
+	assert.Equal(t, int64(4), *runInput.MinCount, "MinCount maps to InstanceCount")
+	assert.Equal(t, int64(4), *runInput.MaxCount, "MaxCount maps to InstanceCount")
+	assert.Equal(t, "idem-token-123", aws.StringValue(runInput.ClientToken), "ClientToken passes through")
+}
+
+func TestRunInputFromLaunchSpec_FieldTranslation(t *testing.T) {
+	spec := validLaunchSpec()
+	spec.UserData = aws.String("dXNlci1kYXRh")
+	spec.Placement = &ec2.SpotPlacement{GroupName: aws.String("pg-spread")}
+	spec.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{Name: aws.String("worker-profile")}
+	input := &ec2.RequestSpotInstancesInput{LaunchSpecification: spec}
+
+	runInput := runInputFromLaunchSpec(input, 1)
+
+	assert.Equal(t, "ami-0abcdef1234567890", aws.StringValue(runInput.ImageId))
+	assert.Equal(t, "t2.micro", aws.StringValue(runInput.InstanceType))
+	assert.Equal(t, "my-key-pair", aws.StringValue(runInput.KeyName))
+	assert.Equal(t, "subnet-6e7f829e", aws.StringValue(runInput.SubnetId))
+	assert.Equal(t, "dXNlci1kYXRh", aws.StringValue(runInput.UserData))
+	assert.Equal(t, []*string{aws.String("sg-0123456789abcdef0")}, runInput.SecurityGroupIds)
+	require.NotNil(t, runInput.Placement)
+	assert.Equal(t, "pg-spread", aws.StringValue(runInput.Placement.GroupName))
+	require.NotNil(t, runInput.IamInstanceProfile)
+	assert.Equal(t, "worker-profile", aws.StringValue(runInput.IamInstanceProfile.Name))
+}
+
+// TestLaunchSpecRoundTrip verifies the spot launch spec survives translation
+// into a RunInstancesInput and back into the read-side LaunchSpecification,
+// including the security-group ID -> GroupIdentifier shape change.
+func TestLaunchSpecRoundTrip(t *testing.T) {
+	spec := validLaunchSpec()
+	spec.UserData = aws.String("dXNlci1kYXRh")
+	spec.Placement = &ec2.SpotPlacement{GroupName: aws.String("pg-cluster")}
+	input := &ec2.RequestSpotInstancesInput{LaunchSpecification: spec}
+
+	runInput := runInputFromLaunchSpec(input, 1)
+	out := launchSpecFromRunInput(runInput)
+
+	assert.Equal(t, "ami-0abcdef1234567890", aws.StringValue(out.ImageId))
+	assert.Equal(t, "t2.micro", aws.StringValue(out.InstanceType))
+	assert.Equal(t, "my-key-pair", aws.StringValue(out.KeyName))
+	assert.Equal(t, "subnet-6e7f829e", aws.StringValue(out.SubnetId))
+	assert.Equal(t, "dXNlci1kYXRh", aws.StringValue(out.UserData))
+	require.Len(t, out.SecurityGroups, 1)
+	assert.Equal(t, "sg-0123456789abcdef0", aws.StringValue(out.SecurityGroups[0].GroupId))
+	require.NotNil(t, out.Placement)
+	assert.Equal(t, "pg-cluster", aws.StringValue(out.Placement.GroupName))
+}
+
+func TestBuildSpotRequests_MapsInstancesAndDefaults(t *testing.T) {
+	input := &ec2.RequestSpotInstancesInput{
+		LaunchSpecification: validLaunchSpec(),
+		InstanceCount:       aws.Int64(2),
+		SpotPrice:           aws.String("0.05"),
+		TagSpecifications: []*ec2.TagSpecification{{
+			ResourceType: aws.String(ec2.ResourceTypeSpotInstancesRequest),
+			Tags:         []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("worker")}},
+		}},
+	}
+	runInput := runInputFromLaunchSpec(input, 2)
+	instances := []*ec2.Instance{
+		{InstanceId: aws.String("i-aaa")},
+		{InstanceId: aws.String("i-bbb")},
+	}
+
+	requests := buildSpotRequests(input, runInput, instances, "ap-southeast-2a")
+
+	require.Len(t, requests, 2)
+	for _, req := range requests {
+		assert.Equal(t, ec2.SpotInstanceStateActive, aws.StringValue(req.State))
+		assert.Equal(t, handlers_ec2_spotinstance.SpotStatusCodeFulfilled, aws.StringValue(req.Status.Code))
+		assert.Equal(t, ec2.SpotInstanceTypeOneTime, aws.StringValue(req.Type), "Type defaults to one-time")
+		assert.Equal(t, ec2.RIProductDescriptionLinuxUnix, aws.StringValue(req.ProductDescription))
+		assert.Equal(t, "ap-southeast-2a", aws.StringValue(req.LaunchedAvailabilityZone))
+		assert.Equal(t, "0.05", aws.StringValue(req.SpotPrice))
+		assert.True(t, strings.HasPrefix(aws.StringValue(req.SpotInstanceRequestId), "sir-"))
+		require.Len(t, req.Tags, 1)
+		assert.Equal(t, "Name", aws.StringValue(req.Tags[0].Key))
+	}
+	assert.Equal(t, "i-aaa", aws.StringValue(requests[0].InstanceId))
+	assert.Equal(t, "i-bbb", aws.StringValue(requests[1].InstanceId))
+	assert.NotEqual(t, aws.StringValue(requests[0].SpotInstanceRequestId), aws.StringValue(requests[1].SpotInstanceRequestId), "each SIR gets a unique id")
+}
+
+func TestBuildSpotRequests_PersistentTypePreserved(t *testing.T) {
+	input := &ec2.RequestSpotInstancesInput{
+		LaunchSpecification: validLaunchSpec(),
+		Type:                aws.String(ec2.SpotInstanceTypePersistent),
+	}
+	runInput := runInputFromLaunchSpec(input, 1)
+
+	requests := buildSpotRequests(input, runInput, []*ec2.Instance{{InstanceId: aws.String("i-ccc")}}, "ap-southeast-2a")
+
+	require.Len(t, requests, 1)
+	assert.Equal(t, ec2.SpotInstanceTypePersistent, aws.StringValue(requests[0].Type))
+}

--- a/spinifex/gateway/ec2/spotinstance/lineage.go
+++ b/spinifex/gateway/ec2/spotinstance/lineage.go
@@ -1,0 +1,85 @@
+package gateway_ec2_spotinstance
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	// spotLineageRetries bounds the wait for the owning daemon to subscribe
+	// ec2.cmd.{id}: it subscribes only after responding with the reservation, so
+	// the write-back can briefly race ahead and see no responder.
+	spotLineageRetries    = 10
+	spotLineageRetryDelay = 100 * time.Millisecond
+	spotLineageReqTimeout = 5 * time.Second
+)
+
+// stampSpotLineage writes the spot lineage (InstanceLifecycle=spot +
+// SpotInstanceRequestId) back to each launched VM via its owner subject. It is
+// best-effort: the VMs are already running and the SIRs persisted, so a
+// persistent miss is logged and the request still succeeds — lineage is a
+// projection, never a launch precondition. Requests with no mapped instance
+// (no VM launched for them) are skipped.
+func stampSpotLineage(natsConn *nats.Conn, requests []*ec2.SpotInstanceRequest, accountID string) {
+	for _, req := range requests {
+		if req == nil {
+			continue
+		}
+		instanceID := aws.StringValue(req.InstanceId)
+		sirID := aws.StringValue(req.SpotInstanceRequestId)
+		if instanceID == "" || sirID == "" {
+			continue
+		}
+		if err := sendSpotLineageCommand(natsConn, instanceID, sirID, accountID); err != nil {
+			slog.Warn("RequestSpotInstances: spot lineage write-back failed",
+				"instance_id", instanceID, "sir_id", sirID, "err", err)
+		}
+	}
+}
+
+// sendSpotLineageCommand sends the SetSpotLineage command to the instance's owner
+// via ec2.cmd.{id}, retrying past nats.ErrNoResponders until the owner subscribes.
+// A non-no-responders transport error or an owner-returned error code stops the
+// retry and is surfaced to the caller.
+func sendSpotLineageCommand(natsConn *nats.Conn, instanceID, sirID, accountID string) error {
+	command := types.EC2InstanceCommand{
+		ID:              instanceID,
+		Attributes:      types.EC2CommandAttributes{SetSpotLineage: true},
+		SpotLineageData: &types.SpotLineageData{SpotInstanceRequestId: sirID},
+	}
+	jsonData, err := json.Marshal(command)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for attempt := range spotLineageRetries {
+		reqMsg := nats.NewMsg("ec2.cmd." + instanceID)
+		reqMsg.Data = jsonData
+		reqMsg.Header.Set(utils.AccountIDHeader, accountID)
+
+		msg, err := natsConn.RequestMsg(reqMsg, spotLineageReqTimeout)
+		if err == nil {
+			if responseError, parseErr := utils.ValidateErrorPayload(msg.Data); parseErr != nil {
+				return errors.New(*responseError.Code)
+			}
+			return nil
+		}
+		if !errors.Is(err, nats.ErrNoResponders) {
+			return err
+		}
+		lastErr = err
+		if attempt < spotLineageRetries-1 {
+			time.Sleep(spotLineageRetryDelay)
+		}
+	}
+	return lastErr
+}

--- a/spinifex/gateway/ec2/spotinstance/lineage_test.go
+++ b/spinifex/gateway/ec2/spotinstance/lineage_test.go
@@ -1,0 +1,105 @@
+package gateway_ec2_spotinstance
+
+import (
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const lineageTestAccount = "111122223333"
+
+// stampSpotLineage targets each instance's owner subject (ec2.cmd.{id}) with the
+// SetSpotLineage command carrying the SIR id and the account header.
+func TestStampSpotLineage_TargetsOwnerWithSIRAndAccount(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+
+	got := make(chan *nats.Msg, 1)
+	sub, err := nc.Subscribe("ec2.cmd.i-owner", func(m *nats.Msg) {
+		got <- m
+		_ = m.Respond([]byte(`{}`))
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	requests := []*ec2.SpotInstanceRequest{{
+		InstanceId:            aws.String("i-owner"),
+		SpotInstanceRequestId: aws.String("sir-owner-1"),
+	}}
+	stampSpotLineage(nc, requests, lineageTestAccount)
+
+	select {
+	case m := <-got:
+		assert.Equal(t, lineageTestAccount, m.Header.Get(utils.AccountIDHeader))
+		var cmd types.EC2InstanceCommand
+		require.NoError(t, json.Unmarshal(m.Data, &cmd))
+		assert.Equal(t, "i-owner", cmd.ID)
+		assert.True(t, cmd.Attributes.SetSpotLineage)
+		require.NotNil(t, cmd.SpotLineageData)
+		assert.Equal(t, "sir-owner-1", cmd.SpotLineageData.SpotInstanceRequestId)
+	case <-time.After(2 * time.Second):
+		t.Fatal("owner never received the spot lineage command")
+	}
+}
+
+// The write-back retries past nats.ErrNoResponders until the owner subscribes,
+// mirroring the daemon subscribing ec2.cmd.{id} only after the launch responds.
+func TestSendSpotLineageCommand_RetriesPastNoResponders(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+
+	var received atomic.Int32
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		sub, err := nc.Subscribe("ec2.cmd.i-late", func(m *nats.Msg) {
+			received.Add(1)
+			_ = m.Respond([]byte(`{}`))
+		})
+		if err == nil {
+			t.Cleanup(func() { _ = sub.Unsubscribe() })
+		}
+	}()
+
+	err := sendSpotLineageCommand(nc, "i-late", "sir-late-1", lineageTestAccount)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), received.Load())
+}
+
+// With no owner ever subscribing, the write-back exhausts its retries and
+// returns the transport error rather than blocking forever.
+func TestSendSpotLineageCommand_ReturnsErrorWhenNoOwner(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+
+	err := sendSpotLineageCommand(nc, "i-absent", "sir-absent-1", lineageTestAccount)
+	require.Error(t, err)
+}
+
+// Requests with no mapped instance (no VM launched) are skipped — no command is sent.
+func TestStampSpotLineage_SkipsRequestsWithNoInstance(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+
+	var received atomic.Int32
+	sub, err := nc.Subscribe("ec2.cmd.>", func(m *nats.Msg) {
+		received.Add(1)
+		_ = m.Respond([]byte(`{}`))
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	requests := []*ec2.SpotInstanceRequest{
+		nil,
+		{SpotInstanceRequestId: aws.String("sir-no-instance")},
+		{InstanceId: aws.String("i-no-sir")},
+	}
+	stampSpotLineage(nc, requests, lineageTestAccount)
+
+	assert.Equal(t, int32(0), received.Load())
+}

--- a/spinifex/gateway/ec2/spotinstance/passthrough_test.go
+++ b/spinifex/gateway/ec2/spotinstance/passthrough_test.go
@@ -1,0 +1,34 @@
+package gateway_ec2_spotinstance
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+)
+
+const testAccountID = "123456789012"
+
+// The Describe/Cancel gateway functions are thin pass-throughs to the NATS spot
+// service, so without a connection the NATSRequest call surfaces an error rather
+// than panicking.
+
+func TestDescribeSpotInstanceRequests_NilNATS(t *testing.T) {
+	_, err := DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{}, nil, testAccountID)
+	assert.Error(t, err)
+}
+
+func TestDescribeSpotInstanceRequests_WithIDsNilNATS(t *testing.T) {
+	_, err := DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-12345678")},
+	}, nil, testAccountID)
+	assert.Error(t, err)
+}
+
+func TestCancelSpotInstanceRequests_NilNATS(t *testing.T) {
+	_, err := CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-12345678")},
+	}, nil, testAccountID)
+	assert.Error(t, err)
+}

--- a/spinifex/handlers/ec2/spotinstance/service.go
+++ b/spinifex/handlers/ec2/spotinstance/service.go
@@ -1,0 +1,12 @@
+package handlers_ec2_spotinstance
+
+import "github.com/aws/aws-sdk-go/service/ec2"
+
+// SpotInstanceService defines the daemon-side persistence operations for Spot
+// Instance Requests routed over NATS. CloseForInstance is in-process only (it is
+// invoked by the teardown cleaner) and lives on the concrete impl.
+type SpotInstanceService interface {
+	PutSpotInstanceRequests(input *PutSpotRequestsInput, accountID string) (*PutSpotRequestsOutput, error)
+	DescribeSpotInstanceRequests(input *ec2.DescribeSpotInstanceRequestsInput, accountID string) (*ec2.DescribeSpotInstanceRequestsOutput, error)
+	CancelSpotInstanceRequests(input *ec2.CancelSpotInstanceRequestsInput, accountID string) (*ec2.CancelSpotInstanceRequestsOutput, error)
+}

--- a/spinifex/handlers/ec2/spotinstance/service_impl.go
+++ b/spinifex/handlers/ec2/spotinstance/service_impl.go
@@ -1,0 +1,394 @@
+package handlers_ec2_spotinstance
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/config"
+	"github.com/mulgadc/spinifex/spinifex/filterutil"
+	"github.com/mulgadc/spinifex/spinifex/migrate"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// Ensure SpotInstanceServiceImpl implements SpotInstanceService.
+var _ SpotInstanceService = (*SpotInstanceServiceImpl)(nil)
+
+// SpotInstanceServiceImpl persists Spot Instance Requests in NATS JetStream KV.
+// Active (open/active) records live in a no-TTL bucket; terminal (closed/cancelled)
+// records live in a separate 1-hour-TTL bucket that JetStream auto-purges.
+type SpotInstanceServiceImpl struct {
+	config     *config.Config
+	natsConn   *nats.Conn
+	activeKV   nats.KeyValue
+	terminalKV nats.KeyValue
+}
+
+// NewSpotInstanceServiceImplWithNATS creates a spot instance service with NATS JetStream.
+func NewSpotInstanceServiceImplWithNATS(cfg *config.Config, natsConn *nats.Conn) (*SpotInstanceServiceImpl, error) {
+	js, err := natsConn.JetStream()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get JetStream context: %w", err)
+	}
+
+	activeKV, err := utils.GetOrCreateKVBucket(js, KVBucketSpotRequests, 10)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create KV bucket %s: %w", KVBucketSpotRequests, err)
+	}
+	if err := migrate.DefaultRegistry.RunKV(KVBucketSpotRequests, activeKV, KVBucketSpotRequestsVersion); err != nil {
+		return nil, fmt.Errorf("migrate %s: %w", KVBucketSpotRequests, err)
+	}
+
+	terminalKV, err := getOrCreateTerminalBucket(js)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create KV bucket %s: %w", KVBucketSpotRequestsTerminal, err)
+	}
+	if err := migrate.DefaultRegistry.RunKV(KVBucketSpotRequestsTerminal, terminalKV, KVBucketSpotRequestsVersion); err != nil {
+		return nil, fmt.Errorf("migrate %s: %w", KVBucketSpotRequestsTerminal, err)
+	}
+
+	slog.Info("Spot instance service initialized with JetStream KV",
+		"active", KVBucketSpotRequests, "terminal", KVBucketSpotRequestsTerminal)
+
+	return &SpotInstanceServiceImpl{
+		config:     cfg,
+		natsConn:   natsConn,
+		activeKV:   activeKV,
+		terminalKV: terminalKV,
+	}, nil
+}
+
+// getOrCreateTerminalBucket creates the terminal bucket with a TTL, mirroring
+// the terminated-instances bucket; GetOrCreateKVBucket cannot set a TTL.
+func getOrCreateTerminalBucket(js nats.JetStreamContext) (nats.KeyValue, error) {
+	kv, err := js.KeyValue(KVBucketSpotRequestsTerminal)
+	if err == nil {
+		return kv, nil
+	}
+	if !errors.Is(err, nats.ErrBucketNotFound) {
+		return nil, err
+	}
+	return js.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket:      KVBucketSpotRequestsTerminal,
+		Description: "Terminal Spot Instance Requests (auto-expire after 1 hour)",
+		History:     1,
+		TTL:         spotTerminalTTL,
+	})
+}
+
+// PutSpotInstanceRequests stores each request in the active bucket.
+func (s *SpotInstanceServiceImpl) PutSpotInstanceRequests(input *PutSpotRequestsInput, accountID string) (*PutSpotRequestsOutput, error) {
+	for _, req := range input.Requests {
+		sirID := aws.StringValue(req.SpotInstanceRequestId)
+		if sirID == "" {
+			return nil, errors.New(awserrors.ErrorMissingParameter)
+		}
+		record := SpotRequestRecord{AccountID: accountID, Request: req}
+		data, err := json.Marshal(record)
+		if err != nil {
+			return nil, errors.New(awserrors.ErrorServerInternal)
+		}
+		if _, err := s.activeKV.Put(utils.AccountKey(accountID, sirID), data); err != nil {
+			slog.Error("PutSpotInstanceRequests: KV put failed", "sirId", sirID, "err", err)
+			return nil, errors.New(awserrors.ErrorServerInternal)
+		}
+	}
+
+	slog.Info("PutSpotInstanceRequests completed", "count", len(input.Requests), "accountID", accountID)
+	return &PutSpotRequestsOutput{}, nil
+}
+
+var describeSpotRequestsValidFilters = map[string]bool{
+	"spot-instance-request-id":   true,
+	"state":                      true,
+	"instance-id":                true,
+	"launch.image-id":            true,
+	"launch.instance-type":       true,
+	"launch.key-name":            true,
+	"type":                       true,
+	"launched-availability-zone": true,
+	"tag-key":                    true,
+}
+
+// DescribeSpotInstanceRequests lists requests from both buckets, merges, and filters.
+func (s *SpotInstanceServiceImpl) DescribeSpotInstanceRequests(input *ec2.DescribeSpotInstanceRequestsInput, accountID string) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
+	parsedFilters, err := filterutil.ParseFilters(input.Filters, describeSpotRequestsValidFilters)
+	if err != nil {
+		slog.Warn("DescribeSpotInstanceRequests: invalid filter", "err", err)
+		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+
+	idSet := make(map[string]bool)
+	for _, id := range input.SpotInstanceRequestIds {
+		if id != nil {
+			idSet[*id] = true
+		}
+	}
+
+	active, err := s.listRequests(s.activeKV, accountID)
+	if err != nil {
+		return nil, err
+	}
+	terminal, err := s.listRequests(s.terminalKV, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	found := make(map[string]bool)
+	var requests []*ec2.SpotInstanceRequest
+	for _, req := range append(active, terminal...) {
+		sirID := aws.StringValue(req.SpotInstanceRequestId)
+		if len(idSet) > 0 && !idSet[sirID] {
+			continue
+		}
+		if !sirMatchesFilters(req, parsedFilters) {
+			continue
+		}
+		if !filterutil.MatchesTags(parsedFilters, filterutil.EC2TagsToMap(req.Tags)) {
+			continue
+		}
+		found[sirID] = true
+		requests = append(requests, req)
+	}
+
+	// Requested IDs that don't exist are an error, matching AWS.
+	for id := range idSet {
+		if !found[id] {
+			return nil, errors.New(awserrors.ErrorInvalidSpotInstanceRequestIDNotFound)
+		}
+	}
+
+	slog.Info("DescribeSpotInstanceRequests completed", "count", len(requests), "accountID", accountID)
+	return &ec2.DescribeSpotInstanceRequestsOutput{SpotInstanceRequests: requests}, nil
+}
+
+// CancelSpotInstanceRequests moves active requests to the terminal bucket as
+// cancelled. The instances keep running. Already-terminal/absent IDs are
+// idempotent. Returns a cancelled entry for every requested ID.
+func (s *SpotInstanceServiceImpl) CancelSpotInstanceRequests(input *ec2.CancelSpotInstanceRequestsInput, accountID string) (*ec2.CancelSpotInstanceRequestsOutput, error) {
+	if len(input.SpotInstanceRequestIds) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+
+	cancelled := make([]*ec2.CancelledSpotInstanceRequest, 0, len(input.SpotInstanceRequestIds))
+	for _, idPtr := range input.SpotInstanceRequestIds {
+		sirID := aws.StringValue(idPtr)
+		key := utils.AccountKey(accountID, sirID)
+
+		record, err := s.readRecord(s.activeKV, key)
+		if err == nil {
+			record.Request.State = aws.String(ec2.SpotInstanceStateCancelled)
+			setSpotStatus(record.Request, SpotStatusCodeCanceledInstanceRunning,
+				"Spot Instance request cancelled; the instance is still running.")
+			if err := s.moveToTerminal(key, record); err != nil {
+				return nil, err
+			}
+		} else if !errors.Is(err, nats.ErrKeyNotFound) {
+			return nil, errors.New(awserrors.ErrorServerInternal)
+		}
+
+		cancelled = append(cancelled, &ec2.CancelledSpotInstanceRequest{
+			SpotInstanceRequestId: aws.String(sirID),
+			State:                 aws.String(ec2.CancelSpotInstanceRequestStateCancelled),
+		})
+	}
+
+	slog.Info("CancelSpotInstanceRequests completed", "count", len(cancelled), "accountID", accountID)
+	return &ec2.CancelSpotInstanceRequestsOutput{CancelledSpotInstanceRequests: cancelled}, nil
+}
+
+// CloseForInstance scans the active bucket for the request fulfilled by
+// instanceID and moves it to the terminal bucket as closed. No-op if none match.
+// Called in-process by the daemon teardown cleaner when an instance terminates.
+func (s *SpotInstanceServiceImpl) CloseForInstance(instanceID, accountID string) error {
+	if instanceID == "" {
+		return nil
+	}
+
+	keys, err := s.activeKV.Keys()
+	if err != nil {
+		if errors.Is(err, nats.ErrNoKeysFound) {
+			return nil
+		}
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+
+	prefix := accountID + "."
+	for _, key := range keys {
+		if key == utils.VersionKey || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		record, err := s.readRecord(s.activeKV, key)
+		if err != nil {
+			continue
+		}
+		if aws.StringValue(record.Request.InstanceId) != instanceID {
+			continue
+		}
+
+		record.Request.State = aws.String(ec2.SpotInstanceStateClosed)
+		setSpotStatus(record.Request, SpotStatusCodeInstanceTerminatedByUser,
+			"Spot Instance request closed; the instance was terminated by the user.")
+		if err := s.moveToTerminal(key, record); err != nil {
+			return err
+		}
+		slog.Info("CloseForInstance moved SIR to terminal", "instanceId", instanceID,
+			"sirId", aws.StringValue(record.Request.SpotInstanceRequestId), "accountID", accountID)
+		return nil
+	}
+
+	return nil
+}
+
+// listRequests reads all account-scoped requests from a bucket.
+func (s *SpotInstanceServiceImpl) listRequests(kv nats.KeyValue, accountID string) ([]*ec2.SpotInstanceRequest, error) {
+	keys, err := kv.Keys()
+	if err != nil {
+		if errors.Is(err, nats.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, errors.New(awserrors.ErrorServerInternal)
+	}
+
+	prefix := accountID + "."
+	var requests []*ec2.SpotInstanceRequest
+	for _, key := range keys {
+		if key == utils.VersionKey || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		record, err := s.readRecord(kv, key)
+		if err != nil {
+			slog.Warn("Failed to read spot request record", "key", key, "err", err)
+			continue
+		}
+		requests = append(requests, record.Request)
+	}
+	return requests, nil
+}
+
+// readRecord fetches and unmarshals a single record. The KV Get error (e.g.
+// nats.ErrKeyNotFound) is returned unwrapped so callers can match on it.
+func (s *SpotInstanceServiceImpl) readRecord(kv nats.KeyValue, key string) (*SpotRequestRecord, error) {
+	entry, err := kv.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	var record SpotRequestRecord
+	if err := json.Unmarshal(entry.Value(), &record); err != nil {
+		return nil, errors.New(awserrors.ErrorServerInternal)
+	}
+	return &record, nil
+}
+
+// moveToTerminal writes the record to the terminal bucket and deletes it from active.
+func (s *SpotInstanceServiceImpl) moveToTerminal(key string, record *SpotRequestRecord) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+	if _, err := s.terminalKV.Put(key, data); err != nil {
+		slog.Error("moveToTerminal: terminal put failed", "key", key, "err", err)
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+	if err := s.activeKV.Delete(key); err != nil {
+		slog.Error("moveToTerminal: active delete failed", "key", key, "err", err)
+		return errors.New(awserrors.ErrorServerInternal)
+	}
+	return nil
+}
+
+// setSpotStatus sets the status code/message and update time on a request.
+func setSpotStatus(req *ec2.SpotInstanceRequest, code, message string) {
+	req.Status = &ec2.SpotInstanceStatus{
+		Code:       aws.String(code),
+		Message:    aws.String(message),
+		UpdateTime: aws.Time(time.Now().UTC()),
+	}
+}
+
+// sirMatchesFilters reports whether a request matches all non-tag filters.
+// tag:* filters are handled separately via filterutil.MatchesTags.
+func sirMatchesFilters(req *ec2.SpotInstanceRequest, filters map[string][]string) bool {
+	for name, values := range filters {
+		switch {
+		case name == "spot-instance-request-id":
+			if !filterutil.MatchesAny(values, aws.StringValue(req.SpotInstanceRequestId)) {
+				return false
+			}
+		case name == "state":
+			if !filterutil.MatchesAny(values, aws.StringValue(req.State)) {
+				return false
+			}
+		case name == "instance-id":
+			if !filterutil.MatchesAny(values, aws.StringValue(req.InstanceId)) {
+				return false
+			}
+		case name == "type":
+			if !filterutil.MatchesAny(values, aws.StringValue(req.Type)) {
+				return false
+			}
+		case name == "launched-availability-zone":
+			if !filterutil.MatchesAny(values, aws.StringValue(req.LaunchedAvailabilityZone)) {
+				return false
+			}
+		case name == "launch.image-id":
+			if !filterutil.MatchesAny(values, launchSpecImageID(req)) {
+				return false
+			}
+		case name == "launch.instance-type":
+			if !filterutil.MatchesAny(values, launchSpecInstanceType(req)) {
+				return false
+			}
+		case name == "launch.key-name":
+			if !filterutil.MatchesAny(values, launchSpecKeyName(req)) {
+				return false
+			}
+		case name == "tag-key":
+			if !sirMatchesTagKey(req.Tags, values) {
+				return false
+			}
+		case strings.HasPrefix(name, "tag:"):
+			// Handled by filterutil.MatchesTags.
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func sirMatchesTagKey(tags []*ec2.Tag, values []string) bool {
+	for _, t := range tags {
+		if t.Key != nil && filterutil.MatchesAny(values, *t.Key) {
+			return true
+		}
+	}
+	return false
+}
+
+func launchSpecImageID(req *ec2.SpotInstanceRequest) string {
+	if req.LaunchSpecification == nil {
+		return ""
+	}
+	return aws.StringValue(req.LaunchSpecification.ImageId)
+}
+
+func launchSpecInstanceType(req *ec2.SpotInstanceRequest) string {
+	if req.LaunchSpecification == nil {
+		return ""
+	}
+	return aws.StringValue(req.LaunchSpecification.InstanceType)
+}
+
+func launchSpecKeyName(req *ec2.SpotInstanceRequest) string {
+	if req.LaunchSpecification == nil {
+		return ""
+	}
+	return aws.StringValue(req.LaunchSpecification.KeyName)
+}

--- a/spinifex/handlers/ec2/spotinstance/service_impl.go
+++ b/spinifex/handlers/ec2/spotinstance/service_impl.go
@@ -339,15 +339,15 @@ func sirMatchesFilters(req *ec2.SpotInstanceRequest, filters map[string][]string
 				return false
 			}
 		case name == "launch.image-id":
-			if !filterutil.MatchesAny(values, launchSpecImageID(req)) {
+			if !filterutil.MatchesAny(values, aws.StringValue(launchSpec(req).ImageId)) {
 				return false
 			}
 		case name == "launch.instance-type":
-			if !filterutil.MatchesAny(values, launchSpecInstanceType(req)) {
+			if !filterutil.MatchesAny(values, aws.StringValue(launchSpec(req).InstanceType)) {
 				return false
 			}
 		case name == "launch.key-name":
-			if !filterutil.MatchesAny(values, launchSpecKeyName(req)) {
+			if !filterutil.MatchesAny(values, aws.StringValue(launchSpec(req).KeyName)) {
 				return false
 			}
 		case name == "tag-key":
@@ -372,23 +372,11 @@ func sirMatchesTagKey(tags []*ec2.Tag, values []string) bool {
 	return false
 }
 
-func launchSpecImageID(req *ec2.SpotInstanceRequest) string {
-	if req.LaunchSpecification == nil {
-		return ""
+// launchSpec returns the request's launch specification, or an empty one when
+// absent, so field reads in filter matching need no nil guard.
+func launchSpec(req *ec2.SpotInstanceRequest) *ec2.LaunchSpecification {
+	if req.LaunchSpecification != nil {
+		return req.LaunchSpecification
 	}
-	return aws.StringValue(req.LaunchSpecification.ImageId)
-}
-
-func launchSpecInstanceType(req *ec2.SpotInstanceRequest) string {
-	if req.LaunchSpecification == nil {
-		return ""
-	}
-	return aws.StringValue(req.LaunchSpecification.InstanceType)
-}
-
-func launchSpecKeyName(req *ec2.SpotInstanceRequest) string {
-	if req.LaunchSpecification == nil {
-		return ""
-	}
-	return aws.StringValue(req.LaunchSpecification.KeyName)
+	return &ec2.LaunchSpecification{}
 }

--- a/spinifex/handlers/ec2/spotinstance/service_impl_test.go
+++ b/spinifex/handlers/ec2/spotinstance/service_impl_test.go
@@ -1,0 +1,310 @@
+package handlers_ec2_spotinstance
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAccountID = "123456789012"
+
+func setupTestService(t *testing.T) *SpotInstanceServiceImpl {
+	t.Helper()
+	_, nc, _ := testutil.StartTestJetStream(t)
+
+	svc, err := NewSpotInstanceServiceImplWithNATS(nil, nc)
+	require.NoError(t, err)
+	return svc
+}
+
+// makeSIR builds an active/fulfilled Spot Instance Request for tests.
+func makeSIR(sirID, instanceID string) *ec2.SpotInstanceRequest {
+	return &ec2.SpotInstanceRequest{
+		SpotInstanceRequestId:    aws.String(sirID),
+		InstanceId:               aws.String(instanceID),
+		State:                    aws.String(ec2.SpotInstanceStateActive),
+		Type:                     aws.String(ec2.SpotInstanceTypeOneTime),
+		LaunchedAvailabilityZone: aws.String("ap-southeast-2a"),
+		Status:                   &ec2.SpotInstanceStatus{Code: aws.String(SpotStatusCodeFulfilled)},
+		LaunchSpecification: &ec2.LaunchSpecification{
+			ImageId:      aws.String("ami-12345678"),
+			InstanceType: aws.String("t3.micro"),
+			KeyName:      aws.String("my-key"),
+		},
+	}
+}
+
+func putSIRs(t *testing.T, svc *SpotInstanceServiceImpl, reqs ...*ec2.SpotInstanceRequest) {
+	t.Helper()
+	_, err := svc.PutSpotInstanceRequests(&PutSpotRequestsInput{Requests: reqs}, testAccountID)
+	require.NoError(t, err)
+}
+
+func describeAll(t *testing.T, svc *SpotInstanceServiceImpl, accountID string) []*ec2.SpotInstanceRequest {
+	t.Helper()
+	out, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{}, accountID)
+	require.NoError(t, err)
+	return out.SpotInstanceRequests
+}
+
+// --- Put / Describe round-trip ---
+
+func TestPutDescribe_RoundTrip(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"), makeSIR("sir-bbb", "i-bbb"))
+
+	got := describeAll(t, svc, testAccountID)
+	require.Len(t, got, 2)
+
+	ids := map[string]string{}
+	for _, r := range got {
+		ids[aws.StringValue(r.SpotInstanceRequestId)] = aws.StringValue(r.InstanceId)
+		assert.Equal(t, ec2.SpotInstanceStateActive, aws.StringValue(r.State))
+	}
+	assert.Equal(t, "i-aaa", ids["sir-aaa"])
+	assert.Equal(t, "i-bbb", ids["sir-bbb"])
+}
+
+func TestPutSpotInstanceRequests_MissingID(t *testing.T) {
+	svc := setupTestService(t)
+	_, err := svc.PutSpotInstanceRequests(&PutSpotRequestsInput{
+		Requests: []*ec2.SpotInstanceRequest{{InstanceId: aws.String("i-noid")}},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorMissingParameter, err.Error())
+}
+
+func TestDescribe_Empty(t *testing.T) {
+	svc := setupTestService(t)
+	assert.Empty(t, describeAll(t, svc, testAccountID))
+}
+
+func TestDescribe_AccountScoped(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"))
+
+	assert.Len(t, describeAll(t, svc, testAccountID), 1)
+	assert.Empty(t, describeAll(t, svc, "999999999999"))
+}
+
+// --- Describe filters ---
+
+func TestDescribe_FilterByID(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"), makeSIR("sir-bbb", "i-bbb"))
+
+	out, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-aaa")},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.SpotInstanceRequests, 1)
+	assert.Equal(t, "sir-aaa", aws.StringValue(out.SpotInstanceRequests[0].SpotInstanceRequestId))
+}
+
+func TestDescribe_UnknownID(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"))
+
+	_, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-ghost")},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidSpotInstanceRequestIDNotFound, err.Error())
+}
+
+func TestDescribe_FilterByState(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"), makeSIR("sir-bbb", "i-bbb"))
+
+	// Cancel one so it becomes terminal/cancelled.
+	_, err := svc.CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-bbb")},
+	}, testAccountID)
+	require.NoError(t, err)
+
+	out, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("state"), Values: []*string{aws.String("active")}}},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.SpotInstanceRequests, 1)
+	assert.Equal(t, "sir-aaa", aws.StringValue(out.SpotInstanceRequests[0].SpotInstanceRequestId))
+}
+
+func TestDescribe_FilterByInstanceID(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"), makeSIR("sir-bbb", "i-bbb"))
+
+	out, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("instance-id"), Values: []*string{aws.String("i-bbb")}}},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.SpotInstanceRequests, 1)
+	assert.Equal(t, "sir-bbb", aws.StringValue(out.SpotInstanceRequests[0].SpotInstanceRequestId))
+}
+
+func TestDescribe_FilterByLaunchImageID(t *testing.T) {
+	svc := setupTestService(t)
+	other := makeSIR("sir-bbb", "i-bbb")
+	other.LaunchSpecification.ImageId = aws.String("ami-99999999")
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"), other)
+
+	out, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("launch.image-id"), Values: []*string{aws.String("ami-12345678")}}},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.SpotInstanceRequests, 1)
+	assert.Equal(t, "sir-aaa", aws.StringValue(out.SpotInstanceRequests[0].SpotInstanceRequestId))
+}
+
+func TestDescribe_FilterByTag(t *testing.T) {
+	svc := setupTestService(t)
+	tagged := makeSIR("sir-aaa", "i-aaa")
+	tagged.Tags = []*ec2.Tag{{Key: aws.String("env"), Value: aws.String("prod")}}
+	putSIRs(t, svc, tagged, makeSIR("sir-bbb", "i-bbb"))
+
+	out, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("tag:env"), Values: []*string{aws.String("prod")}}},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.SpotInstanceRequests, 1)
+	assert.Equal(t, "sir-aaa", aws.StringValue(out.SpotInstanceRequests[0].SpotInstanceRequestId))
+
+	// tag-key matches any value for the key.
+	out, err = svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("tag-key"), Values: []*string{aws.String("env")}}},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.SpotInstanceRequests, 1)
+	assert.Equal(t, "sir-aaa", aws.StringValue(out.SpotInstanceRequests[0].SpotInstanceRequestId))
+}
+
+func TestDescribe_InvalidFilter(t *testing.T) {
+	svc := setupTestService(t)
+	_, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		Filters: []*ec2.Filter{{Name: aws.String("bogus-filter"), Values: []*string{aws.String("x")}}},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, err.Error())
+}
+
+// --- Cancel ---
+
+func TestCancel_MovesActiveToTerminal(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"))
+
+	out, err := svc.CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-aaa")},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.CancelledSpotInstanceRequests, 1)
+	assert.Equal(t, ec2.CancelSpotInstanceRequestStateCancelled, aws.StringValue(out.CancelledSpotInstanceRequests[0].State))
+
+	// Active bucket no longer has it; describe (merged) shows it cancelled with instance still set.
+	got := describeAll(t, svc, testAccountID)
+	require.Len(t, got, 1)
+	assert.Equal(t, ec2.SpotInstanceStateCancelled, aws.StringValue(got[0].State))
+	assert.Equal(t, SpotStatusCodeCanceledInstanceRunning, aws.StringValue(got[0].Status.Code))
+	assert.Equal(t, "i-aaa", aws.StringValue(got[0].InstanceId))
+}
+
+func TestCancel_Idempotent(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"))
+
+	in := &ec2.CancelSpotInstanceRequestsInput{SpotInstanceRequestIds: []*string{aws.String("sir-aaa")}}
+	_, err := svc.CancelSpotInstanceRequests(in, testAccountID)
+	require.NoError(t, err)
+
+	// Second cancel of an already-terminal request succeeds without duplicating.
+	out, err := svc.CancelSpotInstanceRequests(in, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.CancelledSpotInstanceRequests, 1)
+
+	got := describeAll(t, svc, testAccountID)
+	require.Len(t, got, 1)
+	assert.Equal(t, ec2.SpotInstanceStateCancelled, aws.StringValue(got[0].State))
+}
+
+func TestCancel_AbsentIDIdempotent(t *testing.T) {
+	svc := setupTestService(t)
+	out, err := svc.CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-ghost")},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.CancelledSpotInstanceRequests, 1)
+	assert.Equal(t, ec2.CancelSpotInstanceRequestStateCancelled, aws.StringValue(out.CancelledSpotInstanceRequests[0].State))
+}
+
+func TestCancel_MissingIDs(t *testing.T) {
+	svc := setupTestService(t)
+	_, err := svc.CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{}, testAccountID)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorMissingParameter, err.Error())
+}
+
+// --- CloseForInstance ---
+
+func TestCloseForInstance_MovesMatching(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"), makeSIR("sir-bbb", "i-bbb"))
+
+	require.NoError(t, svc.CloseForInstance("i-bbb", testAccountID))
+
+	out, err := svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-bbb")},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.SpotInstanceRequests, 1)
+	assert.Equal(t, ec2.SpotInstanceStateClosed, aws.StringValue(out.SpotInstanceRequests[0].State))
+	assert.Equal(t, SpotStatusCodeInstanceTerminatedByUser, aws.StringValue(out.SpotInstanceRequests[0].Status.Code))
+
+	// sir-aaa is untouched and still active.
+	out, err = svc.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-aaa")},
+	}, testAccountID)
+	require.NoError(t, err)
+	assert.Equal(t, ec2.SpotInstanceStateActive, aws.StringValue(out.SpotInstanceRequests[0].State))
+}
+
+func TestCloseForInstance_NoMatchNoOp(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-aaa", "i-aaa"))
+
+	require.NoError(t, svc.CloseForInstance("i-nomatch", testAccountID))
+
+	got := describeAll(t, svc, testAccountID)
+	require.Len(t, got, 1)
+	assert.Equal(t, ec2.SpotInstanceStateActive, aws.StringValue(got[0].State))
+}
+
+func TestCloseForInstance_EmptyInstanceID(t *testing.T) {
+	svc := setupTestService(t)
+	require.NoError(t, svc.CloseForInstance("", testAccountID))
+}
+
+// --- Merge across buckets ---
+
+func TestDescribe_MergesBothBuckets(t *testing.T) {
+	svc := setupTestService(t)
+	putSIRs(t, svc, makeSIR("sir-active", "i-1"), makeSIR("sir-cancel", "i-2"), makeSIR("sir-close", "i-3"))
+
+	_, err := svc.CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []*string{aws.String("sir-cancel")},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.NoError(t, svc.CloseForInstance("i-3", testAccountID))
+
+	states := map[string]string{}
+	for _, r := range describeAll(t, svc, testAccountID) {
+		states[aws.StringValue(r.SpotInstanceRequestId)] = aws.StringValue(r.State)
+	}
+	assert.Equal(t, ec2.SpotInstanceStateActive, states["sir-active"])
+	assert.Equal(t, ec2.SpotInstanceStateCancelled, states["sir-cancel"])
+	assert.Equal(t, ec2.SpotInstanceStateClosed, states["sir-close"])
+}

--- a/spinifex/handlers/ec2/spotinstance/service_nats.go
+++ b/spinifex/handlers/ec2/spotinstance/service_nats.go
@@ -1,0 +1,34 @@
+package handlers_ec2_spotinstance
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// Ensure NATSSpotInstanceService implements SpotInstanceService.
+var _ SpotInstanceService = (*NATSSpotInstanceService)(nil)
+
+// NATSSpotInstanceService handles spot instance request operations via NATS messaging.
+type NATSSpotInstanceService struct {
+	natsConn *nats.Conn
+}
+
+// NewNATSSpotInstanceService creates a new NATS-based spot instance service.
+func NewNATSSpotInstanceService(conn *nats.Conn) *NATSSpotInstanceService {
+	return &NATSSpotInstanceService{natsConn: conn}
+}
+
+func (s *NATSSpotInstanceService) PutSpotInstanceRequests(input *PutSpotRequestsInput, accountID string) (*PutSpotRequestsOutput, error) {
+	return utils.NATSRequest[PutSpotRequestsOutput](s.natsConn, "ec2.PutSpotInstanceRequests", input, 30*time.Second, accountID)
+}
+
+func (s *NATSSpotInstanceService) DescribeSpotInstanceRequests(input *ec2.DescribeSpotInstanceRequestsInput, accountID string) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
+	return utils.NATSRequest[ec2.DescribeSpotInstanceRequestsOutput](s.natsConn, "ec2.DescribeSpotInstanceRequests", input, 30*time.Second, accountID)
+}
+
+func (s *NATSSpotInstanceService) CancelSpotInstanceRequests(input *ec2.CancelSpotInstanceRequestsInput, accountID string) (*ec2.CancelSpotInstanceRequestsOutput, error) {
+	return utils.NATSRequest[ec2.CancelSpotInstanceRequestsOutput](s.natsConn, "ec2.CancelSpotInstanceRequests", input, 30*time.Second, accountID)
+}

--- a/spinifex/handlers/ec2/spotinstance/types.go
+++ b/spinifex/handlers/ec2/spotinstance/types.go
@@ -1,0 +1,43 @@
+package handlers_ec2_spotinstance
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+const (
+	// KVBucketSpotRequests holds open/active Spot Instance Requests; no TTL.
+	KVBucketSpotRequests = "spinifex-spot-requests"
+	// KVBucketSpotRequestsTerminal holds closed/cancelled SIRs; auto-expires after spotTerminalTTL.
+	KVBucketSpotRequestsTerminal = "spinifex-spot-requests-terminal"
+	// KVBucketSpotRequestsVersion is the schema version for both spot buckets.
+	KVBucketSpotRequestsVersion = 1
+
+	spotTerminalTTL = time.Hour
+)
+
+// Spot request status codes mirror AWS spot-request status codes.
+const (
+	// SpotStatusCodeFulfilled marks an active request whose instance is running.
+	SpotStatusCodeFulfilled = "fulfilled"
+	// SpotStatusCodeCanceledInstanceRunning marks a cancelled request whose instance keeps running.
+	SpotStatusCodeCanceledInstanceRunning = "request-canceled-and-instance-running"
+	// SpotStatusCodeInstanceTerminatedByUser marks a request closed because its instance was terminated.
+	SpotStatusCodeInstanceTerminatedByUser = "instance-terminated-by-user"
+)
+
+// SpotRequestRecord is the persisted form of a Spot Instance Request.
+// The full SDK object is JSON round-tripped to avoid re-mapping ~20 fields.
+type SpotRequestRecord struct {
+	AccountID string                   `json:"account_id"`
+	Request   *ec2.SpotInstanceRequest `json:"request"`
+}
+
+// PutSpotRequestsInput carries Spot Instance Requests to persist in the active bucket.
+type PutSpotRequestsInput struct {
+	Requests []*ec2.SpotInstanceRequest `json:"requests"`
+}
+
+// PutSpotRequestsOutput is empty on success.
+type PutSpotRequestsOutput struct{}

--- a/spinifex/handlers/imds/instance_lookup.go
+++ b/spinifex/handlers/imds/instance_lookup.go
@@ -39,6 +39,7 @@ func (l *natsInstanceLookup) describe(accountID, instanceID string) (*instanceFa
 		architecture:   aws.StringValue(inst.Architecture),
 		amiLaunchIndex: aws.Int64Value(inst.AmiLaunchIndex),
 		reservationID:  aws.StringValue(res.ReservationId),
+		lifecycleType:  aws.StringValue(inst.InstanceLifecycle),
 		pendingTime:    aws.TimeValue(inst.LaunchTime),
 	}
 	if inst.IamInstanceProfile != nil {

--- a/spinifex/handlers/imds/metadata.go
+++ b/spinifex/handlers/imds/metadata.go
@@ -180,7 +180,7 @@ func (s *IMDSServiceImpl) dispatch(w http.ResponseWriter, r *http.Request, eni *
 	case prefixMetaData + "instance-id":
 		writeText(w, eni.instanceID)
 	case prefixMetaData + "instance-life-cycle":
-		writeText(w, "on-demand") // Spot is not modelled yet
+		s.serveInstanceLifecycle(w, eni)
 	case prefixMetaData + "local-ipv4":
 		writeText(w, eni.privateIP)
 	case prefixMetaData + "public-ipv4":
@@ -281,6 +281,18 @@ func (s *IMDSServiceImpl) serveMetaDataRoot(w http.ResponseWriter, eni *eniFacts
 	}
 	sort.Strings(keys)
 	writeText(w, strings.Join(keys, "\n"))
+}
+
+// serveInstanceLifecycle reports "spot" for a spot-launched instance and
+// "on-demand" otherwise. Unlike serveInstanceField it never 404s: the leaf is
+// advertised unconditionally in serveMetaDataRoot, so a resolution miss or error
+// defaults to "on-demand" rather than breaking cloud-init's crawl mid-listing.
+func (s *IMDSServiceImpl) serveInstanceLifecycle(w http.ResponseWriter, eni *eniFacts) {
+	if inst, err := s.resolver.resolveInstance(eni); err == nil && inst != nil && inst.lifecycleType == "spot" {
+		writeText(w, "spot")
+		return
+	}
+	writeText(w, "on-demand")
 }
 
 // serveInstanceField resolves the instance record and writes one of its

--- a/spinifex/handlers/imds/metadata.go
+++ b/spinifex/handlers/imds/metadata.go
@@ -290,8 +290,6 @@ func (s *IMDSServiceImpl) serveMetaDataRoot(w http.ResponseWriter, eni *eniFacts
 func (s *IMDSServiceImpl) serveInstanceLifecycle(w http.ResponseWriter, eni *eniFacts) {
 	inst, err := s.resolver.resolveInstance(eni)
 	if err != nil {
-		// Log but still default to on-demand: this leaf is advertised
-		// unconditionally and must never 404 on a backend fault.
 		slog.Error("IMDS: instance resolution failed", "instance_id", eni.instanceID, "err", err)
 	}
 	if err == nil && inst != nil && inst.lifecycleType == "spot" {

--- a/spinifex/handlers/imds/metadata.go
+++ b/spinifex/handlers/imds/metadata.go
@@ -288,7 +288,13 @@ func (s *IMDSServiceImpl) serveMetaDataRoot(w http.ResponseWriter, eni *eniFacts
 // advertised unconditionally in serveMetaDataRoot, so a resolution miss or error
 // defaults to "on-demand" rather than breaking cloud-init's crawl mid-listing.
 func (s *IMDSServiceImpl) serveInstanceLifecycle(w http.ResponseWriter, eni *eniFacts) {
-	if inst, err := s.resolver.resolveInstance(eni); err == nil && inst != nil && inst.lifecycleType == "spot" {
+	inst, err := s.resolver.resolveInstance(eni)
+	if err != nil {
+		// Log but still default to on-demand: this leaf is advertised
+		// unconditionally and must never 404 on a backend fault.
+		slog.Error("IMDS: instance resolution failed", "instance_id", eni.instanceID, "err", err)
+	}
+	if err == nil && inst != nil && inst.lifecycleType == "spot" {
 		writeText(w, "spot")
 		return
 	}

--- a/spinifex/handlers/imds/metadata_test.go
+++ b/spinifex/handlers/imds/metadata_test.go
@@ -439,6 +439,46 @@ func TestHTTP_PublicFieldsAbsent404(t *testing.T) {
 	}
 }
 
+// instance-life-cycle is "spot" only for a spot-launched instance; it defaults to
+// "on-demand" for on-demand instances and — crucially — for a resolution miss or
+// error, since the leaf is advertised unconditionally and a 404 would break the crawl.
+func TestHTTP_InstanceLifecycle(t *testing.T) {
+	cases := []struct {
+		name string
+		res  *fakeResolver
+		want string
+	}{
+		{"Spot", &fakeResolver{eni: testENI(), inst: &instanceFacts{lifecycleType: "spot"}}, "spot"},
+		{"OnDemand", &fakeResolver{eni: testENI(), inst: &instanceFacts{}}, "on-demand"},
+		{"ResolutionMiss", &fakeResolver{eni: testENI()}, "on-demand"},
+		{"ResolutionError", &fakeResolver{eni: testENI(), instErr: errors.New("backend down")}, "on-demand"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			svc, _ := newTestService(c.res, &fakeIAM{}, &fakeAssumer{})
+			h := withTapENI(svc.httpHandler(), testENI())
+			token := issueToken(t, h)
+			rec := get(t, h, prefixMetaData+"instance-life-cycle", token)
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, c.want, rec.Body.String())
+		})
+	}
+}
+
+// A never-interrupted spot instance has no scheduled action, so spot/instance-action
+// and spot/termination-time 404 (the dispatch default) — a 200 body would trigger
+// interruption handling in pollers like the AWS Node Termination Handler.
+func TestHTTP_SpotPathsReturn404(t *testing.T) {
+	res := &fakeResolver{eni: testENI(), inst: &instanceFacts{lifecycleType: "spot"}}
+	svc, _ := newTestService(res, &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+	token := issueToken(t, h)
+	for _, leaf := range []string{"spot/instance-action", "spot/termination-time"} {
+		rec := get(t, h, prefixMetaData+leaf, token)
+		assert.Equal(t, http.StatusNotFound, rec.Code, "leaf=%s", leaf)
+	}
+}
+
 // The meta-data root lists every served child, alphabetically, to match AWS. With
 // no instance profile attached, iam/ is omitted entirely — real EC2 omits it so
 // cloud-init never descends into a subtree whose leaves would 404 and fail the crawl.

--- a/spinifex/handlers/imds/resolver.go
+++ b/spinifex/handlers/imds/resolver.go
@@ -39,6 +39,7 @@ type instanceFacts struct {
 	keyName               string
 	architecture          string
 	reservationID         string
+	lifecycleType         string // "spot" for spot-launched instances, else empty (on-demand)
 	amiLaunchIndex        int64
 	pendingTime           time.Time
 	userData              []byte

--- a/spinifex/types/ec2.go
+++ b/spinifex/types/ec2.go
@@ -10,6 +10,7 @@ type EC2InstanceCommand struct {
 	AttachENIData             *AttachENIData             `json:"attach_eni_data,omitempty"`
 	DetachENIData             *DetachENIData             `json:"detach_eni_data,omitempty"`
 	IamProfileAssociationData *IamProfileAssociationData `json:"iam_profile_association_data,omitempty"`
+	SpotLineageData           *SpotLineageData           `json:"spot_lineage_data,omitempty"`
 }
 
 // EC2CommandAttributes indicates which action the daemon should perform.
@@ -23,6 +24,7 @@ type EC2CommandAttributes struct {
 	AttachENI                   bool `json:"attach_eni"`
 	DetachENI                   bool `json:"detach_eni"`
 	AssociateIamInstanceProfile bool `json:"associate_iam_instance_profile,omitempty"`
+	SetSpotLineage              bool `json:"set_spot_lineage,omitempty"`
 }
 
 // AttachVolumeData carries parameters for an attach-volume command.
@@ -56,4 +58,10 @@ type DetachENIData struct {
 // only needs the ARN to persist on vm.VM.
 type IamProfileAssociationData struct {
 	InstanceProfileArn string `json:"instance_profile_arn"`
+}
+
+// SpotLineageData carries the SIR id stamped onto a spot-launched instance.
+// Lifecycle is always "spot" for this command, so only the SIR id travels.
+type SpotLineageData struct {
+	SpotInstanceRequestId string `json:"spot_instance_request_id"`
 }

--- a/spinifex/vm/fakes_test.go
+++ b/spinifex/vm/fakes_test.go
@@ -213,6 +213,7 @@ type recordingInstanceCleaner struct {
 	releasePublicIP     []string
 	detachAndDeleteENI  []string
 	removeFromPlacement []string
+	removeFromSpot      []string
 	releaseGPU          []string
 
 	// Injectable per-method errors so tests can drive failed-teardown marks.
@@ -220,6 +221,7 @@ type recordingInstanceCleaner struct {
 	releasePublicIPErr error
 	detachENIErr       error
 	removePlacementErr error
+	removeSpotErr      error
 	releaseGPUErr      error
 }
 
@@ -255,6 +257,13 @@ func (c *recordingInstanceCleaner) RemoveFromPlacementGroup(v *VM) error {
 	defer c.mu.Unlock()
 	c.removeFromPlacement = append(c.removeFromPlacement, v.ID)
 	return c.removePlacementErr
+}
+
+func (c *recordingInstanceCleaner) RemoveFromSpotRequest(v *VM) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.removeFromSpot = append(c.removeFromSpot, v.ID)
+	return c.removeSpotErr
 }
 
 func (c *recordingInstanceCleaner) ReleaseGPU(v *VM) error {

--- a/spinifex/vm/instance_cleaner.go
+++ b/spinifex/vm/instance_cleaner.go
@@ -27,6 +27,12 @@ type InstanceCleaner interface {
 	// group, if one is set. Called only on Terminate.
 	RemoveFromPlacementGroup(v *VM) error
 
+	// RemoveFromSpotRequest closes the Spot Instance Request fulfilled by this
+	// instance, if any, by scanning the active spot bucket for its ID. The VM
+	// carries no spot marker, so this is best-effort and untracked (no teardown
+	// stamp): a no-match is the common case. Called only on Terminate.
+	RemoveFromSpotRequest(v *VM) error
+
 	// ReleaseGPU unbinds the instance's GPU from vfio-pci and rebinds to
 	// its original host driver. Called on both Stop and Terminate. No-op
 	// when the instance has no GPU allocation.

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -335,6 +335,13 @@ func (m *Manager) terminateCleanup(instance *VM) {
 		if instance.PlacementGroupName != "" {
 			m.markTeardownResult(instance, TeardownPlacement, placementErr)
 		}
+
+		// Spot Instance Requests carry no VM-side marker, so this is a best-effort
+		// scan that no-ops for non-spot instances. It is not a tracked teardown
+		// dependency: without a marker we cannot stamp it only when it applies.
+		if err := m.deps.InstanceCleaner.RemoveFromSpotRequest(instance); err != nil {
+			slog.Warn("Failed to close spot request on termination", "id", instance.ID, "err", err)
+		}
 	}
 
 	m.deallocateResources(instance)

--- a/spinifex/vm/vm.go
+++ b/spinifex/vm/vm.go
@@ -152,6 +152,14 @@ type VM struct {
 	// was launched into (targeted launch). Empty for instances on general
 	// capacity. Drives slot restore to the reservation on stop/terminate.
 	CapacityReservationId string `json:"capacity_reservation_id,omitempty"`
+
+	// InstanceLifecycle is "spot" when launched via RequestSpotInstances, empty
+	// for on-demand (matching AWS, which sets it only for spot/scheduled/
+	// capacity-block). SpotInstanceRequestId links the VM back to its SIR. Both
+	// are stamped post-launch by the spot write-back; absence on old records is
+	// tolerated by migrate.
+	InstanceLifecycle     string `json:"instance_lifecycle,omitempty"`
+	SpotInstanceRequestId string `json:"spot_instance_request_id,omitempty"`
 }
 
 // ResetNodeLocalState zeroes node-specific fields after deserializing a VM

--- a/tests/e2e/single/spot_test.go
+++ b/tests/e2e/single/spot_test.go
@@ -95,9 +95,15 @@ func runSpotInstanceLifecycle(t *testing.T, fix *Fixture) {
 		launchedIDs = append(launchedIDs, instID)
 	}
 
-	// Both backing VMs are real on-demand launches — wait for running.
-	for _, instID := range sirInstance {
-		harness.WaitForInstanceState(t, fix.AWS, instID, "running")
+	// Both backing VMs are real on-demand launches — wait for running, then assert
+	// full spot lineage: each VM reports InstanceLifecycle=spot and links back to
+	// its originating SIR via SpotInstanceRequestId (stamped by the write-back).
+	for sirID, instID := range sirInstance {
+		inst := harness.WaitForInstanceState(t, fix.AWS, instID, "running")
+		assert.Equal(t, ec2.InstanceLifecycleTypeSpot, aws.StringValue(inst.InstanceLifecycle),
+			"instance %s should report InstanceLifecycle=spot", instID)
+		assert.Equal(t, sirID, aws.StringValue(inst.SpotInstanceRequestId),
+			"instance %s should link back to SIR %s", instID, sirID)
 	}
 
 	cancelSIR, termSIR := sirIDs[0], sirIDs[1]

--- a/tests/e2e/single/spot_test.go
+++ b/tests/e2e/single/spot_test.go
@@ -1,0 +1,186 @@
+//go:build e2e
+
+package single
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runSpotInstanceLifecycle exercises the Spot Instance Request mock end to end.
+// RequestSpotInstances synchronously launches real VMs via the on-demand path
+// and reports the requests active/fulfilled — there is no bidding, interruption,
+// or reclamation. One SIR is cancelled (request goes cancelled, instance keeps
+// running); the other's instance is terminated (request moves to closed). A final
+// oversized request asserts capacity failure persists no SIRs. Maps to the E2E
+// row in docs/development/feature/spot-instances-v1.md.
+func runSpotInstanceLifecycle(t *testing.T, fix *Fixture) {
+	harness.Phase(t, "Single — Spot Instance Requests (mock fulfilment)")
+
+	amiID := needAMI(t, fix)
+	instType, _ := needInstanceTypeArch(t, fix)
+	keyName, _ := needKeyPair(t, fix)
+
+	// InstanceCount=2 -> MinCount=MaxCount=2 (all-or-nothing). Two requests let
+	// us drive both terminal transitions: cancel one, terminate the other.
+	const count = 2
+	harness.Step(t, "request-spot-instances ami=%s type=%s count=%d", amiID, instType, count)
+	reqOut, err := fix.AWS.EC2.RequestSpotInstances(&ec2.RequestSpotInstancesInput{
+		InstanceCount: aws.Int64(count),
+		Type:          aws.String(ec2.SpotInstanceTypeOneTime),
+		LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
+			ImageId:      aws.String(amiID),
+			InstanceType: aws.String(instType),
+			KeyName:      aws.String(keyName),
+		},
+	})
+	require.NoError(t, err, "request-spot-instances --instance-count 2")
+	require.Lenf(t, reqOut.SpotInstanceRequests, count,
+		"expected %d spot instance requests, got %d", count, len(reqOut.SpotInstanceRequests))
+
+	sirIDs := make([]string, 0, count)
+	for _, sir := range reqOut.SpotInstanceRequests {
+		id := aws.StringValue(sir.SpotInstanceRequestId)
+		require.NotEmpty(t, id, "empty SpotInstanceRequestId in response")
+		require.Truef(t, strings.HasPrefix(id, "sir-"), "SIR id %q lacks sir- prefix", id)
+		sirIDs = append(sirIDs, id)
+		assert.Equal(t, ec2.SpotInstanceStateActive, aws.StringValue(sir.State),
+			"SIR %s should be active at create", id)
+	}
+	harness.Detail(t, "sir_cancel", sirIDs[0], "sir_terminate", sirIDs[1])
+
+	// Pre-register teardown of every launched VM before the first blocking wait,
+	// so a fatal still tears the real instances down.
+	var launchedIDs []string
+	t.Cleanup(func() {
+		if len(launchedIDs) == 0 {
+			return
+		}
+		_, _ = fix.AWS.EC2.TerminateInstances(&ec2.TerminateInstancesInput{
+			InstanceIds: aws.StringSlice(launchedIDs),
+		})
+	})
+
+	// `aws ec2 wait spot-instance-request-fulfilled` — fulfilment is synchronous,
+	// so the waiter returns on the first poll.
+	harness.Step(t, "wait spot-instance-request-fulfilled")
+	require.NoError(t, fix.AWS.EC2.WaitUntilSpotInstanceRequestFulfilled(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: aws.StringSlice(sirIDs),
+	}), "wait spot-instance-request-fulfilled")
+
+	// Describe both SIRs: active + fulfilled + an InstanceId mapped per request.
+	descOut, err := fix.AWS.EC2.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: aws.StringSlice(sirIDs),
+	})
+	require.NoError(t, err, "describe-spot-instance-requests")
+	require.Lenf(t, descOut.SpotInstanceRequests, count,
+		"expected %d SIRs from describe, got %d", count, len(descOut.SpotInstanceRequests))
+
+	sirInstance := make(map[string]string, count)
+	for _, sir := range descOut.SpotInstanceRequests {
+		id := aws.StringValue(sir.SpotInstanceRequestId)
+		assert.Equal(t, ec2.SpotInstanceStateActive, aws.StringValue(sir.State), "SIR %s state", id)
+		require.NotNilf(t, sir.Status, "SIR %s missing status", id)
+		assert.Equal(t, "fulfilled", aws.StringValue(sir.Status.Code), "SIR %s status code", id)
+		instID := aws.StringValue(sir.InstanceId)
+		require.NotEmptyf(t, instID, "SIR %s has no InstanceId", id)
+		sirInstance[id] = instID
+		launchedIDs = append(launchedIDs, instID)
+	}
+
+	// Both backing VMs are real on-demand launches — wait for running.
+	for _, instID := range sirInstance {
+		harness.WaitForInstanceState(t, fix.AWS, instID, "running")
+	}
+
+	cancelSIR, termSIR := sirIDs[0], sirIDs[1]
+	cancelInst, termInst := sirInstance[cancelSIR], sirInstance[termSIR]
+	require.NotEmpty(t, cancelInst, "cancel SIR resolved no instance")
+	require.NotEmpty(t, termInst, "terminate SIR resolved no instance")
+
+	// Cancel one request: it flips to cancelled but the instance keeps running
+	// (cancel != terminate). The gateway->daemon move is synchronous.
+	harness.Step(t, "cancel-spot-instance-requests %s", cancelSIR)
+	cancelOut, err := fix.AWS.EC2.CancelSpotInstanceRequests(&ec2.CancelSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: aws.StringSlice([]string{cancelSIR}),
+	})
+	require.NoError(t, err, "cancel-spot-instance-requests %s", cancelSIR)
+	require.Lenf(t, cancelOut.CancelledSpotInstanceRequests, 1,
+		"expected 1 cancelled request, got %d", len(cancelOut.CancelledSpotInstanceRequests))
+	assert.Equal(t, ec2.CancelSpotInstanceRequestStateCancelled,
+		aws.StringValue(cancelOut.CancelledSpotInstanceRequests[0].State))
+
+	cancelled := describeSpotRequest(t, fix, cancelSIR)
+	assert.Equal(t, ec2.SpotInstanceStateCancelled, aws.StringValue(cancelled.State),
+		"SIR %s should be cancelled", cancelSIR)
+	require.NotNil(t, cancelled.Status)
+	assert.Equal(t, "request-canceled-and-instance-running", aws.StringValue(cancelled.Status.Code))
+
+	running := harness.WaitForInstanceState(t, fix.AWS, cancelInst, "running")
+	assert.Equal(t, "running", aws.StringValue(running.State.Name),
+		"cancelled SIR's instance %s must keep running", cancelInst)
+
+	// Terminate the other request's instance: the daemon teardown cleaner scans
+	// the active bucket by InstanceId and moves the SIR to closed.
+	harness.Step(t, "terminate-instances %s (closes %s)", termInst, termSIR)
+	_, err = fix.AWS.EC2.TerminateInstances(&ec2.TerminateInstancesInput{
+		InstanceIds: aws.StringSlice([]string{termInst}),
+	})
+	require.NoError(t, err, "terminate-instances %s", termInst)
+	harness.WaitForInstanceState(t, fix.AWS, termInst, "terminated")
+
+	// The close runs through the async teardown chain, so poll for it.
+	var closed *ec2.SpotInstanceRequest
+	harness.Eventually(t, func() bool {
+		out, derr := fix.AWS.EC2.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+			SpotInstanceRequestIds: aws.StringSlice([]string{termSIR}),
+		})
+		if derr != nil || len(out.SpotInstanceRequests) != 1 {
+			return false
+		}
+		closed = out.SpotInstanceRequests[0]
+		return aws.StringValue(closed.State) == ec2.SpotInstanceStateClosed
+	}, 60*time.Second, 2*time.Second, "SIR %s should move to closed after terminate", termSIR)
+	require.NotNil(t, closed, "describe never returned SIR %s", termSIR)
+	require.NotNil(t, closed.Status)
+	assert.Equal(t, "instance-terminated-by-user", aws.StringValue(closed.Status.Code))
+
+	// Insufficient capacity: an oversized request short-circuits before any
+	// launch (totalCapacity < MinCount) and persists no SIRs.
+	t.Run("InsufficientCapacityNoSIRs", func(t *testing.T) {
+		harness.Step(t, "request-spot-instances count=1000000 (capacity short-circuit)")
+		out, rerr := fix.AWS.EC2.RequestSpotInstances(&ec2.RequestSpotInstancesInput{
+			InstanceCount: aws.Int64(1_000_000),
+			LaunchSpecification: &ec2.RequestSpotLaunchSpecification{
+				ImageId:      aws.String(amiID),
+				InstanceType: aws.String(instType),
+				KeyName:      aws.String(keyName),
+			},
+		})
+		harness.AssertAWSError(t, rerr, "InsufficientInstanceCapacity")
+		if out != nil {
+			assert.Empty(t, out.SpotInstanceRequests,
+				"capacity failure must persist/return no SIRs")
+		}
+	})
+}
+
+// describeSpotRequest returns the single SIR matching sirID, failing the test if
+// the gateway does not return exactly one.
+func describeSpotRequest(t *testing.T, fix *Fixture, sirID string) *ec2.SpotInstanceRequest {
+	t.Helper()
+	out, err := fix.AWS.EC2.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: aws.StringSlice([]string{sirID}),
+	})
+	require.NoError(t, err, "describe-spot-instance-requests %s", sirID)
+	require.Lenf(t, out.SpotInstanceRequests, 1,
+		"expected exactly 1 SIR for %s, got %d", sirID, len(out.SpotInstanceRequests))
+	return out.SpotInstanceRequests[0]
+}

--- a/tests/e2e/single/tests_test.go
+++ b/tests/e2e/single/tests_test.go
@@ -180,6 +180,13 @@ func TestRunInstancesMultiCount(t *testing.T) {
 	runRunInstancesMultiCount(t, requireSingleNodeFixture(t))
 }
 
+// TestSpotInstanceLifecycle drives the Spot Instance Request mock: request ->
+// fulfilled -> running -> cancel/terminate terminal transitions. Sequential: it
+// consumes node capacity for its own short-lived VMs like the multi-count test.
+func TestSpotInstanceLifecycle(t *testing.T) {
+	runSpotInstanceLifecycle(t, requireSingleNodeFixture(t))
+}
+
 // --- Sequential: shared-state / sub-test-parallel Tests ---
 
 func TestNegativeErrorPaths(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds AWS-compatible EC2 Spot Instance support to Spinifex as a **mock** over the existing on-demand `RunInstances` path. Spinifex runs on the operator's own bare-metal compute, so there is no spot market: a Spot Instance Request (SIR) synchronously launches real VMs and is then reported `active`/`fulfilled`. There is no bidding, price rejection, interruption, or reclamation. We model the API surface faithfully so SDKs, Terraform, and the `aws` CLI work. Each launched VM also carries full spot lineage — `InstanceLifecycle=spot`, `SpotInstanceRequestId`, and dynamic IMDS `instance-life-cycle` — without changing that mock contract.

Three actions only — `RequestSpotInstances`, `DescribeSpotInstanceRequests`, `CancelSpotInstanceRequests`. `DescribeSpotPriceHistory` is intentionally out (returns `InvalidAction`).
## What's included

- **Daemon spot service** (`handlers/ec2/spotinstance/`) — two NATS KV buckets: `spinifex-spot-requests` (active, no TTL) and `spinifex-spot-requests-terminal` (closed/cancelled, 1h TTL). Put / Describe (merges both buckets) / Cancel (move active→terminal) / CloseForInstance (terminate-time scan). Stores the full `*ec2.SpotInstanceRequest` JSON round-tripped; no CAS.
- **Daemon wiring** — `PutSpotInstanceRequests`, `DescribeSpotInstanceRequests`, `CancelSpotInstanceRequests` handlers on the `spinifex-workers` queue group; service init alongside placement-group; `RemoveFromSpotRequest` teardown cleaner so terminating an instance moves its SIR to `closed`.
- **Gateway orchestration** (`gateway/ec2/spotinstance/`) — `RequestSpotInstances` validates + translates `LaunchSpecification` → `RunInstancesInput` with `MinCount=MaxCount=InstanceCount` (all-or-nothing) and `ClientToken` pass-through, reuses the core launch path, then builds and persists one `active`/`fulfilled` SIR per launched VM. After persisting it stamps each launched VM with its spot lineage via a best-effort write-back over the per-instance `ec2.cmd.{id}` subject (retries past `nats.ErrNoResponders` until the owning daemon subscribes; VMs/SIRs persist regardless of a stamp miss — lineage is a projection, never a launch precondition). `Describe`/`Cancel` are thin pass-throughs. Three actions registered in `ec2Actions`.
- **Instance-side lineage** — `vm.VM` gains `InstanceLifecycle` + `SpotInstanceRequestId`; the daemon `handleSetSpotLineage` handler stamps them via the lock-safe `UpdateAndPersist` path, `DescribeInstances` projects both fields, and IMDS `instance-life-cycle` is now dynamic (`spot` vs `on-demand`, defaulting to `on-demand` on a resolution miss so the always-advertised leaf never 404s). `spot/instance-action` + `spot/termination-time` stay 404 by contract for a never-interrupted instance (a 200 body would trigger interruption handling in pollers like the AWS Node Termination Handler / Karpenter).

## Key decisions

- **Full instance-side lineage via best-effort write-back.** One `RunInstances` call launches N VMs that the gateway maps to N `sir-…` IDs by order, so the daemon cannot know each VM's SIR at launch — the gateway stamps it post-launch over `ec2.cmd.{id}`. The write-back is best-effort (the VMs run and the SIRs persist regardless), avoiding a half-done marker; the link also lives on `SpotInstanceRequest.InstanceId`.
- **All-or-nothing fulfilment.** `InstanceCount` maps to `MinCount=MaxCount`; on insufficient capacity `RunInstances` rolls back and the request returns `InsufficientInstanceCapacity`, persisting no SIRs (no zombie `open` requests).
- **Terminal SIRs in a separate 1h-TTL bucket.** Transitions are moves (write terminal + delete active), mirroring `WriteTerminatedInstance`; Describe merges both buckets.
- **Both `one-time` and `persistent` accepted**, behaviour identical (no reclamation loop to drive `persistent`).