### PR TITLE
feat: OVN OVSDB RAFT clustering for multinode Spinifex (epic mulga-siv-486)

### DIFF
--- a/cmd/installer/firstboot/firstboot.go
+++ b/cmd/installer/firstboot/firstboot.go
@@ -91,6 +91,31 @@ func writeScript(root string, cfg Config) error {
 		setupOVN += fmt.Sprintf(" --encap-ip=%s", cfg.EncapIP)
 	}
 
+	// Pre-start OVS and OVN central so their databases are initialised before
+	// setup-ovn.sh runs. On physical hardware, first-boot DB initialisation takes
+	// longer than setup-ovn.sh's internal 15-second timeout allows. Starting them
+	// here and waiting until the NB DB is ready means setup-ovn.sh sees a live DB
+	// the moment it starts — no races, no timeout failures.
+	ovnPrestart := `systemctl start openvswitch-switch
+systemctl start ovn-central
+echo "Waiting for OVN NB DB to initialise..."
+for _i in $(seq 1 120); do
+    if ovn-nbctl --timeout=2 get-connection >/dev/null 2>&1; then
+        echo "OVN NB DB ready (${_i}s)"
+        break
+    fi
+    sleep 1
+done`
+
+	// When a provisioning controller owns formation (SkipFormation) it also owns
+	// the clustered OVN bring-up via setup-ovn.sh's RAFT flags. firstboot must
+	// not start a standalone ovn-central here: the single-node .db it would leave
+	// blocks ovn-ctl's create/join (which require a clean DB). Defer both.
+	if cfg.SkipFormation {
+		ovnPrestart = `echo "[firstboot] OVN bring-up deferred to provisioning controller"`
+		setupOVN = `echo "[firstboot] setup-ovn deferred to provisioning controller"`
+	}
+
 	callbackBlock := ""
 	if cfg.InstallCallback != "" {
 		callbackBlock = fmt.Sprintf(
@@ -123,21 +148,7 @@ fi
 # Set hostname
 hostnamectl set-hostname %s
 
-# Pre-start OVS and OVN central so their databases are initialised before
-# setup-ovn.sh runs. On physical hardware, first-boot DB initialisation takes
-# longer than setup-ovn.sh's internal 15-second timeout allows. Starting them
-# here and waiting until the NB DB is ready means setup-ovn.sh sees a live DB
-# the moment it starts — no races, no timeout failures.
-systemctl start openvswitch-switch
-systemctl start ovn-central
-echo "Waiting for OVN NB DB to initialise..."
-for _i in $(seq 1 120); do
-    if ovn-nbctl --timeout=2 get-connection >/dev/null 2>&1; then
-        echo "OVN NB DB ready (${_i}s)"
-        break
-    fi
-    sleep 1
-done
+%s
 
 # Create default nameservers if DHCP server returns blank
 printf "nameserver 1.1.1.1\nnameserver 8.8.8.8\n" > /etc/resolvconf/resolv.conf.d/base
@@ -229,7 +240,7 @@ if grep -q 'external_mode.*pool' /etc/spinifex/spinifex.toml 2>/dev/null; then
         echo "[firstboot] warning: br-ext not up after 30s — external networking may be delayed"
     fi
 fi
-`, cfg.Hostname, setupOVN, clusterCmd, callbackBlock)
+`, cfg.Hostname, ovnPrestart, setupOVN, clusterCmd, callbackBlock)
 
 	path := filepath.Join(root, "usr/local/bin/spinifex-firstboot.sh")
 	return os.WriteFile(path, []byte(script), 0o755)

--- a/cmd/installer/firstboot/firstboot_test.go
+++ b/cmd/installer/firstboot/firstboot_test.go
@@ -66,6 +66,54 @@ func TestWriteScriptEmbedsCurlWhenCallbackSet(t *testing.T) {
 	}
 }
 
+func TestWriteScriptRunsOVNWhenFormationOwned(t *testing.T) {
+	root := t.TempDir()
+	makeRootDirs(t, root)
+
+	cfg := Config{Hostname: "test-node", ClusterRole: "init"}
+	if err := Write(root, cfg); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	content := readScript(t, root)
+
+	if !strings.Contains(content, "setup-ovn.sh --management") {
+		t.Error("script should run setup-ovn --management when firstboot owns formation")
+	}
+	if !strings.Contains(content, "systemctl start ovn-central") {
+		t.Error("script should pre-start ovn-central when firstboot owns formation")
+	}
+}
+
+func TestWriteScriptDefersOVNWhenSkipFormation(t *testing.T) {
+	root := t.TempDir()
+	makeRootDirs(t, root)
+
+	cfg := Config{Hostname: "test-node", ClusterRole: "init", SkipFormation: true}
+	if err := Write(root, cfg); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	content := readScript(t, root)
+
+	if strings.Contains(content, "setup-ovn.sh --management") {
+		t.Error("script must not run setup-ovn --management when a controller owns OVN")
+	}
+	if strings.Contains(content, "systemctl start ovn-central") {
+		t.Error("script must not pre-start ovn-central when a controller owns OVN")
+	}
+	if !strings.Contains(content, "setup-ovn deferred") {
+		t.Error("script should note setup-ovn is deferred under SkipFormation")
+	}
+}
+
+func readScript(t *testing.T, root string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, "usr/local/bin/spinifex-firstboot.sh"))
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	return string(b)
+}
+
 func TestWriteScriptCallbackAfterDoneMarker(t *testing.T) {
 	root := t.TempDir()
 	makeRootDirs(t, root)

--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -1616,6 +1616,7 @@ func runAdminInitMultiNode(cmd *cobra.Command, accessKey, secretKey, accountID, 
 	allNodes := fs.Nodes()
 	clusterRoutes := formation.BuildClusterRoutes(allNodes)
 	predastoreNodes := formation.BuildPredastoreNodes(allNodes)
+	ovnNBAddr, ovnSBAddr := formation.BuildOVNDBAddrs(allNodes)
 
 	fmt.Println("\n📝 Creating configuration files...")
 
@@ -1677,9 +1678,10 @@ func runAdminInitMultiNode(cmd *cobra.Command, accessKey, secretKey, accountID, 
 
 		EncryptionKeyFile: viperblockKeyPath,
 
-		// Init node runs ovn-central locally
-		OVNNBAddr: "tcp:127.0.0.1:6641",
-		OVNSBAddr: "tcp:127.0.0.1:6642",
+		// Multi-endpoint OVN NB/SB list across the RAFT quorum; the init node's
+		// own address leads, the rest provide failover.
+		OVNNBAddr: ovnNBAddr,
+		OVNSBAddr: ovnSBAddr,
 	}
 
 	if networkConfig != nil {
@@ -1762,13 +1764,6 @@ func runAdminJoin(cmd *cobra.Command, args []string) {
 	if leaderHost == "" {
 		fmt.Fprintf(os.Stderr, "❌ Error: --host is required\n")
 		os.Exit(1)
-	}
-
-	// Extract leader IP for OVN NB/SB DB address (strip port from host:port)
-	leaderIP, _, err := net.SplitHostPort(leaderHost)
-	if err != nil {
-		// leaderHost might be an IP without port
-		leaderIP = leaderHost
 	}
 
 	// Validate IP address format
@@ -2073,6 +2068,7 @@ func runAdminJoin(cmd *cobra.Command, args []string) {
 	// Build cluster topology from formation data
 	clusterRoutes := formation.BuildClusterRoutes(statusResp.Nodes)
 	predastoreNodes := formation.BuildPredastoreNodes(statusResp.Nodes)
+	ovnNBAddr, ovnSBAddr := formation.BuildOVNDBAddrs(statusResp.Nodes)
 
 	fmt.Println("📝 Creating configuration files...")
 
@@ -2139,9 +2135,10 @@ func runAdminJoin(cmd *cobra.Command, args []string) {
 
 		EncryptionKeyFile: viperblockKeyPath,
 
-		// Joining nodes connect to the init node's OVN NB/SB DB
-		OVNNBAddr: fmt.Sprintf("tcp:%s:6641", leaderIP),
-		OVNSBAddr: fmt.Sprintf("tcp:%s:6642", leaderIP),
+		// Multi-endpoint OVN NB/SB list across the RAFT quorum so the client
+		// fails over instead of pinning to a single init node.
+		OVNNBAddr: ovnNBAddr,
+		OVNSBAddr: ovnSBAddr,
 	}
 
 	if statusResp.NetworkConfig != nil {

--- a/docs/compute/vpc-networking/README.md
+++ b/docs/compute/vpc-networking/README.md
@@ -483,13 +483,16 @@ These are different things:
 
 ```toml
 [nodes.spx1.vpcd]
-ovn_nb_addr        = "tcp:10.1.3.181:6641"   # OVN Northbound DB
-ovn_sb_addr        = "tcp:10.1.3.181:6642"   # OVN Southbound DB
+# Comma-separated list of the OVN NB/SB quorum endpoints (3 DB nodes). vpcd and
+# ovn-controller fail over across them and follow the RAFT leader.
+ovn_nb_addr        = "tcp:10.1.3.181:6641,tcp:10.1.3.182:6641,tcp:10.1.3.183:6641"
+ovn_sb_addr        = "tcp:10.1.3.181:6642,tcp:10.1.3.182:6642,tcp:10.1.3.183:6642"
 external_interface = "br-wan"                 # WAN Linux bridge name
 ```
 
 | Field                | Description                                                                                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ovn_nb_addr` / `ovn_sb_addr` | OVN Northbound / Southbound DB endpoint(s). The NB and SB databases run clustered via OVSDB RAFT across the first three nodes (client ports 6641/6642, RAFT ports 6643/6644). Each node's config lists all three quorum endpoints so the loss of one DB node does not stall the control plane. A single `tcp:IP:6641` string remains valid for single-node dev. |
 | `external_interface` | Linux bridge that owns the WAN uplink on this node (e.g. `br-wan`, `br-public`). The physical NIC is enslaved to this bridge — not configured here. Different nodes may differ. |
 
 ## Pool Selection Logic
@@ -1045,6 +1048,27 @@ sudo ovn-trace ext-vpc-{vpcId} \
   'inport=="ext-port-vpc-{vpcId}" && eth.dst==ff:ff:ff:ff:ff:ff && \
    arp.op==1 && arp.spa==192.168.1.13 && arp.tpa==192.168.1.201'
 ```
+
+### OVN DB RAFT cluster (NB/SB replication)
+
+The NB and SB databases run clustered across the first three nodes via native
+OVSDB RAFT. A 3-node quorum tolerates the loss of one DB node; check status when
+the control plane stalls.
+
+```bash
+# NB cluster status: expect 3 servers and exactly one "Role: leader"
+sudo ovn-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound
+
+# SB cluster status
+sudo ovn-appctl -t /var/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound
+
+# Drive a CLI at the whole quorum (fails over past a dead node)
+sudo ovn-nbctl --db=tcp:10.1.3.181:6641,tcp:10.1.3.182:6641,tcp:10.1.3.183:6641 show
+```
+
+A node showing only itself under `Servers:` never joined the cluster — confirm
+it was bootstrapped with `--db-cluster-remote-addr` pointing at the creator and
+that RAFT ports 6643/6644 are reachable between DB nodes.
 
 ### OVS (datapath / physical wiring)
 

--- a/docs/security/network-connections/README.md
+++ b/docs/security/network-connections/README.md
@@ -88,8 +88,10 @@ The inventory in [§1](#1-inbound-listeners)–[§2](#2-outbound-connections) sa
 | 8443 | spinifex-predastore | HTTPS | Cluster | S3-compatible object storage (AMIs, snapshots, user objects) | AWS SigV4 + TLS |
 | 6660–6662 | predastore (Raft) | TCP | Cluster | Metadata consensus (3 nodes) | Cluster network only |
 | 9991–9993 | predastore (data shards) | TCP | Cluster | Erasure-coded data shard transport | Cluster network only |
-| 6641 | OVN Northbound DB | OVSDB/TCP | Cluster | Logical network topology consumed by vpcd | Cluster network only; TLS planned |
-| 6642 | OVN Southbound DB | OVSDB/TCP | Cluster | Chassis / port / MAC binding state | Cluster network only; TLS planned |
+| 6641 | OVN Northbound DB (client) | OVSDB/TCP | Cluster | Logical network topology consumed by vpcd | Cluster network only; TLS planned |
+| 6642 | OVN Southbound DB (client) | OVSDB/TCP | Cluster | Chassis / port / MAC binding state | Cluster network only; TLS planned |
+| 6643 | OVN Northbound DB (RAFT) | OVSDB/TCP | Cluster | NB database RAFT replication between the 3 quorum nodes | Cluster network only; TLS planned |
+| 6644 | OVN Southbound DB (RAFT) | OVSDB/TCP | Cluster | SB database RAFT replication between the 3 quorum nodes | Cluster network only; TLS planned |
 | 8222 | spinifex-nats (monitoring) | HTTP | Localhost | `varz`/`subsz` metrics consumed by the daemon | Loopback only |
 | socket / dynamic TCP | nbdkit (Viperblock) | NBD | Host-local / cluster | Block device transport for guest EBS volumes | Unix socket by default; TCP only in remote/DPU mode |
 
@@ -126,7 +128,8 @@ Control-plane and data-plane traffic between Spinifex nodes, for completeness an
 | Predastore S3 | 8443 | TLS + AWS SigV4 | Cross-node object reads/writes |
 | Predastore Raft | 6660–6662 | Cluster network only | Metadata consensus |
 | Predastore shards | 9991–9993 | Cluster network only | Erasure-coded data shards |
-| OVN NB/SB | 6641 / 6642 | Cluster network only (TLS planned) | Network control plane |
+| OVN NB/SB (client) | 6641 / 6642 | Cluster network only (TLS planned) | Network control plane; vpcd and ovn-controller dial the quorum |
+| OVN NB/SB (RAFT) | 6643 / 6644 | Cluster network only (TLS planned) | NB/SB database replication across the 3 quorum nodes |
 | OVN tunnels (Geneve) | UDP 6081 | None | Tenant traffic overlay between chassis, inside the cluster subnet |
 
 Nodes **must** sit on a network segment that is not routed to tenant/guest VMs or to the internet. Predastore Raft/shards and OVN DBs are cluster-internal and must not be reachable from anywhere else.
@@ -140,7 +143,7 @@ Default external surface is three listeners — **9999** (AWS API), **3000** (UI
 tcp dport { 22, 9999, 3000 } accept
 
 # Cluster-only: replace 10.0.1.0/24 with your cluster CIDR
-ip saddr 10.0.1.0/24 tcp dport { 4222, 4248, 8443, 6641, 6642, 6660-6662, 9991-9993 } accept
+ip saddr 10.0.1.0/24 tcp dport { 4222, 4248, 8443, 6641-6644, 6660-6662, 9991-9993 } accept
 ip saddr 10.0.1.0/24 udp dport 6081 accept
 
 # Default deny
@@ -172,6 +175,6 @@ Every listener and outbound destination is controlled by one of these files. Cha
 - Formation port 4432 is closed on nodes not actively running a bootstrap token.
 - Outbound HTTPS restricted to the [§2](#2-outbound-connections) image-catalogue hosts, or replaced with air-gapped import.
 - Install telemetry (`install.mulgadc.com`) is either permitted and recorded in the security plan, or disabled via `SPX_NO_TELEMETRY=1` / `--no-telemetry`.
-- OVN NB/SB (6641/6642) exposure limited to the cluster subnet pending the L2 TLS work.
+- OVN NB/SB client and RAFT ports (6641–6644) exposure limited to the cluster subnet pending the L2 TLS work.
 - SSH (22) configured to operator-managed keys only; password auth disabled in `sshd_config`.
 - Periodic review (at least annually, and after any topology change) confirms this inventory still matches the deployed configuration.

--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -22,8 +22,16 @@
 #   --mgmt-cidr=CIDR     IPv4 CIDR to assign on the mgmt bridge (default: 10.15.8.1/24)
 #   --mgmt-iface=NAME    Physical/virtual NIC to enslave to the mgmt bridge (multi-node only)
 #   --no-mgmt-bridge     Skip mgmt bridge provisioning (for dev-networking hosts)
-#   --ovn-remote=ADDR    OVN SB DB address (default: tcp:127.0.0.1:6642)
+#   --ovn-remote=ADDR    OVN SB DB address; accepts a comma-separated list of
+#                        SB endpoints for compute nodes pointing at a RAFT
+#                        cluster (default: tcp:127.0.0.1:6642)
 #   --encap-ip=IP        Geneve tunnel endpoint IP (default: auto-detect)
+#   --db-cluster-local-addr=IP   This DB node's own IP for OVSDB RAFT clustering.
+#                        Enables clustered NB(6643)/SB(6644) DBs (requires
+#                        --management). Empty --db-cluster-remote-addr ⇒ create
+#                        the cluster; set ⇒ join it.
+#   --db-cluster-remote-addr=IP  An existing cluster DB node's IP to join. Omit
+#                        on the first (init) DB node that forms the cluster.
 #
 # WAN Bridge Auto-Detection:
 #   When no --wan-bridge is given, the script checks the default route interface:
@@ -42,6 +50,16 @@
 #   # Compute node joining an existing cluster:
 #   ./scripts/setup-ovn.sh --ovn-remote=tcp:10.0.0.1:6642 --encap-ip=10.0.0.2
 #
+#   # DB node 1 — create an OVSDB RAFT cluster (init):
+#   ./scripts/setup-ovn.sh --management --db-cluster-local-addr=10.0.0.1
+#
+#   # DB nodes 2,3 — join the cluster:
+#   ./scripts/setup-ovn.sh --management --db-cluster-local-addr=10.0.0.2 \
+#       --db-cluster-remote-addr=10.0.0.1
+#
+#   # Compute node pointing at all 3 clustered SB endpoints:
+#   ./scripts/setup-ovn.sh --ovn-remote=tcp:10.0.0.1:6642,tcp:10.0.0.2:6642,tcp:10.0.0.3:6642
+#
 #   # No WAN bridge (overlay-only, no public subnet):
 #   ./scripts/setup-ovn.sh --management --encap-ip=10.0.0.1
 
@@ -58,6 +76,11 @@ MGMT_CIDR="10.15.8.1/24"
 MGMT_IFACE=""
 OVN_REMOTE="tcp:127.0.0.1:6642"
 ENCAP_IP=""
+# OVSDB RAFT clustering. Empty by default ⇒ single, non-clustered ovn-central
+# (dev box, existing single-node clusters). When LOCAL_ADDR is set, the NB/SB
+# DBs run clustered; REMOTE_ADDR empty ⇒ create the cluster, set ⇒ join it.
+DB_CLUSTER_LOCAL_ADDR=""
+DB_CLUSTER_REMOTE_ADDR=""
 # NODE_NAME is left empty by default. The chassis-id pin block at Step 4
 # only runs when --node-name=NAME is explicitly given. Passing nothing
 # preserves whatever system-id already lives in OVS (gold-image UUID,
@@ -80,9 +103,11 @@ for arg in "$@"; do
         --no-mgmt-bridge)   MGMT_BRIDGE_ENABLED=false ;;
         --ovn-remote=*)     OVN_REMOTE="${arg#*=}" ;;
         --encap-ip=*)       ENCAP_IP="${arg#*=}" ;;
+        --db-cluster-local-addr=*)  DB_CLUSTER_LOCAL_ADDR="${arg#*=}" ;;
+        --db-cluster-remote-addr=*) DB_CLUSTER_REMOTE_ADDR="${arg#*=}" ;;
         --node-name=*)      NODE_NAME="${arg#*=}" ;;
         --help|-h)
-            head -50 "$0" | tail -48
+            sed -n '3,/^set -e/{/^set -e/!p}' "$0"
             exit 0
             ;;
         *)
@@ -91,6 +116,18 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# OVSDB RAFT clustering runs the NB/SB DBs, so it only applies to management
+# (DB) nodes. A remote addr without a local addr is meaningless (nothing to
+# join with). Fail loudly rather than silently starting a single-node DB.
+if [ -n "$DB_CLUSTER_LOCAL_ADDR" ] && [ "$MANAGEMENT" != true ]; then
+    echo "ERROR: --db-cluster-local-addr requires --management (clustered DBs run on management nodes)"
+    exit 1
+fi
+if [ -n "$DB_CLUSTER_REMOTE_ADDR" ] && [ -z "$DB_CLUSTER_LOCAL_ADDR" ]; then
+    echo "ERROR: --db-cluster-remote-addr requires --db-cluster-local-addr"
+    exit 1
+fi
 
 # --- WAN bridge auto-detection ---
 # Determine the WAN bridge name and how to set it up.
@@ -195,6 +232,13 @@ fi
 
 echo "=== Spinifex OVN Compute Node Setup ==="
 echo "  Management node:  $MANAGEMENT"
+if [ -n "$DB_CLUSTER_LOCAL_ADDR" ]; then
+    if [ -n "$DB_CLUSTER_REMOTE_ADDR" ]; then
+        echo "  DB RAFT role:     join (local=$DB_CLUSTER_LOCAL_ADDR remote=$DB_CLUSTER_REMOTE_ADDR)"
+    else
+        echo "  DB RAFT role:     create (local=$DB_CLUSTER_LOCAL_ADDR)"
+    fi
+fi
 if [ -n "$WAN_BRIDGE" ]; then
     echo "  WAN bridge:       $WAN_BRIDGE ($WAN_BRIDGE_MODE)"
     if [ -n "$LINUX_BRIDGE" ]; then
@@ -246,8 +290,33 @@ echo "  openvswitch-switch: started"
 
 if [ "$MANAGEMENT" = true ]; then
     sudo systemctl enable ovn-central
-    sudo systemctl start ovn-central
-    echo "  ovn-central: started (NB DB + SB DB + ovn-northd)"
+
+    if [ -n "$DB_CLUSTER_LOCAL_ADDR" ]; then
+        # Clustered NB/SB via native OVSDB RAFT. Both per-DB units source one
+        # shared OVN_CTL_OPTS from /etc/default/ovn-central; each run_*_ovsdb
+        # consumes only its own --db-{nb,sb}-* flags. RAFT ports default to NB
+        # 6643 / SB 6644. ovn-ctl creates the cluster when no remote-addr is
+        # given (and no existing .db file), joins when one is.
+        OVN_CTL_OPTS="--db-nb-cluster-local-addr=$DB_CLUSTER_LOCAL_ADDR --db-sb-cluster-local-addr=$DB_CLUSTER_LOCAL_ADDR"
+        if [ -n "$DB_CLUSTER_REMOTE_ADDR" ]; then
+            OVN_CTL_OPTS="$OVN_CTL_OPTS --db-nb-cluster-remote-addr=$DB_CLUSTER_REMOTE_ADDR --db-sb-cluster-remote-addr=$DB_CLUSTER_REMOTE_ADDR"
+            echo "  ovn-central: joining RAFT cluster (local=$DB_CLUSTER_LOCAL_ADDR remote=$DB_CLUSTER_REMOTE_ADDR)"
+        else
+            echo "  ovn-central: creating RAFT cluster (local=$DB_CLUSTER_LOCAL_ADDR)"
+        fi
+
+        echo "OVN_CTL_OPTS=\"$OVN_CTL_OPTS\"" | sudo tee /etc/default/ovn-central >/dev/null
+        echo "  wrote /etc/default/ovn-central"
+
+        # The ovn-central aggregator is ExecStart=/bin/true, so restarting it
+        # won't restart the children — restart the per-DB units directly to
+        # pick up the new OVN_CTL_OPTS.
+        sudo systemctl restart ovn-ovsdb-server-nb ovn-ovsdb-server-sb ovn-northd
+        echo "  ovn-central: started clustered (NB DB + SB DB + ovn-northd)"
+    else
+        sudo systemctl start ovn-central
+        echo "  ovn-central: started (NB DB + SB DB + ovn-northd)"
+    fi
 
     # Wait for OVN NB DB socket to become available
     for i in $(seq 1 15); do
@@ -258,11 +327,15 @@ if [ "$MANAGEMENT" = true ]; then
         sleep 1
     done
 
-    # Allow remote connections to NB and SB databases
-    sudo ovn-nbctl set-connection ptcp:6641
-    sudo ovn-sbctl set-connection ptcp:6642
-    echo "  OVN NB DB listening on tcp:6641"
-    echo "  OVN SB DB listening on tcp:6642"
+    # Set the NB/SB client listen addresses. set-connection writes through RAFT
+    # (replicated cluster-wide), so it only runs on the create node — a joining
+    # node would redirect to the leader, which the init node already configured.
+    if [ -z "$DB_CLUSTER_REMOTE_ADDR" ]; then
+        sudo ovn-nbctl set-connection ptcp:6641
+        sudo ovn-sbctl set-connection ptcp:6642
+        echo "  OVN NB DB listening on tcp:6641"
+        echo "  OVN SB DB listening on tcp:6642"
+    fi
 fi
 
 # --- Step 3: Create and configure br-int ---

--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -116,10 +116,25 @@ type ViperblockConfig struct {
 
 // VPCDConfig holds the VPC daemon (vpcd) configuration.
 type VPCDConfig struct {
-	OVNNBAddr         string `json:"OVNNBAddr" mapstructure:"ovn_nb_addr"`                // OVN Northbound DB address (e.g., "tcp:127.0.0.1:6641")
-	OVNSBAddr         string `json:"OVNSBAddr" mapstructure:"ovn_sb_addr"`                // OVN Southbound DB address (e.g., "tcp:127.0.0.1:6642")
+	OVNNBAddr         string `json:"OVNNBAddr" mapstructure:"ovn_nb_addr"`                // OVN Northbound DB address; comma-separated list for a RAFT cluster (e.g., "tcp:127.0.0.1:6641" or "tcp:ip1:6641,tcp:ip2:6641,tcp:ip3:6641")
+	OVNSBAddr         string `json:"OVNSBAddr" mapstructure:"ovn_sb_addr"`                // OVN Southbound DB address; comma-separated list for a RAFT cluster (e.g., "tcp:127.0.0.1:6642" or "tcp:ip1:6642,tcp:ip2:6642,tcp:ip3:6642")
 	ExternalInterface string `json:"ExternalInterface" mapstructure:"external_interface"` // WAN NIC name (e.g., "eth1", "enp0s3") — the physical NIC on the WAN bridge
 	BridgeMode        string `json:"BridgeMode" mapstructure:"bridge_mode"`               // "direct" or "veth" (auto-detected if empty)
+}
+
+// ParseEndpoints splits a comma-separated OVSDB endpoint list (NB/SB RAFT
+// cluster) into individual endpoints, trimming whitespace and dropping empties.
+// A single endpoint yields a one-element slice; empty input yields nil. Both the
+// libovsdb NB client (one WithEndpoint each) and ovn-sbctl --db= (which also
+// accepts the raw comma list) consume the cluster form.
+func ParseEndpoints(addr string) []string {
+	var out []string
+	for p := range strings.SplitSeq(addr, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 type PredastoreConfig struct {

--- a/spinifex/config/config_test.go
+++ b/spinifex/config/config_test.go
@@ -783,3 +783,24 @@ shardwal = true
 	require.NotNil(t, n.Viperblock.ShardWAL)
 	assert.True(t, *n.Viperblock.ShardWAL)
 }
+
+func TestParseEndpoints(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "tcp:127.0.0.1:6641", []string{"tcp:127.0.0.1:6641"}},
+		{"cluster", "tcp:ip1:6641,tcp:ip2:6641,tcp:ip3:6641",
+			[]string{"tcp:ip1:6641", "tcp:ip2:6641", "tcp:ip3:6641"}},
+		{"whitespace and trailing comma", " tcp:ip1:6641 , tcp:ip2:6641 ,",
+			[]string{"tcp:ip1:6641", "tcp:ip2:6641"}},
+		{"only commas", ",,", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ParseEndpoints(tc.in))
+		})
+	}
+}

--- a/spinifex/formation/helpers.go
+++ b/spinifex/formation/helpers.go
@@ -1,10 +1,23 @@
 package formation
 
 import (
+	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/mulgadc/spinifex/spinifex/admin"
+)
+
+// ovnDBQuorum is the number of nodes that host the clustered OVN NB/SB
+// databases. The first ovnDBQuorum nodes (by sorted name) form the RAFT
+// quorum; every other node is OVN compute-only and dials these endpoints.
+const ovnDBQuorum = 3
+
+// OVN database client ports served by each RAFT quorum node.
+const (
+	ovnNBPort = 6641
+	ovnSBPort = 6642
 )
 
 // hasService reports whether the node's service list includes name.
@@ -55,6 +68,24 @@ func BuildPredastoreNodes(nodes map[string]NodeInfo) []admin.PredastoreNodeConfi
 		}
 	}
 	return out
+}
+
+// BuildOVNDBAddrs returns comma-separated OVN NB and SB endpoint lists for the
+// RAFT quorum nodes (first ovnDBQuorum by sorted name). Every node — quorum and
+// compute alike — points its OVN client at the full list so libovsdb fails over
+// across the cluster. BindIP is the cross-node dial address.
+func BuildOVNDBAddrs(nodes map[string]NodeInfo) (nbAddr, sbAddr string) {
+	sorted := sortedNodes(nodes)
+	if len(sorted) > ovnDBQuorum {
+		sorted = sorted[:ovnDBQuorum]
+	}
+	nb := make([]string, len(sorted))
+	sb := make([]string, len(sorted))
+	for i, n := range sorted {
+		nb[i] = fmt.Sprintf("tcp:%s:%d", n.BindIP, ovnNBPort)
+		sb[i] = fmt.Sprintf("tcp:%s:%d", n.BindIP, ovnSBPort)
+	}
+	return strings.Join(nb, ","), strings.Join(sb, ",")
 }
 
 // sortedNodes returns nodes sorted by name.

--- a/spinifex/formation/helpers_test.go
+++ b/spinifex/formation/helpers_test.go
@@ -73,6 +73,32 @@ func TestBuildPredastoreNodes_EmptyServicesIncludesAll(t *testing.T) {
 	require.Len(t, pnodes, 3)
 }
 
+func TestBuildOVNDBAddrs_CapsAtQuorum(t *testing.T) {
+	t.Parallel()
+	nodes := map[string]NodeInfo{
+		"node1": {Name: "node1", BindIP: "10.0.0.1"},
+		"node2": {Name: "node2", BindIP: "10.0.0.2"},
+		"node3": {Name: "node3", BindIP: "10.0.0.3"},
+		"node4": {Name: "node4", BindIP: "10.0.0.4"},
+	}
+
+	nb, sb := BuildOVNDBAddrs(nodes)
+	assert.Equal(t, "tcp:10.0.0.1:6641,tcp:10.0.0.2:6641,tcp:10.0.0.3:6641", nb)
+	assert.Equal(t, "tcp:10.0.0.1:6642,tcp:10.0.0.2:6642,tcp:10.0.0.3:6642", sb)
+}
+
+func TestBuildOVNDBAddrs_FewerThanQuorum(t *testing.T) {
+	t.Parallel()
+	nodes := map[string]NodeInfo{
+		"node1": {Name: "node1", BindIP: "10.0.0.1"},
+		"node2": {Name: "node2", BindIP: "10.0.0.2"},
+	}
+
+	nb, sb := BuildOVNDBAddrs(nodes)
+	assert.Equal(t, "tcp:10.0.0.1:6641,tcp:10.0.0.2:6641", nb)
+	assert.Equal(t, "tcp:10.0.0.1:6642,tcp:10.0.0.2:6642", sb)
+}
+
 func TestBuildClusterRoutes_MixedServicesAndEmpty(t *testing.T) {
 	t.Parallel()
 	nodes := map[string]NodeInfo{

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
 	"github.com/ovn-kubernetes/libovsdb/client"
 	"github.com/ovn-kubernetes/libovsdb/model"
@@ -124,10 +125,19 @@ func (c *LiveClient) Connect(ctx context.Context) error {
 		backoff.WithMaxElapsedTime(0),
 		backoff.WithMaxInterval(reconnectMaxInterval),
 	)
-	ovn, err := client.NewOVSDBClient(dbModel,
-		client.WithEndpoint(c.endpoint),
-		client.WithInactivityCheck(inactivityTimeout, reconnectTimeout, bo),
-	)
+	// One WithEndpoint per RAFT cluster member; libovsdb tries them in order,
+	// fails over on disconnect, and follows leader redirects. A single-endpoint
+	// string yields one endpoint (single-node dev, backward compatible).
+	endpoints := config.ParseEndpoints(c.endpoint)
+	if len(endpoints) == 0 {
+		endpoints = []string{c.endpoint}
+	}
+	opts := make([]client.Option, 0, len(endpoints)+1)
+	for _, ep := range endpoints {
+		opts = append(opts, client.WithEndpoint(ep))
+	}
+	opts = append(opts, client.WithInactivityCheck(inactivityTimeout, reconnectTimeout, bo))
+	ovn, err := client.NewOVSDBClient(dbModel, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create OVSDB client: %w", err)
 	}

--- a/tests/e2e/multinode/ovn_raft_test.go
+++ b/tests/e2e/multinode/ovn_raft_test.go
@@ -1,0 +1,155 @@
+//go:build e2e
+
+package multinode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ovnNBSock   = "/var/run/ovn/ovnnb_db.ctl"
+	ovnSBSock   = "/var/run/ovn/ovnsb_db.ctl"
+	ovnNBSchema = "OVN_Northbound"
+	ovnSBSchema = "OVN_Southbound"
+)
+
+// runOVNRaft asserts the clustered OVN control plane: every DB node's NB and SB
+// RAFT cluster reports the full quorum with exactly one leader, then kills the
+// NB leader's ovn-central and proves NB writes still land via a surviving
+// endpoint (libovsdb-style multi-endpoint failover, here through ovn-nbctl).
+func runOVNRaft(t *testing.T, fix *Fixture) {
+	harness.Phase(t, "Multinode — OVN OVSDB RAFT")
+
+	require.GreaterOrEqualf(t, len(fix.Cluster.Nodes), 3,
+		"OVN RAFT quorum requires a 3-node cluster, have %d", len(fix.Cluster.Nodes))
+	// The first three nodes host the clustered NB/SB DBs (mirrors
+	// formation.BuildOVNDBAddrs); in a 3-node cluster that is every node.
+	dbNodes := fix.Cluster.Nodes[:3]
+	ssh := harness.NewPeerSSH()
+
+	// 1. Quorum health: 3 servers + exactly one leader, per schema, per node.
+	for _, db := range []struct{ name, sock, schema string }{
+		{"NB", ovnNBSock, ovnNBSchema},
+		{"SB", ovnSBSock, ovnSBSchema},
+	} {
+		leaders := 0
+		for _, n := range dbNodes {
+			harness.Step(t, "%s cluster/status on %s (%s)", db.name, n.Name, n.Addr)
+			servers, role := ovnClusterStatus(t, ssh, n, db.sock, db.schema)
+			harness.Detail(t, fmt.Sprintf("%s_%s_servers", db.name, n.Name), servers)
+			harness.Detail(t, fmt.Sprintf("%s_%s_role", db.name, n.Name), role)
+			require.Equalf(t, 3, servers, "%s on %s: want 3 servers in quorum", db.name, n.Name)
+			if role == "leader" {
+				leaders++
+			}
+		}
+		require.Equalf(t, 1, leaders, "%s: want exactly one leader across the quorum", db.name)
+	}
+
+	// 2. Failover: kill the NB leader and confirm an NB write still succeeds.
+	var leader harness.Node
+	var survivors []harness.Node
+	for _, n := range dbNodes {
+		if _, role := ovnClusterStatus(t, ssh, n, ovnNBSock, ovnNBSchema); role == "leader" {
+			leader = n
+		} else {
+			survivors = append(survivors, n)
+		}
+	}
+	require.NotEmptyf(t, leader.Name, "no NB leader found across quorum")
+	require.NotEmptyf(t, survivors, "no surviving DB node to write through")
+
+	harness.Step(t, "stop ovn-central on NB leader %s (%s)", leader.Name, leader.Addr)
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer stopCancel()
+	_, err := ssh.Run(stopCtx, leader.Addr,
+		"sudo systemctl stop ovn-central ovn-ovsdb-server-nb ovn-ovsdb-server-sb ovn-northd")
+	require.NoErrorf(t, err, "stop ovn-central on %s", leader.Name)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if _, e := ssh.Run(ctx, leader.Addr,
+			"sudo systemctl start ovn-ovsdb-server-nb ovn-ovsdb-server-sb ovn-northd"); e != nil {
+			t.Logf("cleanup: restart ovn-central on %s: %v", leader.Name, e)
+		}
+	})
+
+	// The --db list includes the dead leader so the write must fail over past it.
+	dbList := nbEndpointList(dbNodes)
+	sw := fmt.Sprintf("e2e-raft-failover-%d", time.Now().Unix())
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		_, _ = ssh.Run(ctx, survivors[0].Addr,
+			fmt.Sprintf("sudo ovn-nbctl --db=%s --timeout=10 --if-exists ls-del %s", dbList, sw))
+	})
+
+	harness.Step(t, "NB write (ls-add %s) via %s after leader loss", sw, survivors[0].Name)
+	// RAFT re-election after the leader drops takes a beat; retry the write
+	// until a new leader accepts it or the deadline passes.
+	var writeErr error
+	deadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+		_, writeErr = ssh.Run(ctx, survivors[0].Addr,
+			fmt.Sprintf("sudo ovn-nbctl --db=%s --timeout=20 ls-add %s", dbList, sw))
+		cancel()
+		if writeErr == nil {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+	require.NoErrorf(t, writeErr, "NB ls-add via surviving endpoint after leader %s loss", leader.Name)
+
+	harness.Step(t, "confirm %s is present in NB via surviving endpoint", sw)
+	readCtx, readCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer readCancel()
+	out, err := ssh.Run(readCtx, survivors[0].Addr,
+		fmt.Sprintf("sudo ovn-nbctl --db=%s --timeout=15 ls-list", dbList))
+	require.NoError(t, err, "NB ls-list via surviving endpoint")
+	require.Containsf(t, string(out), sw, "switch %s not visible after failover write", sw)
+}
+
+// ovnClusterStatus runs cluster/status for one schema on a node and returns the
+// reported server count and the queried server's role.
+func ovnClusterStatus(t *testing.T, ssh *harness.PeerSSH, n harness.Node, sock, schema string) (servers int, role string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	out, err := ssh.Run(ctx, n.Addr, fmt.Sprintf("sudo ovn-appctl -t %s cluster/status %s", sock, schema))
+	require.NoErrorf(t, err, "cluster/status %s on %s", schema, n.Name)
+	return parseClusterStatus(string(out))
+}
+
+// parseClusterStatus extracts the quorum size and this server's role from
+// ovs cluster/status output. Each member appears as a "<id> at tcp:<addr>" line
+// under Servers:; the "Role:" header reports the queried server's own role.
+func parseClusterStatus(out string) (servers int, role string) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Role:") {
+			role = strings.TrimSpace(strings.TrimPrefix(line, "Role:"))
+		}
+		if strings.Contains(line, " at tcp:") {
+			servers++
+		}
+	}
+	return servers, role
+}
+
+// nbEndpointList builds the comma-separated NB client endpoint list used by
+// ovn-nbctl --db across the given DB nodes.
+func nbEndpointList(nodes []harness.Node) string {
+	eps := make([]string, len(nodes))
+	for i, n := range nodes {
+		eps[i] = fmt.Sprintf("tcp:%s:6641", n.Addr)
+	}
+	return strings.Join(eps, ",")
+}

--- a/tests/e2e/multinode/tests_test.go
+++ b/tests/e2e/multinode/tests_test.go
@@ -75,6 +75,12 @@ func TestMultinodeNodeRecovery(t *testing.T) {
 	runNodeRecovery(t, requireMultiNodeFixture(t))
 }
 
+// TestMultinodeOVNRaft is sequential: stops ovn-central on the NB leader to
+// prove DB failover, restoring it in cleanup before later tests run.
+func TestMultinodeOVNRaft(t *testing.T) {
+	runOVNRaft(t, requireMultiNodeFixture(t))
+}
+
 // TestMultinodeSpread is sequential after NodeRecovery; owns 10.100.0.0/16 + EIP pool.
 func TestMultinodeSpread(t *testing.T) {
 	runSpread(t, requireMultiNodeFixture(t))


### PR DESCRIPTION
Epic **mulga-siv-486** — replicate the OVN NB/SB databases across a multinode cluster via native OVSDB RAFT (3-node quorum), removing the init host as a single point of failure for the OVN control plane.

All phases land on this branch (`feat/ovn-raft`). Provisioning changes (bm-bootstrap, ansible dev wrapper, plan doc) live in the mulga repo.

## Design

The prod provisioning path is primary: the provisioning layer (`bm-bootstrap.sh` / firstboot) owns `setup-ovn.sh` invocation with cluster flags, and `spx admin init/join` writes each node's multi-endpoint OVN NB/SB config. The DB quorum is the first three nodes by byte-order-sorted node name — selected identically by `bm-bootstrap.sh`, `formation.BuildOVNDBAddrs`, and the ansible dev wrapper, so all three agree on which nodes host the DBs. Ansible carries no bespoke RAFT logic; it calls the same `setup-ovn.sh` primitive.

## Phases

- [x] **A — `setup-ovn.sh` cluster primitives** (mulga-siv-487): `--db-cluster-local-addr`/`--db-cluster-remote-addr` flags; clustered NB(6643)/SB(6644) via `/etc/default/ovn-central` `OVN_CTL_OPTS`; restart per-DB units; single-node path unchanged.
- [x] **B — prod + dev provisioning pass cluster flags** (mulga-siv-488): `bm-bootstrap.sh` selects the sorted quorum and runs create/join cluster flags (compute-only `--ovn-remote` on the rest), wiping stale `.db`; `firstboot.go` defers OVN bring-up under `SkipFormation`; ansible `cluster-bootstrap.yml` mirrors the same selection. *(mulga repo)*
- [x] **C — Go OVN client multi-endpoint failover** (mulga-siv-489): `config.ParseEndpoints` + one libovsdb `WithEndpoint` per endpoint plus `WithInactivityCheck` reconnect in `live.go`; `ovn-sbctl --db=` comma passthrough for SB CLI consumers.
- [x] **D — config gen: emit clustered NB/SB endpoint lists** (mulga-siv-490): `formation.BuildOVNDBAddrs` returns the comma-separated NB/SB lists for the first three quorum nodes; `runAdminInitMultiNode` + `runAdminJoin` write them instead of loopback / single-leader.
- [x] **E — multinode RAFT e2e + docs** (mulga-siv-491): `tests/e2e/multinode/ovn_raft_test.go` asserts a 3-server NB/SB quorum with one leader, then kills the NB leader and proves an NB write lands via a surviving endpoint; vpc-networking + network-connections docs updated with the clustered topology and 6643/6644 ports.

See `docs/development/archive/feature/ovn-ovsdb-raft-clustering.md` (mulga repo).

## Testing

- `make preflight` green. Unit: `ParseEndpoints`, `BuildOVNDBAddrs` (caps at quorum / fewer-than-quorum), firstboot defers/runs OVN by `SkipFormation`.
- **Verified end-to-end on env19** (3-node tofu, full re-bootstrap): NB+SB `cluster/status` reported 3 servers with a single leader (the name-sorted-first node); every node's `spinifex.toml` carried the identical 3-endpoint list; killing the NB leader's `ovn-central` triggered a re-election and an `ovn-nbctl` write via the surviving endpoints succeeded and replicated.
