### PR TITLE
feat: IAM Group inline policies v1

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -593,10 +593,10 @@ All IAM operations are account-scoped. Root user (account `000000000000`) bypass
 | `attach-group-policy` | `--group-name`, `--policy-arn` | — | **DONE** |
 | `detach-group-policy` | `--group-name`, `--policy-arn` | — | **DONE** |
 | `list-attached-group-policies` | `--group-name`, `--path-prefix` | `--max-items`, `--marker` | **DONE** |
-| `put-group-policy` | — | `--group-name`, `--policy-name`, `--policy-document` | **NOT STARTED** |
-| `get-group-policy` | — | `--group-name`, `--policy-name` | **NOT STARTED** |
-| `delete-group-policy` | — | `--group-name`, `--policy-name` | **NOT STARTED** |
-| `list-group-policies` | — | `--group-name` | **NOT STARTED** |
+| `put-group-policy` | `--group-name`, `--policy-name`, `--policy-document` | — | **DONE** |
+| `get-group-policy` | `--group-name`, `--policy-name` | — | **DONE** |
+| `delete-group-policy` | `--group-name`, `--policy-name` | — | **DONE** |
+| `list-group-policies` | `--group-name` | `--max-items`, `--marker` | **DONE** |
 
 ---
 

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -210,6 +210,18 @@ func (m *mockIAMService) DetachGroupPolicy(_ string, _ *iam.DetachGroupPolicyInp
 func (m *mockIAMService) ListAttachedGroupPolicies(_ string, _ *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error) {
 	return &iam.ListAttachedGroupPoliciesOutput{}, nil
 }
+func (m *mockIAMService) PutGroupPolicy(_ string, _ *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
+	return &iam.PutGroupPolicyOutput{}, nil
+}
+func (m *mockIAMService) GetGroupPolicy(_ string, _ *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
+	return &iam.GetGroupPolicyOutput{}, nil
+}
+func (m *mockIAMService) DeleteGroupPolicy(_ string, _ *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
+	return &iam.DeleteGroupPolicyOutput{}, nil
+}
+func (m *mockIAMService) ListGroupPolicies(_ string, _ *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
+	return &iam.ListGroupPoliciesOutput{}, nil
+}
 
 // testMasterKey is a fixed 32-byte key for deterministic tests.
 var testMasterKey []byte

--- a/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
+++ b/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
@@ -200,6 +200,18 @@ func (f *fakeIAMService) DetachGroupPolicy(string, *iam.DetachGroupPolicyInput) 
 func (f *fakeIAMService) ListAttachedGroupPolicies(string, *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error) {
 	return &iam.ListAttachedGroupPoliciesOutput{}, nil
 }
+func (f *fakeIAMService) PutGroupPolicy(string, *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
+	return &iam.PutGroupPolicyOutput{}, nil
+}
+func (f *fakeIAMService) GetGroupPolicy(string, *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
+	return &iam.GetGroupPolicyOutput{}, nil
+}
+func (f *fakeIAMService) DeleteGroupPolicy(string, *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
+	return &iam.DeleteGroupPolicyOutput{}, nil
+}
+func (f *fakeIAMService) ListGroupPolicies(string, *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
+	return &iam.ListGroupPoliciesOutput{}, nil
+}
 
 var _ handlers_iam.IAMService = (*fakeIAMService)(nil)
 

--- a/spinifex/gateway/iam.go
+++ b/spinifex/gateway/iam.go
@@ -217,6 +217,20 @@ var iamActions = map[string]IAMHandler{
 	"ListAttachedGroupPolicies": iamHandler(func(accountID string, input *iam.ListAttachedGroupPoliciesInput, gw *GatewayConfig) (any, error) {
 		return gateway_iam.ListAttachedGroupPolicies(accountID, input, gw.IAMService)
 	}),
+
+	// Group inline policies
+	"PutGroupPolicy": iamHandler(func(accountID string, input *iam.PutGroupPolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.PutGroupPolicy(accountID, input, gw.IAMService)
+	}),
+	"GetGroupPolicy": iamHandler(func(accountID string, input *iam.GetGroupPolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.GetGroupPolicy(accountID, input, gw.IAMService)
+	}),
+	"DeleteGroupPolicy": iamHandler(func(accountID string, input *iam.DeleteGroupPolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.DeleteGroupPolicy(accountID, input, gw.IAMService)
+	}),
+	"ListGroupPolicies": iamHandler(func(accountID string, input *iam.ListGroupPoliciesInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.ListGroupPolicies(accountID, input, gw.IAMService)
+	}),
 }
 
 func (gw *GatewayConfig) IAM_Request(w http.ResponseWriter, r *http.Request) error {

--- a/spinifex/gateway/iam/group.go
+++ b/spinifex/gateway/iam/group.go
@@ -86,3 +86,43 @@ func ListAttachedGroupPolicies(accountID string, input *iam.ListAttachedGroupPol
 	}
 	return svc.ListAttachedGroupPolicies(accountID, input)
 }
+
+func PutGroupPolicy(accountID string, input *iam.PutGroupPolicyInput, svc handlers_iam.IAMService) (*iam.PutGroupPolicyOutput, error) {
+	if input.GroupName == nil || *input.GroupName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyName == nil || *input.PolicyName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyDocument == nil || *input.PolicyDocument == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.PutGroupPolicy(accountID, input)
+}
+
+func GetGroupPolicy(accountID string, input *iam.GetGroupPolicyInput, svc handlers_iam.IAMService) (*iam.GetGroupPolicyOutput, error) {
+	if input.GroupName == nil || *input.GroupName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyName == nil || *input.PolicyName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.GetGroupPolicy(accountID, input)
+}
+
+func DeleteGroupPolicy(accountID string, input *iam.DeleteGroupPolicyInput, svc handlers_iam.IAMService) (*iam.DeleteGroupPolicyOutput, error) {
+	if input.GroupName == nil || *input.GroupName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if input.PolicyName == nil || *input.PolicyName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.DeleteGroupPolicy(accountID, input)
+}
+
+func ListGroupPolicies(accountID string, input *iam.ListGroupPoliciesInput, svc handlers_iam.IAMService) (*iam.ListGroupPoliciesOutput, error) {
+	if input.GroupName == nil || *input.GroupName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.ListGroupPolicies(accountID, input)
+}

--- a/spinifex/gateway/iam/group_test.go
+++ b/spinifex/gateway/iam/group_test.go
@@ -241,3 +241,109 @@ func TestListAttachedGroupPolicies(t *testing.T) {
 		})
 	}
 }
+
+const validGroupInlineDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ec2:DescribeInstances","Resource":"*"}]}`
+
+func TestPutGroupPolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.PutGroupPolicyInput
+		wantErr string
+	}{
+		{"nil GroupName", &iam.PutGroupPolicyInput{PolicyName: aws.String("p"), PolicyDocument: aws.String(validGroupInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"empty GroupName", &iam.PutGroupPolicyInput{GroupName: aws.String(""), PolicyName: aws.String("p"), PolicyDocument: aws.String(validGroupInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"nil PolicyName", &iam.PutGroupPolicyInput{GroupName: aws.String("g"), PolicyDocument: aws.String(validGroupInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"empty PolicyName", &iam.PutGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String(""), PolicyDocument: aws.String(validGroupInlineDoc)}, awserrors.ErrorMissingParameter},
+		{"nil PolicyDocument", &iam.PutGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"empty PolicyDocument", &iam.PutGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String("p"), PolicyDocument: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.PutGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String("p"), PolicyDocument: aws.String(validGroupInlineDoc)}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PutGroupPolicy(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetGroupPolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.GetGroupPolicyInput
+		wantErr string
+	}{
+		{"nil GroupName", &iam.GetGroupPolicyInput{PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"empty GroupName", &iam.GetGroupPolicyInput{GroupName: aws.String(""), PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"nil PolicyName", &iam.GetGroupPolicyInput{GroupName: aws.String("g")}, awserrors.ErrorMissingParameter},
+		{"empty PolicyName", &iam.GetGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.GetGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String("p")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := GetGroupPolicy(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDeleteGroupPolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.DeleteGroupPolicyInput
+		wantErr string
+	}{
+		{"nil GroupName", &iam.DeleteGroupPolicyInput{PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"empty GroupName", &iam.DeleteGroupPolicyInput{GroupName: aws.String(""), PolicyName: aws.String("p")}, awserrors.ErrorMissingParameter},
+		{"nil PolicyName", &iam.DeleteGroupPolicyInput{GroupName: aws.String("g")}, awserrors.ErrorMissingParameter},
+		{"empty PolicyName", &iam.DeleteGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.DeleteGroupPolicyInput{GroupName: aws.String("g"), PolicyName: aws.String("p")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DeleteGroupPolicy(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListGroupPolicies(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.ListGroupPoliciesInput
+		wantErr string
+	}{
+		{"nil GroupName", &iam.ListGroupPoliciesInput{}, awserrors.ErrorMissingParameter},
+		{"empty GroupName", &iam.ListGroupPoliciesInput{GroupName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.ListGroupPoliciesInput{GroupName: aws.String("g")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListGroupPolicies(testAccountID, tc.input, svc)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/spinifex/gateway/iam/handler_test.go
+++ b/spinifex/gateway/iam/handler_test.go
@@ -205,6 +205,18 @@ func (s *stubIAMService) DetachGroupPolicy(_ string, _ *iam.DetachGroupPolicyInp
 func (s *stubIAMService) ListAttachedGroupPolicies(_ string, _ *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error) {
 	return &iam.ListAttachedGroupPoliciesOutput{}, nil
 }
+func (s *stubIAMService) PutGroupPolicy(_ string, _ *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
+	return &iam.PutGroupPolicyOutput{}, nil
+}
+func (s *stubIAMService) GetGroupPolicy(_ string, _ *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
+	return &iam.GetGroupPolicyOutput{}, nil
+}
+func (s *stubIAMService) DeleteGroupPolicy(_ string, _ *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
+	return &iam.DeleteGroupPolicyOutput{}, nil
+}
+func (s *stubIAMService) ListGroupPolicies(_ string, _ *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
+	return &iam.ListGroupPoliciesOutput{}, nil
+}
 
 func TestCreateUser(t *testing.T) {
 	svc := &stubIAMService{}

--- a/spinifex/gateway/iam_request_test.go
+++ b/spinifex/gateway/iam_request_test.go
@@ -235,6 +235,18 @@ func (m *flexMockIAMService) DetachGroupPolicy(_ string, _ *iam.DetachGroupPolic
 func (m *flexMockIAMService) ListAttachedGroupPolicies(_ string, _ *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error) {
 	return &iam.ListAttachedGroupPoliciesOutput{}, nil
 }
+func (m *flexMockIAMService) PutGroupPolicy(_ string, _ *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
+	return &iam.PutGroupPolicyOutput{}, nil
+}
+func (m *flexMockIAMService) GetGroupPolicy(_ string, _ *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
+	return &iam.GetGroupPolicyOutput{}, nil
+}
+func (m *flexMockIAMService) DeleteGroupPolicy(_ string, _ *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
+	return &iam.DeleteGroupPolicyOutput{}, nil
+}
+func (m *flexMockIAMService) ListGroupPolicies(_ string, _ *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
+	return &iam.ListGroupPoliciesOutput{}, nil
+}
 
 // setupIAMRequestHandler wires an http.Handler for IAM_Request with injected SigV4 context values.
 func setupIAMRequestHandler(svc handlers_iam.IAMService) http.Handler {

--- a/spinifex/gateway/sts/handler_test.go
+++ b/spinifex/gateway/sts/handler_test.go
@@ -260,6 +260,18 @@ func (s *stubIAMService) DetachGroupPolicy(string, *iam.DetachGroupPolicyInput) 
 func (s *stubIAMService) ListAttachedGroupPolicies(string, *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error) {
 	panic("unexpected ListAttachedGroupPolicies call")
 }
+func (s *stubIAMService) PutGroupPolicy(string, *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
+	panic("unexpected PutGroupPolicy call")
+}
+func (s *stubIAMService) GetGroupPolicy(string, *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
+	panic("unexpected GetGroupPolicy call")
+}
+func (s *stubIAMService) DeleteGroupPolicy(string, *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
+	panic("unexpected DeleteGroupPolicy call")
+}
+func (s *stubIAMService) ListGroupPolicies(string, *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
+	panic("unexpected ListGroupPolicies call")
+}
 
 func TestAssumeRole_HappyPath(t *testing.T) {
 	var calledWith struct {

--- a/spinifex/handlers/iam/groups.go
+++ b/spinifex/handlers/iam/groups.go
@@ -391,6 +391,127 @@ func (s *IAMServiceImpl) ListAttachedGroupPolicies(accountID string, input *iam.
 }
 
 // ---------------------------------------------------------------------------
+// Group inline policies
+// ---------------------------------------------------------------------------
+
+// PutGroupPolicy embeds an inline policy document in a group, keyed by PolicyName.
+// Idempotent upsert: a same-name policy is overwritten, mirroring AWS. Uses a
+// blind read-modify-write Put like the other group writers (no CAS).
+func (s *IAMServiceImpl) PutGroupPolicy(accountID string, input *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
+	groupName := *input.GroupName
+	policyName := *input.PolicyName
+	policyDoc := *input.PolicyDocument
+	kvKey := accountID + "." + groupName
+
+	if err := validatePolicyName(policyName); err != nil {
+		return nil, errors.New(awserrors.ErrorIAMInvalidInput)
+	}
+	if _, err := ValidatePolicyDocument(policyDoc); err != nil {
+		return nil, errors.New(awserrors.ErrorIAMMalformedPolicyDocument)
+	}
+
+	group, err := s.getGroup(accountID, groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	if group.InlinePolicies == nil {
+		group.InlinePolicies = map[string]string{}
+	}
+	group.InlinePolicies[policyName] = policyDoc
+
+	data, err := json.Marshal(group)
+	if err != nil {
+		return nil, fmt.Errorf("marshal group: %w", err)
+	}
+
+	if _, err := s.groupsBucket.Put(kvKey, data); err != nil {
+		return nil, fmt.Errorf("update group: %w", err)
+	}
+
+	slog.Info("IAM inline policy put on group", "accountID", accountID, "groupName", groupName, "policyName", policyName)
+	return &iam.PutGroupPolicyOutput{}, nil
+}
+
+// GetGroupPolicy returns a group's inline policy document by name as a raw JSON
+// string, matching the in-repo convention used by GetRolePolicy.
+func (s *IAMServiceImpl) GetGroupPolicy(accountID string, input *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
+	groupName := *input.GroupName
+	policyName := *input.PolicyName
+
+	group, err := s.getGroup(accountID, groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, ok := group.InlinePolicies[policyName]
+	if !ok {
+		return nil, errors.New(awserrors.ErrorIAMNoSuchEntity)
+	}
+
+	return &iam.GetGroupPolicyOutput{
+		GroupName:      aws.String(groupName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(doc),
+	}, nil
+}
+
+// DeleteGroupPolicy removes a group's inline policy by name. A missing name
+// yields NoSuchEntity, matching AWS. Blind Put like the other group writers.
+func (s *IAMServiceImpl) DeleteGroupPolicy(accountID string, input *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
+	groupName := *input.GroupName
+	policyName := *input.PolicyName
+	kvKey := accountID + "." + groupName
+
+	group, err := s.getGroup(accountID, groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := group.InlinePolicies[policyName]; !ok {
+		return nil, errors.New(awserrors.ErrorIAMNoSuchEntity)
+	}
+	delete(group.InlinePolicies, policyName)
+
+	data, err := json.Marshal(group)
+	if err != nil {
+		return nil, fmt.Errorf("marshal group: %w", err)
+	}
+
+	if _, err := s.groupsBucket.Put(kvKey, data); err != nil {
+		return nil, fmt.Errorf("update group: %w", err)
+	}
+
+	slog.Info("IAM inline policy deleted from group", "accountID", accountID, "groupName", groupName, "policyName", policyName)
+	return &iam.DeleteGroupPolicyOutput{}, nil
+}
+
+// ListGroupPolicies returns the names of a group's inline policies, sorted for
+// deterministic output. Pagination is not implemented: IsTruncated is always false.
+func (s *IAMServiceImpl) ListGroupPolicies(accountID string, input *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
+	group, err := s.getGroup(accountID, *input.GroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	rawNames := make([]string, 0, len(group.InlinePolicies))
+	for name := range group.InlinePolicies {
+		rawNames = append(rawNames, name)
+	}
+	slices.Sort(rawNames)
+
+	names := make([]*string, 0, len(rawNames))
+	for _, name := range rawNames {
+		names = append(names, aws.String(name))
+	}
+
+	return &iam.ListGroupPoliciesOutput{
+		PolicyNames: names,
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/spinifex/handlers/iam/groups.go
+++ b/spinifex/handlers/iam/groups.go
@@ -167,6 +167,10 @@ func (s *IAMServiceImpl) DeleteGroup(accountID string, input *iam.DeleteGroupInp
 		return nil, errors.New(awserrors.ErrorIAMDeleteConflict)
 	}
 
+	if len(group.InlinePolicies) > 0 {
+		return nil, errors.New(awserrors.ErrorIAMDeleteConflict)
+	}
+
 	members, err := s.findGroupMembers(accountID, groupName)
 	if err != nil {
 		return nil, fmt.Errorf("check group members: %w", err)

--- a/spinifex/handlers/iam/groups_test.go
+++ b/spinifex/handlers/iam/groups_test.go
@@ -1,6 +1,7 @@
 package handlers_iam
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -641,6 +642,285 @@ func TestListAttachedGroupPolicies_GroupNotFound(t *testing.T) {
 }
 
 // ============================================================================
+// Group Inline Policy Tests (Put / Get / Delete / List)
+// ============================================================================
+
+func TestPutGroupPolicy_RoundTrip(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "inline-group")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("inline-group"),
+		PolicyName:     aws.String("AllowDescribe"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	out, err := svc.GetGroupPolicy(testAccountID, &iam.GetGroupPolicyInput{
+		GroupName:  aws.String("inline-group"),
+		PolicyName: aws.String("AllowDescribe"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inline-group", *out.GroupName)
+	assert.Equal(t, "AllowDescribe", *out.PolicyName)
+	assert.Equal(t, validPolicyDocument(), *out.PolicyDocument)
+}
+
+func TestPutGroupPolicy_IdempotentOverwrite(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "overwrite-group")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("overwrite-group"),
+		PolicyName:     aws.String("Policy"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("overwrite-group"),
+		PolicyName:     aws.String("Policy"),
+		PolicyDocument: aws.String(inlineDenyDocument()),
+	})
+	require.NoError(t, err)
+
+	out, err := svc.GetGroupPolicy(testAccountID, &iam.GetGroupPolicyInput{
+		GroupName:  aws.String("overwrite-group"),
+		PolicyName: aws.String("Policy"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, inlineDenyDocument(), *out.PolicyDocument)
+
+	list, err := svc.ListGroupPolicies(testAccountID, &iam.ListGroupPoliciesInput{
+		GroupName: aws.String("overwrite-group"),
+	})
+	require.NoError(t, err)
+	assert.Len(t, list.PolicyNames, 1, "overwrite must not duplicate the name")
+}
+
+func TestPutGroupPolicy_InvalidName(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "badname-group")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("badname-group"),
+		PolicyName:     aws.String("bad name"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMInvalidInput)
+}
+
+func TestPutGroupPolicy_MalformedDocument(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "malformed-group")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("malformed-group"),
+		PolicyName:     aws.String("Bad"),
+		PolicyDocument: aws.String(`{not valid json`),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMMalformedPolicyDocument)
+}
+
+func TestPutGroupPolicy_OversizedDocument(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "oversized-group")
+
+	huge := strings.Repeat("a", maxPolicyDocumentSize+1)
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("oversized-group"),
+		PolicyName:     aws.String("Huge"),
+		PolicyDocument: aws.String(huge),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMMalformedPolicyDocument)
+}
+
+func TestPutGroupPolicy_GroupNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("ghost"),
+		PolicyName:     aws.String("Policy"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestGetGroupPolicy_UnknownName(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "get-unknown")
+
+	_, err := svc.GetGroupPolicy(testAccountID, &iam.GetGroupPolicyInput{
+		GroupName:  aws.String("get-unknown"),
+		PolicyName: aws.String("missing"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestGetGroupPolicy_GroupNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.GetGroupPolicy(testAccountID, &iam.GetGroupPolicyInput{
+		GroupName:  aws.String("ghost"),
+		PolicyName: aws.String("Policy"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestListGroupPolicies_Sorted(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "list-group")
+
+	for _, name := range []string{"Charlie", "Alpha", "Bravo"} {
+		_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+			GroupName:      aws.String("list-group"),
+			PolicyName:     aws.String(name),
+			PolicyDocument: aws.String(validPolicyDocument()),
+		})
+		require.NoError(t, err)
+	}
+
+	out, err := svc.ListGroupPolicies(testAccountID, &iam.ListGroupPoliciesInput{
+		GroupName: aws.String("list-group"),
+	})
+	require.NoError(t, err)
+	require.False(t, *out.IsTruncated)
+	got := make([]string, 0, len(out.PolicyNames))
+	for _, n := range out.PolicyNames {
+		got = append(got, *n)
+	}
+	assert.Equal(t, []string{"Alpha", "Bravo", "Charlie"}, got)
+}
+
+func TestListGroupPolicies_Empty(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "empty-inline-group")
+
+	out, err := svc.ListGroupPolicies(testAccountID, &iam.ListGroupPoliciesInput{
+		GroupName: aws.String("empty-inline-group"),
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, out.PolicyNames)
+	assert.Len(t, out.PolicyNames, 0)
+	assert.False(t, *out.IsTruncated)
+}
+
+func TestListGroupPolicies_GroupNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.ListGroupPolicies(testAccountID, &iam.ListGroupPoliciesInput{
+		GroupName: aws.String("ghost"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestDeleteGroupPolicy(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "del-inline-group")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("del-inline-group"),
+		PolicyName:     aws.String("Doomed"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteGroupPolicy(testAccountID, &iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String("del-inline-group"),
+		PolicyName: aws.String("Doomed"),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.GetGroupPolicy(testAccountID, &iam.GetGroupPolicyInput{
+		GroupName:  aws.String("del-inline-group"),
+		PolicyName: aws.String("Doomed"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+
+	list, err := svc.ListGroupPolicies(testAccountID, &iam.ListGroupPoliciesInput{
+		GroupName: aws.String("del-inline-group"),
+	})
+	require.NoError(t, err)
+	assert.Len(t, list.PolicyNames, 0)
+}
+
+func TestDeleteGroupPolicy_DoubleDelete(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "double-del-group")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("double-del-group"),
+		PolicyName:     aws.String("Once"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteGroupPolicy(testAccountID, &iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String("double-del-group"),
+		PolicyName: aws.String("Once"),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteGroupPolicy(testAccountID, &iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String("double-del-group"),
+		PolicyName: aws.String("Once"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+func TestDeleteGroupPolicy_GroupNotFound(t *testing.T) {
+	svc := setupTestIAMService(t)
+
+	_, err := svc.DeleteGroupPolicy(testAccountID, &iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String("ghost"),
+		PolicyName: aws.String("Policy"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMNoSuchEntity)
+}
+
+// TestDeleteGroup_WithInlinePolicy proves a group carrying an inline policy
+// refuses deletion until the inline policy is removed, mirroring DeleteRole.
+func TestDeleteGroup_WithInlinePolicy(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "inline-conflict-group")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("inline-conflict-group"),
+		PolicyName:     aws.String("Blocker"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteGroup(testAccountID, &iam.DeleteGroupInput{
+		GroupName: aws.String("inline-conflict-group"),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorIAMDeleteConflict)
+
+	// Succeeds once the inline policy is removed.
+	_, err = svc.DeleteGroupPolicy(testAccountID, &iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String("inline-conflict-group"),
+		PolicyName: aws.String("Blocker"),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteGroup(testAccountID, &iam.DeleteGroupInput{
+		GroupName: aws.String("inline-conflict-group"),
+	})
+	require.NoError(t, err)
+}
+
+// ============================================================================
 // Authorization Integration — the linchpin (GetUserPolicies resolves groups)
 // ============================================================================
 
@@ -763,6 +1043,122 @@ func TestGetUserPolicies_SkipsMissingGroup(t *testing.T) {
 		UserName:  aws.String("kim"),
 	})
 	require.NoError(t, err)
+}
+
+// putRawGroupInlinePolicy writes an inline policy document into a group record
+// directly via the bucket, bypassing PutGroupPolicy validation. Used to plant a
+// corrupt stored document that the write path would otherwise reject.
+func putRawGroupInlinePolicy(t *testing.T, svc *IAMServiceImpl, groupName, policyName, raw string) {
+	t.Helper()
+	group, err := svc.getGroup(testAccountID, groupName)
+	require.NoError(t, err)
+	if group.InlinePolicies == nil {
+		group.InlinePolicies = map[string]string{}
+	}
+	group.InlinePolicies[policyName] = raw
+	data, err := json.Marshal(group)
+	require.NoError(t, err)
+	_, err = svc.groupsBucket.Put(testAccountID+"."+groupName, data)
+	require.NoError(t, err)
+}
+
+// TestGetUserPolicies_GroupInlineInheritance is the linchpin: an inline policy
+// embedded in a group must contribute its grant to every member's effective
+// permission set, and stop contributing once the inline policy is removed.
+// Without this, group inline policies are cosmetic and grant nothing.
+func TestGetUserPolicies_GroupInlineInheritance(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "inline-grantor")
+	createTestUser(t, svc, "nora")
+
+	_, err := svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("inline-grantor"),
+		PolicyName:     aws.String("InlineGrant"),
+		PolicyDocument: aws.String(validPolicyDocument()),
+	})
+	require.NoError(t, err)
+
+	// Before joining: the group's inline grant is absent.
+	docs, err := svc.GetUserPolicies(testAccountID, "nora")
+	require.NoError(t, err)
+	assert.False(t, policiesGrant(docs, "ec2:DescribeInstances"), "grant must be absent before joining")
+
+	_, err = svc.AddUserToGroup(testAccountID, &iam.AddUserToGroupInput{
+		GroupName: aws.String("inline-grantor"),
+		UserName:  aws.String("nora"),
+	})
+	require.NoError(t, err)
+
+	// After joining: the inline grant flows through to the member.
+	docs, err = svc.GetUserPolicies(testAccountID, "nora")
+	require.NoError(t, err)
+	require.Len(t, docs, 1)
+	assert.True(t, policiesGrant(docs, "ec2:DescribeInstances"), "group inline grant must flow to the member")
+
+	// After removing the inline policy: the grant disappears again.
+	_, err = svc.DeleteGroupPolicy(testAccountID, &iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String("inline-grantor"),
+		PolicyName: aws.String("InlineGrant"),
+	})
+	require.NoError(t, err)
+
+	docs, err = svc.GetUserPolicies(testAccountID, "nora")
+	require.NoError(t, err)
+	assert.False(t, policiesGrant(docs, "ec2:DescribeInstances"), "grant must vanish after the inline policy is deleted")
+}
+
+// TestGetUserPolicies_GroupManagedAndInline proves a group's managed attachment
+// and its inline document both surface in a member's combined effective set —
+// inline grants supplement managed grants rather than replacing them.
+func TestGetUserPolicies_GroupManagedAndInline(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "combined-inline-group")
+	createTestUser(t, svc, "omar")
+	managed := createTestPolicy(t, svc, "ManagedGrant")
+
+	_, err := svc.AttachGroupPolicy(testAccountID, &iam.AttachGroupPolicyInput{
+		GroupName: aws.String("combined-inline-group"),
+		PolicyArn: managed.Arn,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.PutGroupPolicy(testAccountID, &iam.PutGroupPolicyInput{
+		GroupName:      aws.String("combined-inline-group"),
+		PolicyName:     aws.String("InlineDeny"),
+		PolicyDocument: aws.String(inlineDenyDocument()),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.AddUserToGroup(testAccountID, &iam.AddUserToGroupInput{
+		GroupName: aws.String("combined-inline-group"),
+		UserName:  aws.String("omar"),
+	})
+	require.NoError(t, err)
+
+	docs, err := svc.GetUserPolicies(testAccountID, "omar")
+	require.NoError(t, err)
+	require.Len(t, docs, 2, "both the managed attachment and the inline document must resolve")
+	assert.True(t, policiesGrant(docs, "ec2:DescribeInstances"), "managed Allow surfaced")
+}
+
+// TestGetUserPolicies_GroupInlineMalformedFailsClosed proves a corrupt inline
+// document on a resolvable group fails the whole resolution closed rather than
+// silently dropping the grant source, mirroring GetRolePolicies.
+func TestGetUserPolicies_GroupInlineMalformedFailsClosed(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestGroup(t, svc, "corrupt-inline-group")
+	createTestUser(t, svc, "pam")
+
+	_, err := svc.AddUserToGroup(testAccountID, &iam.AddUserToGroupInput{
+		GroupName: aws.String("corrupt-inline-group"),
+		UserName:  aws.String("pam"),
+	})
+	require.NoError(t, err)
+
+	putRawGroupInlinePolicy(t, svc, "corrupt-inline-group", "Bad", `{not valid json`)
+
+	_, err = svc.GetUserPolicies(testAccountID, "pam")
+	assert.Error(t, err, "a malformed inline doc on a resolvable group must fail closed")
 }
 
 // ============================================================================

--- a/spinifex/handlers/iam/groups_test.go
+++ b/spinifex/handlers/iam/groups_test.go
@@ -1139,6 +1139,7 @@ func TestGetUserPolicies_GroupManagedAndInline(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, docs, 2, "both the managed attachment and the inline document must resolve")
 	assert.True(t, policiesGrant(docs, "ec2:DescribeInstances"), "managed Allow surfaced")
+	assert.True(t, policiesGrant(docs, "s3:DeleteObject"), "inline doc surfaced")
 }
 
 // TestGetUserPolicies_GroupInlineMalformedFailsClosed proves a corrupt inline

--- a/spinifex/handlers/iam/roles_test.go
+++ b/spinifex/handlers/iam/roles_test.go
@@ -1099,6 +1099,7 @@ func TestGetRolePolicies_ManagedAndInline(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, docs, 2)
 	assert.True(t, policiesGrant(docs, "ec2:DescribeInstances"), "managed Allow surfaced")
+	assert.True(t, policiesGrant(docs, "s3:DeleteObject"), "inline doc surfaced")
 }
 
 // ============================================================================

--- a/spinifex/handlers/iam/service.go
+++ b/spinifex/handlers/iam/service.go
@@ -64,6 +64,12 @@ type IAMService interface {
 	DetachGroupPolicy(accountID string, input *iam.DetachGroupPolicyInput) (*iam.DetachGroupPolicyOutput, error)
 	ListAttachedGroupPolicies(accountID string, input *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error)
 
+	// Group inline policies — account-scoped
+	PutGroupPolicy(accountID string, input *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error)
+	GetGroupPolicy(accountID string, input *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error)
+	DeleteGroupPolicy(accountID string, input *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error)
+	ListGroupPolicies(accountID string, input *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error)
+
 	// Instance profile CRUD — account-scoped
 	CreateInstanceProfile(accountID string, input *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error)
 	GetInstanceProfile(accountID string, input *iam.GetInstanceProfileInput) (*iam.GetInstanceProfileOutput, error)

--- a/spinifex/handlers/iam/service_impl.go
+++ b/spinifex/handlers/iam/service_impl.go
@@ -1337,6 +1337,15 @@ func (s *IAMServiceImpl) GetUserPolicies(accountID, userName string) ([]PolicyDo
 				docs = append(docs, doc)
 			}
 		}
+		// Group-inherited inline policies. A malformed document within a
+		// resolvable group fails closed, mirroring GetRolePolicies.
+		for name, raw := range group.InlinePolicies {
+			var doc PolicyDocument
+			if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+				return nil, fmt.Errorf("parse group inline policy %s/%s: %w", groupName, name, err) // fail closed
+			}
+			docs = append(docs, doc)
+		}
 	}
 
 	return docs, nil

--- a/spinifex/handlers/iam/service_impl.go
+++ b/spinifex/handlers/iam/service_impl.go
@@ -1342,7 +1342,7 @@ func (s *IAMServiceImpl) GetUserPolicies(accountID, userName string) ([]PolicyDo
 		for name, raw := range group.InlinePolicies {
 			var doc PolicyDocument
 			if err := json.Unmarshal([]byte(raw), &doc); err != nil {
-				return nil, fmt.Errorf("parse group inline policy %s/%s: %w", groupName, name, err) // fail closed
+				return nil, fmt.Errorf("parse group inline policy %s/%s: %w", groupName, name, err)
 			}
 			docs = append(docs, doc)
 		}

--- a/spinifex/handlers/iam/types.go
+++ b/spinifex/handlers/iam/types.go
@@ -31,14 +31,15 @@ type User struct {
 // Members are NOT stored here; membership is canonical on the User record
 // (User.Groups) so the authorization hot path never scans the groups bucket.
 type Group struct {
-	GroupName        string   `json:"group_name"`
-	GroupID          string   `json:"group_id"`
-	AccountID        string   `json:"account_id"`
-	ARN              string   `json:"arn"`
-	Path             string   `json:"path"`
-	CreatedAt        string   `json:"created_at"`
-	AttachedPolicies []string `json:"attached_policies"` // policy ARNs
-	Tags             []Tag    `json:"tags"`
+	GroupName        string            `json:"group_name"`
+	GroupID          string            `json:"group_id"`
+	AccountID        string            `json:"account_id"`
+	ARN              string            `json:"arn"`
+	Path             string            `json:"path"`
+	CreatedAt        string            `json:"created_at"`
+	AttachedPolicies []string          `json:"attached_policies"`         // policy ARNs
+	InlinePolicies   map[string]string `json:"inline_policies,omitempty"` // policyName → document JSON
+	Tags             []Tag             `json:"tags"`
 }
 
 // AccessKey represents an IAM access key stored in JetStream KV.

--- a/tests/e2e/harness/iam.go
+++ b/tests/e2e/harness/iam.go
@@ -75,10 +75,10 @@ func IAMDeleteRoleAndProfilesBestEffort(c *AWSClient, roleName string, profileNa
 }
 
 // IAMDeleteGroupBestEffort tears down a group: removes any members, detaches all
-// attached policies, then deletes the group. Each step swallows errors so a
-// missing fragment never cascades; usable both as a pre-test sweep and as a
-// fixture-teardown cleanup. Order matters: a group cannot be deleted while it
-// still has members or attached policies.
+// attached policies, deletes any inline policies, then deletes the group. Each
+// step swallows errors so a missing fragment never cascades; usable both as a
+// pre-test sweep and as a fixture-teardown cleanup. Order matters: a group cannot
+// be deleted while it still has members, attached policies, or inline policies.
 func IAMDeleteGroupBestEffort(c *AWSClient, groupName string, memberUsers []string, policyARNs ...string) {
 	for _, u := range memberUsers {
 		_, _ = c.IAM.RemoveUserFromGroup(&iam.RemoveUserFromGroupInput{
@@ -101,6 +101,18 @@ func IAMDeleteGroupBestEffort(c *AWSClient, groupName string, memberUsers []stri
 			_, _ = c.IAM.DetachGroupPolicy(&iam.DetachGroupPolicyInput{
 				GroupName: aws.String(groupName),
 				PolicyArn: p.PolicyArn,
+			})
+		}
+	}
+	// Defensive: delete any inline policies so the inline-policy guard can't block
+	// the final DeleteGroup after a partial run.
+	if inline, err := c.IAM.ListGroupPolicies(&iam.ListGroupPoliciesInput{
+		GroupName: aws.String(groupName),
+	}); err == nil {
+		for _, name := range inline.PolicyNames {
+			_, _ = c.IAM.DeleteGroupPolicy(&iam.DeleteGroupPolicyInput{
+				GroupName:  aws.String(groupName),
+				PolicyName: name,
 			})
 		}
 	}

--- a/tests/e2e/iam/iam_groups_test.go
+++ b/tests/e2e/iam/iam_groups_test.go
@@ -19,10 +19,15 @@ const (
 	grpLifecycleGroup  = "grp-e2e-developers"
 	grpLifecycleUser   = "grp-e2e-lc-user"
 	grpLifecyclePolicy = "grp-e2e-lc-describe-regions"
+	grpLifecycleInline = "grp-e2e-lc-inline-describe-regions"
 
 	grpEnforceGroup  = "grp-e2e-enforce"
 	grpEnforceUser   = "grp-e2e-enf-user"
 	grpEnforcePolicy = "grp-e2e-enf-describe-regions"
+
+	grpInlineEnforceGroup = "grp-e2e-inline-enforce"
+	grpInlineEnforceUser  = "grp-e2e-inl-enf-user"
+	grpInlineEnforceName  = "grp-e2e-inl-enf-describe-regions"
 
 	// A single-action grant so the enforcement positive case proves a specific
 	// group-attached policy was resolved and evaluated — not a blanket allow.
@@ -30,9 +35,10 @@ const (
 )
 
 // runIAMGroupsLifecycle exercises the full group surface: CRUD, membership,
-// group-policy attachment, the listing reverse-lookups, and every deletion guard
-// (delete-group while attached, delete-group while non-empty, delete-user while
-// in a group), then a clean teardown. Mirrors runIAMRolesAndProfiles in shape.
+// group-policy attachment, inline group policies (put/get/list), the listing
+// reverse-lookups, and every deletion guard (delete-group while attached, while
+// inline-policied, while non-empty, delete-user while in a group), then a clean
+// teardown. Mirrors runIAMRolesAndProfiles in shape.
 func runIAMGroupsLifecycle(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Single — IAM Groups Lifecycle")
 	adminAccount := harness.IAMAccountID(t, fix.AWS)
@@ -213,6 +219,73 @@ func runIAMGroupsLifecycle(t *testing.T, fix *Fixture) {
 		return e
 	})
 
+	// --- Inline group policies (put / get / list) ---
+
+	harness.Step(t, "put-group-policy ghost group (expect NoSuchEntity)")
+	harness.ExpectError(t, "NoSuchEntity", func() error {
+		_, e := fix.AWS.IAM.PutGroupPolicy(&iam.PutGroupPolicyInput{
+			GroupName:      aws.String("ghost-group"),
+			PolicyName:     aws.String(grpLifecycleInline),
+			PolicyDocument: aws.String(grpPolicyDoc),
+		})
+		return e
+	})
+
+	// PutGroupPolicy — upsert; re-put with the same name must overwrite, not add.
+	harness.Step(t, "put-group-policy %s/%s (grants ec2:DescribeRegions)", grpLifecycleGroup, grpLifecycleInline)
+	_, err = fix.AWS.IAM.PutGroupPolicy(&iam.PutGroupPolicyInput{
+		GroupName:      aws.String(grpLifecycleGroup),
+		PolicyName:     aws.String(grpLifecycleInline),
+		PolicyDocument: aws.String(grpPolicyDoc),
+	})
+	require.NoError(t, err, "put-group-policy")
+
+	_, err = fix.AWS.IAM.PutGroupPolicy(&iam.PutGroupPolicyInput{
+		GroupName:      aws.String(grpLifecycleGroup),
+		PolicyName:     aws.String(grpLifecycleInline),
+		PolicyDocument: aws.String(grpPolicyDoc),
+	})
+	require.NoError(t, err, "idempotent re-put")
+
+	// GetGroupPolicy — round-trips the stored document (raw, not URL-encoded).
+	harness.Step(t, "get-group-policy %s/%s (round-trip)", grpLifecycleGroup, grpLifecycleInline)
+	inlineGot, err := fix.AWS.IAM.GetGroupPolicy(&iam.GetGroupPolicyInput{
+		GroupName:  aws.String(grpLifecycleGroup),
+		PolicyName: aws.String(grpLifecycleInline),
+	})
+	require.NoError(t, err, "get-group-policy")
+	require.Equal(t, grpLifecycleGroup, aws.StringValue(inlineGot.GroupName))
+	require.Equal(t, grpLifecycleInline, aws.StringValue(inlineGot.PolicyName))
+	require.JSONEq(t, grpPolicyDoc, aws.StringValue(inlineGot.PolicyDocument),
+		"get-group-policy must round-trip the stored document")
+
+	harness.Step(t, "get-group-policy unknown name (expect NoSuchEntity)")
+	harness.ExpectError(t, "NoSuchEntity", func() error {
+		_, e := fix.AWS.IAM.GetGroupPolicy(&iam.GetGroupPolicyInput{
+			GroupName:  aws.String(grpLifecycleGroup),
+			PolicyName: aws.String("ghost-inline"),
+		})
+		return e
+	})
+
+	// ListGroupPolicies — surfaces exactly the one inline name, never truncated.
+	harness.Step(t, "list-group-policies %s (expect 1)", grpLifecycleGroup)
+	inlineList, err := fix.AWS.IAM.ListGroupPolicies(&iam.ListGroupPoliciesInput{
+		GroupName: aws.String(grpLifecycleGroup),
+	})
+	require.NoError(t, err, "list-group-policies")
+	require.Len(t, inlineList.PolicyNames, 1, "exactly one inline policy expected")
+	require.Equal(t, grpLifecycleInline, aws.StringValue(inlineList.PolicyNames[0]))
+	require.False(t, aws.BoolValue(inlineList.IsTruncated), "list-group-policies is never truncated")
+
+	harness.Step(t, "list-group-policies ghost group (expect NoSuchEntity)")
+	harness.ExpectError(t, "NoSuchEntity", func() error {
+		_, e := fix.AWS.IAM.ListGroupPolicies(&iam.ListGroupPoliciesInput{
+			GroupName: aws.String("ghost-group"),
+		})
+		return e
+	})
+
 	// --- Deletion guards ---
 
 	// delete-user while still a group member → DeleteConflict.
@@ -261,6 +334,37 @@ func runIAMGroupsLifecycle(t *testing.T, fix *Fixture) {
 		PolicyArn: aws.String(policyARN),
 	})
 	require.NoError(t, err, "detach-group-policy")
+
+	// With the managed policy gone, the inline policy alone must still block the
+	// delete — the new inline guard, symmetric with the attached-policy guard.
+	harness.Step(t, "delete-group while only inline policy present (expect DeleteConflict)")
+	harness.ExpectError(t, "DeleteConflict", func() error {
+		_, e := fix.AWS.IAM.DeleteGroup(&iam.DeleteGroupInput{GroupName: aws.String(grpLifecycleGroup)})
+		return e
+	})
+
+	harness.Step(t, "delete-group-policy unknown name (expect NoSuchEntity)")
+	harness.ExpectError(t, "NoSuchEntity", func() error {
+		_, e := fix.AWS.IAM.DeleteGroupPolicy(&iam.DeleteGroupPolicyInput{
+			GroupName:  aws.String(grpLifecycleGroup),
+			PolicyName: aws.String("ghost-inline"),
+		})
+		return e
+	})
+
+	harness.Step(t, "delete-group-policy %s", grpLifecycleInline)
+	_, err = fix.AWS.IAM.DeleteGroupPolicy(&iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String(grpLifecycleGroup),
+		PolicyName: aws.String(grpLifecycleInline),
+	})
+	require.NoError(t, err, "delete-group-policy")
+
+	harness.Step(t, "list-group-policies after delete (expect 0)")
+	emptyInline, err := fix.AWS.IAM.ListGroupPolicies(&iam.ListGroupPoliciesInput{
+		GroupName: aws.String(grpLifecycleGroup),
+	})
+	require.NoError(t, err, "list-group-policies after delete")
+	require.Empty(t, emptyInline.PolicyNames, "inline policy must be gone after delete-group-policy")
 
 	harness.Step(t, "delete-group %s", grpLifecycleGroup)
 	_, err = fix.AWS.IAM.DeleteGroup(&iam.DeleteGroupInput{GroupName: aws.String(grpLifecycleGroup)})
@@ -355,6 +459,84 @@ func runIAMGroupEnforcement(t *testing.T, fix *Fixture) {
 	require.NoError(t, err, "remove-user-from-group")
 
 	harness.Step(t, "describe-regions after leaving group (expect AccessDenied)")
+	harness.ExpectError(t, "AccessDenied", func() error {
+		_, e := memberCli.EC2.DescribeRegions(&ec2.DescribeRegionsInput{})
+		return e
+	})
+}
+
+// runIAMGroupInlineEnforcement proves the inline-policy linchpin: an inline
+// policy embedded in a group grants its permission to every member, exactly as a
+// managed attachment does. A user with its own access key is denied a guarded
+// action; once an inline policy granting that action is put on a group the user
+// joins, the same live credentials are allowed (policies resolved per request);
+// after the inline policy is deleted — with the user still a member — the action
+// is denied again, proving the inline document was the grant source. Mirrors
+// runIAMGroupEnforcement with put-group-policy in place of attach-group-policy.
+func runIAMGroupInlineEnforcement(t *testing.T, fix *Fixture) {
+	harness.Phase(t, "Single — IAM Group inline-policy authorization enforcement")
+
+	// No managed policy here — the inline doc lives in the group record, so the
+	// best-effort sweep clears it via ListGroupPolicies/DeleteGroupPolicy.
+	sweep := func() {
+		harness.IAMDeleteGroupBestEffort(fix.AWS, grpInlineEnforceGroup, []string{grpInlineEnforceUser})
+		iamDeleteUserBestEffort(fix, grpInlineEnforceUser)
+	}
+	sweep()
+	fix.Harness.RegisterCleanup(sweep)
+
+	// Member with its own static credentials.
+	harness.Step(t, "create-user %q + access key", grpInlineEnforceUser)
+	_, err := fix.AWS.IAM.CreateUser(&iam.CreateUserInput{UserName: aws.String(grpInlineEnforceUser)})
+	require.NoError(t, err, "create-user")
+	key, err := fix.AWS.IAM.CreateAccessKey(&iam.CreateAccessKeyInput{UserName: aws.String(grpInlineEnforceUser)})
+	require.NoError(t, err, "create-access-key")
+	memberCli := harness.NewAWSClientWithCreds(t, fix.Env,
+		aws.StringValue(key.AccessKey.AccessKeyId),
+		aws.StringValue(key.AccessKey.SecretAccessKey))
+
+	// No grant anywhere yet: the active key authenticates, then default-denies.
+	harness.Step(t, "describe-regions with no grant (expect AccessDenied)")
+	harness.ExpectError(t, "AccessDenied", func() error {
+		_, e := memberCli.EC2.DescribeRegions(&ec2.DescribeRegionsInput{})
+		return e
+	})
+
+	// Group with an inline policy granting ec2:DescribeRegions, then join the user.
+	harness.Step(t, "create-group %q", grpInlineEnforceGroup)
+	_, err = fix.AWS.IAM.CreateGroup(&iam.CreateGroupInput{GroupName: aws.String(grpInlineEnforceGroup)})
+	require.NoError(t, err, "create-group")
+
+	harness.Step(t, "put-group-policy %q (grants ec2:DescribeRegions)", grpInlineEnforceName)
+	_, err = fix.AWS.IAM.PutGroupPolicy(&iam.PutGroupPolicyInput{
+		GroupName:      aws.String(grpInlineEnforceGroup),
+		PolicyName:     aws.String(grpInlineEnforceName),
+		PolicyDocument: aws.String(grpPolicyDoc),
+	})
+	require.NoError(t, err, "put-group-policy")
+
+	harness.Step(t, "add-user-to-group %s <- %s", grpInlineEnforceGroup, grpInlineEnforceUser)
+	_, err = fix.AWS.IAM.AddUserToGroup(&iam.AddUserToGroupInput{
+		GroupName: aws.String(grpInlineEnforceGroup),
+		UserName:  aws.String(grpInlineEnforceUser),
+	})
+	require.NoError(t, err, "add-user-to-group")
+
+	// Same live credentials are now allowed — the inline grant flows through the group.
+	harness.Step(t, "describe-regions after inline group grant (expect success)")
+	_, err = memberCli.EC2.DescribeRegions(&ec2.DescribeRegionsInput{})
+	require.NoError(t, err, "describe-regions must be allowed once the group inline policy grants it")
+
+	// Delete the inline policy while the user is still a member — the grant must
+	// evaporate, isolating the inline document as the sole grant source.
+	harness.Step(t, "delete-group-policy %s (user stays a member)", grpInlineEnforceName)
+	_, err = fix.AWS.IAM.DeleteGroupPolicy(&iam.DeleteGroupPolicyInput{
+		GroupName:  aws.String(grpInlineEnforceGroup),
+		PolicyName: aws.String(grpInlineEnforceName),
+	})
+	require.NoError(t, err, "delete-group-policy")
+
+	harness.Step(t, "describe-regions after inline policy removed (expect AccessDenied)")
 	harness.ExpectError(t, "AccessDenied", func() error {
 		_, e := memberCli.EC2.DescribeRegions(&ec2.DescribeRegionsInput{})
 		return e

--- a/tests/e2e/iam/tests_test.go
+++ b/tests/e2e/iam/tests_test.go
@@ -78,6 +78,14 @@ func TestIAMGroupEnforcement(t *testing.T) {
 	runIAMGroupEnforcement(t, requireIAMFixture(t))
 }
 
+// TestIAMGroupInlineEnforcement proves a group inline policy grants its
+// permission to members: denied with no grant, allowed once the inline policy is
+// put and the user joins, denied again after the inline policy is deleted (with
+// the user still a member). Sequential to avoid racing the mid-test grant.
+func TestIAMGroupInlineEnforcement(t *testing.T) {
+	runIAMGroupInlineEnforcement(t, requireIAMFixture(t))
+}
+
 // TestIAMInstanceProfileAssociation exercises the EC2 IAM instance-profile
 // association lifecycle (associate/replace/disassociate, RunInstances
 // --iam-instance-profile, auto-disassociate on terminate). It boots its own


### PR DESCRIPTION
## Summary

Adds **inline policies** to IAM Groups — `put-group-policy`, `get-group-policy`, `delete-group-policy`, `list-group-policies` — with the inline documents wired into authorization so an inline policy embedded in a group actually grants its permissions to every member.

The implementation mirrors the existing **Role inline policy** pattern (`PutRolePolicy` / `GetRolePolicy` / `DeleteRolePolicy` / `ListRolePolicies`) transposed onto the `Group` record. The one load-bearing behaviour beyond CRUD is the authorization integration: `GetUserPolicies` now resolves a group's inline documents for its members in addition to its managed attachments.

## Changes

- **Data model**: additive `InlinePolicies map[string]string` field on `Group` (`omitempty`, no migration, nil maps unmarshal safely).
- **Service**: `PutGroupPolicy` / `GetGroupPolicy` / `DeleteGroupPolicy` / `ListGroupPolicies` using blind read-modify-write `Put` to match the existing group-record writers
- **Authorization linchpin**: `GetUserPolicies` parses and appends each group's `InlinePolicies` inside the existing per-group block — skips a missing group, fails closed on a malformed inline document (matching `GetRolePolicies`).
- **DeleteGroup guard**: refuses deletion when `InlinePolicies` is non-empty (`DeleteConflict`), alongside the existing attached-policy and membership guards.
- **Gateway**: four new handlers with required-field validation, registered in `iamActions`.
- **Validation**: reuses `validatePolicyName` and `ValidatePolicyDocument`; no new validators or size constants.