### PR TITLE
fix: auto-reconnect vpcd OVN-NB client after NB restart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.26
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.25
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -60,7 +61,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/boltdb/bolt v1.3.1 // indirect
 	github.com/buraksezer/consistent v0.10.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/hub v1.0.2 // indirect
 	github.com/cenkalti/rpc2 v1.0.5 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
 	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/model"
@@ -23,6 +24,16 @@ const ensureRefetchInterval = 20 * time.Millisecond
 // ensureWaitTimeoutMS=0 makes the wait-op fail fast so we fall through to the
 // refetch path on conflict.
 const ensureWaitTimeoutMS = 0
+
+// inactivityTimeout is the Echo-probe cadence; a missed probe marks the NB peer
+// dead and triggers reconnect. Must exceed reconnectTimeout (libovsdb invariant).
+const inactivityTimeout = 10 * time.Second
+
+// reconnectTimeout bounds each reconnect attempt's Connect context.
+const reconnectTimeout = 5 * time.Second
+
+// reconnectMaxInterval caps exponential backoff between reconnect attempts.
+const reconnectMaxInterval = 30 * time.Second
 
 // ensureNamedRowOps returns ops that insert createObj unless a row with the same
 // Name exists. The wait-op serialises concurrent writers; `until=!=` is required
@@ -106,7 +117,17 @@ func (c *LiveClient) Connect(ctx context.Context) error {
 		return fmt.Errorf("failed to create database model: %w", err)
 	}
 
-	ovn, err := client.NewOVSDBClient(dbModel, client.WithEndpoint(c.endpoint))
+	// Infinite backoff (MaxElapsedTime=0) so a daemon keeps reconnecting across a
+	// long NB outage. WithInactivityCheck enables reconnect and adds the Echo
+	// probe that detects a dead/half-open socket the OS never reports.
+	bo := backoff.NewExponentialBackOff(
+		backoff.WithMaxElapsedTime(0),
+		backoff.WithMaxInterval(reconnectMaxInterval),
+	)
+	ovn, err := client.NewOVSDBClient(dbModel,
+		client.WithEndpoint(c.endpoint),
+		client.WithInactivityCheck(inactivityTimeout, reconnectTimeout, bo),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create OVSDB client: %w", err)
 	}

--- a/spinifex/network/subscribers/security.go
+++ b/spinifex/network/subscribers/security.go
@@ -4,10 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/network/policy"
 	"github.com/nats-io/nats.go"
 )
+
+// sgHandlerTimeout bounds each SG handler's OVN work so a stuck NB op frees the
+// worker instead of hanging on context.Background forever. Sits above worst-case
+// OVN write under raft lag, well under any pathological hang.
+const sgHandlerTimeout = 10 * time.Second
 
 func (e SGEvent) toSpec() policy.SGSpec {
 	return policy.SGSpec{
@@ -40,7 +46,8 @@ func (s *Subscriber) handleCreateSG(msg *nats.Msg) {
 		respond(msg, err)
 		return
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), sgHandlerTimeout)
+	defer cancel()
 	if err := s.topology.EnsureSGPortGroup(ctx, evt.GroupId); err != nil {
 		slog.Error("subscribers: EnsureSGPortGroup failed", "group_id", evt.GroupId, "err", err)
 		respond(msg, err)
@@ -68,7 +75,9 @@ func (s *Subscriber) handleDeleteSG(msg *nats.Msg) {
 		respond(msg, err)
 		return
 	}
-	if err := s.topology.DeleteSGPortGroup(context.Background(), evt.GroupId); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), sgHandlerTimeout)
+	defer cancel()
+	if err := s.topology.DeleteSGPortGroup(ctx, evt.GroupId); err != nil {
 		slog.Error("subscribers: DeleteSGPortGroup failed", "group_id", evt.GroupId, "err", err)
 		respond(msg, err)
 		return
@@ -85,7 +94,9 @@ func (s *Subscriber) handleUpdateSG(msg *nats.Msg) {
 		respond(msg, err)
 		return
 	}
-	if err := s.sg.UpdateSG(context.Background(), evt.toSpec()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), sgHandlerTimeout)
+	defer cancel()
+	if err := s.sg.UpdateSG(ctx, evt.toSpec()); err != nil {
 		slog.Error("subscribers: UpdateSG failed", "group_id", evt.GroupId, "err", err)
 		respond(msg, err)
 		return


### PR DESCRIPTION
## Summary

vpcd's libovsdb client to the OVN Northbound DB was a single long-lived connection with no reconnect logic. After the NB server restarts (host reboot, service restart), every vpcd holding a dead/half-open socket never re-established it — even once the NB endpoint was reachable again. OVN-write handlers then blocked until the caller's timeout fired.

`vpc.create-sg` is queue-distributed across all vpcd, so requests landing on a dead client hung in `EnsureSGPortGroup`/`EnsureSG` until the 5s timeout, failing `createDefaultSecurityGroupInternal` and returning `CreateVpc` `ServerInternal`. Presented as intermittent ~40% success.

## Changes

- **`network/ovn/live.go`** — add `client.WithInactivityCheck(10s, 5s, infinite-backoff)` to the OVSDB client. The Echo probe detects a dead/half-open peer the OS never reports and triggers reconnect against the configured endpoint; infinite backoff (`MaxElapsedTime=0`) keeps a daemon retrying across a long outage. (`WithInactivityCheck` implies reconnect.)
- **`network/subscribers/security.go`** — bound `handleCreateSG`/`handleUpdateSG`/`handleDeleteSG` with a 10s timeout context so a stuck OVN op frees the worker instead of hanging on `context.Background`.
- **`go.mod`** — promote `cenkalti/backoff/v4` indirect → direct.

## Out of scope (follow-up)

- Topology handlers share the same `context.Background` pattern — bound in a later pass.
- Multi-endpoint NB/SB failover — separate clustering work (mulga-siv-486 Phase C).

## Testing

- `make preflight` green (vet, lint, race tests).
- **Verified on env19** (3-node cluster, NB single-homed on init): deployed the branch, restarted `ovn-ovsdb-server-nb.service` on the init node. Both remote vpcd re-established their `:6641` connection (source ports rotated, vpcd pids unchanged — no vpcd restart). CreateVpc 6/6 OK afterward (was ~1/5 pre-fix).