### PR TITLE
feat: honor gp3 Iops on CreateVolume + clear UnknownVolumeType error (siv-380)

### DIFF
--- a/spinifex/gateway/ec2/volume/CreateVolume.go
+++ b/spinifex/gateway/ec2/volume/CreateVolume.go
@@ -23,7 +23,7 @@ func ValidateCreateVolumeInput(input *ec2.CreateVolumeInput) error {
 	}
 
 	if input.VolumeType != nil && *input.VolumeType != "" && *input.VolumeType != "gp3" {
-		return errors.New(awserrors.ErrorInvalidParameterValue)
+		return errors.New(awserrors.ErrorUnknownVolumeType)
 	}
 
 	return nil

--- a/spinifex/gateway/ec2/volume/CreateVolume_test.go
+++ b/spinifex/gateway/ec2/volume/CreateVolume_test.go
@@ -105,7 +105,7 @@ func TestValidateCreateVolumeInput(t *testing.T) {
 				VolumeType:       aws.String("io1"),
 			},
 			wantErr: true,
-			errMsg:  awserrors.ErrorInvalidParameterValue,
+			errMsg:  awserrors.ErrorUnknownVolumeType,
 		},
 		{
 			name: "InvalidVolumeType_GP2",
@@ -115,7 +115,7 @@ func TestValidateCreateVolumeInput(t *testing.T) {
 				VolumeType:       aws.String("gp2"),
 			},
 			wantErr: true,
-			errMsg:  awserrors.ErrorInvalidParameterValue,
+			errMsg:  awserrors.ErrorUnknownVolumeType,
 		},
 		{
 			name: "ValidInput_EmptyVolumeType",

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -28,7 +28,13 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
-const defaultGP3IOPS = 3000
+const (
+	// gp3 IOPS envelope (AWS): 3000 baseline on any size, up to 500 IOPS/GiB,
+	// capped at 16000.
+	defaultGP3IOPS = 3000
+	maxGP3IOPS     = 16000
+	gp3IOPSPerGiB  = 500
+)
 
 // Ensure VolumeServiceImpl implements VolumeService
 var _ VolumeService = (*VolumeServiceImpl)(nil)
@@ -92,7 +98,7 @@ func (s *VolumeServiceImpl) CreateVolume(input *ec2.CreateVolumeInput, accountID
 
 	// Validate volume type: only gp3 supported (or empty defaults to gp3)
 	if input.VolumeType != nil && *input.VolumeType != "" && *input.VolumeType != "gp3" {
-		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
+		return nil, errors.New(awserrors.ErrorUnknownVolumeType)
 	}
 	volumeType := "gp3"
 
@@ -141,7 +147,17 @@ func (s *VolumeServiceImpl) CreateVolume(input *ec2.CreateVolumeInput, accountID
 	now := time.Now()
 	volumeID := utils.GenerateResourceID("vol")
 
+	// Honor caller-supplied Iops for gp3, else the 3000 baseline. The ceiling is
+	// min(16000, 500*size) but never below the free baseline, so small volumes
+	// still get 3000.
 	iops := defaultGP3IOPS
+	if input.Iops != nil {
+		iops = int(*input.Iops)
+	}
+	maxIOPS := min(max(int(size)*gp3IOPSPerGiB, defaultGP3IOPS), maxGP3IOPS)
+	if iops < defaultGP3IOPS || iops > maxIOPS {
+		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
+	}
 
 	slog.Info("CreateVolume", "volumeId", volumeID, "size", size, "type", volumeType,
 		"az", *input.AvailabilityZone, "snapshotId", snapshotID)

--- a/spinifex/handlers/ec2/volume/service_impl_test.go
+++ b/spinifex/handlers/ec2/volume/service_impl_test.go
@@ -92,7 +92,7 @@ func TestCreateVolume_Validation(t *testing.T) {
 				AvailabilityZone: aws.String("ap-southeast-2a"),
 				VolumeType:       aws.String("io1"),
 			},
-			wantErr: awserrors.ErrorInvalidParameterValue,
+			wantErr: awserrors.ErrorUnknownVolumeType,
 		},
 		{
 			name: "UnsupportedVolumeType_GP2",
@@ -102,7 +102,7 @@ func TestCreateVolume_Validation(t *testing.T) {
 				AvailabilityZone: aws.String("ap-southeast-2a"),
 				VolumeType:       aws.String("gp2"),
 			},
-			wantErr: awserrors.ErrorInvalidParameterValue,
+			wantErr: awserrors.ErrorUnknownVolumeType,
 		},
 		{
 			name: "UnsupportedVolumeType_ST1",
@@ -111,6 +111,36 @@ func TestCreateVolume_Validation(t *testing.T) {
 				Size:             aws.Int64(80),
 				AvailabilityZone: aws.String("ap-southeast-2a"),
 				VolumeType:       aws.String("st1"),
+			},
+			wantErr: awserrors.ErrorUnknownVolumeType,
+		},
+		{
+			name: "Iops_BelowBaseline",
+			az:   "ap-southeast-2a",
+			input: &ec2.CreateVolumeInput{
+				Size:             aws.Int64(80),
+				AvailabilityZone: aws.String("ap-southeast-2a"),
+				Iops:             aws.Int64(2999),
+			},
+			wantErr: awserrors.ErrorInvalidParameterValue,
+		},
+		{
+			name: "Iops_AboveCeiling",
+			az:   "ap-southeast-2a",
+			input: &ec2.CreateVolumeInput{
+				Size:             aws.Int64(80),
+				AvailabilityZone: aws.String("ap-southeast-2a"),
+				Iops:             aws.Int64(16001),
+			},
+			wantErr: awserrors.ErrorInvalidParameterValue,
+		},
+		{
+			name: "Iops_AboveRatioForSmallVolume",
+			az:   "ap-southeast-2a",
+			input: &ec2.CreateVolumeInput{
+				Size:             aws.Int64(10),
+				AvailabilityZone: aws.String("ap-southeast-2a"),
+				Iops:             aws.Int64(6000),
 			},
 			wantErr: awserrors.ErrorInvalidParameterValue,
 		},
@@ -178,6 +208,14 @@ func TestCreateVolume_PassesValidation(t *testing.T) {
 			input: &ec2.CreateVolumeInput{
 				Size:             aws.Int64(80),
 				AvailabilityZone: aws.String("ap-southeast-2a"),
+			},
+		},
+		{
+			name: "ExplicitIopsInRange",
+			input: &ec2.CreateVolumeInput{
+				Size:             aws.Int64(80),
+				AvailabilityZone: aws.String("ap-southeast-2a"),
+				Iops:             aws.Int64(8000),
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Closes EBS CreateVolume API fidelity gaps #3 and #4 from the EKS EBS CSI plan:

- **gap #3 (Iops)** — `CreateVolume` hardcoded `iops := defaultGP3IOPS`, silently dropping any caller-supplied `Iops`. Now honors `input.Iops` within the AWS gp3 envelope: 3000 IOPS baseline on any size, 500 IOPS/GiB ratio cap, 16000 ceiling. Out-of-range → `InvalidParameterValue`. The value already flows to `VolumeMetadata.IOPS` and back out via `DescribeVolumes`.
- **gap #4 (VolumeType)** — both the handler (`service_impl.go`) and gateway validator (`CreateVolume.go`) rejected non-gp3 types with the generic `InvalidParameterValue`. Now return the volume-type-specific `UnknownVolumeType` (existing AWS-faithful code). Stays gp3-only.

**gap #2 (gp3 Throughput)** is deferred to a follow-up bead — it needs a new `Throughput` field on viperblock's `VolumeMetadata`.

## Testing

- Unit: Iops honored in-range, defaulted when nil, rejected below 3000 / above 16000 / above the 500×size ratio for small volumes.
- Unit: non-gp3 VolumeType (io1/gp2/st1) → `UnknownVolumeType`; gp3/empty accepted.
- `make preflight` green.