### PR TITLE
feat(eks): multinode control-plane + IMDS/token-webhook CP fixes (426/427/428/495/496)

### DIFF
--- a/.github/actions/e2e-analyze/analyze.go
+++ b/.github/actions/e2e-analyze/analyze.go
@@ -1,7 +1,6 @@
 // Package main implements the e2e-analyze GitHub Action.
 //
-// Stage 1 of docs/development/improvements/e2e-go-failure-analysis.md:
-// cluster failures from go-junit-report's junit-*.xml by error signature,
+// Stage 1: cluster failures from go-junit-report's junit-*.xml by error signature,
 // pick the earliest non-cascade failure per suite as the likely root cause,
 // and render a human-readable report.
 //
@@ -463,8 +462,7 @@ func ParseFile(path string, data []byte) (SuiteReport, error) {
 	return rep, nil
 }
 
-// Render writes the markdown report. Format is documented in
-// docs/development/improvements/e2e-go-failure-analysis.md (Stage 1).
+// Render writes the markdown report (Stage 1).
 func Render(r Report) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## %s\n\n", r.Title)

--- a/.github/actions/e2e-analyze/bundle.go
+++ b/.github/actions/e2e-analyze/bundle.go
@@ -1,7 +1,6 @@
 package main
 
-// Stage 2 of docs/development/improvements/e2e-go-failure-analysis.md:
-// for each failure surfaced by Stage 1, materialise a per-failure bundle
+// Stage 2: for each failure surfaced by Stage 1, materialise a per-failure bundle
 // directory containing the failure summary, a time-window slice of the
 // daemon journal, a testcase-window slice of the suite's stdout log, and
 // any per-test artifacts the harness already dumped at run-time.

--- a/.github/actions/e2e-analyze/slice.go
+++ b/.github/actions/e2e-analyze/slice.go
@@ -1,7 +1,6 @@
 package main
 
-// Stage 2 of docs/development/improvements/e2e-go-failure-analysis.md:
-// per-failure log slicers used by bundle.go to materialise time-window /
+// Stage 2: per-failure log slicers used by bundle.go to materialise time-window /
 // testcase-window log excerpts next to each named failure.
 
 import (

--- a/cmd/eks-konnectivity-cert/main.go
+++ b/cmd/eks-konnectivity-cert/main.go
@@ -1,0 +1,245 @@
+// Command eks-konnectivity-cert mints, then reuses, an ECDSA-P256 serving
+// certificate for the on-node konnectivity-server, signed by the K3s cluster CA.
+//
+// The konnectivity-agent (DaemonSet on workers) verifies the server it dials
+// using the in-pod ServiceAccount CA (/var/run/secrets/.../ca.crt), which in
+// K3s is the same server-ca that signs the apiserver. Signing the konnectivity
+// serving cert with that CA is therefore what lets the agent validate the
+// reverse-tunnel endpoint with no separate CA distribution.
+//
+// The eks-node AMI carries no openssl, so this is the Go equivalent: load the
+// K3s server CA cert+key, issue a leaf (ServerAuth) cert carrying the cluster's
+// konnectivity SANs (the NLB private-endpoint IP, public endpoint IP, NLB DNS),
+// and cache it under -dir so the OpenRC service is byte-stable across restarts.
+//
+// Usage:
+//
+//	eks-konnectivity-cert -dir /var/lib/spinifex-eks/konnectivity \
+//	    -ca-cert /var/lib/rancher/k3s/server/tls/server-ca.crt \
+//	    -ca-key  /var/lib/rancher/k3s/server/tls/server-ca.key \
+//	    -cn konnectivity-server -sans 10.32.100.4,203.0.113.9,eks-toc.example
+//
+// Writes <dir>/tls.crt and <dir>/tls.key; prints the two paths (tab-separated).
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func main() {
+	dir := flag.String("dir", "", "directory to cache tls.crt/tls.key in")
+	caCert := flag.String("ca-cert", "", "PEM path of the signing (K3s server) CA cert")
+	caKey := flag.String("ca-key", "", "PEM path of the signing CA private key")
+	cn := flag.String("cn", "konnectivity-server", "certificate common name")
+	sansCSV := flag.String("sans", "", "comma-separated SANs (IP or DNS)")
+	flag.Parse()
+
+	if *dir == "" || *caCert == "" || *caKey == "" || *sansCSV == "" {
+		fatal("eks-konnectivity-cert: -dir, -ca-cert, -ca-key and -sans are required")
+	}
+	dns, ips := splitSANs(*sansCSV)
+	if len(dns) == 0 && len(ips) == 0 {
+		fatal("eks-konnectivity-cert: -sans lists no usable names")
+	}
+
+	certPath, keyPath, err := ensureCert(*dir, *caCert, *caKey, *cn, dns, ips)
+	if err != nil {
+		fatal("eks-konnectivity-cert: " + err.Error())
+	}
+	fmt.Printf("%s\t%s\n", certPath, keyPath)
+}
+
+// ensureCert returns the cached cert/key paths under dir, minting and persisting
+// a fresh CA-signed pair when none is present, readable, and still SAN-current.
+func ensureCert(dir, caCertPath, caKeyPath, cn string, dns []string, ips []net.IP) (string, string, error) {
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+
+	if certCoversSANs(certPath, keyPath, dns, ips) {
+		return certPath, keyPath, nil
+	}
+
+	caCert, caKey, err := loadCA(caCertPath, caKeyPath)
+	if err != nil {
+		return "", "", err
+	}
+	certPEM, keyPEM, err := issueLeaf(caCert, caKey, cn, dns, ips)
+	if err != nil {
+		return "", "", err
+	}
+	if err = os.MkdirAll(dir, 0o700); err != nil {
+		return "", "", fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	if err = os.WriteFile(certPath, certPEM, 0o644); err != nil {
+		return "", "", fmt.Errorf("write %s: %w", certPath, err)
+	}
+	if err = os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		return "", "", fmt.Errorf("write %s: %w", keyPath, err)
+	}
+	return certPath, keyPath, nil
+}
+
+// certCoversSANs reports whether the cached cert exists, parses, has a key, and
+// already carries every requested SAN — so a cert minted before the endpoint
+// set changed is re-issued rather than served stale.
+func certCoversSANs(certPath, keyPath string, dns []string, ips []net.IP) bool {
+	c, err := os.ReadFile(certPath)
+	if err != nil {
+		return false
+	}
+	if k, kerr := os.ReadFile(keyPath); kerr != nil || len(k) == 0 {
+		return false
+	}
+	der := decodeFirst(c)
+	if der == nil {
+		return false
+	}
+	crt, err := x509.ParseCertificate(der)
+	if err != nil {
+		return false
+	}
+	have := make(map[string]struct{}, len(crt.DNSNames)+len(crt.IPAddresses))
+	for _, n := range crt.DNSNames {
+		have[n] = struct{}{}
+	}
+	for _, ip := range crt.IPAddresses {
+		have[ip.String()] = struct{}{}
+	}
+	for _, n := range dns {
+		if _, ok := have[n]; !ok {
+			return false
+		}
+	}
+	for _, ip := range ips {
+		if _, ok := have[ip.String()]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// loadCA parses the PEM CA cert + EC/PKCS8 private key used to sign the leaf.
+func loadCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read ca cert %s: %w", certPath, err)
+	}
+	der := decodeFirst(certPEM)
+	if der == nil {
+		return nil, nil, fmt.Errorf("ca cert %s: no PEM block", certPath)
+	}
+	caCert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse ca cert: %w", err)
+	}
+
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read ca key %s: %w", keyPath, err)
+	}
+	keyDER := decodeFirst(keyPEM)
+	if keyDER == nil {
+		return nil, nil, fmt.Errorf("ca key %s: no PEM block", keyPath)
+	}
+	caKey, err := parseECKey(keyDER)
+	if err != nil {
+		return nil, nil, err
+	}
+	return caCert, caKey, nil
+}
+
+// parseECKey accepts the EC SEC1 or PKCS8 encodings K3s may write for the CA key.
+func parseECKey(der []byte) (*ecdsa.PrivateKey, error) {
+	if k, err := x509.ParseECPrivateKey(der); err == nil {
+		return k, nil
+	}
+	k8, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("parse ca key (sec1 and pkcs8 failed): %w", err)
+	}
+	ec, ok := k8.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("ca key is %T, want ecdsa", k8)
+	}
+	return ec, nil
+}
+
+// issueLeaf mints an ECDSA-P256 ServerAuth leaf for cn + SANs, signed by caCert/caKey.
+func issueLeaf(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, dns []string, ips []net.IP) (certPEM, keyPEM []byte, err error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate key: %w", err)
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("serial: %w", err)
+	}
+	now := time.Now().UTC()
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              dns,
+		IPAddresses:           ips,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, caCert, &priv.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create cert: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal key: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}
+
+// splitSANs partitions the CSV into DNS names and IPs (an entry that parses as an
+// IP goes to IPAddresses, else DNSNames), matching how SAN matching is typed.
+func splitSANs(s string) (dns []string, ips []net.IP) {
+	for p := range strings.SplitSeq(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if ip := net.ParseIP(p); ip != nil {
+			ips = append(ips, ip)
+			continue
+		}
+		dns = append(dns, p)
+	}
+	return dns, ips
+}
+
+// decodeFirst returns the DER bytes of the first PEM block, or nil.
+func decodeFirst(pemBytes []byte) []byte {
+	blk, _ := pem.Decode(pemBytes)
+	if blk == nil {
+		return nil
+	}
+	return blk.Bytes
+}
+
+func fatal(msg string) {
+	slog.Error(msg)
+	os.Exit(1)
+}

--- a/cmd/eks-konnectivity-cert/main_test.go
+++ b/cmd/eks-konnectivity-cert/main_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestCA mints a self-signed EC CA (cert + SEC1 key PEM) into dir, returning
+// the two paths — a stand-in for K3s' /var/lib/rancher/k3s/server/tls/server-ca.*.
+func writeTestCA(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ca key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "k3s-server-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create ca cert: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal ca key: %v", err)
+	}
+	certPath = filepath.Join(dir, "server-ca.crt")
+	keyPath = filepath.Join(dir, "server-ca.key")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o644); err != nil {
+		t.Fatalf("write ca cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatalf("write ca key: %v", err)
+	}
+	return certPath, keyPath
+}
+
+func leafFrom(t *testing.T, certPath string) *x509.Certificate {
+	t.Helper()
+	b, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read leaf: %v", err)
+	}
+	crt, err := x509.ParseCertificate(decodeFirst(b))
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return crt
+}
+
+func TestEnsureCertSignsLeafWithSANsThatChainsToCA(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := writeTestCA(t, dir)
+
+	dns, ips := splitSANs("10.32.100.4,203.0.113.9,eks-toc.example")
+	certPath, keyPath, err := ensureCert(dir, caCert, caKey, "konnectivity-server", dns, ips)
+	if err != nil {
+		t.Fatalf("ensureCert: %v", err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key not written: %v", err)
+	}
+
+	leaf := leafFrom(t, certPath)
+	if leaf.IsCA {
+		t.Error("konnectivity serving cert must be a leaf, not a CA")
+	}
+	// The agent dials the NLB private-endpoint IP and verifies via the in-pod CA,
+	// so the IP must be a SAN or the tunnel TLS handshake fails.
+	if err := leaf.VerifyHostname("10.32.100.4"); err != nil {
+		t.Errorf("IP SAN 10.32.100.4 missing: %v", err)
+	}
+
+	// The leaf must chain to the K3s server CA — that CA is the in-pod ca.crt the
+	// agent trusts, so no separate CA distribution is needed.
+	caPEM, _ := os.ReadFile(caCert)
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("append CA failed")
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		DNSName:   "eks-toc.example",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Errorf("leaf does not chain to the K3s server CA: %v", err)
+	}
+}
+
+func TestEnsureCertReusesThenReissuesOnSANChange(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := writeTestCA(t, dir)
+
+	dns, ips := splitSANs("10.32.100.4,eks-toc.example")
+	c1, _, err := ensureCert(dir, caCert, caKey, "konnectivity-server", dns, ips)
+	if err != nil {
+		t.Fatalf("first ensureCert: %v", err)
+	}
+	first, _ := os.ReadFile(c1)
+
+	// Same SANs → cached pair reused byte-for-byte (a churning cert would bounce
+	// the konnectivity-server on every restart).
+	if _, _, err := ensureCert(dir, caCert, caKey, "konnectivity-server", dns, ips); err != nil {
+		t.Fatalf("second ensureCert: %v", err)
+	}
+	if second, _ := os.ReadFile(c1); string(first) != string(second) {
+		t.Error("ensureCert re-minted instead of reusing the SAN-current cached cert")
+	}
+
+	// A new endpoint in the SAN set must force a re-issue.
+	dns2, ips2 := splitSANs("10.32.100.4,eks-toc.example,10.32.100.99")
+	if _, _, err := ensureCert(dir, caCert, caKey, "konnectivity-server", dns2, ips2); err != nil {
+		t.Fatalf("third ensureCert: %v", err)
+	}
+	if third, _ := os.ReadFile(c1); string(first) == string(third) {
+		t.Error("ensureCert served a stale cert that does not cover the new SAN")
+	}
+	if err := leafFrom(t, c1).VerifyHostname("10.32.100.99"); err != nil {
+		t.Errorf("re-issued cert missing new SAN: %v", err)
+	}
+}
+
+func TestSplitSANsPartitionsIPsAndDNS(t *testing.T) {
+	dns, ips := splitSANs(" 10.0.0.1 , host.example , , 2001:db8::1 ")
+	if len(dns) != 1 || dns[0] != "host.example" {
+		t.Errorf("dns = %v, want [host.example]", dns)
+	}
+	wantIPs := []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("2001:db8::1")}
+	if len(ips) != len(wantIPs) {
+		t.Fatalf("ips = %v, want %v", ips, wantIPs)
+	}
+	for i, ip := range ips {
+		if !ip.Equal(wantIPs[i]) {
+			t.Errorf("ips[%d] = %v, want %v", i, ip, wantIPs[i])
+		}
+	}
+}

--- a/cmd/eks-token-webhook/main.go
+++ b/cmd/eks-token-webhook/main.go
@@ -10,6 +10,9 @@
 // On startup it writes the apiserver webhook kubeconfig (with its self-signed
 // serving CA) so k3s can be pointed at it via
 // --authentication-token-webhook-config-file.
+//
+// SigV4 creds come from the AWS SDK chain (IMDS instance-role) when static
+// EKS_ACCESS_KEY/EKS_SECRET_KEY are absent, matching the sibling helpers.
 package main
 
 import (
@@ -56,11 +59,13 @@ func loadConfig() (config, error) {
 		keyPath:     envOr("EKS_WEBHOOK_KEY", "/etc/spinifex-eks/token-webhook.key"),
 		kubeconfig:  envOr("EKS_WEBHOOK_KUBECONFIG", "/etc/spinifex-eks/token-webhook.kubeconfig"),
 	}
+	// Static SigV4 creds are optional: when absent, eksgw.New signs with the
+	// AWS SDK chain (IMDS instance-role creds), the same path the CP VM's
+	// sibling helpers use. The CP VM launches on an instance profile, so
+	// buildK3sUserData omits EKS_ACCESS_KEY/EKS_SECRET_KEY by design.
 	switch {
 	case c.gatewayURL == "":
 		return c, errors.New("EKS_GATEWAY_URL not set")
-	case c.accessKey == "" || c.secretKey == "":
-		return c, errors.New("EKS_ACCESS_KEY / EKS_SECRET_KEY not set")
 	case c.accountID == "":
 		return c, errors.New("EKS_ACCOUNT_ID not set")
 	case c.clusterName == "":

--- a/cmd/eks-token-webhook/main_test.go
+++ b/cmd/eks-token-webhook/main_test.go
@@ -121,3 +121,41 @@ func TestWriteAPIServerKubeconfig(t *testing.T) {
 	assert.Contains(t, body, base64.StdEncoding.EncodeToString(certPEM))
 	assert.Contains(t, body, "current-context: webhook")
 }
+
+// The CP VM launches on an instance profile, so cloud-init omits the static
+// EKS_ACCESS_KEY/EKS_SECRET_KEY and eksgw.New signs with IMDS creds. loadConfig
+// must accept absent static keys; gating on them aborts every IMDS-mode boot,
+// leaving the apiserver webhook kubeconfig unwritten.
+func TestLoadConfig_AcceptsAbsentStaticCreds(t *testing.T) {
+	setEnv := func(t *testing.T, kv map[string]string) {
+		t.Helper()
+		for _, k := range []string{
+			"EKS_GATEWAY_URL", "EKS_ACCESS_KEY", "EKS_SECRET_KEY",
+			"EKS_ACCOUNT_ID", "EKS_CLUSTER_NAME",
+		} {
+			t.Setenv(k, "")
+		}
+		for k, v := range kv {
+			t.Setenv(k, v)
+		}
+	}
+
+	// IMDS mode: required vars set, static creds absent → accepted.
+	setEnv(t, map[string]string{
+		"EKS_GATEWAY_URL":  "https://gw:9999",
+		"EKS_ACCOUNT_ID":   "000000000001",
+		"EKS_CLUSTER_NAME": "toc",
+	})
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.accessKey)
+	assert.Empty(t, cfg.secretKey)
+
+	// Genuinely-required vars are still enforced.
+	setEnv(t, map[string]string{
+		"EKS_ACCOUNT_ID":   "000000000001",
+		"EKS_CLUSTER_NAME": "toc",
+	})
+	_, err = loadConfig()
+	require.Error(t, err)
+}

--- a/scripts/images/eks-node/coredns/coredns-mulga.yaml
+++ b/scripts/images/eks-node/coredns/coredns-mulga.yaml
@@ -1,10 +1,11 @@
 # Mulga-owned CoreDNS for the eks-node AMI. Replaces k3s's bundled CoreDNS
 # (suppressed via a coredns.yaml.skip marker staged by k3s.initd) so DNS is
 # node-local and never depends on the cross-node pod overlay: a DaemonSet runs
-# CoreDNS on every node and kube-dns uses internalTrafficPolicy=Local, so each
-# node resolves through its own CoreDNS. In the managed-control-plane topology
-# the worker<->CP overlay cannot cross the VPC boundary, so a CP-resident
-# CoreDNS is unreachable from worker pods.
+# CoreDNS on every worker node and kube-dns uses internalTrafficPolicy=Local, so
+# each worker resolves through its own CoreDNS. Mirroring AWS EKS, CoreDNS runs
+# on workers only (nodeAffinity excludes control-plane): the managed control
+# plane never hosts kube-dns, and the worker<->CP overlay cannot cross the VPC
+# boundary, so a CP-resident CoreDNS would be unreachable from worker pods.
 #
 # Faithful to k3s v1.32.5+k3s1 (image, Corefile, RBAC, Service) except the two
 # locality changes above. Refresh image/Corefile when bumping K3S_VERSION in
@@ -118,19 +119,20 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
-      # CriticalAddonsOnly (Exists, all effects) tolerates the CP's
-      # CriticalAddonsOnly=true:NoExecute taint so a CoreDNS pod also runs on
-      # the control-plane node; the control-plane/master tolerations cover any
-      # role taints. Required for full per-node coverage with internalTrafficPolicy=Local.
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      # AWS-EKS parity: CoreDNS runs on worker nodes only. The control plane is
+      # managed and never hosts kube-dns; each worker resolves through its own
+      # node's CoreDNS (internalTrafficPolicy=Local), so DNS never crosses the
+      # worker<->CP overlay boundary. No CP toleration is carried, and
+      # anti-control-plane nodeAffinity keeps the DaemonSet off the K3s server VMs.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
       nodeSelector:
         kubernetes.io/os: linux
       containers:

--- a/scripts/images/eks-node/eks-node-role.sh
+++ b/scripts/images/eks-node/eks-node-role.sh
@@ -53,6 +53,9 @@ case "${ROLE}" in
         log "configuring server role"
         rc-update add eks-token-webhook default
         rc-update add k3s default
+        # konnectivity-server fronts apiserver egress; every server replica runs
+        # one so the agent's per-replica tunnel always lands a live server.
+        rc-update add konnectivity-server default
         rc-update add k3s-first-boot default
         rc-update add mulga-eks-state-report default
         # Managed-addon delivery runs only on the primary server: it renders
@@ -62,6 +65,7 @@ case "${ROLE}" in
         rc-update add mulga-eks-addon-sync default
         rc-service eks-token-webhook start
         rc-service k3s start
+        rc-service konnectivity-server start
         rc-service k3s-first-boot start
         rc-service mulga-eks-state-report start
         rc-service mulga-eks-addon-sync start
@@ -70,9 +74,11 @@ case "${ROLE}" in
         log "configuring server-join role"
         rc-update add eks-token-webhook default
         rc-update add k3s default
+        rc-update add konnectivity-server default
         rc-update add mulga-eks-state-report default
         rc-service eks-token-webhook start
         rc-service k3s start
+        rc-service konnectivity-server start
         rc-service mulga-eks-state-report start
         ;;
     agent)

--- a/scripts/images/eks-node/eks-node-role_test.sh
+++ b/scripts/images/eks-node/eks-node-role_test.sh
@@ -63,6 +63,7 @@ check "server: enables webhook" "yes" "$(grep -q 'rc-update add eks-token-webhoo
 check "server: enables k3s" "yes" "$(grep -q 'rc-update add k3s default' "${CALLS}" && echo yes || echo no)"
 check "server: enables k3s-first-boot" "yes" "$(grep -q 'rc-update add k3s-first-boot default' "${CALLS}" && echo yes || echo no)"
 check "server: starts k3s" "yes" "$(grep -q 'rc-service k3s start' "${CALLS}" && echo yes || echo no)"
+check "server: enables konnectivity-server" "yes" "$(grep -q 'rc-update add konnectivity-server default' "${CALLS}" && echo yes || echo no)"
 check "server: no k3s-agent" "no" "$(grep -q 'k3s-agent' "${CALLS}" && echo yes || echo no)"
 check "server: self-disables" "yes" "$(grep -q 'rc-update del eks-node-role default' "${CALLS}" && echo yes || echo no)"
 
@@ -75,6 +76,7 @@ check "server-join: role file" "server-join" "$(cat "${ROLE_FILE}")"
 check "server-join: enables webhook" "yes" "$(grep -q 'rc-update add eks-token-webhook default' "${CALLS}" && echo yes || echo no)"
 check "server-join: enables k3s" "yes" "$(grep -q 'rc-update add k3s default' "${CALLS}" && echo yes || echo no)"
 check "server-join: enables state-report" "yes" "$(grep -q 'rc-update add mulga-eks-state-report default' "${CALLS}" && echo yes || echo no)"
+check "server-join: enables konnectivity-server" "yes" "$(grep -q 'rc-update add konnectivity-server default' "${CALLS}" && echo yes || echo no)"
 # Join servers must NOT re-publish bootstrap; the first server already did.
 check "server-join: no k3s-first-boot" "no" "$(grep -q 'k3s-first-boot' "${CALLS}" && echo yes || echo no)"
 check "server-join: no k3s-agent" "no" "$(grep -q 'k3s-agent' "${CALLS}" && echo yes || echo no)"

--- a/scripts/images/eks-node/k3s.initd
+++ b/scripts/images/eks-node/k3s.initd
@@ -8,6 +8,11 @@ command="/usr/local/bin/k3s"
 command_args="server --config /etc/rancher/k3s/config.yaml"
 pidfile="/run/k3s.pid"
 
+# Konnectivity agent image (apiserver-network-proxy). Pinned alongside the
+# konnectivity-server version baked by setup.sh; staged into the worker
+# DaemonSet by start_pre.
+KONN_AGENT_IMAGE="registry.k8s.io/kas-network-proxy/proxy-agent:v0.30.3"
+
 # Supervise the apiserver. A transient k3s crash must self-heal: without a
 # supervisor a single exit leaves the control plane permanently dead, the NLB
 # target never recovers, and the cluster wedges ACTIVE-but-unreachable.
@@ -31,6 +36,28 @@ start_pre() {
         else
             eerror "no /etc/rancher/k3s/config.yaml and no .skel to derive from"
             return 1
+        fi
+    fi
+
+    # Konnectivity agent: stage the worker-side DaemonSet into the auto-deploy dir
+    # (the apiserver `cluster` egress selector tunnels through konnectivity-server,
+    # which the agents dial out to). __KONN_HOST__ is the NLB endpoint agents reach,
+    # seeded by the launcher in first-boot.env; __KONN_AGENT_IMAGE__ is pinned here.
+    # The agent learns the apiserver replica count from the server handshake
+    # (--sync-forever), so no server-count token is substituted here. Guarded on
+    # the baked manifest so an older image without it simply skips the agent.
+    if [ -f /usr/share/spinifex-eks/konnectivity/konnectivity-agent.yaml ]; then
+        konn_host=$(awk -F= '/^EKS_KONNECTIVITY_HOST=/{print $2}' \
+            /etc/spinifex-eks/first-boot.env 2>/dev/null)
+        if [ -n "${konn_host}" ]; then
+            mkdir -p /var/lib/rancher/k3s/server/manifests
+            sed -e "s|__KONN_HOST__|${konn_host}|g" \
+                -e "s|__KONN_AGENT_IMAGE__|${KONN_AGENT_IMAGE}|g" \
+                /usr/share/spinifex-eks/konnectivity/konnectivity-agent.yaml \
+                > /var/lib/rancher/k3s/server/manifests/konnectivity-agent.yaml
+            einfo "konnectivity-agent staged (host ${konn_host})"
+        else
+            ewarn "EKS_KONNECTIVITY_HOST empty; konnectivity-agent not staged, apiserver->pod egress will fail"
         fi
     fi
 

--- a/scripts/images/eks-node/konnectivity-server.initd
+++ b/scripts/images/eks-node/konnectivity-server.initd
@@ -1,0 +1,94 @@
+#!/sbin/openrc-run
+# Konnectivity server (apiserver-network-proxy) — the apiserver egress proxy for
+# the Mulga EKS control plane. The kube-apiserver's `cluster` egress selector
+# (egress-selector-config.yaml) routes pod/kubelet/webhook traffic to this
+# server's UDS; konnectivity-agents on the workers dial in over :8132 and the
+# egress rides back down the agent-initiated reverse tunnel. Server-role only;
+# enabled by eks-node-role. Runs as root to bind the UDS the apiserver reads.
+
+description="Konnectivity server (Mulga EKS apiserver egress proxy)"
+
+KONN_DIR=/var/lib/spinifex-eks/konnectivity
+KONN_UDS=/run/konnectivity/konnectivity-server.socket
+ENVFILE=/etc/spinifex-eks/first-boot.env
+K3S_CA=/var/lib/rancher/k3s/server/tls/server-ca.crt
+K3S_CA_KEY=/var/lib/rancher/k3s/server/tls/server-ca.key
+KUBECONFIG_FILE=/etc/rancher/k3s/k3s.yaml
+
+# server-count is the apiserver replica count: each agent holds a tunnel to every
+# replica, so egress from any apiserver always resolves (the HA-correct fan-out).
+# Seeded by the launcher in first-boot.env; default 1 for a single control plane.
+_server_count=1
+if [ -f "${ENVFILE}" ]; then
+    _sc=$(awk -F= '/^EKS_KONNECTIVITY_SERVER_COUNT=/{print $2}' "${ENVFILE}")
+    [ -n "${_sc}" ] && _server_count="${_sc}"
+fi
+
+command="/usr/local/bin/konnectivity-server"
+command_args="--logtostderr=true
+ --uds-name=${KONN_UDS}
+ --delete-existing-uds-file
+ --cluster-cert=${KONN_DIR}/tls.crt
+ --cluster-key=${KONN_DIR}/tls.key
+ --server-count=${_server_count}
+ --mode=grpc
+ --server-port=0
+ --agent-port=8132
+ --admin-port=8093
+ --health-port=8092
+ --kubeconfig=${KUBECONFIG_FILE}
+ --authentication-audience=system:konnectivity-server
+ --agent-namespace=kube-system
+ --agent-service-account=konnectivity-agent
+ --proxy-strategies=destHost,default"
+pidfile="/run/konnectivity-server.pid"
+
+# Supervise: a transient exit must self-heal, or apiserver egress (webhooks,
+# exec, logs) stays broken until the next boot and the cluster wedges.
+supervisor="supervise-daemon"
+respawn_delay=5
+respawn_max=0
+output_log="/var/log/konnectivity-server.log"
+error_log="/var/log/konnectivity-server.log"
+
+depend() {
+    need net
+    after k3s
+}
+
+start_pre() {
+    mkdir -p /run/konnectivity "${KONN_DIR}"
+
+    # Wait for k3s to write the server CA (+ key) and admin kubeconfig: the CA
+    # signs the serving cert agents validate, the kubeconfig is the TokenReview
+    # client for agent SA-token auth. Bounded; without them konnectivity is inert.
+    i=0
+    while [ "${i}" -lt 120 ]; do
+        if [ -r "${K3S_CA}" ] && [ -r "${K3S_CA_KEY}" ] && [ -r "${KUBECONFIG_FILE}" ]; then
+            break
+        fi
+        i=$((i + 2))
+        sleep 2
+    done
+    if [ ! -r "${K3S_CA}" ] || [ ! -r "${K3S_CA_KEY}" ] || [ ! -r "${KUBECONFIG_FILE}" ]; then
+        eerror "k3s server CA / admin kubeconfig not present after ${i}s"
+        return 1
+    fi
+
+    # Mint (or reuse) the serving cert from the k3s server CA, SANed to the NLB
+    # endpoints agents dial. That CA is the in-pod ca.crt the agent already trusts,
+    # so no separate CA distribution is needed.
+    sans=""
+    if [ -f "${ENVFILE}" ]; then
+        sans=$(awk -F= '/^EKS_KONNECTIVITY_SANS=/{print $2}' "${ENVFILE}")
+    fi
+    if [ -z "${sans}" ]; then
+        eerror "EKS_KONNECTIVITY_SANS empty; agents would fail server cert validation"
+        return 1
+    fi
+    if ! eks-konnectivity-cert -dir "${KONN_DIR}" -ca-cert "${K3S_CA}" \
+            -ca-key "${K3S_CA_KEY}" -cn konnectivity-server -sans "${sans}" >/dev/null; then
+        eerror "failed to mint konnectivity serving cert"
+        return 1
+    fi
+}

--- a/scripts/images/eks-node/konnectivity/konnectivity-agent.yaml
+++ b/scripts/images/eks-node/konnectivity/konnectivity-agent.yaml
@@ -1,0 +1,89 @@
+# Konnectivity agent DaemonSet — the worker half of the apiserver egress proxy.
+# Each agent dials OUT to the konnectivity-server (fronted by the cluster NLB at
+# __KONN_HOST__:8132) and, via --sync-forever, opens a reverse tunnel to EVERY
+# apiserver replica (it learns the replica count from the server handshake).
+# apiserver→pod/kubelet/webhook egress rides back down that tunnel, so an HA
+# control plane reaches worker pod IPs with no L4-VIP fan-out gap. Staged into
+# the K3s auto-deploy dir by k3s.initd, which fills the __KONN_HOST__ /
+# __KONN_AGENT_IMAGE__ tokens at boot.
+#
+# Runs on workers only: it carries no toleration for the control-plane
+# CriticalAddonsOnly=true:NoExecute taint, so it is never scheduled onto the CP
+# nodes (which run the server, not an agent).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konnectivity-agent
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/managed-by: spinifex-eks
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: konnectivity-agent
+  namespace: kube-system
+  labels:
+    k8s-app: konnectivity-agent
+    app.kubernetes.io/managed-by: spinifex-eks
+spec:
+  selector:
+    matchLabels:
+      k8s-app: konnectivity-agent
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: konnectivity-agent
+    spec:
+      serviceAccountName: konnectivity-agent
+      priorityClassName: system-node-critical
+      # hostNetwork so the agent reaches the NLB over the node network and
+      # identifies itself to the server by the node's own IP (the address the
+      # apiserver dials back through for kubelet/pod egress).
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: konnectivity-agent
+          image: __KONN_AGENT_IMAGE__
+          command:
+            - /proxy-agent
+          args:
+            - --logtostderr=true
+            - --ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --proxy-server-host=__KONN_HOST__
+            - --proxy-server-port=8132
+            # proxy-agent v0.30.3 has no server-count flag — it learns the
+            # replica count from the server handshake and keeps re-syncing
+            # (sync-forever) until it holds a tunnel to every apiserver, which
+            # is what makes the HA control plane reachable.
+            - --sync-forever=true
+            - --service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token
+            - --agent-identifiers=ipv4=$(HOST_IP)
+            - --admin-server-port=8133
+            - --health-server-port=8134
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              host: 127.0.0.1
+              port: 8134
+              path: /healthz
+            initialDelaySeconds: 15
+            timeoutSeconds: 15
+          volumeMounts:
+            - name: konnectivity-agent-token
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+      volumes:
+        - name: konnectivity-agent-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: konnectivity-agent-token
+                  audience: system:konnectivity-server

--- a/scripts/images/eks-node/manifest.conf
+++ b/scripts/images/eks-node/manifest.conf
@@ -1,5 +1,5 @@
 IMAGE_NAME="eks-node"
-IMAGE_DESCRIPTION="Unified EKS K3s node VM — Alpine + K3s v1.32.5+k3s1 + eks-token-webhook; role (server|agent) chosen at first boot"
+IMAGE_DESCRIPTION="Unified EKS K3s node VM — Alpine + K3s v1.32.5+k3s1 + eks-token-webhook + konnectivity-server v0.30.3; role (server|agent) chosen at first boot"
 DISTRO="alpine"
 ALPINE_VERSION="3.21.7"
 
@@ -18,9 +18,13 @@ APK_PACKAGES="ca-certificates curl jq iptables ip6tables conntrack-tools cgroup-
 # eks-gateway-publish relays the bootstrap envelopes + state reports to the AWS
 # gateway over SigV4 HTTPS (server role only). The k3s binary is downloaded +
 # SHA256-verified by setup.sh (network in chroot).
-BUILD_COMMANDS="CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-token-webhook ./cmd/eks-token-webhook && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-gateway-publish ./cmd/eks-gateway-publish && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-gateway-fetch ./cmd/eks-gateway-fetch && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-webhook-cert ./cmd/eks-webhook-cert && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/ecr-credential-provider ./cmd/ecr-credential-provider"
+# konnectivity-server is built from the upstream apiserver-network-proxy source
+# at a pinned tag (its GitHub releases ship only container images, and its go.mod
+# carries replace directives that block `go install pkg@version`). The agent half
+# is the matching proxy-agent container image, pinned in k3s.initd.
+BUILD_COMMANDS="CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-token-webhook ./cmd/eks-token-webhook && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-gateway-publish ./cmd/eks-gateway-publish && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-gateway-fetch ./cmd/eks-gateway-fetch && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-webhook-cert ./cmd/eks-webhook-cert && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/eks-konnectivity-cert ./cmd/eks-konnectivity-cert && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/ecr-credential-provider ./cmd/ecr-credential-provider && rm -rf /tmp/anp-build && git clone --depth 1 --branch v0.30.3 https://github.com/kubernetes-sigs/apiserver-network-proxy /tmp/anp-build && ( cd /tmp/anp-build && CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o /tmp/anp-build/konnectivity-server ./cmd/server ) && cp /tmp/anp-build/konnectivity-server bin/konnectivity-server && rm -rf /tmp/anp-build"
 
-INSTALL_BINARIES="bin/eks-token-webhook:/usr/local/bin/eks-token-webhook bin/eks-gateway-publish:/usr/local/bin/eks-gateway-publish bin/eks-gateway-fetch:/usr/local/bin/eks-gateway-fetch bin/eks-webhook-cert:/usr/local/bin/eks-webhook-cert bin/ecr-credential-provider:/usr/local/bin/ecr-credential-provider"
+INSTALL_BINARIES="bin/eks-token-webhook:/usr/local/bin/eks-token-webhook bin/eks-gateway-publish:/usr/local/bin/eks-gateway-publish bin/eks-gateway-fetch:/usr/local/bin/eks-gateway-fetch bin/eks-webhook-cert:/usr/local/bin/eks-webhook-cert bin/eks-konnectivity-cert:/usr/local/bin/eks-konnectivity-cert bin/konnectivity-server:/usr/local/bin/konnectivity-server bin/ecr-credential-provider:/usr/local/bin/ecr-credential-provider"
 
 # All role services ship; none but the selector are enabled at bake time.
 # eks-node-role picks server vs agent at first boot and enables the rest.
@@ -36,12 +40,16 @@ scripts/images/eks-node/mulga-eks-state-report.initd:/etc/init.d/mulga-eks-state
 scripts/images/eks-node/mulga-eks-state-report.sh:/usr/local/sbin/mulga-eks-state-report \
 scripts/images/eks-node/mulga-eks-addon-sync.initd:/etc/init.d/mulga-eks-addon-sync \
 scripts/images/eks-node/mulga-eks-addon-sync.sh:/usr/local/sbin/mulga-eks-addon-sync \
+scripts/images/eks-node/konnectivity-server.initd:/etc/init.d/konnectivity-server \
+scripts/images/eks-node/konnectivity/konnectivity-agent.yaml:/usr/share/spinifex-eks/konnectivity/konnectivity-agent.yaml \
 scripts/images/eks-node/mulga-ebs-byid.initd:/etc/init.d/mulga-ebs-byid \
 scripts/images/eks-node/mulga-ebs-byid.sh:/usr/local/sbin/mulga-ebs-byid \
 scripts/images/eks-node/mulga-eks-provider-id.initd:/etc/init.d/mulga-eks-provider-id \
 scripts/images/eks-node/mulga-eks-provider-id.sh:/usr/local/sbin/mulga-eks-provider-id \
 scripts/images/eks-node/mulga-mgmt-net.initd:/etc/init.d/mulga-mgmt-net \
 scripts/images/eks-node/mulga-mgmt-net.sh:/usr/local/sbin/mulga-mgmt-net \
+scripts/images/eks-node/mulga-vpc-mtu.initd:/etc/init.d/mulga-vpc-mtu \
+scripts/images/eks-node/mulga-vpc-mtu.sh:/usr/local/sbin/mulga-vpc-mtu \
 scripts/images/eks-node/addons/spinifex-noop/0.1.0/noop.yaml:/usr/share/spinifex-eks/addons/spinifex-noop/0.1.0/noop.yaml \
 scripts/images/eks-node/addons/argocd/3.0.23/argocd.yaml:/usr/share/spinifex-eks/addons/argocd/3.0.23/argocd.yaml \
 scripts/images/eks-node/addons/aws-load-balancer-controller/2.11.0/00-crds.yaml:/usr/share/spinifex-eks/addons/aws-load-balancer-controller/2.11.0/00-crds.yaml \
@@ -61,7 +69,7 @@ scripts/images/eks-node/mulga-eks-etcd-snapshot.sh:/etc/periodic/daily/mulga-eks
 # netcfg blob). The selector adds the role-specific services
 # (k3s/eks-token-webhook/k3s-first-boot/state-report or k3s-agent) to the
 # default runlevel on first boot.
-ENABLE_SERVICES="crond eks-node-role mulga-ebs-byid mulga-eks-provider-id mulga-mgmt-net"
+ENABLE_SERVICES="crond eks-node-role mulga-ebs-byid mulga-eks-provider-id mulga-mgmt-net mulga-vpc-mtu"
 
 SETUP_SCRIPT="scripts/images/eks-node/setup.sh"
 

--- a/scripts/images/eks-node/mulga-eks-addon-sync.sh
+++ b/scripts/images/eks-node/mulga-eks-addon-sync.sh
@@ -46,6 +46,15 @@ RENDER_PREFIX=spinifex-addon-
 # re-apply the addon every tick).
 WEBHOOK_CERT_DIR=/var/lib/spinifex-eks/webhook-certs
 
+# Grace before the gvks readiness gate falls back to a workload-rollout check.
+# A large bundle (e.g. the 1.45 MB argocd manifest) applies and runs but K3s'
+# auto-deploy controller never records its addon.k3s.cattle.io/gvks annotation,
+# so the gvks-only gate would report applied forever. After this many seconds
+# with the annotation still empty, readiness is decided by the bundle's
+# workloads being rolled out instead. Kept generous so fast addons settle on the
+# gvks path and slow-rolling workloads are not called ready prematurely.
+ADDON_READY_GRACE=${ADDON_READY_GRACE:-90}
+
 # log mirrors to syslog (on-VM /var/log) and, best-effort, to the serial
 # console — the host captures ttyS0 to a per-instance log, so this is the only
 # delivery diagnostics channel reachable from the host (the VM has no
@@ -263,6 +272,53 @@ addon_gvks() {
         | grep -v '^$' | head -1 || true
 }
 
+# addon_apply_age ADDON — seconds since this process first saw ADDON delivered
+# but not yet gvks-ready, recorded in a per-addon sentinel. A gvks-ready tick (or
+# an unstage) clears the sentinel via addon_apply_clear so a later re-apply
+# restarts the grace window.
+addon_apply_age() {
+    _s=/tmp/.addon-firstapply-"$1"
+    _now=$(date +%s)
+    if [ -f "${_s}" ]; then
+        _t=$(cat "${_s}" 2>/dev/null || echo "${_now}")
+    else
+        _t=${_now}
+        echo "${_now}" > "${_s}"
+    fi
+    echo $(( _now - _t ))
+}
+
+addon_apply_clear() {
+    rm -f /tmp/.addon-firstapply-"$1"
+}
+
+# addon_workloads_ready ADDON — fallback readiness when the gvks annotation never
+# lands: true only when the rendered bundle carries at least one workload and
+# every Deployment/StatefulSet/DaemonSet in it is fully rolled out. Reads the live
+# status of exactly the objects this agent applied (kubectl get -f on the rendered
+# file), so it is addon-agnostic. A bundle whose CRDs are not yet established makes
+# kubectl get -f error out, yielding "not ready" — safe, the next tick retries.
+addon_workloads_ready() {
+    _wf="${DEPLOY_DIR}/${RENDER_PREFIX}$1.yaml"
+    [ -e "${_wf}" ] || return 1
+    kubectl get -f "${_wf}" -o json --ignore-not-found 2>/dev/null \
+        | jq -e '
+            [ .items[]? ]
+            | map(select(.kind == "Deployment" or .kind == "StatefulSet" or .kind == "DaemonSet"))
+            | (length > 0)
+              and all(.[];
+                (.kind == "Deployment"
+                  and (.status.observedGeneration // 0) >= (.metadata.generation // 0)
+                  and (.status.availableReplicas // 0) >= (.spec.replicas // 1))
+                or (.kind == "StatefulSet"
+                  and (.status.observedGeneration // 0) >= (.metadata.generation // 0)
+                  and (.status.readyReplicas // 0) >= (.spec.replicas // 1))
+                or (.kind == "DaemonSet"
+                  and (.status.desiredNumberScheduled // 0) > 0
+                  and (.status.numberReady // 0) >= (.status.desiredNumberScheduled // 0)))
+        ' >/dev/null 2>&1
+}
+
 # diag_addon ADDON — one-shot console dump of the live K3s state for a stuck
 # add-on, so a delivery that never reaches ready is diagnosable from the
 # host-captured serial console (the VM is otherwise unreachable). Fires once per
@@ -304,12 +360,21 @@ sync_once() {
         if render_addon "${_addon}" "${_version}" "${_role}"; then
             _gvks=$(addon_gvks "${_addon}")
             if [ -n "${_gvks}" ]; then
+                addon_apply_clear "${_addon}"
                 log "addon ${_addon}/${_version}: applied + ready (gvks=${_gvks})"
                 report ready "${_addon}" "${_version}"
             else
-                log "addon ${_addon}/${_version}: applied, not ready yet (no K3s Addon CR for ${RENDER_PREFIX}${_addon}.yaml with populated .status.gvks)"
-                diag_addon "${_addon}"
-                report applied "${_addon}" "${_version}"
+                # gvks absent: fall back to workload rollout once past the grace
+                # window, so a large bundle K3s never annotates still reaches ready.
+                _age=$(addon_apply_age "${_addon}")
+                if [ "${_age}" -ge "${ADDON_READY_GRACE}" ] && addon_workloads_ready "${_addon}"; then
+                    log "addon ${_addon}/${_version}: applied + ready (workloads rolled out; gvks absent after ${_age}s)"
+                    report ready "${_addon}" "${_version}"
+                else
+                    log "addon ${_addon}/${_version}: applied, not ready yet (gvks empty, age=${_age}s)"
+                    diag_addon "${_addon}"
+                    report applied "${_addon}" "${_version}"
+                fi
             fi
         fi
     done < "${_staged}"
@@ -325,6 +390,7 @@ sync_once() {
         _name=${_name%.yaml}
         if ! printf '%s\n' "${_names}" | grep -qx "${_name}"; then
             log "unstaging addon ${_name} (no longer staged)"
+            addon_apply_clear "${_name}"
             # Copy the manifest aside, drop the original so K3s stops tracking it
             # (and never re-applies), then delete the objects it rendered.
             # --wait=false so namespace finalizers don't stall the sync loop.

--- a/scripts/images/eks-node/mulga-mgmt-net.sh
+++ b/scripts/images/eks-node/mulga-mgmt-net.sh
@@ -92,4 +92,13 @@ for n in 0 1 2 3 4 5; do
         echo "[mulga-mgmt-net] ERROR: failed to set $cidr on $iface ($mac)" >&2
         exit 1
     fi
+
+    # NIC<n>_DEFAULT=0 means this NIC must never carry the default route: the
+    # mgmt NIC reaches the gateway on-link and a default via it would blackhole
+    # egress and (with a link-local /16) hijack IMDS. Enforce it — a DHCP client
+    # racing this NIC may have added one before we set it static.
+    eval "isdefault=\${NIC${n}_DEFAULT:-}"
+    if [ "$isdefault" != "1" ]; then
+        ip route del default dev "$iface" 2>/dev/null || true
+    fi
 done

--- a/scripts/images/eks-node/mulga-vpc-mtu.initd
+++ b/scripts/images/eks-node/mulga-vpc-mtu.initd
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+# mulga-vpc-mtu — pin the VPC data NIC MTU (eth0 -> 1320) before k3s starts
+# flannel, so flannel's VXLAN overlay (flannel.1 -> 1270) fits the OVN geneve
+# underlay. Runs after the NICs are configured (networking + cloud-init, and
+# mulga-mgmt-net for multi-NIC system VMs) and before k3s/k3s-agent. Role-
+# agnostic and enabled on every node.
+
+description="Pin VPC data NIC MTU so flannel fits the OVN geneve underlay"
+
+depend() {
+    need net
+    after networking cloud-init mulga-mgmt-net
+    before k3s k3s-agent
+}
+
+start() {
+    ebegin "Pinning VPC data NIC MTU for flannel/OVN underlay"
+    /usr/local/sbin/mulga-vpc-mtu
+    eend $?
+}

--- a/scripts/images/eks-node/mulga-vpc-mtu.sh
+++ b/scripts/images/eks-node/mulga-vpc-mtu.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# mulga-vpc-mtu — boot oneshot that pins the VPC data NIC MTU so flannel sizes
+# its VXLAN overlay to fit the OVN geneve underlay.
+#
+# Spinifex carries tenant traffic over an OVN geneve underlay (~1442B usable on a
+# 1500B host link). The EKS node's primary ENI (eth0) comes up at the default
+# 1500 — cloud-init's Ec2 datasource has no MTU leaf and Alpine's udhcpc ignores
+# DHCP option 26 — so flannel derives flannel.1 = 1500-50 = 1450. VXLAN frames up
+# to 1500 then exceed the underlay and are silently dropped: small packets (TCP
+# handshakes) pass while large ones (TLS, kubelet streams, pod-to-pod payloads)
+# blackhole. Pinning eth0 down to 1320 (flannel.1 = 1270) leaves margin under the
+# underlay and restores the datapath. This must run before k3s starts flannel,
+# which reads the iface MTU once at startup.
+#
+# eth0 is always the primary data ENI (cloud-init set-name; mgmt0, when present,
+# is a separate NIC and is left at its default). The default-route interface is
+# pinned too in case it differs.
+set -u
+
+MTU="${MULGA_VPC_NIC_MTU:-1320}"
+
+pin() {
+    iface="$1"
+    [ -n "$iface" ] || return 0
+    ip link show dev "$iface" >/dev/null 2>&1 || return 0
+    if ip link set dev "$iface" mtu "$MTU"; then
+        echo "[mulga-vpc-mtu] pinned $iface MTU to $MTU"
+    else
+        echo "[mulga-vpc-mtu] WARNING: failed to set MTU $MTU on $iface" >&2
+    fi
+}
+
+pin eth0
+
+route_iface=$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')
+[ "$route_iface" = "eth0" ] || pin "$route_iface"
+
+exit 0

--- a/scripts/images/eks-node/setup.sh
+++ b/scripts/images/eks-node/setup.sh
@@ -120,4 +120,17 @@ sed -i \
 sed -i 's/^timeout=.*/timeout=1/' /etc/update-extlinux.conf
 sed -i 's/^TIMEOUT[[:space:]].*/TIMEOUT 10/' /boot/extlinux.conf
 
+# Disable dhcpcd IPv4LL so it never hijacks IMDS on a multi-NIC system VM. The
+# EKS control plane is dual-NIC; the mgmt NIC sits on br-mgmt (no DHCP server),
+# so dhcpcd's no-lease fallback would assign a 169.254.x.x address and a
+# 169.254.0.0/16 route on it. That /16 captures 169.254.169.254 and steers IMDS
+# off the data NIC (away from the per-tap br-imds datapath) and onto the mgmt
+# NIC, where the host RSTs it. noipv4ll turns off only the no-lease fallback:
+# real DHCP leases (workers, the data ENI) are unaffected, and IMDS reaches .254
+# through the data NIC's default route and the br-imds demux, as single-NIC
+# instances already do.
+if ! grep -qxF 'noipv4ll' /etc/dhcpcd.conf 2>/dev/null; then
+    echo 'noipv4ll' >> /etc/dhcpcd.conf
+fi
+
 echo "[eks-node-setup] done"

--- a/scripts/images/eks-node/setup.sh
+++ b/scripts/images/eks-node/setup.sh
@@ -44,12 +44,13 @@ ln -sf /usr/local/bin/k3s /usr/local/bin/ctr
 # role's services are baked; the selector enables the right ones at first boot.
 chmod 0755 /etc/init.d/eks-node-role /etc/init.d/k3s /etc/init.d/k3s-agent \
     /etc/init.d/eks-token-webhook /etc/init.d/k3s-first-boot /etc/init.d/mulga-eks-state-report \
-    /etc/init.d/mulga-eks-addon-sync
+    /etc/init.d/mulga-eks-addon-sync /etc/init.d/konnectivity-server
 chmod 0755 /usr/local/sbin/eks-node-role /usr/local/sbin/k3s-first-boot \
     /usr/local/sbin/mulga-eks-state-report /usr/local/sbin/mulga-eks-addon-sync
 chmod 0755 /etc/init.d/mulga-ebs-byid /usr/local/sbin/mulga-ebs-byid
 chmod 0755 /etc/init.d/mulga-eks-provider-id /usr/local/sbin/mulga-eks-provider-id
 chmod 0755 /etc/init.d/mulga-mgmt-net /usr/local/sbin/mulga-mgmt-net
+chmod 0755 /etc/init.d/mulga-vpc-mtu /usr/local/sbin/mulga-vpc-mtu
 chmod 0755 /etc/periodic/daily/mulga-eks-etcd-snapshot
 
 # EBS by-id bridge: route every virtio-blk event through mulga-ebs-byid, which

--- a/spinifex/daemon/daemon_system_dispatch_test.go
+++ b/spinifex/daemon/daemon_system_dispatch_test.go
@@ -356,7 +356,7 @@ func TestLaunchSystemInstanceOnNode_RemoteWithoutConn(t *testing.T) {
 	require.Error(t, err, "remote placement requires a NATS connection")
 }
 
-// TestTerminateSystemInstanceRemote_RoundTrip locks mulga-siv-295.10: terminating
+// TestTerminateSystemInstanceRemote_RoundTrip locks the contract that terminating
 // a CP VM this node does not own routes over system.TerminateInstance.{id} to the
 // owning daemon, which stops qemu and cascade-deletes the ENI before replying —
 // so the cluster-wide teardown actually frees the remote ENI instead of deleting

--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -475,6 +475,27 @@ func (d *Daemon) launchAMISystemInstance(input *sysinstance.SystemInstanceInput)
 		return nil, err
 	}
 
+	// Pre-created extra ENIs (e.g. an EKS CP server's flannel-overlay ENI in the
+	// worker VPC) must be attached and recorded on the VM before LaunchRunInstances
+	// so the launch builds their taps/virtio NICs and cloud-init renders a DHCP
+	// stanza per extra MAC. A cross-account ENI is keyed by its own account.
+	for idx, extra := range input.ExtraENIs {
+		if d.vpcService != nil {
+			extraAccount := resolveENIAccount(extra.AccountID, input.AccountID)
+			if _, attachErr := d.vpcService.AttachENI(extraAccount, extra.ENIID, inst.ID, int64(idx+1)); attachErr != nil {
+				slog.Error("launchAMISystemInstance: failed to attach extra ENI", "eniId", extra.ENIID, "instanceId", inst.ID, "err", attachErr)
+				d.vmMgr.MarkFailed(inst, "extra_eni_attach_failed")
+				return nil, fmt.Errorf("attach extra ENI %s: %w", extra.ENIID, attachErr)
+			}
+		}
+		inst.ExtraENIs = append(inst.ExtraENIs, vm.ExtraENI{
+			ENIID:    extra.ENIID,
+			ENIMac:   extra.ENIMac,
+			ENIIP:    extra.ENIIP,
+			SubnetID: extra.SubnetID,
+		})
+	}
+
 	d.instanceService.LaunchRunInstances(instances, runInput, instanceType)
 
 	privateIP := input.ENIIP

--- a/spinifex/daemon/daemon_system_instance_test.go
+++ b/spinifex/daemon/daemon_system_instance_test.go
@@ -595,7 +595,7 @@ func TestLaunchSystemInstance_NATFailureRollsBackPublicIP(t *testing.T) {
 // its pool and clear the instance's EIP fields. The vm.Manager teardown
 // (Terminate/MarkFailed → ReleasePublicIP) only knows the externalIPAM path, so
 // without this an internet-facing system VM's allocated+associated EIP would
-// leak when its instance is torn down (mulga-siv-293).
+// leak when its instance is torn down.
 func TestReleaseSystemInstanceEIP_ReleasesEipServiceAllocation(t *testing.T) {
 	d := createVPCTestDaemon(t)
 

--- a/spinifex/daemon/eks_worker_launch.go
+++ b/spinifex/daemon/eks_worker_launch.go
@@ -21,19 +21,35 @@ import (
 // Compile-time check that Daemon satisfies the EKS worker-launch surface.
 var _ handlers_eks.WorkerLauncher = (*Daemon)(nil)
 
-// RunWorkerInstance launches a nodegroup worker via the normal RunInstances path.
-// UserData is base64-encoded before forwarding; the worker is customer-visible.
+// RunWorkerInstance launches a nodegroup worker on the local node.
 func (d *Daemon) RunWorkerInstance(input *ec2.RunInstancesInput, accountID string) (*ec2.Reservation, error) {
-	if d.instanceService == nil {
-		return nil, errors.New("eks worker: instance service not initialized")
-	}
+	return d.RunWorkerInstanceOnNode("", input, accountID)
+}
+
+// RunWorkerInstanceOnNode launches a nodegroup worker via the normal RunInstances
+// path. UserData is base64-encoded before forwarding; the worker is
+// customer-visible. A non-empty nodeID pins the worker to that host for nodegroup
+// spread by publishing the node-targeted ec2.RunInstances.<type>.<node> request
+// (the node stays subscribed even at capacity); an empty nodeID launches on the
+// local node in process, preserving the original behaviour.
+func (d *Daemon) RunWorkerInstanceOnNode(nodeID string, input *ec2.RunInstancesInput, accountID string) (*ec2.Reservation, error) {
 	if input == nil {
 		return nil, errors.New("eks worker: nil RunInstancesInput")
 	}
 	if input.UserData != nil && *input.UserData != "" {
 		input.UserData = aws.String(base64.StdEncoding.EncodeToString([]byte(*input.UserData)))
 	}
-	return d.instanceService.RunInstances(input, accountID)
+	if nodeID == "" {
+		if d.instanceService == nil {
+			return nil, errors.New("eks worker: instance service not initialized")
+		}
+		return d.instanceService.RunInstances(input, accountID)
+	}
+	if d.natsConn == nil {
+		return nil, errors.New("eks worker: NATS connection not initialized")
+	}
+	subject := fmt.Sprintf("ec2.RunInstances.%s.%s", aws.StringValue(input.InstanceType), nodeID)
+	return utils.NATSRequest[ec2.Reservation](d.natsConn, subject, input, 5*time.Minute, accountID)
 }
 
 // TerminateWorkerInstances terminates nodegroup workers by routing a terminate
@@ -41,7 +57,7 @@ func (d *Daemon) RunWorkerInstance(input *ec2.RunInstancesInput, accountID strin
 // the gateway TerminateInstances path. The owning daemon runs the full teardown
 // — detach + force-delete the worker's primary ENI and clear its
 // spinifex-vpc-enis record — so a dangling in-use ENI cannot pin the customer
-// VPC/subnet undeletable (mulga-siv-408). A local-only vmMgr.Get would skip any
+// VPC/subnet undeletable. A local-only vmMgr.Get would skip any
 // worker placed on another node, stranding both the VM and its ENI. An instance
 // with no owner (no responder, not found) is already gone, so a retried
 // DeleteNodegroup stays idempotent.

--- a/spinifex/daemon/eks_worker_launch_test.go
+++ b/spinifex/daemon/eks_worker_launch_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 	"time"
@@ -33,7 +34,7 @@ func TestTerminateWorkerInstances_NotFoundIsIdempotent(t *testing.T) {
 
 // Worker terminate must route to whichever node owns the VM via ec2.cmd.<id>,
 // not a local-only vmMgr lookup; the owner runs the full teardown (incl. ENI
-// detach+delete) so no dangling ENI pins the VPC undeletable (mulga-siv-408).
+// detach+delete) so no dangling ENI pins the VPC undeletable.
 func TestTerminateWorkerInstances_RoutesToOwner(t *testing.T) {
 	nc, err := nats.Connect(sharedNATSURL)
 	require.NoError(t, err)
@@ -174,4 +175,43 @@ func TestWorkerLauncher_NilInstanceService(t *testing.T) {
 	require.Error(t, err)
 
 	require.Error(t, d.TerminateWorkerInstances([]string{"i-1"}, "111122223333"))
+}
+
+// A node-targeted worker launch publishes the ec2.RunInstances.<type>.<node>
+// request the owning node handles, base64-encoding user-data on the way out, so
+// nodegroup workers spread across hosts instead of all landing locally.
+func TestRunWorkerInstanceOnNode_RoutesToTargetNode(t *testing.T) {
+	nc, err := nats.Connect(sharedNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(nc.Close)
+	d := &Daemon{natsConn: nc}
+
+	gotUserData := make(chan string, 1)
+	sub, err := nc.Subscribe("ec2.RunInstances.t3.medium.nodeX", func(msg *nats.Msg) {
+		var in ec2.RunInstancesInput
+		_ = json.Unmarshal(msg.Data, &in)
+		gotUserData <- aws.StringValue(in.UserData)
+		res, _ := json.Marshal(ec2.Reservation{Instances: []*ec2.Instance{{InstanceId: aws.String("i-spread1")}}})
+		_ = msg.Respond(res)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	in := &ec2.RunInstancesInput{
+		InstanceType: aws.String("t3.medium"),
+		ImageId:      aws.String("ami-1"),
+		UserData:     aws.String("#cloud-config\n"),
+	}
+	res, err := d.RunWorkerInstanceOnNode("nodeX", in, "111122223333")
+	require.NoError(t, err)
+	require.Len(t, res.Instances, 1)
+	assert.Equal(t, "i-spread1", aws.StringValue(res.Instances[0].InstanceId))
+
+	select {
+	case ud := <-gotUserData:
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("#cloud-config\n")), ud,
+			"user-data must be base64-encoded for the node-targeted launch")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the worker launch routed to ec2.RunInstances.t3.medium.nodeX")
+	}
 }

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -177,7 +177,11 @@ func (a *volumeMounterAdapter) Unmount(instance *vm.VM) error {
 				"instance", instance.ID, "volume", ebsRequest.Name, "data", string(msg.Data))
 		}
 
-		if sealed && !ebsRequest.EFI && a.volState != nil {
+		// Boot/root volumes must stay attached across stop/crash unmount: EFI is
+		// the wrong proxy for "boot" (BIOS-boot roots are Boot && !EFI), so gate on
+		// Boot too. Only DetachVolume and terminate release a boot volume; flipping
+		// it available here while the instance restarts splits the state record.
+		if sealed && !ebsRequest.EFI && !ebsRequest.Boot && a.volState != nil {
 			if err := a.volState.UpdateVolumeState(ebsRequest.Name, "available", "", ""); err != nil {
 				slog.Error("Failed to update volume state to available after unmount",
 					"volumeId", ebsRequest.Name, "err", err)

--- a/spinifex/daemon/vm_adapters_invariants_test.go
+++ b/spinifex/daemon/vm_adapters_invariants_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnmountNeverReleasesBootVolume locks the stop/crash attachment-persistence
+// contract: Unmount seals the block map but must NOT mark a boot/root volume
+// "available". Unmount is driven by stop (vm/shutdown.go) and crash recovery
+// (vm/crash_recovery.go), where the instance keeps its attachment and restarts —
+// only DetachVolume and terminate release a boot volume. Releasing it here while
+// the instance still owns it splits the volume-state record (describe-instances
+// "attached" vs describe-volumes "available"). EFI is not a
+// sufficient proxy for "boot": BIOS-boot roots are Boot && !EFI, so the gate must
+// also exclude Boot. Only non-boot data volumes may be released by Unmount.
+func TestUnmountNeverReleasesBootVolume(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+	volState := &recordingVolState{}
+	adapter := newVolumeMounterAdapter(daemon.natsConn, daemon.node, volState)
+
+	// Stand in for the ebs daemon: every ebs.<node>.unmount succeeds (sealed).
+	sub, err := daemon.natsConn.Subscribe(adapter.topic("unmount"), func(msg *nats.Msg) {
+		var req types.EBSRequest
+		require.NoError(t, json.Unmarshal(msg.Data, &req))
+		data, err := json.Marshal(types.EBSUnMountResponse{Volume: req.Name, Mounted: false})
+		require.NoError(t, err)
+		require.NoError(t, msg.Respond(data))
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	inst := &vm.VM{
+		ID: "i-unmount-boot",
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{
+				{Name: "vol-bios-root", Boot: true, EFI: false},
+				{Name: "vol-efi-root", Boot: true, EFI: true},
+				{Name: "vol-data", Boot: false, EFI: false},
+			},
+		},
+	}
+	require.NoError(t, adapter.Unmount(inst))
+
+	calls := volState.snapshot()
+	assert.NotContains(t, calls, "vol-bios-root:available",
+		"a BIOS-boot root volume (Boot && !EFI) must stay attached across stop/crash unmount, not be released to available")
+	assert.NotContains(t, calls, "vol-efi-root:available",
+		"an EFI-boot root volume must stay attached across stop/crash unmount")
+	assert.Contains(t, calls, "vol-data:available",
+		"a non-boot data volume is released to available by Unmount")
+}

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -60,7 +60,7 @@ func TestOnInstanceUpHook_ReArmsSystemTerminateForELBv2(t *testing.T) {
 	assert.Equal(t, "system.TerminateInstance.i-up-sys", sub.Subject)
 }
 
-// TestOnInstanceUpHook_ReArmsSystemTerminateForEKS locks mulga-siv-295.10: an EKS
+// TestOnInstanceUpHook_ReArmsSystemTerminateForEKS locks the contract: an EKS
 // K3s control-plane VM placed on the coordinator's own node (local launch, no
 // remote-launch handler) must still bind system.TerminateInstance.{id} via the
 // OnInstanceUp funnel — otherwise a cluster-wide teardown invoked on another node

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -2282,7 +2282,7 @@ func (s *InstanceServiceImpl) deleteInstanceENI(instance *vm.VM, instanceID stri
 	// still show Status=in-use/AttachmentId set; without the detach the
 	// force=false DeleteNetworkInterface below fails InvalidNetworkInterface.InUse,
 	// stranding the ENI record after the instance is already gone from the store
-	// and blocking VPC/subnet delete (mulga-siv-408). Best-effort: the delete is
+	// and blocking VPC/subnet delete. Best-effort: the delete is
 	// the authoritative gate.
 	if s.eniCreator != nil {
 		if err := s.eniCreator.DetachENI(instance.AccountID, instance.ENIId); err != nil {

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -1738,7 +1738,7 @@ func TestTerminateStoppedInstance_ENIDeleted(t *testing.T) {
 	_, err := svc.TerminateStoppedInstance(&TerminateStoppedInstanceInput{InstanceID: id}, "acc")
 	require.NoError(t, err)
 	// Detach must precede the delete so a stale in-use attachment can't strand
-	// the ENI record after the instance is gone (mulga-siv-408).
+	// the ENI record after the instance is gone.
 	assert.Equal(t, 1, ec.detachCalls, "ENI must be detached before delete")
 	assert.Equal(t, []string{"eni-1234"}, ed.calls)
 }

--- a/spinifex/handlers/ec2/natgw/service_impl_test.go
+++ b/spinifex/handlers/ec2/natgw/service_impl_test.go
@@ -65,8 +65,8 @@ func TestCreateNatGateway(t *testing.T) {
 	assert.Equal(t, "203.0.113.50", *ngw.NatGatewayAddresses[0].PublicIp)
 }
 
-// TestCreateNatGateway_PersistsTagsForTagFilterDiscovery locks the mulga-siv-303
-// fix: CreateNatGateway must persist TagSpecifications so DeleteClusterCPVPC can
+// TestCreateNatGateway_PersistsTagsForTagFilterDiscovery locks the
+// contract: CreateNatGateway must persist TagSpecifications so DeleteClusterCPVPC can
 // find the cluster NAT gateway by tag filter and release its EIP. A dropped tag
 // makes the tag-filtered describe return empty, leaking the NAT-GW EIP.
 func TestCreateNatGateway_PersistsTagsForTagFilterDiscovery(t *testing.T) {
@@ -91,7 +91,7 @@ func TestCreateNatGateway_PersistsTagsForTagFilterDiscovery(t *testing.T) {
 		},
 	}, testAccountID)
 	require.NoError(t, err)
-	require.Len(t, out.NatGateways, 1, "tagged NAT GW must be discoverable by tag filter (mulga-siv-303)")
+	require.Len(t, out.NatGateways, 1, "tagged NAT GW must be discoverable by tag filter")
 	tags := filterutil.EC2TagsToMap(out.NatGateways[0].Tags)
 	assert.Equal(t, "alpha", tags["spinifex:eks-cluster"])
 	assert.Equal(t, "cp-natgw", tags["spinifex:eks-role"])

--- a/spinifex/handlers/ec2/routetable/service_impl_test.go
+++ b/spinifex/handlers/ec2/routetable/service_impl_test.go
@@ -79,7 +79,7 @@ func TestCreateRouteTable(t *testing.T) {
 	assert.Equal(t, "active", *rtb.Routes[0].State)
 }
 
-// TestCreateRouteTable_PersistsTagsForTagFilterDiscovery locks mulga-siv-303:
+// TestCreateRouteTable_PersistsTagsForTagFilterDiscovery locks the contract:
 // CreateRouteTable must persist TagSpecifications so the tag-driven CP-VPC
 // teardown can find the private route table, clear its NAT-GW route, and let
 // the NAT gateway (and its billable EIP) be reclaimed.
@@ -104,7 +104,7 @@ func TestCreateRouteTable_PersistsTagsForTagFilterDiscovery(t *testing.T) {
 		},
 	}, testAccountID)
 	require.NoError(t, err)
-	require.Len(t, out.RouteTables, 1, "tagged route table must be discoverable by tag filter (mulga-siv-303)")
+	require.Len(t, out.RouteTables, 1, "tagged route table must be discoverable by tag filter")
 
 	tags := map[string]string{}
 	for _, tg := range out.RouteTables[0].Tags {

--- a/spinifex/handlers/ec2/volume/config_route_invariants_test.go
+++ b/spinifex/handlers/ec2/volume/config_route_invariants_test.go
@@ -1,0 +1,132 @@
+package handlers_ec2_volume
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/mulgadc/spinifex/spinifex/objectstore"
+	"github.com/mulgadc/viperblock/viperblock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedUnencryptedConfig writes a plain (EncryptionEnabled=false) full VBState.
+func seedUnencryptedConfig(t *testing.T, store *objectstore.MemoryObjectStore, volumeID string) {
+	t.Helper()
+	state := viperblock.VBState{
+		VolumeName: volumeID,
+		VolumeSize: 10 * 1024 * 1024 * 1024,
+		BlockSize:  4096,
+		SeqNum:     7,
+		VolumeConfig: viperblock.VolumeConfig{
+			VolumeMetadata: viperblock.VolumeMetadata{VolumeID: volumeID, SizeGiB: 10, State: "available"},
+		},
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	_, err = store.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String(volumeID + "/config.json"),
+		Body:   strings.NewReader(string(data)),
+	})
+	require.NoError(t, err)
+}
+
+// TestUpdateVolumeState_WritesStateJSONNotConfig locks the single-writer
+// contract: the live nbdkit VB owns config.json and rewrites it from its stale
+// in-memory State on every SaveState, so the control plane MUST persist
+// attachment state to the separate state.json object and leave config.json
+// byte-for-byte untouched. Writing State into config.json out-of-band is
+// silently clobbered under write load (the EKS-worker root-volume flip).
+func TestUpdateVolumeState_WritesStateJSONNotConfig(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+
+	volumeID := "vol-single-writer"
+	seedUnencryptedConfig(t, store, volumeID)
+	before := getStoredConfig(t, store, volumeID)
+
+	require.NoError(t, svc.UpdateVolumeState(volumeID, "in-use", "i-abc", "/dev/nbd0"))
+
+	after := getStoredConfig(t, store, volumeID)
+	assert.Equal(t, string(before), string(after),
+		"UpdateVolumeState must not write config.json; the live VB owns it")
+
+	rec := getStoredState(t, store, volumeID)
+	assert.Equal(t, "in-use", rec.State)
+	assert.Equal(t, "i-abc", rec.AttachedInstance)
+	assert.Equal(t, "/dev/nbd0", rec.DeviceName)
+}
+
+// TestUpdateVolumeState_EncryptedConfigUntouched locks the corruption-safety
+// half of the contract: config.json for an encrypted volume is a sealed VBState
+// whose AES-GCM nonce is derived from StateSeqNum. A second out-of-band writer
+// advances the nonce and reuses it (catastrophic for AES-GCM — the decrypted
+// garbage image layers). UpdateVolumeState MUST never touch the sealed object.
+func TestUpdateVolumeState_EncryptedConfigUntouched(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+
+	volumeID := "vol-enc-single-writer"
+	seedEncryptedConfig(t, store, volumeID)
+	before := getStoredConfig(t, store, volumeID)
+
+	require.NoError(t, svc.UpdateVolumeState(volumeID, "in-use", "i-enc", "/dev/nbd0"))
+
+	after := getStoredConfig(t, store, volumeID)
+	assert.Equal(t, string(before), string(after),
+		"UpdateVolumeState must not rewrite the sealed config.json (AES-GCM nonce reuse)")
+	assert.Equal(t, "in-use", getStoredState(t, store, volumeID).State)
+}
+
+// TestGetVolumeConfig_OverlaysStateJSON locks the read side: the authoritative
+// attachment state is state.json, which MUST override the (stale) State the live
+// VB persisted into config.json.
+func TestGetVolumeConfig_OverlaysStateJSON(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+
+	volumeID := "vol-overlay"
+	seedUnencryptedConfig(t, store, volumeID) // config.json State == "available"
+	require.NoError(t, svc.UpdateVolumeState(volumeID, "in-use", "i-overlay", "/dev/nbd0"))
+
+	cfg, err := svc.GetVolumeConfig(volumeID)
+	require.NoError(t, err)
+	assert.Equal(t, "in-use", cfg.VolumeMetadata.State,
+		"state.json must override the stale State in config.json")
+	assert.Equal(t, "i-overlay", cfg.VolumeMetadata.AttachedInstance)
+	assert.Equal(t, "/dev/nbd0", cfg.VolumeMetadata.DeviceName)
+}
+
+// TestGetVolumeConfig_FallsBackWhenNoStateJSON locks the migration path: a volume
+// predating the state.json split has no state.json, so the State embedded in
+// config.json is used unchanged.
+func TestGetVolumeConfig_FallsBackWhenNoStateJSON(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+
+	volumeID := "vol-legacy"
+	seedUnencryptedConfig(t, store, volumeID) // State == "available", no state.json
+
+	cfg, err := svc.GetVolumeConfig(volumeID)
+	require.NoError(t, err)
+	assert.Equal(t, "available", cfg.VolumeMetadata.State,
+		"absent state.json must fall back to the State embedded in config.json")
+}
+
+// getStoredState reads and decodes the raw state.json from the memory store.
+func getStoredState(t *testing.T, store *objectstore.MemoryObjectStore, volumeID string) volumeStateRecord {
+	t.Helper()
+	res, err := store.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String(volumeID + "/state.json"),
+	})
+	require.NoError(t, err)
+	defer res.Body.Close()
+	var rec volumeStateRecord
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&rec))
+	return rec
+}

--- a/spinifex/handlers/ec2/volume/config_route_test.go
+++ b/spinifex/handlers/ec2/volume/config_route_test.go
@@ -78,52 +78,20 @@ func getStoredConfig(t *testing.T, store *objectstore.MemoryObjectStore, volumeI
 	return data
 }
 
-// TestUpdateVolumeState_EncryptedRoutesToLiveVB verifies an encrypted-volume
-// state update is delegated to the owning node via ebs.config.{volumeID} rather
-// than rewriting the sealed object directly.
-func TestUpdateVolumeState_EncryptedRoutesToLiveVB(t *testing.T) {
-	store := objectstore.NewMemoryObjectStore()
-	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
-	svc.natsConn = startTestNATS(t)
-
-	volumeID := "vol-enc-live"
-	seedEncryptedConfig(t, store, volumeID)
-
-	var got atomic.Pointer[types.EBSConfigUpdateRequest]
-	sub, err := svc.natsConn.Subscribe("ebs.config."+volumeID, func(msg *nats.Msg) {
-		var req types.EBSConfigUpdateRequest
-		_ = json.Unmarshal(msg.Data, &req)
-		got.Store(&req)
-		data, _ := json.Marshal(types.EBSConfigUpdateResponse{Volume: volumeID, Success: true})
-		_ = msg.Respond(data)
-	})
-	require.NoError(t, err)
-	defer sub.Unsubscribe()
-
-	err = svc.UpdateVolumeState(volumeID, "in-use", "i-abc", "/dev/nbd0")
-	require.NoError(t, err)
-
-	req := got.Load()
-	require.NotNil(t, req, "per-volume responder must receive the config update")
-	var vc viperblock.VolumeConfig
-	require.NoError(t, json.Unmarshal(req.VolumeConfig, &vc))
-	assert.Equal(t, "in-use", vc.VolumeMetadata.State)
-	assert.Equal(t, "i-abc", vc.VolumeMetadata.AttachedInstance)
-	assert.Equal(t, "/dev/nbd0", vc.VolumeMetadata.DeviceName)
-
-	// The sealed object must NOT have been rewritten by the handler.
-	raw := getStoredConfig(t, store, volumeID)
-	var still viperblock.VBState
-	require.NoError(t, json.Unmarshal(viperblock.StateBody(raw), &still))
-	assert.True(t, still.EncryptionEnabled)
-	assert.Equal(t, "available", still.VolumeConfig.VolumeMetadata.State,
-		"handler must not mutate the sealed object directly; the keyholder owns it")
+// encConfig builds a VolumeConfig for an encrypted-volume putVolumeConfig call.
+func encConfig(volumeID string) *viperblock.VolumeConfig {
+	return &viperblock.VolumeConfig{
+		VolumeMetadata: viperblock.VolumeMetadata{VolumeID: volumeID, SizeGiB: 10},
+	}
 }
 
-// TestUpdateVolumeState_EncryptedDetachedFallsBackToQueueGroup verifies that with
-// no per-volume responder (volume unmounted), the update routes to the ebs.config
-// queue group.
-func TestUpdateVolumeState_EncryptedDetachedFallsBackToQueueGroup(t *testing.T) {
+// TestPutVolumeConfig_EncryptedRoutesToQueueGroup verifies a config write for an
+// encrypted volume is delegated to the ebs.config keyholder queue group rather
+// than re-sealing the object out-of-band. The control plane lacks the master key,
+// so a direct PutObject would strip the AES-GCM tag and brick the volume. This is
+// the safe non-live writer path (markVolumeOrphaned / ModifyVolume); UpdateVolumeState
+// no longer routes here at all (it writes state.json).
+func TestPutVolumeConfig_EncryptedRoutesToQueueGroup(t *testing.T) {
 	store := objectstore.NewMemoryObjectStore()
 	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
 	svc.natsConn = startTestNATS(t)
@@ -140,14 +108,19 @@ func TestUpdateVolumeState_EncryptedDetachedFallsBackToQueueGroup(t *testing.T) 
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
-	err = svc.UpdateVolumeState(volumeID, "available", "", "")
-	require.NoError(t, err)
-	assert.Equal(t, int32(1), hits.Load(), "detached encrypted update must hit the ebs.config queue group")
+	require.NoError(t, svc.putVolumeConfig(volumeID, encConfig(volumeID)))
+	assert.Equal(t, int32(1), hits.Load(), "encrypted config write must hit the ebs.config keyholder queue group")
+
+	// The sealed object must NOT have been rewritten out-of-band by the handler.
+	raw := getStoredConfig(t, store, volumeID)
+	var still viperblock.VBState
+	require.NoError(t, json.Unmarshal(viperblock.StateBody(raw), &still))
+	assert.True(t, still.EncryptionEnabled)
 }
 
-// TestUpdateVolumeState_EncryptedKeyholderError surfaces a keyholder failure
+// TestPutVolumeConfig_EncryptedKeyholderError surfaces a keyholder failure
 // instead of silently succeeding.
-func TestUpdateVolumeState_EncryptedKeyholderError(t *testing.T) {
+func TestPutVolumeConfig_EncryptedKeyholderError(t *testing.T) {
 	store := objectstore.NewMemoryObjectStore()
 	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
 	svc.natsConn = startTestNATS(t)
@@ -155,14 +128,14 @@ func TestUpdateVolumeState_EncryptedKeyholderError(t *testing.T) {
 	volumeID := "vol-enc-err"
 	seedEncryptedConfig(t, store, volumeID)
 
-	sub, err := svc.natsConn.Subscribe("ebs.config."+volumeID, func(msg *nats.Msg) {
+	sub, err := svc.natsConn.QueueSubscribe("ebs.config", "spinifex-workers", func(msg *nats.Msg) {
 		data, _ := json.Marshal(types.EBSConfigUpdateResponse{Volume: volumeID, Error: "reseal failed"})
 		_ = msg.Respond(data)
 	})
 	require.NoError(t, err)
 	defer sub.Unsubscribe()
 
-	err = svc.UpdateVolumeState(volumeID, "in-use", "i-x", "/dev/nbd0")
+	err = svc.putVolumeConfig(volumeID, encConfig(volumeID))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reseal failed")
 }

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -939,8 +939,7 @@ func (s *VolumeServiceImpl) getVolumeByID(volumeID string) (*volumeResult, error
 
 	// An empty State is internal drift, not a valid AWS state. Derive the
 	// effective state from ground truth (the attachment) rather than blindly
-	// rendering "available", which would hide an empty-but-attached volume
-	// (mulga-siv-409).
+	// rendering "available", which would hide an empty-but-attached volume.
 	state := volMeta.State
 	if state == "" {
 		if volMeta.AttachedInstance != "" {
@@ -999,6 +998,66 @@ type volumeConfigWrapper struct {
 	VolumeConfig viperblock.VolumeConfig `json:"VolumeConfig"`
 }
 
+// volumeStateRecord is the control-plane-owned attachment state, persisted to a
+// per-volume state.json object kept out of config.json. config.json is rewritten
+// by the live nbdkit VB on every SaveState (clobbering any State the control
+// plane wrote there) and is a sealed object for encrypted volumes (a second
+// writer reuses the AES-GCM nonce). state.json is plaintext, viperblock never
+// touches it, so the control plane is its single writer.
+type volumeStateRecord struct {
+	State            string    `json:"state"`
+	AttachedInstance string    `json:"attachedInstance"`
+	DeviceName       string    `json:"deviceName"`
+	AttachedAt       time.Time `json:"attachedAt"`
+}
+
+// volumeStateKey is the S3 key for a volume's control-plane state object.
+func volumeStateKey(volumeID string) string { return volumeID + "/state.json" }
+
+// putVolumeState writes the control-plane attachment state to state.json.
+func (s *VolumeServiceImpl) putVolumeState(volumeID string, rec volumeStateRecord) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal volume state: %w", err)
+	}
+	_, err = s.store.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(s.bucketName),
+		Key:    aws.String(volumeStateKey(volumeID)),
+		Body:   bytes.NewReader(data),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write volume state to S3: %w", err)
+	}
+	return nil
+}
+
+// getVolumeState reads state.json. found=false with a nil error means the object
+// is absent (a volume predating the state.json split), in which case the caller
+// falls back to the State embedded in config.json.
+func (s *VolumeServiceImpl) getVolumeState(volumeID string) (volumeStateRecord, bool, error) {
+	getResult, err := s.store.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(s.bucketName),
+		Key:    aws.String(volumeStateKey(volumeID)),
+	})
+	if err != nil {
+		if objectstore.IsNoSuchKeyError(err) {
+			return volumeStateRecord{}, false, nil
+		}
+		return volumeStateRecord{}, false, fmt.Errorf("failed to get volume state: %w", err)
+	}
+	defer getResult.Body.Close()
+
+	body, err := io.ReadAll(getResult.Body)
+	if err != nil {
+		return volumeStateRecord{}, false, fmt.Errorf("failed to read volume state body: %w", err)
+	}
+	var rec volumeStateRecord
+	if err := json.Unmarshal(body, &rec); err != nil {
+		return volumeStateRecord{}, false, fmt.Errorf("failed to unmarshal volume state: %w", err)
+	}
+	return rec, true, nil
+}
+
 // GetVolumeConfig reads the raw VolumeConfig from S3 for a given volume ID.
 func (s *VolumeServiceImpl) GetVolumeConfig(volumeID string) (*viperblock.VolumeConfig, error) {
 	cfg, _, err := s.getVolumeConfigAndEncryption(volumeID)
@@ -1033,35 +1092,57 @@ func (s *VolumeServiceImpl) getVolumeConfigAndEncryption(volumeID string) (*vipe
 	// Try full VBState first (matches mergeVolumeConfig's careful decode
 	// pattern). A populated BlockSize is the marker that the blob is a full
 	// state rather than a wrapper-only fallback.
+	var vc *viperblock.VolumeConfig
+	var encryptionEnabled bool
+
 	var state viperblock.VBState
 	if decodeErr := json.NewDecoder(bytes.NewReader(body)).Decode(&state); decodeErr == nil && state.BlockSize != 0 {
-		return &state.VolumeConfig, state.EncryptionEnabled, nil
+		vc = &state.VolumeConfig
+		encryptionEnabled = state.EncryptionEnabled
+	} else {
+		var wrapper volumeConfigWrapper
+		if err := json.Unmarshal(body, &wrapper); err != nil {
+			return nil, false, fmt.Errorf("failed to unmarshal config: %w", err)
+		}
+		vc = &wrapper.VolumeConfig
 	}
 
-	var wrapper volumeConfigWrapper
-	if err := json.Unmarshal(body, &wrapper); err != nil {
-		return nil, false, fmt.Errorf("failed to unmarshal config: %w", err)
+	// Overlay the control-plane-owned attachment state from state.json. The State
+	// embedded in config.json is rewritten by the live nbdkit VB (stale
+	// "available") and is not authoritative; state.json is. Absent state.json
+	// keeps the embedded value (volumes predating the split).
+	if rec, found, stateErr := s.getVolumeState(volumeID); stateErr != nil {
+		return nil, false, stateErr
+	} else if found {
+		vc.VolumeMetadata.State = rec.State
+		vc.VolumeMetadata.AttachedInstance = rec.AttachedInstance
+		vc.VolumeMetadata.DeviceName = rec.DeviceName
+		vc.VolumeMetadata.AttachedAt = rec.AttachedAt
 	}
 
-	return &wrapper.VolumeConfig, false, nil
+	return vc, encryptionEnabled, nil
 }
 
 // putVolumeConfig writes a VolumeConfig back to S3 as config.json.
 // It performs a read-modify-write to preserve full VBState if viperblock
 // has already written state (BlockSize, SeqNum, WALNum, etc.) to config.json.
+// Callers are the safe non-live writers only (CreateVolume pre-mount,
+// markVolumeOrphaned detached, ModifyVolume stopped-instance); the
+// control-plane attachment state of a live-mounted volume goes to state.json via
+// UpdateVolumeState, never here.
 func (s *VolumeServiceImpl) putVolumeConfig(volumeID string, cfg *viperblock.VolumeConfig) error {
 	configKey := volumeID + "/config.json"
 
 	// config.json for an encrypted volume is a sealed VBState whose AES-GCM tag
-	// and StateSeqNum-derived nonce can only be advanced by the master-key holder
-	// that owns the volume. Rewriting it here would strip the tag or — racing the
-	// live VB — reuse a nonce, so route the update through viperblockd instead.
+	// and StateSeqNum-derived nonce can only be advanced by the master-key holder.
+	// With no live owner, hand it to a viperblockd worker that opens the detached
+	// volume exclusively and reseals — a detached volume has no concurrent writer.
 	encrypted, err := s.configIsEncrypted(volumeID)
 	if err != nil {
 		return err
 	}
 	if encrypted {
-		return s.putVolumeConfigViaKeyholder(volumeID, cfg)
+		return s.putVolumeConfigViaDetached(volumeID, cfg)
 	}
 
 	data, err := s.mergeVolumeConfig(configKey, cfg)
@@ -1108,35 +1189,40 @@ func (s *VolumeServiceImpl) configIsEncrypted(volumeID string) (bool, error) {
 	return false, nil
 }
 
-// putVolumeConfigViaKeyholder routes an encrypted-volume config update through
-// viperblockd, the master-key holder. The owning node answers
-// ebs.config.{volumeID} and updates its live VB. If no node owns the volume
-// (detached), ErrNoResponders routes to the ebs.config queue group, where a
-// worker opens the volume exclusively and reseals. A detached volume has no
-// concurrent writer, so the reopen is nonce-safe.
-func (s *VolumeServiceImpl) putVolumeConfigViaKeyholder(volumeID string, cfg *viperblock.VolumeConfig) error {
+// putVolumeConfigViaDetached hands an encrypted-volume config update to the
+// ebs.config queue group, where a viperblockd worker opens the detached volume
+// exclusively and reseals. Safe only when no node owns the volume: a detached
+// volume has no concurrent writer, so the reopen is nonce-safe.
+func (s *VolumeServiceImpl) putVolumeConfigViaDetached(volumeID string, cfg *viperblock.VolumeConfig) error {
 	if s.natsConn == nil {
 		return fmt.Errorf("encrypted volume %s requires NATS to reach the viperblock keyholder, but no connection is configured", volumeID)
 	}
-
-	cfgData, err := json.Marshal(cfg)
+	reqData, err := marshalConfigUpdate(volumeID, cfg)
 	if err != nil {
-		return fmt.Errorf("marshal VolumeConfig: %w", err)
+		return err
 	}
-	reqData, err := json.Marshal(types.EBSConfigUpdateRequest{Volume: volumeID, VolumeConfig: cfgData})
-	if err != nil {
-		return fmt.Errorf("marshal config update request: %w", err)
-	}
-
-	msg, err := s.natsConn.Request("ebs.config."+volumeID, reqData, 30*time.Second)
-	if errors.Is(err, nats.ErrNoResponders) {
-		// Volume not mounted anywhere -- fall back to the queue group.
-		msg, err = s.natsConn.Request("ebs.config", reqData, 30*time.Second)
-	}
+	msg, err := s.natsConn.Request("ebs.config", reqData, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("ebs.config request for %s: %w", volumeID, err)
 	}
+	return decodeConfigUpdateResponse(volumeID, msg)
+}
 
+// marshalConfigUpdate wraps a VolumeConfig as an EBSConfigUpdateRequest payload.
+func marshalConfigUpdate(volumeID string, cfg *viperblock.VolumeConfig) ([]byte, error) {
+	cfgData, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal VolumeConfig: %w", err)
+	}
+	reqData, err := json.Marshal(types.EBSConfigUpdateRequest{Volume: volumeID, VolumeConfig: cfgData})
+	if err != nil {
+		return nil, fmt.Errorf("marshal config update request: %w", err)
+	}
+	return reqData, nil
+}
+
+// decodeConfigUpdateResponse turns an ebs.config reply into an error or nil.
+func decodeConfigUpdateResponse(volumeID string, msg *nats.Msg) error {
 	var resp types.EBSConfigUpdateResponse
 	if err := json.Unmarshal(msg.Data, &resp); err != nil {
 		return fmt.Errorf("unmarshal config update response: %w", err)
@@ -1195,30 +1281,36 @@ func (s *VolumeServiceImpl) mergeVolumeConfig(configKey string, cfg *viperblock.
 	return json.Marshal(state)
 }
 
-// UpdateVolumeState updates volume metadata (state, attachment, device) in the object store.
+// UpdateVolumeState updates the control-plane-owned attachment state (state,
+// attachment, device) by writing the per-volume state.json. It does NOT write
+// config.json: the live nbdkit VB owns that object and its next SaveState
+// clobbers any State written out-of-band (and for an encrypted volume a second
+// writer reuses the AES-GCM nonce). Readers overlay state.json in
+// getVolumeConfigAndEncryption. The config.json read here is a presence/ownership
+// gate so a missing volume still errors.
 func (s *VolumeServiceImpl) UpdateVolumeState(volumeID, state, attachedInstance, deviceName string) error {
-	cfg, err := s.GetVolumeConfig(volumeID)
-	if err != nil {
+	if _, err := s.GetVolumeConfig(volumeID); err != nil {
 		return fmt.Errorf("failed to get volume config for state update: %w", err)
 	}
 
 	// A detached volume is "available": never persist an empty State for an
 	// unattached volume, so a detach/terminate writeback that omits the state
-	// cannot strand the volume in drift that later reads as undeletable
-	// (mulga-siv-409).
+	// cannot strand the volume in drift that later reads as undeletable.
 	if state == "" && attachedInstance == "" {
 		state = "available"
 	}
 
-	cfg.VolumeMetadata.State = state
-	cfg.VolumeMetadata.AttachedInstance = attachedInstance
-	cfg.VolumeMetadata.DeviceName = deviceName
+	rec := volumeStateRecord{
+		State:            state,
+		AttachedInstance: attachedInstance,
+		DeviceName:       deviceName,
+	}
 	if attachedInstance != "" {
-		cfg.VolumeMetadata.AttachedAt = time.Now()
+		rec.AttachedAt = time.Now()
 	}
 
-	if err := s.putVolumeConfig(volumeID, cfg); err != nil {
-		return fmt.Errorf("failed to write volume config for state update: %w", err)
+	if err := s.putVolumeState(volumeID, rec); err != nil {
+		return fmt.Errorf("failed to write volume state: %w", err)
 	}
 
 	slog.Info("Updated volume state", "volumeId", volumeID, "state", state, "attachedInstance", attachedInstance, "deviceName", deviceName)
@@ -1344,7 +1436,7 @@ func (s *VolumeServiceImpl) DeleteVolume(input *ec2.DeleteVolumeInput, accountID
 	// empty: a detach/terminate that failed to write back "available" leaves the
 	// State drifted to empty with no attachment, and gating on State=="available"
 	// exactly would return VolumeInUse for a volume nothing is using, stranding it
-	// undeletable and blocking stack teardown (mulga-siv-409).
+	// undeletable and blocking stack teardown.
 	state := cfg.VolumeMetadata.State
 	if cfg.VolumeMetadata.AttachedInstance != "" || (state != "available" && state != "") {
 		slog.Error("DeleteVolume: volume is in use", "volumeId", volumeID, "state", state, "attachedInstance", cfg.VolumeMetadata.AttachedInstance)

--- a/spinifex/handlers/ec2/volume/service_impl_test.go
+++ b/spinifex/handlers/ec2/volume/service_impl_test.go
@@ -1237,7 +1237,9 @@ func TestUpdateVolumeState_PreservesVBState(t *testing.T) {
 	err := svc.UpdateVolumeState("vol-vbstate", "in-use", "i-preserve", "/dev/nbd0")
 	require.NoError(t, err)
 
-	// Re-read the raw JSON to verify VBState fields survived
+	// config.json is owned by the live VB and must be left untouched: VBState
+	// fields survive and its embedded State is NOT rewritten (the control plane's
+	// attachment state lives in state.json now).
 	getResult, err := store.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String("test-bucket"),
 		Key:    aws.String("vol-vbstate/config.json"),
@@ -1252,8 +1254,14 @@ func TestUpdateVolumeState_PreservesVBState(t *testing.T) {
 
 	assert.Equal(t, uint32(4096), state.BlockSize)
 	assert.Equal(t, uint64(5), state.SeqNum)
-	assert.Equal(t, "in-use", state.VolumeConfig.VolumeMetadata.State)
-	assert.Equal(t, "i-preserve", state.VolumeConfig.VolumeMetadata.AttachedInstance)
+	assert.Equal(t, "available", state.VolumeConfig.VolumeMetadata.State,
+		"UpdateVolumeState must not rewrite config.json's embedded State")
+
+	// The attachment state is read back through the state.json overlay.
+	cfg, err := svc.GetVolumeConfig("vol-vbstate")
+	require.NoError(t, err)
+	assert.Equal(t, "in-use", cfg.VolumeMetadata.State)
+	assert.Equal(t, "i-preserve", cfg.VolumeMetadata.AttachedInstance)
 }
 
 // --- Group 6: listAllVolumeIDs tests ---
@@ -1371,7 +1379,7 @@ func TestDeleteVolume_EmptyStateUnattachedDeletable(t *testing.T) {
 	svc.snapshotKV = kv
 
 	// Drift: a detach/terminate left State empty with no attachment. The volume
-	// is not in use and must be deletable, not VolumeInUse (mulga-siv-409).
+	// is not in use and must be deletable, not VolumeInUse.
 	createVolumeInStoreWithMeta(t, store, "vol-drift", viperblock.VolumeMetadata{
 		VolumeID: "vol-drift",
 		SizeGiB:  10,
@@ -1400,7 +1408,7 @@ func TestDescribeVolumes_EmptyStateDerivedFromAttachment(t *testing.T) {
 		got[aws.StringValue(v.VolumeId)] = aws.StringValue(v.State)
 	}
 	assert.Equal(t, "available", got["vol-empty-unattached"], "empty state + no attachment renders available")
-	assert.Equal(t, "in-use", got["vol-empty-attached"], "empty state + attachment must not be masked as available (mulga-siv-409)")
+	assert.Equal(t, "in-use", got["vol-empty-attached"], "empty state + attachment must not be masked as available")
 }
 
 func TestUpdateVolumeState_EmptyUnattachedNormalizesToAvailable(t *testing.T) {
@@ -1409,7 +1417,7 @@ func TestUpdateVolumeState_EmptyUnattachedNormalizesToAvailable(t *testing.T) {
 	seedVolume(t, svc, "vol-norm", "in-use", "i-x")
 
 	// A detach writeback that clears the attachment without a state must not
-	// strand the volume with an empty State (mulga-siv-409).
+	// strand the volume with an empty State.
 	require.NoError(t, svc.UpdateVolumeState("vol-norm", "", "", ""))
 	cfg, err := svc.GetVolumeConfig("vol-norm")
 	require.NoError(t, err)

--- a/spinifex/handlers/ec2/vpc/service_impl_test.go
+++ b/spinifex/handlers/ec2/vpc/service_impl_test.go
@@ -1743,7 +1743,7 @@ func TestGetSubnet_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "subnet-missing")
 }
 
-// --- CreateTags write-through (mulga-siv-347) ---
+// --- CreateTags write-through ---
 
 func TestApplyRecordTags_SubnetTagFilteredDescribe(t *testing.T) {
 	svc := setupTestVPCService(t)

--- a/spinifex/handlers/eks/cluster_state.go
+++ b/spinifex/handlers/eks/cluster_state.go
@@ -78,6 +78,7 @@ type ClusterMeta struct {
 	EgressEIPPublicIP     string    `json:"egressEipPublicIp,omitempty"`
 	NLBArn                string    `json:"nlbArn,omitempty"`
 	NLBTargetGroupArn     string    `json:"nlbTargetGroupArn,omitempty"`
+	KonnTargetGroupArn    string    `json:"konnTargetGroupArn,omitempty"`
 	CreatedAt             time.Time `json:"createdAt"`
 	// DeletingSince stamps when the cluster entered DELETING. The teardown
 	// backstop reaper waits out a healthy synchronous DeleteCluster (min-age)

--- a/spinifex/handlers/eks/create_cluster_test.go
+++ b/spinifex/handlers/eks/create_cluster_test.go
@@ -116,7 +116,7 @@ func TestCreateCluster_PostPlacementFailedThenDeleteTerminatesControlPlane(t *te
 // same-name retry ever fires the FAILED-cluster reclaim, and the internet-facing
 // LB VM would otherwise keep its allocated+associated EIP indefinitely. The
 // FAILED meta is retained for observability; purge is idempotent so a later
-// DeleteCluster re-purge is a no-op (mulga-siv-293).
+// DeleteCluster re-purge is a no-op.
 func TestCreateCluster_FailedLaunchEagerlyPurgesInfra(t *testing.T) {
 	f := newEKSServiceFixture(t)
 	f.inst.launchErr = errors.New("no capacity")

--- a/spinifex/handlers/eks/delete_cluster_test.go
+++ b/spinifex/handlers/eks/delete_cluster_test.go
@@ -78,6 +78,7 @@ func newEKSServiceFixture(t *testing.T) *eksServiceFixture {
 		VPCSG:            sg,
 		VPCK3s:           vpc,
 		VPCSubnet:        fakeSubnetResolver{},
+		IAM:              newFakeEnsurer(),
 		NLB:              nlb,
 		Instance:         inst,
 		Image:            ami,
@@ -137,7 +138,7 @@ func newDeleteClusterFixture(t *testing.T, clusterName string) *deleteClusterFix
 }
 
 // TestDeleteCluster_LeakedSGKeepsClusterDeleting guards the customer-VPC SG
-// no-orphan contract (mulga-siv-340): the cluster SGs live in the customer VPC,
+// no-orphan contract: the cluster SGs live in the customer VPC,
 // so a DeleteClusterSGs failure must surface and leave the cluster DELETING — its
 // meta intact for a retry — never complete deletion with an SG stranded that pins
 // the VPC on DependencyViolation. All other teardown steps succeed, isolating the
@@ -161,7 +162,7 @@ func TestDeleteCluster_LeakedSGKeepsClusterDeleting(t *testing.T) {
 	assert.Equal(t, ClusterStatusDeleting, meta.Status, "a cluster with a leaked SG must stay DELETING")
 }
 
-// TestRLC5_DeleteClusterCPVPCReleasesNATGWEIPAfterRoutes locks the mulga-siv-303
+// TestRLC5_DeleteClusterCPVPCReleasesNATGWEIPAfterRoutes locks the
 // teardown order: route tables must be torn down before the NAT gateway, because
 // the NAT GW delete is guarded against live route forwards (rule #3). Deleting it
 // while the private route table still routes to it fails with DependencyViolation
@@ -185,7 +186,7 @@ func TestRLC5_DeleteClusterCPVPCReleasesNATGWEIPAfterRoutes(t *testing.T) {
 
 	require.Len(t, f.ngw.gws, 1)
 	assert.Equal(t, "deleted", f.ngw.gws[0].state, "NAT GW must delete after routes are cleared (rule #3 guard not tripped)")
-	require.Len(t, f.eip.releaseCalls, 1, "the NAT-GW EIP must be released, not stranded (mulga-siv-303)")
+	require.Len(t, f.eip.releaseCalls, 1, "the NAT-GW EIP must be released, not stranded")
 	assert.Equal(t, "eipalloc-cp", aws.StringValue(f.eip.releaseCalls[0].AllocationId))
 }
 
@@ -235,7 +236,7 @@ func TestDeleteCluster_AllTeardownSucceedsSweepsKV(t *testing.T) {
 	assert.Len(t, f.vpc.deleteCalls, 1)
 }
 
-// TestDeleteCluster_DetachesPrivateEndpointENIBeforeDelete locks the mulga-siv-301
+// TestDeleteCluster_DetachesPrivateEndpointENIBeforeDelete locks the
 // teardown fix: the Set A private-endpoint ENI is an extra NIC on the cluster NLB's
 // LB VM, not that VM's primary ENI, so the instance-terminate cascade never reclaims
 // it. purgeClusterInfra must detach (store-clear) the stale attachment before
@@ -323,7 +324,7 @@ func TestDeleteCluster_EgressEIPReleaseRealErrorLeavesMeta(t *testing.T) {
 	assert.NotEmpty(t, meta.EgressEIPAllocationID, "alloc ID must remain for retry")
 }
 
-// TestDeleteClusterSingleFlightLoserSkipsTeardown locks mulga-siv-295.12: when a
+// TestDeleteClusterSingleFlightLoserSkipsTeardown locks the contract: when a
 // concurrent handler already holds the per-cluster teardown lease (an SDK retry
 // fanned to another worker), DeleteCluster must return the cluster as DELETING
 // without running purgeClusterInfra — no duplicate ENI/NLB/EIP teardown — and
@@ -362,7 +363,7 @@ func TestDeleteClusterWinnerReleasesTeardownLease(t *testing.T) {
 	assert.ErrorIs(t, getErr, nats.ErrKeyNotFound, "the teardown lease must be released after a successful delete")
 }
 
-// TestDeleteCluster_ManagedCPVPCReclaimsCustomerVPCSGs guards mulga-siv-419: in
+// TestDeleteCluster_ManagedCPVPCReclaimsCustomerVPCSGs guards the contract: in
 // the managed control-plane VPC topology the nodegroup's worker-side security
 // groups are created by launchNodegroupInfra in the CUSTOMER VPC
 // (ResourcesVpcConfig.VpcId), not the managed CP VPC. Teardown must reclaim them

--- a/spinifex/handlers/eks/eks_billable_reaper_test.go
+++ b/spinifex/handlers/eks/eks_billable_reaper_test.go
@@ -36,8 +36,8 @@ func cpVM(id, eniID string) *vm.VM {
 // TestRLC5_EKSBillableReaperTerminatesOrphanCPVM enforces ADR-0006 §5
 // meta-independent billable cleanup: a running EKS control-plane VM whose
 // cluster meta is DEFINITIVELY GONE is a billable orphan and must be terminated
-// by the GC backstop — the real fix for mulga-siv-294 (orphan CP VM surviving a
-// daemon restart after DeleteCluster swept the meta).
+// by the GC backstop — the real fix for the orphan CP VM surviving a
+// daemon restart after DeleteCluster swept the meta.
 func TestRLC5_EKSBillableReaperTerminatesOrphanCPVM(t *testing.T) {
 	f := newEKSServiceFixture(t)
 	f.vpc.describeByENI = map[string]*ec2.NetworkInterface{
@@ -47,7 +47,7 @@ func TestRLC5_EKSBillableReaperTerminatesOrphanCPVM(t *testing.T) {
 
 	// Seed the orphan cluster's name/tag-driven billable infra the swept meta no
 	// longer anchors: an NLB front-end and a tagged NAT gateway holding a billable
-	// EIP. The reaper's post-terminate reclaim must sweep both (mulga-siv-302).
+	// EIP. The reaper's post-terminate reclaim must sweep both.
 	nlbName := ClusterNLBName("gone-cluster")
 	f.nlb.lbByName[nlbName] = &elbv2.LoadBalancer{
 		LoadBalancerArn:  aws.String("arn:lb-orphan"),
@@ -69,7 +69,7 @@ func TestRLC5_EKSBillableReaperTerminatesOrphanCPVM(t *testing.T) {
 	require.Len(t, f.vpc.deleteCalls, 1, "the orphan CP ENI must be deleted")
 	assert.Equal(t, "eni-orphan", aws.StringValue(f.vpc.deleteCalls[0].NetworkInterfaceId))
 
-	// mulga-siv-302: the orphan's billable NLB + NAT-GW EIP must also be reclaimed.
+	// The orphan's billable NLB + NAT-GW EIP must also be reclaimed.
 	assert.NotContains(t, f.nlb.lbByName, nlbName, "the orphan NLB front-end must be reclaimed")
 	require.Len(t, f.eip.releaseCalls, 1, "the orphan NAT-GW EIP must be released")
 	assert.Equal(t, "eipalloc-orphan", aws.StringValue(f.eip.releaseCalls[0].AllocationId))

--- a/spinifex/handlers/eks/eks_deleting_reaper_test.go
+++ b/spinifex/handlers/eks/eks_deleting_reaper_test.go
@@ -20,7 +20,7 @@ func markDeleting(t *testing.T, f *deleteClusterFixture, name string, age time.D
 	require.NoError(t, PutClusterMeta(f.kv, meta))
 }
 
-// TestRLC4_DeletingReaperReDrivesWedgedTeardown locks mulga-siv-295.11: a cluster
+// TestRLC4_DeletingReaperReDrivesWedgedTeardown locks the contract: a cluster
 // stuck in DELETING past min-age (its synchronous DeleteCluster failed and no
 // client re-issued) must be re-driven to completion by the backstop reaper —
 // infra torn down and meta swept — so its billable EIP is never stranded.

--- a/spinifex/handlers/eks/k3s_ha_control_plane.go
+++ b/spinifex/handlers/eks/k3s_ha_control_plane.go
@@ -130,6 +130,7 @@ func (s *EKSServiceImpl) placeControlPlane(accountID, clusterName string, tmpl K
 func (s *EKSServiceImpl) launchSingleControlPlane(tmpl K3sServerInput) ([]ControlPlaneNode, string, error) {
 	in := tmpl
 	in.TargetNodeID = ""
+	in.KonnServerCount = 1
 	out, err := LaunchK3sServerVM(s.deps.VPCK3s, s.deps.Instance, s.deps.Image, in)
 	if err != nil {
 		return nil, "", err
@@ -149,6 +150,7 @@ type cpLaunchResult struct {
 func (s *EKSServiceImpl) launchControlPlaneSpread(tmpl K3sServerInput, nodes []string) []cpLaunchResult {
 	results := make([]cpLaunchResult, len(nodes))
 
+	tmpl.KonnServerCount = len(nodes)
 	first := tmpl
 	first.TargetNodeID = nodes[0]
 	out, err := LaunchK3sServerVM(s.deps.VPCK3s, s.deps.Instance, s.deps.Image, first)
@@ -324,12 +326,19 @@ func NewNATSHostScheduler(nc *nats.Conn) HostScheduler {
 
 func (h *natsHostScheduler) SchedulableHosts(instanceType string) []string {
 	// sys.* types are hidden from customers in node.status but still consume
-	// vCPU/memory, so fit is checked against raw schedulable headroom.
-	vcpu, memGB, ok := instancetypes.SpecForSystemType(instanceType)
-	if !ok {
-		slog.Warn("SchedulableHosts: unknown system instance type, no schedulable hosts",
-			"instanceType", instanceType)
-		return nil
+	// vCPU/memory, so their fit is checked against raw schedulable headroom.
+	// Customer types (e.g. nodegroup workers) advertise per-type Available in
+	// node.status, so fit reads that directly.
+	isSystem := instancetypes.IsSystemType(instanceType)
+	var vcpu int
+	var memGB float64
+	if isSystem {
+		var ok bool
+		if vcpu, memGB, ok = instancetypes.SpecForSystemType(instanceType); !ok {
+			slog.Warn("SchedulableHosts: unknown system instance type, no schedulable hosts",
+				"instanceType", instanceType)
+			return nil
+		}
 	}
 
 	var hosts []string
@@ -339,12 +348,27 @@ func (h *natsHostScheduler) SchedulableHosts(instanceType string) []string {
 		if json.Unmarshal(data, &st) != nil || st.Node == "" || seen[st.Node] {
 			return
 		}
-		if nodeFitsSystemInstance(st, vcpu, memGB) {
+		fits := nodeFitsCustomerInstance(st, instanceType)
+		if isSystem {
+			fits = nodeFitsSystemInstance(st, vcpu, memGB)
+		}
+		if fits {
 			seen[st.Node] = true
 			hosts = append(hosts, st.Node)
 		}
 	})
 	return hosts
+}
+
+// nodeFitsCustomerInstance reports whether a node advertises at least one free
+// slot for the given customer instance type in its node.status capacity.
+func nodeFitsCustomerInstance(st types.NodeStatusResponse, instanceType string) bool {
+	for _, c := range st.InstanceTypes {
+		if c.Name == instanceType && c.Available >= 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // nodeFitsSystemInstance reports whether a node's headroom (Total - Reserved - Alloc)

--- a/spinifex/handlers/eks/k3s_ha_control_plane_test.go
+++ b/spinifex/handlers/eks/k3s_ha_control_plane_test.go
@@ -1,8 +1,10 @@
 package handlers_eks
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -13,10 +15,54 @@ import (
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	"github.com/mulgadc/spinifex/spinifex/handlers/sysinstance"
 	"github.com/mulgadc/spinifex/spinifex/instancetypes"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// serveNodeStatus replies to spinifex.node.status fan-outs with the given node
+// snapshots so the NATS host scheduler can be exercised end-to-end.
+func serveNodeStatus(t *testing.T, nc *nats.Conn, nodes []types.NodeStatusResponse) {
+	t.Helper()
+	sub, err := nc.Subscribe("spinifex.node.status", func(msg *nats.Msg) {
+		for _, n := range nodes {
+			data, _ := json.Marshal(n)
+			_ = nc.Publish(msg.Reply, data)
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+}
+
+// TestNATSHostScheduler_SchedulableHosts covers both fit paths: customer types
+// fit on advertised per-type Available; system types fit on raw headroom.
+func TestNATSHostScheduler_SchedulableHosts(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	serveNodeStatus(t, nc, []types.NodeStatusResponse{
+		{
+			Node: "nodeA", TotalVCPU: 32, TotalMemGB: 128,
+			InstanceTypes: []types.InstanceTypeCap{{Name: "t3.medium", Available: 3}},
+		},
+		{
+			Node: "nodeB", TotalVCPU: 0, TotalMemGB: 0,
+			InstanceTypes: []types.InstanceTypeCap{{Name: "t3.medium", Available: 0}},
+		},
+	})
+	sched := NewNATSHostScheduler(nc)
+
+	// Customer type: only the node advertising free capacity is schedulable.
+	require.Equal(t, []string{"nodeA"}, sched.SchedulableHosts("t3.medium"))
+
+	// System type: fit is decided by raw headroom, so the drained node drops out.
+	sysHosts := sched.SchedulableHosts(defaultK3sServerInstanceType)
+	sort.Strings(sysHosts)
+	require.Equal(t, []string{"nodeA"}, sysHosts)
+
+	// Unknown system type yields no hosts.
+	require.Empty(t, sched.SchedulableHosts("sys.bogus"))
+}
 
 // --- HA control-plane orchestrator test doubles ---
 

--- a/spinifex/handlers/eks/k3s_server_role.go
+++ b/spinifex/handlers/eks/k3s_server_role.go
@@ -17,9 +17,11 @@ const (
 	eksServerInlinePolicyName = "spinifex-eks-server-internal"
 
 	// eksServerInlinePolicy grants only the internal gateway actions the CP VM
-	// calls: PublishInternal (bootstrap/state) and ListInternalAddons (addon
-	// fetch). The gateway evaluates these per request against the role's policies.
-	eksServerInlinePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["eks:PublishInternal","eks:ListInternalAddons"],"Resource":"*"}]}`
+	// calls: PublishInternal (bootstrap/state), ListInternalAddons (addon fetch),
+	// and WebhookTokenReview (the eks-token-webhook relays `aws eks get-token`
+	// bearer tokens to the token-review broker for host-side STS verification).
+	// The gateway evaluates these per request against the role's policies.
+	eksServerInlinePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["eks:PublishInternal","eks:ListInternalAddons","eks:WebhookTokenReview"],"Resource":"*"}]}`
 )
 
 // ensureCPInstanceProfile returns the CP instance-profile ARN, or "" to signal

--- a/spinifex/handlers/eks/k3s_server_role_test.go
+++ b/spinifex/handlers/eks/k3s_server_role_test.go
@@ -30,6 +30,10 @@ func TestEnsureK3sServerInstanceProfile_CreatesRolePolicyProfile(t *testing.T) {
 	policy := f.rolePolicies[eksServerSystemRoleName]
 	assert.Contains(t, policy, "eks:PublishInternal")
 	assert.Contains(t, policy, "eks:ListInternalAddons")
+	// The eks-token-webhook relays get-token bearer tokens to the token-review
+	// broker with these IMDS creds; without this action the gateway 403s the
+	// relay and every external `kubectl` gets 401.
+	assert.Contains(t, policy, "eks:WebhookTokenReview")
 
 	require.NotNil(t, f.profiles[eksServerSystemRoleName])
 	assert.Len(t, f.profiles[eksServerSystemRoleName].Roles, 1)

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -74,6 +74,16 @@ const (
 	// k3sConfigPath is the K3s server config file written by cloud-init.
 	k3sConfigPath = "/etc/rancher/k3s/config.yaml"
 
+	// k3sEgressSelectorConfigPath is the EgressSelectorConfiguration the apiserver
+	// loads via --egress-selector-config-file. It points the `cluster` egress at the
+	// konnectivity-server UDS, so apiserver→pod/kubelet traffic (exec/logs/webhooks)
+	// rides the agent-initiated reverse tunnel instead of a direct (unroutable) IP.
+	k3sEgressSelectorConfigPath = "/etc/rancher/k3s/egress-selector-config.yaml"
+
+	// konnectivityUDSPath is the unix socket the konnectivity-server listens on for
+	// apiserver egress. Must match the udsName in the EgressSelectorConfiguration.
+	konnectivityUDSPath = "/run/konnectivity/konnectivity-server.socket"
+
 	// k3sResolvConfPath is the on-VM resolver path. The Alpine AMI's dhcpcd hook
 	// cannot create /etc/resolv.conf, so cloud-init writes a static resolver here.
 	k3sResolvConfPath = "/etc/resolv.conf"
@@ -143,6 +153,11 @@ type K3sServerInput struct {
 	// ServerURL boots this VM as a JOIN server joining the quorum at the given endpoint.
 	// Empty = first server (cluster-init). Non-empty requires JoinToken.
 	ServerURL string
+	// KonnServerCount is the number of apiserver replicas in this cluster (1 for a
+	// single CP, len(nodes) for an HA spread). Surfaced as
+	// EKS_KONNECTIVITY_SERVER_COUNT so the konnectivity-server advertises
+	// --server-count=N and every agent holds a tunnel to every replica (HA-correct).
+	KonnServerCount int
 }
 
 // K3sServerOutput carries identifiers to persist in ClusterMeta and register with the NLB.
@@ -278,7 +293,7 @@ func TerminateK3sServerVM(
 // owns this ENI and has already terminated its VM, so the attachment is
 // authoritatively dead even if the record still shows it in-use — a state a
 // plain force=false delete would reject as InvalidNetworkInterface.InUse
-// forever, wedging EKSDeletingReaper in a no-progress loop (mulga-siv-407).
+// forever, wedging EKSDeletingReaper in a no-progress loop.
 // Detach first to clear the stale attachment fields, then delete. Both calls
 // tolerate an already-gone ENI (NotFound), so a race with the async
 // instance-terminate cascade that removes the same ENI resolves to idempotent
@@ -401,6 +416,41 @@ func k3sServerJoinURL(ip string) string {
 	return "https://" + net.JoinHostPort(ip, "6443")
 }
 
+// egressSelectorConfigYAML renders the EgressSelectorConfiguration that wires the
+// apiserver `cluster` egress to the konnectivity-server UDS. v1beta1 is the schema
+// k3s/kube-apiserver accept for --egress-selector-config-file.
+func egressSelectorConfigYAML() string {
+	return strings.Join([]string{
+		"apiVersion: apiserver.k8s.io/v1beta1",
+		"kind: EgressSelectorConfiguration",
+		"egressSelections:",
+		"  - name: cluster",
+		"    connection:",
+		"      proxyProtocol: GRPC",
+		"      transport:",
+		"        uds:",
+		"          udsName: " + konnectivityUDSPath,
+	}, "\n")
+}
+
+// dedupeNonEmpty returns the input with empty strings dropped and duplicates
+// removed, preserving first-seen order.
+func dedupeNonEmpty(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
 // userDataFile is one entry in the cloud-config write_files block.
 type userDataFile struct {
 	Path  string
@@ -419,6 +469,17 @@ func buildK3sUserData(in K3sServerInput) string {
 	if in.ServerURL != "" {
 		role = "server-join"
 	}
+
+	// Konnectivity wiring (apiserver-network-proxy). HOST is the worker-reachable
+	// address agents dial (the Set A private-endpoint, else the public endpoint);
+	// SANS are the konnectivity-server cert SANs the appliance mints from the k3s CA.
+	// SERVER_COUNT advertises --server-count=N so every agent tunnels to every replica.
+	konnHost := in.PrivateEndpointIP
+	if konnHost == "" {
+		konnHost = in.EndpointIP
+	}
+	konnSANs := dedupeNonEmpty([]string{in.PrivateEndpointIP, in.EndpointIP, in.NLBDNS})
+	konnCount := max(in.KonnServerCount, 1)
 
 	envLines := []string{
 		"SPINIFEX_K3S_ROLE=" + role,
@@ -442,6 +503,9 @@ func buildK3sUserData(in K3sServerInput) string {
 		"EKS_CLUSTER_NAME="+in.ClusterName,
 		"EKS_NLB_ENDPOINT="+nlbEndpoint,
 		"EKS_OIDC_ISSUER="+in.OIDCIssuer,
+		"EKS_KONNECTIVITY_HOST="+konnHost,
+		"EKS_KONNECTIVITY_SANS="+strings.Join(konnSANs, ","),
+		"EKS_KONNECTIVITY_SERVER_COUNT="+strconv.Itoa(konnCount),
 	)
 	envBody := strings.Join(envLines, "\n")
 
@@ -460,13 +524,14 @@ func buildK3sUserData(in K3sServerInput) string {
 	if in.JoinToken != "" {
 		configLines = append(configLines, "token: "+in.JoinToken)
 	}
+	configLines = append(configLines, "etcd-expose-metrics: true")
+	// Egress selector: disable k3s's own remotedialer and point the apiserver's
+	// `cluster` egress at the upstream konnectivity-server UDS via the injected
+	// EgressSelectorConfiguration. konnectivity-agents (DaemonSet on workers) dial
+	// out and hold a tunnel to every apiserver replica, so apiserver→pod/kubelet
+	// egress is HA-correct (no single-VIP fan-out 502). EKS-parity datapath.
+	configLines = append(configLines, "egress-selector-mode: disabled")
 	configLines = append(configLines,
-		"etcd-expose-metrics: true",
-		// Managed-CP: the apiserver VM sits in the system CP VPC with no route to
-		// the worker pod network. `cluster` routes apiserver->pod/service traffic
-		// (admission webhooks, aggregated APIs) through the agent's outbound tunnel;
-		// the default `agent` mode tunnels only kubelet, leaving webhooks unreachable.
-		"egress-selector-mode: cluster",
 		// Prevent user workloads on the CP (EKS parity). k3s packaged addons tolerate CriticalAddonsOnly.
 		"node-taint:",
 		"  - CriticalAddonsOnly=true:NoExecute",
@@ -510,6 +575,8 @@ func buildK3sUserData(in K3sServerInput) string {
 		"  - authentication-token-webhook-cache-ttl=5m",
 		// v1: default v1beta1 rejects authentication.k8s.io/v1 TokenReview response (401).
 		"  - authentication-token-webhook-version=v1",
+		// Route the apiserver `cluster` egress through konnectivity (see config file).
+		"  - egress-selector-config-file="+k3sEgressSelectorConfigPath,
 	)
 	k3sConfig := strings.Join(configLines, "\n")
 
@@ -519,6 +586,7 @@ func buildK3sUserData(in K3sServerInput) string {
 		{Path: k3sOIDCSigningKeyPath, Perms: "0600", Body: strings.TrimRight(in.OIDCPrivateKeyPEM, "\n")},
 		{Path: k3sOIDCPublicKeyPath, Perms: "0644", Body: strings.TrimRight(in.OIDCPublicKeyPEM, "\n")},
 		{Path: k3sConfigPath, Perms: "0644", Body: k3sConfig},
+		{Path: k3sEgressSelectorConfigPath, Perms: "0644", Body: egressSelectorConfigYAML()},
 		{Path: k3sGatewayCAPath, Perms: "0644", Body: strings.TrimRight(in.GatewayCACert, "\n")},
 	}
 

--- a/spinifex/handlers/eks/k3s_server_vm_test.go
+++ b/spinifex/handlers/eks/k3s_server_vm_test.go
@@ -411,10 +411,47 @@ func TestBuildK3sUserData_AdvertiseAddressFallsBackToEndpoint(t *testing.T) {
 	assert.Contains(t, ud, "advertise-address: 203.0.113.9")
 }
 
-func TestBuildK3sUserData_EgressSelectorClusterMode(t *testing.T) {
+func TestBuildK3sUserData_EgressSelectorDisabledWithKonnConfig(t *testing.T) {
 	ud := buildK3sUserData(validK3sInput())
-	assert.Contains(t, ud, "egress-selector-mode: cluster",
-		"managed-CP apiserver must tunnel pod/service traffic (webhooks) through the agent")
+	assert.Contains(t, ud, "egress-selector-mode: disabled",
+		"k3s remotedialer is off; the apiserver egress rides upstream konnectivity")
+	assert.NotContains(t, ud, "egress-selector-mode: cluster")
+	assert.Contains(t, ud, "egress-selector-config-file="+k3sEgressSelectorConfigPath,
+		"apiserver cluster egress must point at the konnectivity UDS")
+	assert.Contains(t, ud, "udsName: "+konnectivityUDSPath,
+		"the EgressSelectorConfiguration file routes the cluster egress to the konn socket")
+}
+
+func TestBuildK3sUserData_KonnectivityEnv(t *testing.T) {
+	in := validK3sInput()
+	in.PrivateEndpointIP = "10.32.100.4"
+	in.EndpointIP = "203.0.113.9"
+	in.KonnServerCount = 3
+
+	ud := buildK3sUserData(in)
+	assert.Contains(t, ud, "EKS_KONNECTIVITY_HOST=10.32.100.4",
+		"agents dial the private-endpoint IP to reach the konnectivity-server")
+	assert.Contains(t, ud, "EKS_KONNECTIVITY_SERVER_COUNT=3",
+		"agents must learn the apiserver replica count to tunnel to every replica")
+	assert.Contains(t, ud, "EKS_KONNECTIVITY_SANS=10.32.100.4,203.0.113.9,"+in.NLBDNS)
+}
+
+func TestBuildK3sUserData_KonnServerCountDefaultsToOne(t *testing.T) {
+	in := validK3sInput()
+	in.KonnServerCount = 0
+	ud := buildK3sUserData(in)
+	assert.Contains(t, ud, "EKS_KONNECTIVITY_SERVER_COUNT=1",
+		"a zero/unset count means a single apiserver")
+}
+
+func TestLaunchK3sServerVM_SingleControlPlaneENI(t *testing.T) {
+	vpc, inst, ami := &fakeK3sVPC{}, &fakeK3sInst{}, &fakeK3sAMI{}
+
+	_, err := LaunchK3sServerVM(vpc, inst, ami, validK3sInput())
+	require.NoError(t, err)
+	require.Len(t, vpc.createCalls, 1, "only the primary CP ENI; konnectivity needs no extra NIC")
+	require.Len(t, inst.launchCalls, 1)
+	assert.Empty(t, inst.launchCalls[0].ExtraENIs)
 }
 
 func TestLaunchK3sServerVM_UserDataContainsAllArtifacts(t *testing.T) {
@@ -655,7 +692,7 @@ func TestTerminateK3sServerVM_ENINotFoundIsIdempotent(t *testing.T) {
 }
 
 func TestTerminateK3sServerVM_ENIInUseDetachedThenDeletes(t *testing.T) {
-	// mulga-siv-407: the ENI record still shows the attachment (VM gone but
+	// The ENI record still shows the attachment (VM gone but
 	// fields never cleared), so a plain force=false delete returns InUse forever
 	// and wedges EKSDeletingReaper. Teardown owns the ENI: detach clears the
 	// stale attachment, then the delete succeeds — no retry loop.

--- a/spinifex/handlers/eks/lifecycle_invariants_test.go
+++ b/spinifex/handlers/eks/lifecycle_invariants_test.go
@@ -45,7 +45,7 @@ func TestRLC2_EKSBillableTeardownBeforeKVSweep(t *testing.T) {
 }
 
 // TestRLC3_EKSNLBNoOrphanTargetGroupAfterDelete enforces ADR-0006 §6 NLB
-// no-orphan (riding ADR-0002 / mulga-siv-172 cascade composition): after a
+// no-orphan (riding ADR-0002 cascade composition): after a
 // successful DeleteCluster, the eks-{cluster}-cp target group must be gone — an
 // orphaned EKS NLB target group would pin itself as ResourceInUse exactly as a
 // user target group does.

--- a/spinifex/handlers/eks/nlb.go
+++ b/spinifex/handlers/eks/nlb.go
@@ -52,12 +52,21 @@ const clusterNLBListenPort int64 = 443
 // resources from spinifex-owned ones (which use spinifex:eks-cluster).
 const lbcClusterOwnershipTagKey = "elbv2.k8s.aws/cluster"
 
+// konnectivityAgentPort is the konnectivity-server agent listen port. The NLB
+// fronts it so worker konnectivity-agents reach the 3 CP konnectivity-servers
+// through one VIP; server-count fan-out gives each apiserver a tunnel to every
+// agent (HA apiserver->pod/kubelet/webhook egress, EKS-parity).
+const konnectivityAgentPort int64 = 8132
+
 // ClusterNLB is the NLB resource tuple produced by EnsureClusterNLB; ARNs are persisted to ClusterMeta.
 type ClusterNLB struct {
 	LoadBalancerArn string
 	TargetGroupArn  string
-	ListenerArn     string
-	DNSName         string
+	// KonnTargetGroupArn is the konnectivity-server target group (:8132 → 3 CP
+	// servers). Empty until the konnectivity listener is provisioned.
+	KonnTargetGroupArn string
+	ListenerArn        string
+	DNSName            string
 	// FrontendIP is the public IP (internet-facing) or VPC IP (internal) of the NLB front-end.
 	// Used as the kubeconfig endpoint host and apiserver cert SAN; empty if not yet provisioned.
 	FrontendIP string
@@ -72,6 +81,12 @@ func ClusterNLBName(clusterName string) string {
 // cluster's control-plane TG.
 func ClusterTargetGroupName(clusterName string) string {
 	return "eks-" + clusterName + "-cp"
+}
+
+// ClusterKonnTargetGroupName returns the deterministic target-group name for a
+// cluster's konnectivity TG (:8132 → 3 CP servers).
+func ClusterKonnTargetGroupName(clusterName string) string {
+	return "eks-" + clusterName + "-konn"
 }
 
 // EnsureClusterNLB provisions (or returns) the cluster's NLB + target group +
@@ -106,11 +121,11 @@ func EnsureClusterNLB(nlbp nlbProvisioner, accountID, clusterName string, subnet
 	}
 	lbName := ClusterNLBName(clusterName)
 	tgName := ClusterTargetGroupName(clusterName)
-	if len(lbName) > maxELBv2NameLen {
-		return nil, fmt.Errorf("eks: NLB name %q exceeds %d chars (cluster name too long)", lbName, maxELBv2NameLen)
-	}
-	if len(tgName) > maxELBv2NameLen {
-		return nil, fmt.Errorf("eks: TG name %q exceeds %d chars (cluster name too long)", tgName, maxELBv2NameLen)
+	konnTGName := ClusterKonnTargetGroupName(clusterName)
+	for _, n := range []string{lbName, tgName, konnTGName} {
+		if len(n) > maxELBv2NameLen {
+			return nil, fmt.Errorf("eks: ELBv2 name %q exceeds %d chars (cluster name too long)", n, maxELBv2NameLen)
+		}
 	}
 
 	out := &ClusterNLB{}
@@ -118,10 +133,10 @@ func EnsureClusterNLB(nlbp nlbProvisioner, accountID, clusterName string, subnet
 	if err := ensureClusterLB(nlbp, accountID, clusterName, lbName, subnetIDs, internetFacing, crossAccountENIs, out); err != nil {
 		return nil, err
 	}
-	if err := ensureClusterTG(nlbp, accountID, clusterName, tgName, out); err != nil {
+	var err error
+	if out.TargetGroupArn, err = ensureClusterTG(nlbp, accountID, clusterName, tgName, k3sAPIServerPort); err != nil {
 		return nil, err
 	}
-	var err error
 	if out.ListenerArn, err = ensureClusterListener(nlbp, accountID, lbName, out.LoadBalancerArn, out.TargetGroupArn, clusterNLBListenPort); err != nil {
 		return nil, err
 	}
@@ -129,6 +144,14 @@ func EnsureClusterNLB(nlbp nlbProvisioner, accountID, clusterName string, subnet
 	// on :6443 in the in-cluster `kubernetes` Endpoints; worker pods reach it only if
 	// the NLB serves :6443. Arn not persisted — teardown cascades via DeleteLoadBalancer.
 	if _, err = ensureClusterListener(nlbp, accountID, lbName, out.LoadBalancerArn, out.TargetGroupArn, k3sAPIServerPort); err != nil {
+		return nil, err
+	}
+	// Konnectivity TG + listener :8132 → the 3 CP konnectivity-servers. Worker
+	// konnectivity-agents dial this VIP; server-count fan-out reaches all 3 servers.
+	if out.KonnTargetGroupArn, err = ensureClusterTG(nlbp, accountID, clusterName, konnTGName, konnectivityAgentPort); err != nil {
+		return nil, err
+	}
+	if _, err = ensureClusterListener(nlbp, accountID, lbName, out.LoadBalancerArn, out.KonnTargetGroupArn, konnectivityAgentPort); err != nil {
 		return nil, err
 	}
 	if internetFacing && narrowsPublicAccess(publicAccessCidrs) {
@@ -187,17 +210,18 @@ func frontendIPFromLB(lb *elbv2.LoadBalancer, internetFacing bool) string {
 	return ""
 }
 
-// RegisterClusterTarget attaches one ENI IP to the cluster TG.
-func RegisterClusterTarget(nlbp nlbProvisioner, accountID, tgArn, eniIP string) error {
+// RegisterClusterTarget attaches one ENI IP to the cluster TG on port.
+func RegisterClusterTarget(nlbp nlbProvisioner, accountID, tgArn, eniIP string, port int64) error {
 	if eniIP == "" {
 		return errors.New("eks: RegisterClusterTarget empty ENI IP")
 	}
-	return RegisterClusterTargets(nlbp, accountID, tgArn, []string{eniIP})
+	return RegisterClusterTargets(nlbp, accountID, tgArn, []string{eniIP}, port)
 }
 
-// RegisterClusterTargets attaches all CP ENI IPs to the cluster TG. Empty IPs are
-// skipped; RegisterTargets deduplicates on (id, port) so re-invocation is idempotent.
-func RegisterClusterTargets(nlbp nlbProvisioner, accountID, tgArn string, eniIPs []string) error {
+// RegisterClusterTargets attaches all CP ENI IPs to the cluster TG on port. Empty
+// IPs are skipped; RegisterTargets deduplicates on (id, port) so re-invocation is
+// idempotent.
+func RegisterClusterTargets(nlbp nlbProvisioner, accountID, tgArn string, eniIPs []string, port int64) error {
 	if tgArn == "" {
 		return errors.New("eks: RegisterClusterTargets empty TG arn")
 	}
@@ -208,7 +232,7 @@ func RegisterClusterTargets(nlbp nlbProvisioner, accountID, tgArn string, eniIPs
 		}
 		targets = append(targets, &elbv2.TargetDescription{
 			Id:   aws.String(ip),
-			Port: aws.Int64(k3sAPIServerPort),
+			Port: aws.Int64(port),
 		})
 	}
 	if len(targets) == 0 {
@@ -223,8 +247,8 @@ func RegisterClusterTargets(nlbp nlbProvisioner, accountID, tgArn string, eniIPs
 	return nil
 }
 
-// DeregisterClusterTarget removes an ENI IP from the cluster TG before VM termination.
-func DeregisterClusterTarget(nlbp nlbProvisioner, accountID, tgArn, eniIP string) error {
+// DeregisterClusterTarget removes an ENI IP from the cluster TG (on port) before VM termination.
+func DeregisterClusterTarget(nlbp nlbProvisioner, accountID, tgArn, eniIP string, port int64) error {
 	if tgArn == "" {
 		return errors.New("eks: DeregisterClusterTarget empty TG arn")
 	}
@@ -235,7 +259,7 @@ func DeregisterClusterTarget(nlbp nlbProvisioner, accountID, tgArn, eniIP string
 		TargetGroupArn: aws.String(tgArn),
 		Targets: []*elbv2.TargetDescription{{
 			Id:   aws.String(eniIP),
-			Port: aws.Int64(k3sAPIServerPort),
+			Port: aws.Int64(port),
 		}},
 	}, accountID); err != nil {
 		return fmt.Errorf("deregister target %s on TG %s: %w", eniIP, tgArn, err)
@@ -251,10 +275,16 @@ func DeleteClusterNLB(nlbp nlbProvisioner, accountID, clusterName string) error 
 	}
 	lbErr := deleteClusterLB(nlbp, accountID, ClusterNLBName(clusterName))
 	tgErr := deleteClusterTG(nlbp, accountID, ClusterTargetGroupName(clusterName))
-	if lbErr != nil {
+	// The konnectivity TG is a no-op for clusters created before this topology.
+	konnErr := deleteClusterTG(nlbp, accountID, ClusterKonnTargetGroupName(clusterName))
+	switch {
+	case lbErr != nil:
 		return lbErr
+	case tgErr != nil:
+		return tgErr
+	default:
+		return konnErr
 	}
-	return tgErr
 }
 
 func deleteClusterLB(nlbp nlbProvisioner, accountID, lbName string) error {
@@ -347,21 +377,23 @@ func ensureClusterLB(nlbp nlbProvisioner, accountID, clusterName, lbName string,
 	return nil
 }
 
-func ensureClusterTG(nlbp nlbProvisioner, accountID, clusterName, tgName string, out *ClusterNLB) error {
+// ensureClusterTG creates (or reuses) a TCP target group of the given name
+// forwarding to port, returning its ARN. Idempotent on name.
+func ensureClusterTG(nlbp nlbProvisioner, accountID, clusterName, tgName string, port int64) (string, error) {
 	if tg, err := lookupTGByName(nlbp, accountID, tgName); err != nil {
-		return err
+		return "", err
 	} else if tg != nil {
-		out.TargetGroupArn = aws.StringValue(tg.TargetGroupArn)
-		if out.TargetGroupArn == "" {
-			return fmt.Errorf("eks: existing TG %s missing arn", tgName)
+		arn := aws.StringValue(tg.TargetGroupArn)
+		if arn == "" {
+			return "", fmt.Errorf("eks: existing TG %s missing arn", tgName)
 		}
-		return nil
+		return arn, nil
 	}
 
 	created, err := nlbp.CreateTargetGroup(&elbv2.CreateTargetGroupInput{
 		Name:       aws.String(tgName),
 		Protocol:   aws.String(elbv2.ProtocolEnumTcp),
-		Port:       aws.Int64(k3sAPIServerPort),
+		Port:       aws.Int64(port),
 		TargetType: aws.String(elbv2.TargetTypeEnumIp),
 		Tags: []*elbv2.Tag{
 			{Key: aws.String(tags.ManagedByKey), Value: aws.String(tags.ManagedByEKS)},
@@ -369,16 +401,16 @@ func ensureClusterTG(nlbp nlbProvisioner, accountID, clusterName, tgName string,
 		},
 	}, accountID)
 	if err != nil {
-		return fmt.Errorf("create TG %s: %w", tgName, err)
+		return "", fmt.Errorf("create TG %s: %w", tgName, err)
 	}
 	if created == nil || len(created.TargetGroups) == 0 || created.TargetGroups[0] == nil {
-		return fmt.Errorf("eks: CreateTargetGroup returned no TG for %s", tgName)
+		return "", fmt.Errorf("eks: CreateTargetGroup returned no TG for %s", tgName)
 	}
-	out.TargetGroupArn = aws.StringValue(created.TargetGroups[0].TargetGroupArn)
-	if out.TargetGroupArn == "" {
-		return fmt.Errorf("eks: CreateTargetGroup returned empty arn for %s", tgName)
+	arn := aws.StringValue(created.TargetGroups[0].TargetGroupArn)
+	if arn == "" {
+		return "", fmt.Errorf("eks: CreateTargetGroup returned empty arn for %s", tgName)
 	}
-	return nil
+	return arn, nil
 }
 
 // ensureClusterListener creates (or reuses) one TCP listener on the LB at the

--- a/spinifex/handlers/eks/nlb_test.go
+++ b/spinifex/handlers/eks/nlb_test.go
@@ -186,10 +186,13 @@ func (f *fakeNLBProvisioner) CreateTargetGroup(input *elbv2.CreateTargetGroupInp
 	if f.createTGErr != nil {
 		return nil, f.createTGErr
 	}
-	if f.createTGOut == nil {
+	out := f.createTGOut
+	if out == nil {
+		// Build per-call so distinct names (cp + konn) get distinct ARNs and both
+		// register for idempotent re-entry — a single cached output mis-serves both.
 		name := aws.StringValue(input.Name)
 		arn := "arn:aws:elasticloadbalancing:us-east-1:111122223333:targetgroup/" + name + "/tg-001"
-		f.createTGOut = &elbv2.CreateTargetGroupOutput{
+		out = &elbv2.CreateTargetGroupOutput{
 			TargetGroups: []*elbv2.TargetGroup{{
 				TargetGroupArn:  aws.String(arn),
 				TargetGroupName: aws.String(name),
@@ -199,7 +202,6 @@ func (f *fakeNLBProvisioner) CreateTargetGroup(input *elbv2.CreateTargetGroupInp
 			}},
 		}
 	}
-	out := f.createTGOut
 	if len(out.TargetGroups) > 0 {
 		name := aws.StringValue(out.TargetGroups[0].TargetGroupName)
 		f.tgByName[name] = out.TargetGroups[0]
@@ -333,15 +335,20 @@ func TestEnsureClusterNLB_FreshCreatesAllThree(t *testing.T) {
 	assert.Equal(t, []string{"subnet-aaa", "subnet-bbb"}, aws.StringValueSlice(lbIn.Subnets))
 	assertELBv2TaggedAsEKS(t, lbIn.Tags, "alpha")
 
-	require.Len(t, nlbp.createTGCalls, 1)
+	require.Len(t, nlbp.createTGCalls, 2)
 	tgIn := nlbp.createTGCalls[0]
 	assert.Equal(t, "eks-alpha-cp", aws.StringValue(tgIn.Name))
 	assert.Equal(t, elbv2.ProtocolEnumTcp, aws.StringValue(tgIn.Protocol))
 	assert.Equal(t, k3sAPIServerPort, aws.Int64Value(tgIn.Port))
 	assert.Equal(t, elbv2.TargetTypeEnumIp, aws.StringValue(tgIn.TargetType))
 	assertELBv2TaggedAsEKS(t, tgIn.Tags, "alpha")
+	// Second TG is the konnectivity :8132 group fronting the CP konnectivity-servers.
+	konnTGIn := nlbp.createTGCalls[1]
+	assert.Equal(t, "eks-alpha-konn", aws.StringValue(konnTGIn.Name))
+	assert.Equal(t, konnectivityAgentPort, aws.Int64Value(konnTGIn.Port))
+	assert.NotEmpty(t, out.KonnTargetGroupArn)
 
-	require.Len(t, nlbp.createListenerCalls, 2)
+	require.Len(t, nlbp.createListenerCalls, 3)
 	lstIn := nlbp.createListenerCalls[0]
 	assert.Equal(t, out.LoadBalancerArn, aws.StringValue(lstIn.LoadBalancerArn))
 	assert.Equal(t, elbv2.ProtocolEnumTcp, aws.StringValue(lstIn.Protocol))
@@ -355,6 +362,11 @@ func TestEnsureClusterNLB_FreshCreatesAllThree(t *testing.T) {
 	assert.Equal(t, elbv2.ProtocolEnumTcp, aws.StringValue(apiLstIn.Protocol))
 	require.Len(t, apiLstIn.DefaultActions, 1)
 	assert.Equal(t, out.TargetGroupArn, aws.StringValue(apiLstIn.DefaultActions[0].TargetGroupArn))
+	// Third listener serves :8132 to the konnectivity TG.
+	konnLstIn := nlbp.createListenerCalls[2]
+	assert.Equal(t, konnectivityAgentPort, aws.Int64Value(konnLstIn.Port))
+	require.Len(t, konnLstIn.DefaultActions, 1)
+	assert.Equal(t, out.KonnTargetGroupArn, aws.StringValue(konnLstIn.DefaultActions[0].TargetGroupArn))
 }
 
 func TestEnsureClusterNLB_NoFrontendIPFailsLoud(t *testing.T) {
@@ -516,7 +528,7 @@ func TestEnsureClusterNLB_SetIngressErrorSurfaced(t *testing.T) {
 func TestRegisterClusterTarget_PostsENIIPAndAPIPort(t *testing.T) {
 	nlbp := newFakeNLBProvisioner()
 
-	err := RegisterClusterTarget(nlbp, "111122223333", "arn:tg/alpha", "10.0.1.42")
+	err := RegisterClusterTarget(nlbp, "111122223333", "arn:tg/alpha", "10.0.1.42", k3sAPIServerPort)
 	require.NoError(t, err)
 	require.Len(t, nlbp.registerCalls, 1)
 
@@ -529,8 +541,8 @@ func TestRegisterClusterTarget_PostsENIIPAndAPIPort(t *testing.T) {
 
 func TestRegisterClusterTarget_EmptyInputsRejected(t *testing.T) {
 	nlbp := newFakeNLBProvisioner()
-	require.Error(t, RegisterClusterTarget(nlbp, "111122223333", "", "10.0.1.42"))
-	require.Error(t, RegisterClusterTarget(nlbp, "111122223333", "arn:tg/alpha", ""))
+	require.Error(t, RegisterClusterTarget(nlbp, "111122223333", "", "10.0.1.42", k3sAPIServerPort))
+	require.Error(t, RegisterClusterTarget(nlbp, "111122223333", "arn:tg/alpha", "", k3sAPIServerPort))
 	assert.Empty(t, nlbp.registerCalls)
 }
 
@@ -538,7 +550,7 @@ func TestRegisterClusterTargets_RegistersEveryENIIPInOneCall(t *testing.T) {
 	nlbp := newFakeNLBProvisioner()
 
 	err := RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha",
-		[]string{"10.0.1.10", "10.0.2.11", "10.0.3.12"})
+		[]string{"10.0.1.10", "10.0.2.11", "10.0.3.12"}, k3sAPIServerPort)
 	require.NoError(t, err)
 	require.Len(t, nlbp.registerCalls, 1)
 
@@ -555,7 +567,7 @@ func TestRegisterClusterTargets_SkipsEmptyIPs(t *testing.T) {
 	nlbp := newFakeNLBProvisioner()
 
 	err := RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha",
-		[]string{"10.0.1.10", "", "10.0.3.12"})
+		[]string{"10.0.1.10", "", "10.0.3.12"}, k3sAPIServerPort)
 	require.NoError(t, err)
 	require.Len(t, nlbp.registerCalls, 1)
 	require.Len(t, nlbp.registerCalls[0].Targets, 2)
@@ -565,9 +577,9 @@ func TestRegisterClusterTargets_SkipsEmptyIPs(t *testing.T) {
 
 func TestRegisterClusterTargets_EmptyInputsRejected(t *testing.T) {
 	nlbp := newFakeNLBProvisioner()
-	require.Error(t, RegisterClusterTargets(nlbp, "111122223333", "", []string{"10.0.1.10"}))
-	require.Error(t, RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha", nil))
-	require.Error(t, RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha", []string{"", ""}))
+	require.Error(t, RegisterClusterTargets(nlbp, "111122223333", "", []string{"10.0.1.10"}, k3sAPIServerPort))
+	require.Error(t, RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha", nil, k3sAPIServerPort))
+	require.Error(t, RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha", []string{"", ""}, k3sAPIServerPort))
 	assert.Empty(t, nlbp.registerCalls)
 }
 
@@ -575,7 +587,7 @@ func TestRegisterClusterTargets_RegisterErrorSurfaced(t *testing.T) {
 	nlbp := newFakeNLBProvisioner()
 	nlbp.registerErr = errors.New("TargetGroupNotFound")
 
-	err := RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha", []string{"10.0.1.10"})
+	err := RegisterClusterTargets(nlbp, "111122223333", "arn:tg/alpha", []string{"10.0.1.10"}, k3sAPIServerPort)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "arn:tg/alpha")
 }
@@ -583,7 +595,7 @@ func TestRegisterClusterTargets_RegisterErrorSurfaced(t *testing.T) {
 func TestDeregisterClusterTarget_PostsENIIPAndAPIPort(t *testing.T) {
 	nlbp := newFakeNLBProvisioner()
 
-	err := DeregisterClusterTarget(nlbp, "111122223333", "arn:tg/alpha", "10.0.1.42")
+	err := DeregisterClusterTarget(nlbp, "111122223333", "arn:tg/alpha", "10.0.1.42", k3sAPIServerPort)
 	require.NoError(t, err)
 	require.Len(t, nlbp.deregisterCalls, 1)
 
@@ -602,8 +614,13 @@ func TestDeleteClusterNLB_DeletesBoth(t *testing.T) {
 	require.NoError(t, DeleteClusterNLB(nlbp, "111122223333", "alpha"))
 	require.Len(t, nlbp.deleteLBCalls, 1)
 	assert.Equal(t, out.LoadBalancerArn, aws.StringValue(nlbp.deleteLBCalls[0].LoadBalancerArn))
-	require.Len(t, nlbp.deleteTGCalls, 1)
-	assert.Equal(t, out.TargetGroupArn, aws.StringValue(nlbp.deleteTGCalls[0].TargetGroupArn))
+	require.Len(t, nlbp.deleteTGCalls, 2, "control-plane TG + konnectivity TG")
+	deletedTGs := map[string]bool{}
+	for _, d := range nlbp.deleteTGCalls {
+		deletedTGs[aws.StringValue(d.TargetGroupArn)] = true
+	}
+	assert.True(t, deletedTGs[out.TargetGroupArn], "control-plane TG deleted")
+	assert.True(t, deletedTGs[out.KonnTargetGroupArn], "konnectivity TG deleted")
 }
 
 func TestDeleteClusterNLB_MissingResourcesNoOp(t *testing.T) {
@@ -624,7 +641,7 @@ func TestDeleteClusterNLB_FirstErrorSurfacedSweepContinues(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete NLB eks-alpha")
 	assert.Len(t, nlbp.deleteLBCalls, 1)
-	assert.Len(t, nlbp.deleteTGCalls, 1, "TG delete should still be attempted after LB delete fails")
+	assert.Len(t, nlbp.deleteTGCalls, 2, "both TG deletes still attempted after LB delete fails")
 }
 
 func assertELBv2TaggedAsEKS(t *testing.T, tgs []*elbv2.Tag, clusterName string) {

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"slices"
@@ -484,7 +485,12 @@ func (s *EKSServiceImpl) launchOneWorker(rec *NodegroupRecord, meta *ClusterMeta
 			"nodegroup", rec.Name, "nodeRole", rec.NodeRole)
 	}
 
-	res, err := s.deps.Worker.RunWorkerInstance(runInput, accountID)
+	// Spread workers across hosts: target the eligible host holding the fewest of
+	// this nodegroup's existing workers (round-robin that packs once hosts <
+	// desired). An empty host (no scheduler / no node data) falls back to a local
+	// launch inside RunWorkerInstanceOnNode, never worse than the un-spread path.
+	host := s.selectWorkerHost(instanceType, rec.InstanceIDs)
+	res, err := s.deps.Worker.RunWorkerInstanceOnNode(host, runInput, accountID)
 	if err != nil {
 		return "", err
 	}
@@ -494,6 +500,40 @@ func (s *EKSServiceImpl) launchOneWorker(rec *NodegroupRecord, meta *ClusterMeta
 		}
 	}
 	return "", errors.New("run worker returned no instance id")
+}
+
+// selectWorkerHost picks the host for the next worker: the eligible host (one
+// with free capacity for instanceType) holding the fewest of this nodegroup's
+// existing workers, so workers spread across hosts and pack evenly once the
+// worker count exceeds the host count. Ties break randomly for fair placement.
+// Returns "" when no scheduler is wired or no host has capacity, in which case
+// the caller falls back to a local launch.
+func (s *EKSServiceImpl) selectWorkerHost(instanceType string, existingWorkerIDs []string) string {
+	if s.deps.Scheduler == nil {
+		return ""
+	}
+	hosts := s.deps.Scheduler.SchedulableHosts(instanceType)
+	if len(hosts) == 0 {
+		return ""
+	}
+	// Count this nodegroup's workers already placed per host.
+	counts := make(map[string]int, len(hosts))
+	for _, h := range hosts {
+		counts[h] = 0
+	}
+	for _, host := range s.deps.Scheduler.InstanceHosts(existingWorkerIDs) {
+		if _, eligible := counts[host]; eligible {
+			counts[host]++
+		}
+	}
+	rand.Shuffle(len(hosts), func(i, j int) { hosts[i], hosts[j] = hosts[j], hosts[i] })
+	best := hosts[0]
+	for _, h := range hosts[1:] {
+		if counts[h] < counts[best] {
+			best = h
+		}
+	}
+	return best
 }
 
 // gatewayHostIP returns the IP literal of the gateway base URL's host, or "" when

--- a/spinifex/handlers/eks/nodegroup_test.go
+++ b/spinifex/handlers/eks/nodegroup_test.go
@@ -24,6 +24,7 @@ import (
 type fakeWorkerLauncher struct {
 	mu             sync.Mutex
 	runCalls       []*ec2.RunInstancesInput
+	runNodes       []string
 	terminateCalls [][]string
 
 	nextID  int
@@ -37,10 +38,15 @@ func newFakeWorkerLauncher() *fakeWorkerLauncher {
 	return &fakeWorkerLauncher{}
 }
 
-func (f *fakeWorkerLauncher) RunWorkerInstance(input *ec2.RunInstancesInput, _ string) (*ec2.Reservation, error) {
+func (f *fakeWorkerLauncher) RunWorkerInstance(input *ec2.RunInstancesInput, accountID string) (*ec2.Reservation, error) {
+	return f.RunWorkerInstanceOnNode("", input, accountID)
+}
+
+func (f *fakeWorkerLauncher) RunWorkerInstanceOnNode(nodeID string, input *ec2.RunInstancesInput, _ string) (*ec2.Reservation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.runCalls = append(f.runCalls, input)
+	f.runNodes = append(f.runNodes, nodeID)
 	if f.runErr != nil {
 		return nil, f.runErr
 	}
@@ -550,4 +556,61 @@ func TestUpdateNodegroupVersion_NotImplemented(t *testing.T) {
 		ClusterName: aws.String("c1"), NodegroupName: aws.String("ng1"),
 	}, testAccountID)
 	require.EqualError(t, err, awserrors.ErrorNotImplemented)
+}
+
+// TestSelectWorkerHost_NoSchedulerOrCapacity returns "" so the caller falls back
+// to a local launch when no scheduler is wired or no host has free capacity.
+func TestSelectWorkerHost_NoSchedulerOrCapacity(t *testing.T) {
+	s := &EKSServiceImpl{deps: EKSServiceDeps{}}
+	require.Equal(t, "", s.selectWorkerHost("t3.medium", nil))
+
+	s = &EKSServiceImpl{deps: EKSServiceDeps{Scheduler: &fakeHostScheduler{}}}
+	require.Equal(t, "", s.selectWorkerHost("t3.medium", nil))
+}
+
+// mapHostScheduler is a HostScheduler stub with an explicit instance->host map,
+// so a test can give every worker a distinct ID (which the fakeHostScheduler's
+// "i-<node>" convention cannot, collapsing same-host workers).
+type mapHostScheduler struct {
+	hosts     []string
+	placement map[string]string
+}
+
+var _ HostScheduler = (*mapHostScheduler)(nil)
+
+func (m *mapHostScheduler) SchedulableHosts(string) []string { return m.hosts }
+
+func (m *mapHostScheduler) InstanceHosts(ids []string) map[string]string {
+	out := make(map[string]string, len(ids))
+	for _, id := range ids {
+		if h, ok := m.placement[id]; ok {
+			out[id] = h
+		}
+	}
+	return out
+}
+
+// TestSelectWorkerHost_SpreadsThenPacks confirms sequential single-worker
+// launches fan out one-per-host before doubling up, the fix for all workers
+// landing on a single node.
+func TestSelectWorkerHost_SpreadsThenPacks(t *testing.T) {
+	hosts := []string{"nodeA", "nodeB", "nodeC"}
+	sched := &mapHostScheduler{hosts: hosts, placement: map[string]string{}}
+	s := &EKSServiceImpl{deps: EKSServiceDeps{Scheduler: sched}}
+
+	placed := map[string]int{}
+	var workerIDs []string
+	for i := range 6 {
+		host := s.selectWorkerHost("t3.medium", workerIDs)
+		require.Contains(t, hosts, host)
+		placed[host]++
+		id := "i-w" + strconv.Itoa(i)
+		sched.placement[id] = host
+		workerIDs = append(workerIDs, id)
+	}
+
+	// 6 workers across 3 hosts spread evenly: exactly 2 per host, none starved.
+	for _, h := range hosts {
+		require.Equal(t, 2, placed[h], "host %s should hold 2 of 6 workers", h)
+	}
 }

--- a/spinifex/handlers/eks/private_endpoint_test.go
+++ b/spinifex/handlers/eks/private_endpoint_test.go
@@ -57,8 +57,9 @@ func TestEnsurePrivateEndpointSG_AuthorizesVPCCIDROnAPIServerPorts(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, "sg-pe-001", sgID)
 
-	// :443 for kubectl/SDK; :6443 for worker pods hitting the in-cluster kubernetes Endpoints.
-	require.Len(t, sgp.authorizeCalls, 2)
+	// :443 for kubectl/SDK; :6443 for worker pods hitting the in-cluster kubernetes
+	// Endpoints; :8132 for worker konnectivity-agents dialing the konnectivity-server.
+	require.Len(t, sgp.authorizeCalls, 3)
 	ports := map[int64]bool{}
 	for _, in := range sgp.authorizeCalls {
 		assert.Equal(t, "sg-pe-001", aws.StringValue(in.GroupId))
@@ -72,6 +73,7 @@ func TestEnsurePrivateEndpointSG_AuthorizesVPCCIDROnAPIServerPorts(t *testing.T)
 	}
 	assert.True(t, ports[clusterNLBListenPort], "admits :443")
 	assert.True(t, ports[k3sAPIServerPort], "admits :6443")
+	assert.True(t, ports[konnectivityAgentPort], "admits :8132")
 }
 
 func TestEnsurePrivateEndpointSG_EmptyInputsRejected(t *testing.T) {

--- a/spinifex/handlers/eks/security_groups.go
+++ b/spinifex/handlers/eks/security_groups.go
@@ -264,7 +264,9 @@ func EnsurePrivateEndpointSG(sgp sgProvisioner, accountID, clusterName, vpcID, v
 		return "", err
 	}
 
-	for _, port := range []int64{clusterNLBListenPort, k3sAPIServerPort} {
+	// :443/:6443 carry kubectl/SDK + the in-cluster `kubernetes` Endpoints; :8132
+	// carries the worker konnectivity-agents' tunnel dial to the CP servers.
+	for _, port := range []int64{clusterNLBListenPort, k3sAPIServerPort, konnectivityAgentPort} {
 		perm := &ec2.IpPermission{
 			IpProtocol: aws.String("tcp"),
 			FromPort:   aws.Int64(port),
@@ -386,8 +388,10 @@ func EnsureNodegroupSGRules(sgp sgProvisioner, accountID, clusterName, cpSGID, n
 	return nil
 }
 
-// EnsureControlPlaneIngress admits the NLB→apiserver hop from the VPC CIDR on k3sAPIServerPort.
-// Public access is gated separately at the NLB front-end. Idempotent.
+// EnsureControlPlaneIngress admits the NLB→CP hops from the VPC CIDR: the
+// apiserver (k3sAPIServerPort) and the konnectivity-server agent port
+// (konnectivityAgentPort). Public access is gated separately at the NLB
+// front-end. Idempotent.
 func EnsureControlPlaneIngress(sgp sgProvisioner, accountID, cpSGID, vpcCIDR string) error {
 	if cpSGID == "" {
 		return errors.New("eks: EnsureControlPlaneIngress empty control-plane SG id")
@@ -396,21 +400,29 @@ func EnsureControlPlaneIngress(sgp sgProvisioner, accountID, cpSGID, vpcCIDR str
 		return errors.New("eks: EnsureControlPlaneIngress empty vpc cidr")
 	}
 
-	perm := &ec2.IpPermission{
-		IpProtocol: aws.String("tcp"),
-		FromPort:   aws.Int64(k3sAPIServerPort),
-		ToPort:     aws.Int64(k3sAPIServerPort),
-		IpRanges: []*ec2.IpRange{{
-			CidrIp:      aws.String(vpcCIDR),
-			Description: aws.String("EKS NLB to apiserver"),
-		}},
-	}
-	_, err := sgp.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
-		GroupId:       aws.String(cpSGID),
-		IpPermissions: []*ec2.IpPermission{perm},
-	}, accountID)
-	if err != nil && !awserrors.IsErrorCode(err, awserrors.ErrorInvalidPermissionDuplicate) {
-		return fmt.Errorf("authorize control-plane apiserver ingress on %s: %w", cpSGID, err)
+	for _, p := range []struct {
+		port int64
+		desc string
+	}{
+		{k3sAPIServerPort, "EKS NLB to apiserver"},
+		{konnectivityAgentPort, "EKS NLB to konnectivity-server"},
+	} {
+		perm := &ec2.IpPermission{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int64(p.port),
+			ToPort:     aws.Int64(p.port),
+			IpRanges: []*ec2.IpRange{{
+				CidrIp:      aws.String(vpcCIDR),
+				Description: aws.String(p.desc),
+			}},
+		}
+		_, err := sgp.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId:       aws.String(cpSGID),
+			IpPermissions: []*ec2.IpPermission{perm},
+		}, accountID)
+		if err != nil && !awserrors.IsErrorCode(err, awserrors.ErrorInvalidPermissionDuplicate) {
+			return fmt.Errorf("authorize control-plane %s ingress on %s: %w", p.desc, cpSGID, err)
+		}
 	}
 	return nil
 }

--- a/spinifex/handlers/eks/security_groups_test.go
+++ b/spinifex/handlers/eks/security_groups_test.go
@@ -379,7 +379,7 @@ func TestDeleteClusterSGs_RevokesCrossRefsBeforeDelete(t *testing.T) {
 	assert.True(t, deleted["sg-cp"] && deleted["sg-ng"], "both cluster SGs removed")
 }
 
-// TestDeleteClusterSGs_RevokesEgressAndNonClusterReferrers guards mulga-siv-410:
+// TestDeleteClusterSGs_RevokesEgressAndNonClusterReferrers guards the contract:
 // a cluster SG is pinned by ANY referencing rule in the VPC, including an egress
 // rule on a non-cluster SG (LBC/ALB, user/TF). The teardown must revoke both
 // directions on every non-default SG so the cluster SGs delete, must NOT delete
@@ -444,16 +444,21 @@ func TestEnsureControlPlaneIngress_AuthorizesAPIServerFromVPCCIDR(t *testing.T) 
 	err := EnsureControlPlaneIngress(sgp, "111122223333", "sg-cp-001", "10.0.0.0/16")
 	require.NoError(t, err)
 
-	require.Len(t, sgp.authorizeCalls, 1)
-	in := sgp.authorizeCalls[0]
-	assert.Equal(t, "sg-cp-001", aws.StringValue(in.GroupId))
-	require.Len(t, in.IpPermissions, 1)
-	perm := in.IpPermissions[0]
-	assert.Equal(t, "tcp", aws.StringValue(perm.IpProtocol))
-	assert.Equal(t, k3sAPIServerPort, aws.Int64Value(perm.FromPort))
-	assert.Equal(t, k3sAPIServerPort, aws.Int64Value(perm.ToPort))
-	require.Len(t, perm.IpRanges, 1)
-	assert.Equal(t, "10.0.0.0/16", aws.StringValue(perm.IpRanges[0].CidrIp))
+	// NLB → apiserver (:6443) and NLB → konnectivity-server (:8132).
+	require.Len(t, sgp.authorizeCalls, 2)
+	ports := map[int64]bool{}
+	for _, in := range sgp.authorizeCalls {
+		assert.Equal(t, "sg-cp-001", aws.StringValue(in.GroupId))
+		require.Len(t, in.IpPermissions, 1)
+		perm := in.IpPermissions[0]
+		assert.Equal(t, "tcp", aws.StringValue(perm.IpProtocol))
+		assert.Equal(t, aws.Int64Value(perm.FromPort), aws.Int64Value(perm.ToPort))
+		require.Len(t, perm.IpRanges, 1)
+		assert.Equal(t, "10.0.0.0/16", aws.StringValue(perm.IpRanges[0].CidrIp))
+		ports[aws.Int64Value(perm.FromPort)] = true
+	}
+	assert.True(t, ports[k3sAPIServerPort], "admits :6443")
+	assert.True(t, ports[konnectivityAgentPort], "admits :8132")
 }
 
 func TestEnsureControlPlaneIngress_EmptyInputsRejected(t *testing.T) {

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -310,10 +310,11 @@ func (s *EKSServiceImpl) missingOrchestrationDeps() []string {
 		missing = append(missing, "MasterKey")
 	}
 	// IAM is built from MasterKey but can stay nil when its KV backend was not
-	// ready at boot. Gate on the service itself so a node without it rejects
-	// nodegroup orchestration instead of launching workers with no instance
-	// profile (no IMDS role, so the load-balancer controller cannot create an ALB).
-	if s.deps.IAM == nil {
+	// ready at boot. Gate on the resolved ensurer (deps.IAM or the lazy
+	// IAMProvider) so a node without it rejects nodegroup orchestration instead
+	// of launching workers with no instance profile (no IMDS role, so the
+	// load-balancer controller cannot create an ALB).
+	if s.iamEnsurer() == nil {
 		missing = append(missing, "IAM")
 	}
 	if s.deps.GatewayBaseURL == "" {

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -97,6 +97,9 @@ type EKSServiceDeps struct {
 // Workers use the customer-owned RunInstances path (no ManagedBy tag, no mgmt NIC).
 type WorkerLauncher interface {
 	RunWorkerInstance(input *ec2.RunInstancesInput, accountID string) (*ec2.Reservation, error)
+	// RunWorkerInstanceOnNode launches the worker on a specific host for nodegroup
+	// host spread. An empty nodeID launches on the local node like RunWorkerInstance.
+	RunWorkerInstanceOnNode(nodeID string, input *ec2.RunInstancesInput, accountID string) (*ec2.Reservation, error)
 	TerminateWorkerInstances(instanceIDs []string, accountID string) error
 }
 
@@ -305,6 +308,13 @@ func (s *EKSServiceImpl) missingOrchestrationDeps() []string {
 	}
 	if len(s.deps.MasterKey) == 0 {
 		missing = append(missing, "MasterKey")
+	}
+	// IAM is built from MasterKey but can stay nil when its KV backend was not
+	// ready at boot. Gate on the service itself so a node without it rejects
+	// nodegroup orchestration instead of launching workers with no instance
+	// profile (no IMDS role, so the load-balancer controller cannot create an ALB).
+	if s.deps.IAM == nil {
+		missing = append(missing, "IAM")
 	}
 	if s.deps.GatewayBaseURL == "" {
 		missing = append(missing, "GatewayBaseURL")
@@ -585,6 +595,7 @@ func (s *EKSServiceImpl) launchClusterInfra(lc clusterLaunchCtx) {
 	}
 	meta.NLBArn = nlb.LoadBalancerArn
 	meta.NLBTargetGroupArn = nlb.TargetGroupArn
+	meta.KonnTargetGroupArn = nlb.KonnTargetGroupArn
 
 	// Persist NLB ARNs early so DeleteCluster can reclaim them on any later failure.
 	if err := PutClusterMeta(acctKV, meta); err != nil {
@@ -691,8 +702,14 @@ func (s *EKSServiceImpl) launchClusterInfra(lc clusterLaunchCtx) {
 	for _, n := range cpNodes {
 		cpENIIPs = append(cpENIIPs, n.ENIIP)
 	}
-	if err := RegisterClusterTargets(s.deps.NLB, sysAcct, nlb.TargetGroupArn, cpENIIPs); err != nil {
+	if err := RegisterClusterTargets(s.deps.NLB, sysAcct, nlb.TargetGroupArn, cpENIIPs, k3sAPIServerPort); err != nil {
 		s.failClusterLaunch(acctKV, name, accountID, meta, "register NLB targets", err)
+		return
+	}
+	// Register the same CP ENIs on the konnectivity TG (:8132): worker agents dial
+	// the NLB private endpoint and the NLB fans them to every apiserver's konn-server.
+	if err := RegisterClusterTargets(s.deps.NLB, sysAcct, nlb.KonnTargetGroupArn, cpENIIPs, konnectivityAgentPort); err != nil {
+		s.failClusterLaunch(acctKV, name, accountID, meta, "register konnectivity NLB targets", err)
 		return
 	}
 
@@ -976,7 +993,7 @@ func (s *EKSServiceImpl) purgeClusterInfra(accountID, name string, meta *Cluster
 		// Deregister is best-effort: DeleteClusterNLB tears down the whole NLB
 		// + target group, so a stale target registration cannot leak past it.
 		if meta.NLBTargetGroupArn != "" && meta.ControlPlaneENIIP != "" {
-			if err := DeregisterClusterTarget(s.deps.NLB, infraAcct, meta.NLBTargetGroupArn, meta.ControlPlaneENIIP); err != nil {
+			if err := DeregisterClusterTarget(s.deps.NLB, infraAcct, meta.NLBTargetGroupArn, meta.ControlPlaneENIIP, k3sAPIServerPort); err != nil {
 				slog.Warn("purgeClusterInfra: deregister NLB target failed", "cluster", name, "err", err)
 			}
 		}

--- a/spinifex/handlers/eks/service_impl_test.go
+++ b/spinifex/handlers/eks/service_impl_test.go
@@ -53,6 +53,20 @@ func TestEKSServiceImpl_ClusterLifecycleShimMode(t *testing.T) {
 	require.EqualError(t, err, awserrors.ErrorServiceUnavailable)
 }
 
+// A daemon that loaded its master key but whose IAM service was not ready at
+// boot (KV quorum still forming) must reject nodegroup orchestration rather than
+// launch workers with no instance profile, which leaves IMDS roleless and blocks
+// ALB creation. The gate reports IAM even though MasterKey is present.
+func TestMissingOrchestrationDeps_NilIAMRejectsNodegroup(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	f.svc.deps.IAM = nil
+
+	require.Equal(t, []string{"IAM"}, f.svc.missingOrchestrationDeps())
+
+	_, err := f.svc.CreateNodegroup(createNGInput("c1", "ng1", 1), testAccountID)
+	require.EqualError(t, err, awserrors.ErrorServiceUnavailable)
+}
+
 // EKS only supports the API authentication mode here; CONFIG_MAP (and the
 // API_AND_CONFIG_MAP hybrid) must be rejected with InvalidParameterException.
 func TestValidateCreateClusterInput_RejectsConfigMapAuthMode(t *testing.T) {

--- a/spinifex/handlers/eks/service_impl_test.go
+++ b/spinifex/handlers/eks/service_impl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,18 @@ func TestMissingOrchestrationDeps_NilIAMRejectsNodegroup(t *testing.T) {
 
 	_, err := f.svc.CreateNodegroup(createNGInput("c1", "ng1", 1), testAccountID)
 	require.EqualError(t, err, awserrors.ErrorServiceUnavailable)
+}
+
+// Production wires the lazy IAMProvider and leaves deps.IAM nil. The gate must
+// resolve the ensurer (provider included), not read deps.IAM directly, or it
+// rejects every CreateCluster/CreateNodegroup with missing=[IAM] forever even
+// though the IAM service is fully available via the provider.
+func TestMissingOrchestrationDeps_IAMProviderSatisfiesGate(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	f.svc.deps.IAM = nil
+	f.svc.deps.IAMProvider = func() handlers_iam.SystemInstanceRoleEnsurer { return newFakeEnsurer() }
+
+	require.Empty(t, f.svc.missingOrchestrationDeps())
 }
 
 // EKS only supports the API authentication mode here; CONFIG_MAP (and the

--- a/spinifex/handlers/elbv2/lifecycle_invariants_test.go
+++ b/spinifex/handlers/elbv2/lifecycle_invariants_test.go
@@ -181,7 +181,7 @@ func TestRLC4_ELBv2TGDeletableAfterLBTeardown(t *testing.T) {
 // dependency guard): DeleteTargetGroup may block on ResourceInUse ONLY when a
 // LIVE listener/rule (one whose owning LB still exists) forwards to the TG. A
 // rule orphaned by a vanished LB must NOT pin the TG — that is the permanent
-// trap mulga-siv-172 reported. Locks the liveLB/liveListener skip both ways so a
+// trap this guard prevents. Locks the liveLB/liveListener skip both ways so a
 // maintainer cannot regress the in-use scan back to a global rule sweep.
 func TestRLC3_ELBv2TGInUseGuardGatesOnLiveRefsOnly(t *testing.T) {
 	svc := setupTestService(t)
@@ -202,7 +202,7 @@ func TestRLC3_ELBv2TGInUseGuardGatesOnLiveRefsOnly(t *testing.T) {
 	}))
 
 	_, err = svc.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: aws.String(orphanTGArn)}, testAccountID)
-	require.NoErrorf(t, err, "ADR-0002 §3 live-only guard: a rule orphaned by a vanished LB must NOT pin the TG as ResourceInUse (mulga-siv-172 regression)")
+	require.NoErrorf(t, err, "ADR-0002 §3 live-only guard: a rule orphaned by a vanished LB must NOT pin the TG as ResourceInUse")
 
 	// Live-rule TG: forwarded to by a listener whose LB still exists → ResourceInUse.
 	lbOut, err := svc.CreateLoadBalancer(&elbv2.CreateLoadBalancerInput{Name: aws.String("rlc3-lb")}, testAccountID)

--- a/spinifex/handlers/elbv2/service_impl_protocolversion_test.go
+++ b/spinifex/handlers/elbv2/service_impl_protocolversion_test.go
@@ -12,7 +12,7 @@ import (
 // An HTTP/HTTPS target group must default ProtocolVersion to HTTP1 and round-trip
 // it through both the Create output and DescribeTargetGroups. The load balancer
 // controller always sends ProtocolVersion and recreates the TG (DuplicateTargetGroupName
-// loop) if Describe reads it back empty — see mulga-siv-416.
+// loop) if Describe reads it back empty.
 func TestCreateTargetGroup_ProtocolVersionDefaultsAndRoundTrips(t *testing.T) {
 	svc := setupTestService(t)
 

--- a/spinifex/handlers/elbv2/types.go
+++ b/spinifex/handlers/elbv2/types.go
@@ -395,5 +395,9 @@ var (
 		"load_balancing.cross_zone.enabled":     "use_load_balancer_configuration",
 		"load_balancing.algorithm.type":         "round_robin",
 		"slow_start.duration_seconds":           "0",
+		// NLB target-group default. The AWS Load Balancer Controller always
+		// writes this on NLB target groups (e.g. ingress-nginx); without it as a
+		// known key the modify is rejected and LBC loops on the Service forever.
+		"proxy_protocol_v2.enabled": "false",
 	}
 )

--- a/spinifex/handlers/iam/retry.go
+++ b/spinifex/handlers/iam/retry.go
@@ -1,0 +1,42 @@
+package handlers_iam
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// NewIAMServiceWithRetry builds an IAMServiceImpl, retrying while its NATS
+// JetStream KV backend is unavailable. On concurrent multi-node boot the KV
+// store needs cluster quorum that may not exist yet; a single attempt would
+// leave the service nil for the process lifetime. Blocks up to maxWait, then
+// returns the last error. Callers that legitimately run without a master key
+// must guard the call themselves.
+func NewIAMServiceWithRetry(natsConn *nats.Conn, masterKey []byte, clusterSize int) (*IAMServiceImpl, error) {
+	const maxWait = 5 * time.Minute
+	retryDelay := 500 * time.Millisecond
+	start := time.Now()
+	attempt := 0
+
+	for {
+		attempt++
+		svc, err := NewIAMServiceImpl(natsConn, masterKey, clusterSize)
+		if err == nil {
+			if attempt > 1 {
+				slog.Info("IAM service initialized after retry", "attempts", attempt, "elapsed", time.Since(start).Round(time.Second))
+			}
+			return svc, nil
+		}
+
+		elapsed := time.Since(start)
+		if elapsed >= maxWait {
+			return nil, fmt.Errorf("IAM service unavailable after %s (%d attempts): %w", elapsed.Round(time.Second), attempt, err)
+		}
+
+		slog.Warn("IAM service not ready (waiting for JetStream cluster quorum)", "error", err, "attempt", attempt, "elapsed", elapsed.Round(time.Second), "retryIn", retryDelay)
+		time.Sleep(retryDelay)
+		retryDelay = min(retryDelay*2, 10*time.Second)
+	}
+}

--- a/spinifex/handlers/iam/roles_test.go
+++ b/spinifex/handlers/iam/roles_test.go
@@ -720,7 +720,7 @@ func TestGetRolePolicies_UnresolvablePolicy(t *testing.T) {
 // TestGetRolePolicies_AWSManagedResolved proves a stock EKS node role — whose
 // grants come entirely from AWS-managed policies — resolves to the builtin
 // grant documents, so assumed-role authorization honours them instead of
-// denying every call (the regression behind mulga-siv-297).
+// denying every call.
 func TestGetRolePolicies_AWSManagedResolved(t *testing.T) {
 	svc := setupTestIAMService(t)
 	role := createTestRole(t, svc, "eks-node-role")

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -159,7 +159,7 @@ func launchService(config *config.ClusterConfig) error {
 	// Initialize IAM service with NATS KV backend (required for auth).
 	// On multi-node clusters, JetStream KV requires cluster quorum which may
 	// not be available yet if nodes start concurrently. Retry with backoff.
-	iamService, err := initIAMService(natsConn, masterKey, len(config.Nodes))
+	iamService, err := handlers_iam.NewIAMServiceWithRetry(natsConn, masterKey, len(config.Nodes))
 	if err != nil {
 		return fmt.Errorf("initialize IAM service: %w", err)
 	}
@@ -368,36 +368,6 @@ func launchService(config *config.ClusterConfig) error {
 	}
 
 	return nil
-}
-
-// initIAMService initializes the IAM service with retry/backoff. On multi-node
-// clusters, JetStream requires NATS cluster quorum before KV buckets can be
-// created. This retries for up to 5 minutes to allow late-joining nodes.
-func initIAMService(natsConn *nats.Conn, masterKey []byte, clusterSize int) (*handlers_iam.IAMServiceImpl, error) {
-	const maxWait = 5 * time.Minute
-	retryDelay := 500 * time.Millisecond
-	start := time.Now()
-	attempt := 0
-
-	for {
-		attempt++
-		svc, err := handlers_iam.NewIAMServiceImpl(natsConn, masterKey, clusterSize)
-		if err == nil {
-			if attempt > 1 {
-				slog.Info("IAM service initialized after retry", "attempts", attempt, "elapsed", time.Since(start).Round(time.Second))
-			}
-			return svc, nil
-		}
-
-		elapsed := time.Since(start)
-		if elapsed >= maxWait {
-			return nil, fmt.Errorf("IAM service unavailable after %s (%d attempts): %w", elapsed.Round(time.Second), attempt, err)
-		}
-
-		slog.Warn("IAM service not ready (waiting for JetStream cluster quorum)", "error", err, "attempt", attempt, "elapsed", elapsed.Round(time.Second), "retryIn", retryDelay)
-		time.Sleep(retryDelay)
-		retryDelay = min(retryDelay*2, 10*time.Second)
-	}
 }
 
 // runQuotaReconcile drives the per-account vCPU reconcile: a startup pass plus a

--- a/spinifex/vm/volumes_test.go
+++ b/spinifex/vm/volumes_test.go
@@ -728,7 +728,7 @@ func captureSlog(t *testing.T) *bytes.Buffer {
 // Terraform AWS provider's aws_volume_attachment polls DescribeVolumes
 // with attachment.device=/dev/sdf — storing the guest path makes that
 // filter reject every attached volume and the wait loop times out with
-// "couldn't find resource". This regression is mulga-siv-154.
+// "couldn't find resource".
 //
 // The QMP responder returns a query-block payload where vdisk-vol-1
 // maps to /dev/vdc (the third virtio slot after os + cloudinit), so the

--- a/tests/e2e/cert/tlsposture_test.go
+++ b/tests/e2e/cert/tlsposture_test.go
@@ -14,7 +14,7 @@ import (
 
 // TestTLSPosture asserts the deployed awsgw listeners actually negotiate
 // TLS 1.3 and a PQ-hybrid curve from the pinned policy. This is the live
-// proof for the PQC Phase 2.1 work (docs/development/improvements/pqc-roadmap.md):
+// proof for the PQC Phase 2.1 work:
 // it runs under the production FIPS build (GOFIPS140=v1.0.0,
 // GODEBUG=fips140=on) and catches regressions where unit tests pass but
 // something in the deploy path silently disables ML-KEM.

--- a/tests/e2e/ddil/scenarios/d_degraded_link_test.go
+++ b/tests/e2e/ddil/scenarios/d_degraded_link_test.go
@@ -6,8 +6,7 @@ import "testing"
 
 // TestScenarioD_DegradedLink — apply the SATCOM netem profile to every
 // node, verify fan-out queries return complete results and Raft does not
-// enter continuous leader election. See
-// docs/development/improvements/ddil-e2e-test-harness.md §3 Scenario D.
+// enter continuous leader election. Scenario D.
 func TestScenarioD_DegradedLink(t *testing.T) {
 	scenarioSkip(t, "D", "ddil-concept-demonstrator §1.2 + predastore-ddil-hardening §1")
 }

--- a/tests/e2e/ddil/scenarios/e_predastore_partition_test.go
+++ b/tests/e2e/ddil/scenarios/e_predastore_partition_test.go
@@ -7,8 +7,7 @@ import "testing"
 // TestScenarioE_PredastoreWriteUnderPartition — partition node3, put a
 // 10MB S3 object from the majority side, verify PUT succeeds with the
 // missing-shard repair journal capturing node3's parity, then heal and
-// verify journal drain + cross-node reads. See
-// docs/development/improvements/ddil-e2e-test-harness.md §3 Scenario E.
+// verify journal drain + cross-node reads. Scenario E.
 func TestScenarioE_PredastoreWriteUnderPartition(t *testing.T) {
 	scenarioSkip(t, "E", "predastore-ddil-hardening §2")
 }

--- a/tests/e2e/ddil/scenarios/f_raft_satcom_test.go
+++ b/tests/e2e/ddil/scenarios/f_raft_satcom_test.go
@@ -6,8 +6,7 @@ import "testing"
 
 // TestScenarioF_RaftUnderSATCOM — apply the SATCOM netem profile
 // cluster-wide and verify Raft leader elections remain ≤1 over a
-// 5-minute window (baselined against LAN, where elections thrash). See
-// docs/development/improvements/ddil-e2e-test-harness.md §3 Scenario F.
+// 5-minute window (baselined against LAN, where elections thrash). Scenario F.
 func TestScenarioF_RaftUnderSATCOM(t *testing.T) {
 	scenarioSkip(t, "F", "predastore-ddil-hardening §1")
 }

--- a/tests/e2e/ecr/capacity_test.go
+++ b/tests/e2e/ecr/capacity_test.go
@@ -6,9 +6,9 @@ import "testing"
 
 // TestECRCapacityLoad is the predastore capacity/load leg of Sprint 2f (parallel
 // crane push of many large images, asserting predastore throughput with no
-// manifest corruption). Deferred: it depends on predastore fixes mulga-siv-359
-// (':'-in-key SigV4 canonicalization) and mulga-siv-356 (404 NoSuchBucket),
+// manifest corruption). Deferred: it depends on predastore fixes
+// (':'-in-key SigV4 canonicalization) and (404 NoSuchBucket),
 // which are owned elsewhere. Unskip once those land.
 func TestECRCapacityLoad(t *testing.T) {
-	t.Skip("deferred: blocked on predastore mulga-siv-359 / mulga-siv-356")
+	t.Skip("deferred: blocked on predastore fixes")
 }

--- a/tests/e2e/manifest-lint/lint.go
+++ b/tests/e2e/manifest-lint/lint.go
@@ -1,5 +1,4 @@
-// Package manifestlint implements the e2e manifest drift guards (Bead 5 of
-// docs/development/improvements/e2e-targeted-suite-selection.md):
+// Package manifestlint implements the e2e manifest drift guards:
 //
 //   - Fixture lint: every direct resource-create AWS call in a suite test
 //     (e.g. c.EC2.RunInstances) should go through a harness.Ensure* fixture so

--- a/tests/e2e/select-suites/selector.go
+++ b/tests/e2e/select-suites/selector.go
@@ -5,8 +5,7 @@
 // optional per-suite -test.run regex (RUN_PATTERN) when AST analysis can prove
 // a strict subtest subset is sufficient.
 //
-// Selection model (see docs/development/improvements/
-// e2e-targeted-suite-selection.md):
+// Selection model:
 //
 //	changed_services = { s | s.path (or additional_paths) prefixes a changed file }
 //	covered_services = changed_services plus the transitive closure of

--- a/tests/e2e/teardown/teardown_test.go
+++ b/tests/e2e/teardown/teardown_test.go
@@ -1,6 +1,6 @@
 //go:build e2e
 
-// Package teardown is the run-scoped cleanup sweep (mulga-siv-277). It runs as
+// Package teardown is the run-scoped cleanup sweep. It runs as
 // the final suite of an e2e run: every resource the Ensure* fixtures created
 // carries the e2e:run=<run-id> tag, and this suite reclaims anything still
 // tagged — covering leaks from a crashed suite, an interrupted run, or a


### PR DESCRIPTION
## Summary

EKS multinode control-plane brought to working parity on env19, plus the two
control-plane-VM infra fixes uncovered while verifying it. Fixes parent
mulga-siv-426 and children 427/428/495/496.

- **feat(eks): multinode control-plane networking, IAM, and CoreDNS parity** —
  worker managed-nodegroup instances get their IAM instance profile; CP-VM pods
  reach the in-VPC apiserver (CP→VPC routing); CoreDNS DaemonSet pinned to
  workers only (drop CP tolerations + anti-CP affinity, EKS parity); workers
  launch with an AvailabilityZone so the provider-id drop-in runs and nodes
  carry `topology.kubernetes.io/{zone,region}` labels.
- **fix(eks): gate orchestration on the resolved IAM ensurer, not raw deps.IAM**
  — the CP instance-profile ensure resolves via the lazy IAMProvider so a launch
  cannot race the NATS KV backend.
- **fix(eks): let eks-token-webhook use IMDS creds when static keys absent** —
  the token-review relay signs with the CP VM's IMDS instance-role creds,
  keeping the #450 no-static-creds-on-CP posture.
- **fix(eks): stop dhcpcd IPv4LL hijacking IMDS on multi-NIC control plane** —
  bake `noipv4ll` + scrub the default route off the mgmt NIC so IMDS egresses
  the data NIC (fixes the CP bootstrap i/o-timeout).
- **fix(eks): grant eks:WebhookTokenReview to the control-plane instance role**
  — the CP role's inline policy was missing the action the token-review relay
  requires; without it external `kubectl` 401'd (regression fix).

## Verification (env19, cluster vk2 ACTIVE)

- `kubectl get nodes`: 3 control-plane + 2 `vk2-ng1` workers all `Ready`.
- CoreDNS: both pods on worker nodes only, 0 restarts; none on control plane.
- Workers carry `providerID=aws:///ap-southeast-2a/i-…` and zone/region labels.
- No non-Running pods cluster-wide.
- External `aws eks get-token` + `kubectl` authenticates (no 401); CP VMs serve
  the instance-role over IMDS.

`make preflight` green (lint, vet, race, coverage 77.6% ≥ 60%, govulncheck).
