### PR TITLE
fix: OVN RAFT multi-node bring-up (northd member list, ExecStop, add-nat deadline)

### DIFF
--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -321,6 +321,19 @@ if [ "$MANAGEMENT" = true ]; then
         echo "OVN_CTL_OPTS=\"$OVN_CTL_OPTS\"" | sudo tee /etc/default/ovn-central >/dev/null
         echo "  wrote /etc/default/ovn-central"
 
+        # The packaged ovn-northd.service ExecStop runs `ovn-ctl stop_northd`
+        # without --ovn-manage-ovsdb=no, so restarting northd also tears down the
+        # NB/SB ovsdb-server units. With the split clustered units those DBs are
+        # owned by their own units, so override ExecStop to leave them alone —
+        # otherwise the restart below races and kills the freshly-started DBs.
+        sudo mkdir -p /etc/systemd/system/ovn-northd.service.d
+        sudo tee /etc/systemd/system/ovn-northd.service.d/no-manage-ovsdb.conf >/dev/null <<'EOF'
+[Service]
+ExecStop=
+ExecStop=/usr/share/ovn/scripts/ovn-ctl stop_northd --no-monitor --ovn-manage-ovsdb=no
+EOF
+        sudo systemctl daemon-reload
+
         # The ovn-central aggregator is ExecStart=/bin/true, so restarting it
         # won't restart the children — restart the per-DB units directly to
         # pick up the new OVN_CTL_OPTS.

--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -305,6 +305,19 @@ if [ "$MANAGEMENT" = true ]; then
             echo "  ovn-central: creating RAFT cluster (local=$DB_CLUSTER_LOCAL_ADDR)"
         fi
 
+        # Point ovn-northd's client NB/SB connections at the full RAFT member
+        # list so the active northd follows the leader. Without this it dials the
+        # local member only and stops advancing SB_Global.nb_cfg once leadership
+        # moves off this node, wedging the ovn-nbctl --wait=hv flows barrier.
+        # Derived from OVN_REMOTE (the SB list); the NB list is the same hosts on
+        # 6641. Skipped when OVN_REMOTE is the localhost default (caller passed no
+        # member list) so a lone standalone DB node is unaffected.
+        if [ "$OVN_REMOTE" != "tcp:127.0.0.1:6642" ]; then
+            OVN_REMOTE_NB="${OVN_REMOTE//:6642/:6641}"
+            OVN_CTL_OPTS="$OVN_CTL_OPTS --ovn-northd-nb-db=$OVN_REMOTE_NB --ovn-northd-sb-db=$OVN_REMOTE"
+            echo "  ovn-northd: NB=$OVN_REMOTE_NB SB=$OVN_REMOTE (RAFT member list)"
+        fi
+
         echo "OVN_CTL_OPTS=\"$OVN_CTL_OPTS\"" | sudo tee /etc/default/ovn-central >/dev/null
         echo "  wrote /etc/default/ovn-central"
 

--- a/spinifex/utils/nats.go
+++ b/spinifex/utils/nats.go
@@ -419,13 +419,21 @@ type natEvent struct {
 	MAC        string `json:"mac"`
 }
 
-// AddNAT requests vpcd commit the OVN dnat_and_snat rule via NATS request-reply (10 s timeout).
+// addNATTimeout bounds the vpc.add-nat request-reply. vpcd's handler holds the
+// reply until the flows barrier (ovn-nbctl --wait=hv sync, bounded 30 s) confirms
+// every chassis realised the rule. On a cold multi-node cluster the gateway SB
+// chassisredirect binding can take most of that budget to converge, so the caller
+// deadline must exceed 30 s or it abandons a still-committing rule and rolls back
+// the EIP mid-launch — surfacing as a spurious ServerInternal on RunInstances.
+const addNATTimeout = 45 * time.Second
+
+// AddNAT requests vpcd commit the OVN dnat_and_snat rule via NATS request-reply.
 // A non-nil return means the rule may not be committed; callers must roll back and publish vpc.delete-nat.
 func AddNAT(nc *nats.Conn, vpcID, externalIP, logicalIP, portName, mac string) error {
 	return RequestEvent(nc, "vpc.add-nat", natEvent{
 		VpcId: vpcID, ExternalIP: externalIP, LogicalIP: logicalIP,
 		PortName: portName, MAC: mac,
-	}, 10*time.Second)
+	}, addNATTimeout)
 }
 
 // PublishNATEvent sends a NAT lifecycle event. vpc.add-nat uses request-reply (prevents ARP races);
@@ -437,7 +445,7 @@ func PublishNATEvent(nc *nats.Conn, topic, vpcID, externalIP, logicalIP, portNam
 	}
 
 	if topic == "vpc.add-nat" {
-		if err := RequestEvent(nc, topic, evt, 10*time.Second); err != nil {
+		if err := RequestEvent(nc, topic, evt, addNATTimeout); err != nil {
 			slog.Warn("PublishNATEvent: failed to add NAT rule — OVN dnat_and_snat rule not created; restart vpcd or re-associate EIP to recover",
 				"topic", topic, "externalIP", externalIP, "logicalIP", logicalIP, "err", err)
 		}


### PR DESCRIPTION
## Summary

Fixes multi-node OVN RAFT clusters where DB-node ovn-northd was single-homed to
its local OVSDB member, wedging the `ovn-nbctl --wait=hv` flows barrier and timing
out `vpc.add-nat` / public-IP launches. Also fixes a clean-bootstrap race that
killed the NB/SB DB servers, and extends the add-nat client deadline.

## Changes (`scripts/setup-ovn.sh`, `spinifex/utils/nats.go`)

- **Northd RAFT member list (siv-504):** in the clustered `--management` branch,
  point `ovn-northd`'s client NB/SB DB at the full member list derived from
  `OVN_REMOTE` (`--ovn-northd-nb-db`/`--ovn-northd-sb-db`) so the active northd
  follows the RAFT leader and keeps advancing `SB_Global.nb_cfg`. Guarded on a
  real member list so the standalone single-DB-node path is unchanged.
- **ovn-northd ExecStop drop-in (siv-504):** the packaged unit's ExecStop runs
  `ovn-ctl stop_northd` without `--ovn-manage-ovsdb=no`, so restarting northd
  tears down the split NB/SB ovsdb-server units. On a clean bring-up this races
  and kills the freshly-started DBs, aborting the RAFT create/join. Override
  ExecStop with `--ovn-manage-ovsdb=no`.
- **add-nat deadline (js-206):** raise the request deadline from 10s to 45s so
  the client no longer rolls back before the server-side 30s `--wait=hv` barrier.

## Testing

- `make preflight`: pass.
- env19 (3-node): SB tracks NB, `--wait=hv sync` 0.045s (was 30s timeout),
  member list on all DB nodes.
- multinode E2E: 17 pass / 0 fail (incl. `TestMultinodeSpread`, `TestMultinodeOVNRaft`).
- lb E2E: `TestLoadBalancer` pass (8/8 subtests).

Companion mulga changes wire `--ovn-remote` into the bootstrap paths
(tofu-cluster, ansible, bare-metal) and serialize the ansible OVN join play.