### PR TITLE
test(e2e): capture SNAT datapath on NAT GW egress failure

### DIFF
--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -327,6 +327,28 @@ if [ "$MANAGEMENT" = true ]; then
         sleep 1
     done
 
+    # Wait for the Southbound DB to be serving before ovn-controller (Step 5)
+    # dials it. On a single node ovn-controller races a fresh SB RAFT election
+    # with no join step to absorb the window — attaching before the leader is
+    # elected (and before northd writes the gateway logical flows) leaves it with
+    # a partial datapath that never reconverges. Gate on SB reachable and, when
+    # clustered, an elected leader.
+    for i in $(seq 1 30); do
+        if sudo ovn-sbctl --timeout=2 show >/dev/null 2>&1; then
+            if [ -z "$DB_CLUSTER_LOCAL_ADDR" ]; then
+                break
+            fi
+            SB_LEADER=$(sudo ovs-appctl -t /var/run/ovn/ovnsb_db.ctl \
+                cluster/status OVN_Southbound 2>/dev/null \
+                | awk '/^Leader:/{print $2; exit}')
+            if [ -n "$SB_LEADER" ] && [ "$SB_LEADER" != "unknown" ]; then
+                break
+            fi
+        fi
+        echo "  Waiting for OVN SB DB leader... ($i/30)"
+        sleep 1
+    done
+
     # Set the NB/SB client listen addresses. set-connection writes through RAFT
     # (replicated cluster-wide), so it only runs on the create node — a joining
     # node would redirect to the leader, which the init node already configured.
@@ -700,6 +722,25 @@ echo "  ovn-controller log level: file:warn (via systemd drop-in)"
 
 sudo systemctl restart ovn-controller
 echo "  ovn-controller: started"
+
+# Force a full datapath recompute once ovn-controller has connected to the SB.
+# On a fresh single-node RAFT the controller can attach mid-election and program
+# a partial datapath (SNAT ct-commit without output/delivery), then never
+# reconverge. Recomputing after the SB connection is up rebuilds all OpenFlow
+# from the converged Southbound. Compute nodes race a remote SB too, so this
+# runs on every node.
+for i in $(seq 1 30); do
+    CTRL_STATUS=$(sudo OVS_RUNDIR=/var/run/ovn ovs-appctl -t ovn-controller \
+        connection-status 2>/dev/null)
+    if [ "$CTRL_STATUS" = "connected" ]; then
+        break
+    fi
+    echo "  Waiting for ovn-controller SB connection... ($i/30)"
+    sleep 1
+done
+sudo OVS_RUNDIR=/var/run/ovn ovs-appctl -t ovn-controller inc-engine/recompute \
+    2>/dev/null || true
+echo "  ovn-controller: forced datapath recompute"
 
 # --- Step 6: Sysctl tuning ---
 echo ""

--- a/tests/e2e/harness/diag.go
+++ b/tests/e2e/harness/diag.go
@@ -173,6 +173,14 @@ func dumpDatapathState(t *testing.T, opts VPCDiagnosticsOpts) {
 			grepFor:  []string{opts.ExternalIP, opts.LogicalIP},
 		},
 		{
+			// br-int flows miss the localnet egress hop; br-ext is where
+			// SNAT'd traffic leaves for the physical uplink, so a dropped
+			// or absent flow here pinpoints an egress black-hole.
+			filename: "ovs-flows-brext.txt",
+			label:    "ovs-ofctl dump-flows br-ext (egress localnet)",
+			argv:     []string{"ovs-ofctl", "dump-flows", "br-ext"},
+		},
+		{
 			filename: "conntrack-extip.txt",
 			label:    "conntrack -L (filtered)",
 			argv:     []string{"conntrack", "-L"},

--- a/tests/e2e/harness/diag.go
+++ b/tests/e2e/harness/diag.go
@@ -183,10 +183,24 @@ func dumpDatapathState(t *testing.T, opts VPCDiagnosticsOpts) {
 			argv:     []string{"ovs-ofctl", "dump-flows", "br-ext"},
 		},
 		{
+			// dpctl/dump-conntrack reads the OVS-owned conntrack zone directly,
+			// so it works on hosts without the standalone `conntrack` binary
+			// (absent on the baremetal runner). Shows whether a SNAT ct entry
+			// for the external IP was ever committed.
 			filename: "conntrack-extip.txt",
-			label:    "conntrack -L (filtered)",
-			argv:     []string{"conntrack", "-L"},
+			label:    "ovs-appctl dpctl/dump-conntrack (filtered)",
+			argv:     []string{"ovs-appctl", "dpctl/dump-conntrack"},
 			grepFor:  []string{opts.ExternalIP},
+		},
+		{
+			// Kernel megaflows with hit counters. Shows where the guest's
+			// packets actually land in the datapath and whether any megaflow
+			// carries them toward the uplink, cross-checking the logical-flow
+			// view against real forwarding.
+			filename: "dp-flows.txt",
+			label:    "ovs-appctl dpctl/dump-flows -m (filtered)",
+			argv:     []string{"ovs-appctl", "dpctl/dump-flows", "-m"},
+			grepFor:  []string{opts.ExternalIP, opts.LogicalIP},
 		},
 		{
 			filename: "ip-neigh-extip.txt",
@@ -199,17 +213,6 @@ func dumpDatapathState(t *testing.T, opts VPCDiagnosticsOpts) {
 			label:    "ovn-nbctl find NAT external_ip",
 			argv: []string{"ovn-nbctl", "--bare", "--columns=_uuid,type,external_ip,logical_ip,external_mac,logical_port",
 				"find", "NAT", "external_ip=" + opts.ExternalIP},
-		},
-		{
-			// Per-stage packet counts across the whole gateway pipeline. The
-			// SNAT flow reading n_packets=0 while the guest transmits means
-			// packets die upstream of lr_out_snat; this grep shows which
-			// stage (lr_in_ip_routing, lr_in_arp_resolve, ...) still counts
-			// the packets and which one drops to zero — the exact drop point.
-			filename: "ovn-lflows-extip.txt",
-			label:    "ovn-sbctl --stats lflow-list (filtered)",
-			argv:     []string{"ovn-sbctl", "--stats", "lflow-list"},
-			grepFor:  []string{opts.ExternalIP, opts.LogicalIP},
 		},
 		{
 			// The default route's next-hop must resolve to a MAC before the
@@ -238,6 +241,18 @@ func dumpDatapathState(t *testing.T, opts VPCDiagnosticsOpts) {
 			argv: []string{"ovn-nbctl", "--bare",
 				"--columns=name,addresses,up,type", "list", "Logical_Switch_Port"},
 			grepFor: []string{opts.LogicalIP},
+		},
+		{
+			// Full, unfiltered per-stage packet counts. An IP-filtered lflow
+			// dump hides the default-drop ACL flow (its match carries no IP),
+			// so when the guest's egress dies at ls_out_acl a filtered view
+			// shows the allow-flows at n_packets=0 but not the deny that ate
+			// the packets. This full dump names the exact drop flow and its
+			// hit count. Echoed in full so it survives in the CI stdout log
+			// even when the artifact directory is not bundled.
+			filename: "ovn-lflows-full.txt",
+			label:    "ovn-sbctl --stats lflow-list (full)",
+			argv:     []string{"ovn-sbctl", "--stats", "lflow-list"},
 		},
 	})
 }

--- a/tests/e2e/harness/diag.go
+++ b/tests/e2e/harness/diag.go
@@ -151,10 +151,12 @@ func dumpOVNState(t *testing.T, instanceID string) {
 	}
 }
 
-// dumpDatapathState captures OVS / kernel-side state keyed on the external IP:
-// conntrack, upstream ARP, and OF flow install. Each capture is also written
-// to opts.ArtifactDir when set. Skipped silently when inputs or shell tools
-// are unavailable.
+// dumpDatapathState captures OVS / kernel + OVN control state keyed on the
+// external IP: OF flows, conntrack, upstream ARP, plus the gateway router's
+// per-stage logical-flow packet counts, MAC_Binding, static routes and the
+// VM's logical port — enough to locate a pre-SNAT egress drop. Each capture
+// is also written to opts.ArtifactDir when set. Skipped silently when inputs
+// or shell tools are unavailable.
 func dumpDatapathState(t *testing.T, opts VPCDiagnosticsOpts) {
 	t.Helper()
 	if opts.ExternalIP == "" {
@@ -197,6 +199,45 @@ func dumpDatapathState(t *testing.T, opts VPCDiagnosticsOpts) {
 			label:    "ovn-nbctl find NAT external_ip",
 			argv: []string{"ovn-nbctl", "--bare", "--columns=_uuid,type,external_ip,logical_ip,external_mac,logical_port",
 				"find", "NAT", "external_ip=" + opts.ExternalIP},
+		},
+		{
+			// Per-stage packet counts across the whole gateway pipeline. The
+			// SNAT flow reading n_packets=0 while the guest transmits means
+			// packets die upstream of lr_out_snat; this grep shows which
+			// stage (lr_in_ip_routing, lr_in_arp_resolve, ...) still counts
+			// the packets and which one drops to zero — the exact drop point.
+			filename: "ovn-lflows-extip.txt",
+			label:    "ovn-sbctl --stats lflow-list (filtered)",
+			argv:     []string{"ovn-sbctl", "--stats", "lflow-list"},
+			grepFor:  []string{opts.ExternalIP, opts.LogicalIP},
+		},
+		{
+			// The default route's next-hop must resolve to a MAC before the
+			// router can deliver egress. An empty / stale MAC_Binding for the
+			// uplink next-hop strands the packet in lr_in_arp_resolve, exactly
+			// the pre-SNAT drop we are chasing.
+			filename: "ovn-mac-binding.txt",
+			label:    "ovn-sbctl list MAC_Binding (next-hop ARP)",
+			argv:     []string{"ovn-sbctl", "list", "MAC_Binding"},
+		},
+		{
+			// Is 0.0.0.0/0 → <uplink next-hop> actually programmed, and does
+			// its output_port match the gateway router port? A missing or
+			// mis-pointed default route drops egress in lr_in_ip_routing.
+			filename: "ovn-lr-static-routes.txt",
+			label:    "ovn-nbctl list Logical_Router_Static_Route",
+			argv:     []string{"ovn-nbctl", "list", "Logical_Router_Static_Route"},
+		},
+		{
+			// Maps the VM's private IP to its logical switch port (addresses
+			// column holds "MAC IP") and shows up-state; a down or missing
+			// port would blackhole egress before it reaches the gateway
+			// router. Complements the chassis view in dumpOVNState.
+			filename: "ovn-lsp-logical.txt",
+			label:    "ovn-nbctl list Logical_Switch_Port (VM port)",
+			argv: []string{"ovn-nbctl", "--bare",
+				"--columns=name,addresses,up,type", "list", "Logical_Switch_Port"},
+			grepFor: []string{opts.LogicalIP},
 		},
 	})
 }

--- a/tests/e2e/single/natgw_test.go
+++ b/tests/e2e/single/natgw_test.go
@@ -272,6 +272,17 @@ func runNATGateway(t *testing.T, fix *Fixture) {
 
 	// --- Verify private VM CAN reach the internet now --------------------
 	// OVN needs a beat to install datapath flows after SNAT publishes.
+	// Snapshot the SNAT datapath if egress never comes up; without this the
+	// failure bundle carries no OVN/OVS state to root-cause the loss.
+	harness.OnFailure(t, func() {
+		harness.DumpVPCFlowDiagnostics(t, c, privID,
+			fmt.Sprintf("NAT GW egress — nat_gw=%s external_ip=%s logical_ip=%s", natGWID, natPubIP, privIP),
+			harness.VPCDiagnosticsOpts{
+				ExternalIP:  natPubIP,
+				LogicalIP:   privIP,
+				ArtifactDir: fix.ArtifactDir(t),
+			})
+	})
 	harness.Step(t, "verify private VM reaches 8.8.8.8 via NAT GW")
 	harness.EventuallyErr(t, func() error {
 		out, perr := runSSHQuiet(bastionTgt, pingCmd())


### PR DESCRIPTION
## Summary

`TestNATGateway` captured **nothing** when the private-VM egress probe failed, so the baremetal nightly's intermittent 100% packet loss left no OVN/OVS state in the failure bundle to root-cause it. This wires the existing datapath-diagnostics helper into the NAT GW egress path and adds the one egress-specific capture that was missing.

## Changes

- **`tests/e2e/single/natgw_test.go`** — register `harness.OnFailure` before the egress-verify poll so a failed run dumps the SNAT datapath (OVN show, NAT rules, port bindings incl. the cr-gw chassisredirect binding, br-int flows, conntrack, host ARP, NAT lookup) keyed on the NAT GW external IP. Mirrors the eip/vpc datapath tests, which already do this.
- **`tests/e2e/harness/diag.go`** — add a `br-ext` localnet flow capture to `dumpDatapathState`. `br-int` flows miss the egress hop where SNAT'd traffic leaves for the physical uplink, which is exactly where an egress black-hole shows up.

## Context

The `E2E Nightly` real-hardware baremetal cell has intermittently failed `TestNATGateway` (private VM → `8.8.8.8` via NAT GW, 100% loss) for weeks. Live inspection of a failed node showed the OVN control plane and logical SNAT pipeline healthy at steady state, so the loss is transient — but the failure bundle carried zero data-plane state, making each occurrence unrootcauseable. This change ensures the next failure captures the state needed to distinguish a boot-race / uplink / return-path fault from a control-plane one.

Only touches `//go:build e2e` files. `go vet` / `gofmt` / `go build` clean under `-tags e2e`.