### PR TITLE
feat: IAM resource tagging (tag/untag/list-tags for users, roles, policies, instance profiles, OIDC providers)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -479,9 +479,9 @@ All IAM operations are account-scoped. Root user (account `000000000000`) bypass
 | `get-user-policy` | `--user-name`, `--policy-name` | — | **DONE** |
 | `delete-user-policy` | `--user-name`, `--policy-name` | — | **DONE** |
 | `list-user-policies` | `--user-name` | `--max-items`, `--marker` | **DONE** |
-| `tag-user` | — | `--user-name`, `--tags` | **NOT STARTED** |
-| `untag-user` | — | `--user-name`, `--tag-keys` | **NOT STARTED** |
-| `list-user-tags` | — | `--user-name` | **NOT STARTED** |
+| `tag-user` | `--user-name`, `--tags` | — | **DONE** |
+| `untag-user` | `--user-name`, `--tag-keys` | — | **DONE** |
+| `list-user-tags` | `--user-name` | `--max-items`, `--marker` | **DONE** |
 | `put-user-permissions-boundary` | — | `--user-name`, `--permissions-boundary` | **NOT STARTED** |
 | `delete-user-permissions-boundary` | — | `--user-name` | **NOT STARTED** |
 | `create-login-profile` | — | `--user-name`, `--password` | **NOT STARTED** |
@@ -517,9 +517,9 @@ All IAM operations are account-scoped. Root user (account `000000000000`) bypass
 | `delete-policy-version` | — | `--policy-arn`, `--version-id` | **NOT STARTED** |
 | `set-default-policy-version` | — | `--policy-arn`, `--version-id` | **NOT STARTED** |
 | `list-entities-for-policy` | — | `--policy-arn`, `--entity-filter`, `--path-prefix`, `--policy-usage-filter` | **NOT STARTED** |
-| `tag-policy` | — | `--policy-arn`, `--tags` | **NOT STARTED** |
-| `untag-policy` | — | `--policy-arn`, `--tag-keys` | **NOT STARTED** |
-| `list-policy-tags` | — | `--policy-arn` | **NOT STARTED** |
+| `tag-policy` | `--policy-arn`, `--tags` | — | **DONE** |
+| `untag-policy` | `--policy-arn`, `--tag-keys` | — | **DONE** |
+| `list-policy-tags` | `--policy-arn` | `--max-items`, `--marker` | **DONE** |
 | `generate-service-last-accessed-details` | — | `--arn`, `--granularity` | **NOT STARTED** |
 | `get-service-last-accessed-details` | — | `--job-id` | **NOT STARTED** |
 | `get-service-last-accessed-details-with-entities` | — | `--job-id`, `--service-namespace` | **NOT STARTED** |
@@ -544,9 +544,9 @@ All IAM operations are account-scoped. Root user (account `000000000000`) bypass
 | `delete-role-policy` | `--role-name`, `--policy-name` | — | **DONE** |
 | `put-role-permissions-boundary` | — | `--role-name`, `--permissions-boundary` | **NOT STARTED** |
 | `delete-role-permissions-boundary` | — | `--role-name` | **NOT STARTED** |
-| `tag-role` | — | `--role-name`, `--tags` | **NOT STARTED** |
-| `untag-role` | — | `--role-name`, `--tag-keys` | **NOT STARTED** |
-| `list-role-tags` | — | `--role-name` | **NOT STARTED** |
+| `tag-role` | `--role-name`, `--tags` | — | **DONE** |
+| `untag-role` | `--role-name`, `--tag-keys` | — | **DONE** |
+| `list-role-tags` | `--role-name` | `--max-items`, `--marker` | **DONE** |
 | `update-role-description` | — | `--role-name`, `--description` | **NOT STARTED** |
 
 ### IAM — Instance Profiles
@@ -560,9 +560,9 @@ All IAM operations are account-scoped. Root user (account `000000000000`) bypass
 | `delete-instance-profile` | `--instance-profile-name` | — | **DONE** |
 | `add-role-to-instance-profile` | `--instance-profile-name`, `--role-name` | — | **DONE** |
 | `remove-role-from-instance-profile` | `--instance-profile-name`, `--role-name` | — | **DONE** |
-| `tag-instance-profile` | — | `--instance-profile-name`, `--tags` | **NOT STARTED** |
-| `untag-instance-profile` | — | `--instance-profile-name`, `--tag-keys` | **NOT STARTED** |
-| `list-instance-profile-tags` | — | `--instance-profile-name` | **NOT STARTED** |
+| `tag-instance-profile` | `--instance-profile-name`, `--tags` | — | **DONE** |
+| `untag-instance-profile` | `--instance-profile-name`, `--tag-keys` | — | **DONE** |
+| `list-instance-profile-tags` | `--instance-profile-name` | `--max-items`, `--marker` | **DONE** |
 
 ### IAM — OIDC Providers
 
@@ -575,8 +575,8 @@ All IAM operations are account-scoped. Root user (account `000000000000`) bypass
 | `add-client-id-to-open-id-connect-provider` | — | `--open-id-connect-provider-arn`, `--client-id` | **NOT STARTED** |
 | `remove-client-id-from-open-id-connect-provider` | — | `--open-id-connect-provider-arn`, `--client-id` | **NOT STARTED** |
 | `update-open-id-connect-provider-thumbprint` | — | `--open-id-connect-provider-arn`, `--thumbprint-list` | **NOT STARTED** |
-| `tag-open-id-connect-provider` / `untag-open-id-connect-provider` | — | `--open-id-connect-provider-arn`, `--tags`/`--tag-keys` | **NOT STARTED** |
-| `list-open-id-connect-provider-tags` | — | `--open-id-connect-provider-arn` | **NOT STARTED** |
+| `tag-open-id-connect-provider` / `untag-open-id-connect-provider` | `--open-id-connect-provider-arn`, `--tags`/`--tag-keys` | — | **DONE** |
+| `list-open-id-connect-provider-tags` | `--open-id-connect-provider-arn` | `--max-items`, `--marker` | **DONE** |
 
 ### IAM — Groups
 

--- a/spinifex/gateway/auth_test.go
+++ b/spinifex/gateway/auth_test.go
@@ -2350,3 +2350,49 @@ func TestCheckPolicy_AssumedRole_PassRole_WildcardResource_Allowed(t *testing.T)
 	body, _ := io.ReadAll(resp.Body)
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "body: %s", string(body))
 }
+
+func (m *mockIAMService) TagUser(_ string, _ *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return &iam.TagUserOutput{}, nil
+}
+func (m *mockIAMService) UntagUser(_ string, _ *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
+	return &iam.UntagUserOutput{}, nil
+}
+func (m *mockIAMService) ListUserTags(_ string, _ *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
+	return &iam.ListUserTagsOutput{}, nil
+}
+func (m *mockIAMService) TagRole(_ string, _ *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
+	return &iam.TagRoleOutput{}, nil
+}
+func (m *mockIAMService) UntagRole(_ string, _ *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
+	return &iam.UntagRoleOutput{}, nil
+}
+func (m *mockIAMService) ListRoleTags(_ string, _ *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
+	return &iam.ListRoleTagsOutput{}, nil
+}
+func (m *mockIAMService) TagPolicy(_ string, _ *iam.TagPolicyInput) (*iam.TagPolicyOutput, error) {
+	return &iam.TagPolicyOutput{}, nil
+}
+func (m *mockIAMService) UntagPolicy(_ string, _ *iam.UntagPolicyInput) (*iam.UntagPolicyOutput, error) {
+	return &iam.UntagPolicyOutput{}, nil
+}
+func (m *mockIAMService) ListPolicyTags(_ string, _ *iam.ListPolicyTagsInput) (*iam.ListPolicyTagsOutput, error) {
+	return &iam.ListPolicyTagsOutput{}, nil
+}
+func (m *mockIAMService) TagInstanceProfile(_ string, _ *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error) {
+	return &iam.TagInstanceProfileOutput{}, nil
+}
+func (m *mockIAMService) UntagInstanceProfile(_ string, _ *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error) {
+	return &iam.UntagInstanceProfileOutput{}, nil
+}
+func (m *mockIAMService) ListInstanceProfileTags(_ string, _ *iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error) {
+	return &iam.ListInstanceProfileTagsOutput{}, nil
+}
+func (m *mockIAMService) TagOpenIDConnectProvider(_ string, _ *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	return &iam.TagOpenIDConnectProviderOutput{}, nil
+}
+func (m *mockIAMService) UntagOpenIDConnectProvider(_ string, _ *iam.UntagOpenIDConnectProviderInput) (*iam.UntagOpenIDConnectProviderOutput, error) {
+	return &iam.UntagOpenIDConnectProviderOutput{}, nil
+}
+func (m *mockIAMService) ListOpenIDConnectProviderTags(_ string, _ *iam.ListOpenIDConnectProviderTagsInput) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	return &iam.ListOpenIDConnectProviderTagsOutput{}, nil
+}

--- a/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
+++ b/spinifex/gateway/ec2/instance/IamInstanceProfileAssociation_test.go
@@ -825,3 +825,49 @@ func TestAssociationIDFormat(t *testing.T) {
 	suffix := strings.TrimPrefix(id, "iip-assoc-")
 	assert.NotEmpty(t, suffix, "association ID must carry a non-empty random suffix")
 }
+
+func (f *fakeIAMService) TagUser(_ string, _ *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return &iam.TagUserOutput{}, nil
+}
+func (f *fakeIAMService) UntagUser(_ string, _ *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
+	return &iam.UntagUserOutput{}, nil
+}
+func (f *fakeIAMService) ListUserTags(_ string, _ *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
+	return &iam.ListUserTagsOutput{}, nil
+}
+func (f *fakeIAMService) TagRole(_ string, _ *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
+	return &iam.TagRoleOutput{}, nil
+}
+func (f *fakeIAMService) UntagRole(_ string, _ *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
+	return &iam.UntagRoleOutput{}, nil
+}
+func (f *fakeIAMService) ListRoleTags(_ string, _ *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
+	return &iam.ListRoleTagsOutput{}, nil
+}
+func (f *fakeIAMService) TagPolicy(_ string, _ *iam.TagPolicyInput) (*iam.TagPolicyOutput, error) {
+	return &iam.TagPolicyOutput{}, nil
+}
+func (f *fakeIAMService) UntagPolicy(_ string, _ *iam.UntagPolicyInput) (*iam.UntagPolicyOutput, error) {
+	return &iam.UntagPolicyOutput{}, nil
+}
+func (f *fakeIAMService) ListPolicyTags(_ string, _ *iam.ListPolicyTagsInput) (*iam.ListPolicyTagsOutput, error) {
+	return &iam.ListPolicyTagsOutput{}, nil
+}
+func (f *fakeIAMService) TagInstanceProfile(_ string, _ *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error) {
+	return &iam.TagInstanceProfileOutput{}, nil
+}
+func (f *fakeIAMService) UntagInstanceProfile(_ string, _ *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error) {
+	return &iam.UntagInstanceProfileOutput{}, nil
+}
+func (f *fakeIAMService) ListInstanceProfileTags(_ string, _ *iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error) {
+	return &iam.ListInstanceProfileTagsOutput{}, nil
+}
+func (f *fakeIAMService) TagOpenIDConnectProvider(_ string, _ *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	return &iam.TagOpenIDConnectProviderOutput{}, nil
+}
+func (f *fakeIAMService) UntagOpenIDConnectProvider(_ string, _ *iam.UntagOpenIDConnectProviderInput) (*iam.UntagOpenIDConnectProviderOutput, error) {
+	return &iam.UntagOpenIDConnectProviderOutput{}, nil
+}
+func (f *fakeIAMService) ListOpenIDConnectProviderTags(_ string, _ *iam.ListOpenIDConnectProviderTagsInput) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	return &iam.ListOpenIDConnectProviderTagsOutput{}, nil
+}

--- a/spinifex/gateway/iam.go
+++ b/spinifex/gateway/iam.go
@@ -196,6 +196,53 @@ var iamActions = map[string]IAMHandler{
 		return gateway_iam.DeleteOpenIDConnectProvider(accountID, input, gw.IAMService)
 	}),
 
+	// Resource tagging
+	"TagUser": iamHandler(func(accountID string, input *iam.TagUserInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.TagUser(accountID, input, gw.IAMService)
+	}),
+	"UntagUser": iamHandler(func(accountID string, input *iam.UntagUserInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.UntagUser(accountID, input, gw.IAMService)
+	}),
+	"ListUserTags": iamHandler(func(accountID string, input *iam.ListUserTagsInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.ListUserTags(accountID, input, gw.IAMService)
+	}),
+	"TagRole": iamHandler(func(accountID string, input *iam.TagRoleInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.TagRole(accountID, input, gw.IAMService)
+	}),
+	"UntagRole": iamHandler(func(accountID string, input *iam.UntagRoleInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.UntagRole(accountID, input, gw.IAMService)
+	}),
+	"ListRoleTags": iamHandler(func(accountID string, input *iam.ListRoleTagsInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.ListRoleTags(accountID, input, gw.IAMService)
+	}),
+	"TagPolicy": iamHandler(func(accountID string, input *iam.TagPolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.TagPolicy(accountID, input, gw.IAMService)
+	}),
+	"UntagPolicy": iamHandler(func(accountID string, input *iam.UntagPolicyInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.UntagPolicy(accountID, input, gw.IAMService)
+	}),
+	"ListPolicyTags": iamHandler(func(accountID string, input *iam.ListPolicyTagsInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.ListPolicyTags(accountID, input, gw.IAMService)
+	}),
+	"TagInstanceProfile": iamHandler(func(accountID string, input *iam.TagInstanceProfileInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.TagInstanceProfile(accountID, input, gw.IAMService)
+	}),
+	"UntagInstanceProfile": iamHandler(func(accountID string, input *iam.UntagInstanceProfileInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.UntagInstanceProfile(accountID, input, gw.IAMService)
+	}),
+	"ListInstanceProfileTags": iamHandler(func(accountID string, input *iam.ListInstanceProfileTagsInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.ListInstanceProfileTags(accountID, input, gw.IAMService)
+	}),
+	"TagOpenIDConnectProvider": iamHandler(func(accountID string, input *iam.TagOpenIDConnectProviderInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.TagOpenIDConnectProvider(accountID, input, gw.IAMService)
+	}),
+	"UntagOpenIDConnectProvider": iamHandler(func(accountID string, input *iam.UntagOpenIDConnectProviderInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.UntagOpenIDConnectProvider(accountID, input, gw.IAMService)
+	}),
+	"ListOpenIDConnectProviderTags": iamHandler(func(accountID string, input *iam.ListOpenIDConnectProviderTagsInput, gw *GatewayConfig) (any, error) {
+		return gateway_iam.ListOpenIDConnectProviderTags(accountID, input, gw.IAMService)
+	}),
+
 	// Group CRUD
 	"CreateGroup": iamHandler(func(accountID string, input *iam.CreateGroupInput, gw *GatewayConfig) (any, error) {
 		return gateway_iam.CreateGroup(accountID, input, gw.IAMService)

--- a/spinifex/gateway/iam/handler_test.go
+++ b/spinifex/gateway/iam/handler_test.go
@@ -175,6 +175,52 @@ func (s *stubIAMService) ResolveInstanceProfile(_, _ string) (*handlers_iam.Inst
 	return nil, nil
 }
 
+func (s *stubIAMService) TagUser(_ string, _ *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return &iam.TagUserOutput{}, nil
+}
+func (s *stubIAMService) UntagUser(_ string, _ *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
+	return &iam.UntagUserOutput{}, nil
+}
+func (s *stubIAMService) ListUserTags(_ string, _ *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
+	return &iam.ListUserTagsOutput{}, nil
+}
+func (s *stubIAMService) TagRole(_ string, _ *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
+	return &iam.TagRoleOutput{}, nil
+}
+func (s *stubIAMService) UntagRole(_ string, _ *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
+	return &iam.UntagRoleOutput{}, nil
+}
+func (s *stubIAMService) ListRoleTags(_ string, _ *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
+	return &iam.ListRoleTagsOutput{}, nil
+}
+func (s *stubIAMService) TagPolicy(_ string, _ *iam.TagPolicyInput) (*iam.TagPolicyOutput, error) {
+	return &iam.TagPolicyOutput{}, nil
+}
+func (s *stubIAMService) UntagPolicy(_ string, _ *iam.UntagPolicyInput) (*iam.UntagPolicyOutput, error) {
+	return &iam.UntagPolicyOutput{}, nil
+}
+func (s *stubIAMService) ListPolicyTags(_ string, _ *iam.ListPolicyTagsInput) (*iam.ListPolicyTagsOutput, error) {
+	return &iam.ListPolicyTagsOutput{}, nil
+}
+func (s *stubIAMService) TagInstanceProfile(_ string, _ *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error) {
+	return &iam.TagInstanceProfileOutput{}, nil
+}
+func (s *stubIAMService) UntagInstanceProfile(_ string, _ *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error) {
+	return &iam.UntagInstanceProfileOutput{}, nil
+}
+func (s *stubIAMService) ListInstanceProfileTags(_ string, _ *iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error) {
+	return &iam.ListInstanceProfileTagsOutput{}, nil
+}
+func (s *stubIAMService) TagOpenIDConnectProvider(_ string, _ *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	return &iam.TagOpenIDConnectProviderOutput{}, nil
+}
+func (s *stubIAMService) UntagOpenIDConnectProvider(_ string, _ *iam.UntagOpenIDConnectProviderInput) (*iam.UntagOpenIDConnectProviderOutput, error) {
+	return &iam.UntagOpenIDConnectProviderOutput{}, nil
+}
+func (s *stubIAMService) ListOpenIDConnectProviderTags(_ string, _ *iam.ListOpenIDConnectProviderTagsInput) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	return &iam.ListOpenIDConnectProviderTagsOutput{}, nil
+}
+
 func (s *stubIAMService) CreateGroup(_ string, _ *iam.CreateGroupInput) (*iam.CreateGroupOutput, error) {
 	return &iam.CreateGroupOutput{}, nil
 }

--- a/spinifex/gateway/iam/instance_profile.go
+++ b/spinifex/gateway/iam/instance_profile.go
@@ -94,3 +94,30 @@ func RemoveRoleFromInstanceProfile(accountID string, input *iam.RemoveRoleFromIn
 	}
 	return svc.RemoveRoleFromInstanceProfile(accountID, input)
 }
+
+func TagInstanceProfile(accountID string, input *iam.TagInstanceProfileInput, svc handlers_iam.IAMService) (*iam.TagInstanceProfileOutput, error) {
+	if input.InstanceProfileName == nil || *input.InstanceProfileName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.Tags) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.TagInstanceProfile(accountID, input)
+}
+
+func UntagInstanceProfile(accountID string, input *iam.UntagInstanceProfileInput, svc handlers_iam.IAMService) (*iam.UntagInstanceProfileOutput, error) {
+	if input.InstanceProfileName == nil || *input.InstanceProfileName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.TagKeys) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.UntagInstanceProfile(accountID, input)
+}
+
+func ListInstanceProfileTags(accountID string, input *iam.ListInstanceProfileTagsInput, svc handlers_iam.IAMService) (*iam.ListInstanceProfileTagsOutput, error) {
+	if input.InstanceProfileName == nil || *input.InstanceProfileName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.ListInstanceProfileTags(accountID, input)
+}

--- a/spinifex/gateway/iam/oidc_provider.go
+++ b/spinifex/gateway/iam/oidc_provider.go
@@ -32,3 +32,30 @@ func DeleteOpenIDConnectProvider(accountID string, input *iam.DeleteOpenIDConnec
 	}
 	return svc.DeleteOpenIDConnectProvider(accountID, input)
 }
+
+func TagOpenIDConnectProvider(accountID string, input *iam.TagOpenIDConnectProviderInput, svc handlers_iam.IAMService) (*iam.TagOpenIDConnectProviderOutput, error) {
+	if input.OpenIDConnectProviderArn == nil || *input.OpenIDConnectProviderArn == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.Tags) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.TagOpenIDConnectProvider(accountID, input)
+}
+
+func UntagOpenIDConnectProvider(accountID string, input *iam.UntagOpenIDConnectProviderInput, svc handlers_iam.IAMService) (*iam.UntagOpenIDConnectProviderOutput, error) {
+	if input.OpenIDConnectProviderArn == nil || *input.OpenIDConnectProviderArn == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.TagKeys) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.UntagOpenIDConnectProvider(accountID, input)
+}
+
+func ListOpenIDConnectProviderTags(accountID string, input *iam.ListOpenIDConnectProviderTagsInput, svc handlers_iam.IAMService) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	if input.OpenIDConnectProviderArn == nil || *input.OpenIDConnectProviderArn == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.ListOpenIDConnectProviderTags(accountID, input)
+}

--- a/spinifex/gateway/iam/policy.go
+++ b/spinifex/gateway/iam/policy.go
@@ -79,3 +79,30 @@ func ListAttachedUserPolicies(accountID string, input *iam.ListAttachedUserPolic
 	}
 	return svc.ListAttachedUserPolicies(accountID, input)
 }
+
+func TagPolicy(accountID string, input *iam.TagPolicyInput, svc handlers_iam.IAMService) (*iam.TagPolicyOutput, error) {
+	if input.PolicyArn == nil || *input.PolicyArn == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.Tags) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.TagPolicy(accountID, input)
+}
+
+func UntagPolicy(accountID string, input *iam.UntagPolicyInput, svc handlers_iam.IAMService) (*iam.UntagPolicyOutput, error) {
+	if input.PolicyArn == nil || *input.PolicyArn == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.TagKeys) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.UntagPolicy(accountID, input)
+}
+
+func ListPolicyTags(accountID string, input *iam.ListPolicyTagsInput, svc handlers_iam.IAMService) (*iam.ListPolicyTagsOutput, error) {
+	if input.PolicyArn == nil || *input.PolicyArn == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.ListPolicyTags(accountID, input)
+}

--- a/spinifex/gateway/iam/role.go
+++ b/spinifex/gateway/iam/role.go
@@ -119,3 +119,30 @@ func ListRolePolicies(accountID string, input *iam.ListRolePoliciesInput, svc ha
 	}
 	return svc.ListRolePolicies(accountID, input)
 }
+
+func TagRole(accountID string, input *iam.TagRoleInput, svc handlers_iam.IAMService) (*iam.TagRoleOutput, error) {
+	if input.RoleName == nil || *input.RoleName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.Tags) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.TagRole(accountID, input)
+}
+
+func UntagRole(accountID string, input *iam.UntagRoleInput, svc handlers_iam.IAMService) (*iam.UntagRoleOutput, error) {
+	if input.RoleName == nil || *input.RoleName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.TagKeys) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.UntagRole(accountID, input)
+}
+
+func ListRoleTags(accountID string, input *iam.ListRoleTagsInput, svc handlers_iam.IAMService) (*iam.ListRoleTagsOutput, error) {
+	if input.RoleName == nil || *input.RoleName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.ListRoleTags(accountID, input)
+}

--- a/spinifex/gateway/iam/tag_test.go
+++ b/spinifex/gateway/iam/tag_test.go
@@ -1,0 +1,326 @@
+package gateway_iam
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testTags    = []*iam.Tag{{Key: aws.String("env"), Value: aws.String("dev")}}
+	testTagKeys = []*string{aws.String("env")}
+)
+
+func checkTagValidator(t *testing.T, wantErr string, err error) {
+	t.Helper()
+	if wantErr != "" {
+		require.Error(t, err)
+		assert.Equal(t, wantErr, err.Error())
+	} else {
+		require.NoError(t, err)
+	}
+}
+
+func TestTagUser(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.TagUserInput
+		wantErr string
+	}{
+		{"nil UserName", &iam.TagUserInput{Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"empty UserName", &iam.TagUserInput{UserName: aws.String(""), Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"missing Tags", &iam.TagUserInput{UserName: aws.String("alice")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.TagUserInput{UserName: aws.String("alice"), Tags: testTags}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := TagUser(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestUntagUser(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.UntagUserInput
+		wantErr string
+	}{
+		{"nil UserName", &iam.UntagUserInput{TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"empty UserName", &iam.UntagUserInput{UserName: aws.String(""), TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"missing TagKeys", &iam.UntagUserInput{UserName: aws.String("alice")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.UntagUserInput{UserName: aws.String("alice"), TagKeys: testTagKeys}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UntagUser(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestListUserTags(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.ListUserTagsInput
+		wantErr string
+	}{
+		{"nil UserName", &iam.ListUserTagsInput{}, awserrors.ErrorMissingParameter},
+		{"empty UserName", &iam.ListUserTagsInput{UserName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.ListUserTagsInput{UserName: aws.String("alice")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListUserTags(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestTagRole(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.TagRoleInput
+		wantErr string
+	}{
+		{"nil RoleName", &iam.TagRoleInput{Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"empty RoleName", &iam.TagRoleInput{RoleName: aws.String(""), Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"missing Tags", &iam.TagRoleInput{RoleName: aws.String("myrole")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.TagRoleInput{RoleName: aws.String("myrole"), Tags: testTags}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := TagRole(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestUntagRole(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.UntagRoleInput
+		wantErr string
+	}{
+		{"nil RoleName", &iam.UntagRoleInput{TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"empty RoleName", &iam.UntagRoleInput{RoleName: aws.String(""), TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"missing TagKeys", &iam.UntagRoleInput{RoleName: aws.String("myrole")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.UntagRoleInput{RoleName: aws.String("myrole"), TagKeys: testTagKeys}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UntagRole(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestListRoleTags(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.ListRoleTagsInput
+		wantErr string
+	}{
+		{"nil RoleName", &iam.ListRoleTagsInput{}, awserrors.ErrorMissingParameter},
+		{"empty RoleName", &iam.ListRoleTagsInput{RoleName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.ListRoleTagsInput{RoleName: aws.String("myrole")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListRoleTags(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestTagPolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	arn := "arn:aws:iam::000000000000:policy/mypolicy"
+	tests := []struct {
+		name    string
+		input   *iam.TagPolicyInput
+		wantErr string
+	}{
+		{"nil PolicyArn", &iam.TagPolicyInput{Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"empty PolicyArn", &iam.TagPolicyInput{PolicyArn: aws.String(""), Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"missing Tags", &iam.TagPolicyInput{PolicyArn: aws.String(arn)}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.TagPolicyInput{PolicyArn: aws.String(arn), Tags: testTags}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := TagPolicy(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestUntagPolicy(t *testing.T) {
+	svc := &stubIAMService{}
+	arn := "arn:aws:iam::000000000000:policy/mypolicy"
+	tests := []struct {
+		name    string
+		input   *iam.UntagPolicyInput
+		wantErr string
+	}{
+		{"nil PolicyArn", &iam.UntagPolicyInput{TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"empty PolicyArn", &iam.UntagPolicyInput{PolicyArn: aws.String(""), TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"missing TagKeys", &iam.UntagPolicyInput{PolicyArn: aws.String(arn)}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.UntagPolicyInput{PolicyArn: aws.String(arn), TagKeys: testTagKeys}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UntagPolicy(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestListPolicyTags(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.ListPolicyTagsInput
+		wantErr string
+	}{
+		{"nil PolicyArn", &iam.ListPolicyTagsInput{}, awserrors.ErrorMissingParameter},
+		{"empty PolicyArn", &iam.ListPolicyTagsInput{PolicyArn: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.ListPolicyTagsInput{PolicyArn: aws.String("arn:aws:iam::000000000000:policy/mypolicy")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListPolicyTags(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestTagInstanceProfile(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.TagInstanceProfileInput
+		wantErr string
+	}{
+		{"nil InstanceProfileName", &iam.TagInstanceProfileInput{Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"empty InstanceProfileName", &iam.TagInstanceProfileInput{InstanceProfileName: aws.String(""), Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"missing Tags", &iam.TagInstanceProfileInput{InstanceProfileName: aws.String("myprofile")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.TagInstanceProfileInput{InstanceProfileName: aws.String("myprofile"), Tags: testTags}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := TagInstanceProfile(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestUntagInstanceProfile(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.UntagInstanceProfileInput
+		wantErr string
+	}{
+		{"nil InstanceProfileName", &iam.UntagInstanceProfileInput{TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"empty InstanceProfileName", &iam.UntagInstanceProfileInput{InstanceProfileName: aws.String(""), TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"missing TagKeys", &iam.UntagInstanceProfileInput{InstanceProfileName: aws.String("myprofile")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.UntagInstanceProfileInput{InstanceProfileName: aws.String("myprofile"), TagKeys: testTagKeys}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UntagInstanceProfile(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestListInstanceProfileTags(t *testing.T) {
+	svc := &stubIAMService{}
+	tests := []struct {
+		name    string
+		input   *iam.ListInstanceProfileTagsInput
+		wantErr string
+	}{
+		{"nil InstanceProfileName", &iam.ListInstanceProfileTagsInput{}, awserrors.ErrorMissingParameter},
+		{"empty InstanceProfileName", &iam.ListInstanceProfileTagsInput{InstanceProfileName: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.ListInstanceProfileTagsInput{InstanceProfileName: aws.String("myprofile")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListInstanceProfileTags(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestTagOpenIDConnectProvider(t *testing.T) {
+	svc := &stubIAMService{}
+	arn := "arn:aws:iam::000000000000:oidc-provider/oidc.example.com"
+	tests := []struct {
+		name    string
+		input   *iam.TagOpenIDConnectProviderInput
+		wantErr string
+	}{
+		{"nil Arn", &iam.TagOpenIDConnectProviderInput{Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"empty Arn", &iam.TagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(""), Tags: testTags}, awserrors.ErrorMissingParameter},
+		{"missing Tags", &iam.TagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn)}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.TagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn), Tags: testTags}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := TagOpenIDConnectProvider(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestUntagOpenIDConnectProvider(t *testing.T) {
+	svc := &stubIAMService{}
+	arn := "arn:aws:iam::000000000000:oidc-provider/oidc.example.com"
+	tests := []struct {
+		name    string
+		input   *iam.UntagOpenIDConnectProviderInput
+		wantErr string
+	}{
+		{"nil Arn", &iam.UntagOpenIDConnectProviderInput{TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"empty Arn", &iam.UntagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(""), TagKeys: testTagKeys}, awserrors.ErrorMissingParameter},
+		{"missing TagKeys", &iam.UntagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn)}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.UntagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(arn), TagKeys: testTagKeys}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UntagOpenIDConnectProvider(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}
+
+func TestListOpenIDConnectProviderTags(t *testing.T) {
+	svc := &stubIAMService{}
+	arn := "arn:aws:iam::000000000000:oidc-provider/oidc.example.com"
+	tests := []struct {
+		name    string
+		input   *iam.ListOpenIDConnectProviderTagsInput
+		wantErr string
+	}{
+		{"nil Arn", &iam.ListOpenIDConnectProviderTagsInput{}, awserrors.ErrorMissingParameter},
+		{"empty Arn", &iam.ListOpenIDConnectProviderTagsInput{OpenIDConnectProviderArn: aws.String("")}, awserrors.ErrorMissingParameter},
+		{"valid", &iam.ListOpenIDConnectProviderTagsInput{OpenIDConnectProviderArn: aws.String(arn)}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ListOpenIDConnectProviderTags(testAccountID, tc.input, svc)
+			checkTagValidator(t, tc.wantErr, err)
+		})
+	}
+}

--- a/spinifex/gateway/iam/user.go
+++ b/spinifex/gateway/iam/user.go
@@ -72,3 +72,30 @@ func ListUserPolicies(accountID string, input *iam.ListUserPoliciesInput, svc ha
 	}
 	return svc.ListUserPolicies(accountID, input)
 }
+
+func TagUser(accountID string, input *iam.TagUserInput, svc handlers_iam.IAMService) (*iam.TagUserOutput, error) {
+	if input.UserName == nil || *input.UserName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.Tags) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.TagUser(accountID, input)
+}
+
+func UntagUser(accountID string, input *iam.UntagUserInput, svc handlers_iam.IAMService) (*iam.UntagUserOutput, error) {
+	if input.UserName == nil || *input.UserName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	if len(input.TagKeys) == 0 {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.UntagUser(accountID, input)
+}
+
+func ListUserTags(accountID string, input *iam.ListUserTagsInput, svc handlers_iam.IAMService) (*iam.ListUserTagsOutput, error) {
+	if input.UserName == nil || *input.UserName == "" {
+		return nil, errors.New(awserrors.ErrorMissingParameter)
+	}
+	return svc.ListUserTags(accountID, input)
+}

--- a/spinifex/gateway/iam_examples_contract_test.go
+++ b/spinifex/gateway/iam_examples_contract_test.go
@@ -87,7 +87,7 @@ func TestIAMExamplesContract(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, 33, covered, "covered IAM examples")
+	assert.Equal(t, 39, covered, "covered IAM examples")
 }
 
 func loadIAMExamples(t *testing.T) iamExamplesFile {
@@ -269,6 +269,14 @@ func (svc *echoIAMService) ListGroupsForUser(accountID string, input *iam.ListGr
 	return echoIAMCall[iam.ListGroupsForUserInput, iam.ListGroupsForUserOutput](svc, accountID, input)
 }
 
+func (svc *echoIAMService) ListRoleTags(accountID string, input *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
+	return echoIAMCall[iam.ListRoleTagsInput, iam.ListRoleTagsOutput](svc, accountID, input)
+}
+
+func (svc *echoIAMService) ListUserTags(accountID string, input *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
+	return echoIAMCall[iam.ListUserTagsInput, iam.ListUserTagsOutput](svc, accountID, input)
+}
+
 func (svc *echoIAMService) ListUsers(accountID string, input *iam.ListUsersInput) (*iam.ListUsersOutput, error) {
 	return echoIAMCall[iam.ListUsersInput, iam.ListUsersOutput](svc, accountID, input)
 }
@@ -291,6 +299,22 @@ func (svc *echoIAMService) RemoveRoleFromInstanceProfile(accountID string, input
 
 func (svc *echoIAMService) RemoveUserFromGroup(accountID string, input *iam.RemoveUserFromGroupInput) (*iam.RemoveUserFromGroupOutput, error) {
 	return echoIAMCall[iam.RemoveUserFromGroupInput, iam.RemoveUserFromGroupOutput](svc, accountID, input)
+}
+
+func (svc *echoIAMService) TagRole(accountID string, input *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
+	return echoIAMCall[iam.TagRoleInput, iam.TagRoleOutput](svc, accountID, input)
+}
+
+func (svc *echoIAMService) TagUser(accountID string, input *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return echoIAMCall[iam.TagUserInput, iam.TagUserOutput](svc, accountID, input)
+}
+
+func (svc *echoIAMService) UntagRole(accountID string, input *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
+	return echoIAMCall[iam.UntagRoleInput, iam.UntagRoleOutput](svc, accountID, input)
+}
+
+func (svc *echoIAMService) UntagUser(accountID string, input *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
+	return echoIAMCall[iam.UntagUserInput, iam.UntagUserOutput](svc, accountID, input)
 }
 
 func (svc *echoIAMService) UpdateAccessKey(accountID string, input *iam.UpdateAccessKeyInput) (*iam.UpdateAccessKeyOutput, error) {

--- a/spinifex/gateway/iam_request_test.go
+++ b/spinifex/gateway/iam_request_test.go
@@ -437,3 +437,49 @@ func TestIAMRequest_ValidationError(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	assert.Contains(t, string(body), "MissingParameter")
 }
+
+func (m *flexMockIAMService) TagUser(_ string, _ *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return &iam.TagUserOutput{}, nil
+}
+func (m *flexMockIAMService) UntagUser(_ string, _ *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
+	return &iam.UntagUserOutput{}, nil
+}
+func (m *flexMockIAMService) ListUserTags(_ string, _ *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
+	return &iam.ListUserTagsOutput{}, nil
+}
+func (m *flexMockIAMService) TagRole(_ string, _ *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
+	return &iam.TagRoleOutput{}, nil
+}
+func (m *flexMockIAMService) UntagRole(_ string, _ *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
+	return &iam.UntagRoleOutput{}, nil
+}
+func (m *flexMockIAMService) ListRoleTags(_ string, _ *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
+	return &iam.ListRoleTagsOutput{}, nil
+}
+func (m *flexMockIAMService) TagPolicy(_ string, _ *iam.TagPolicyInput) (*iam.TagPolicyOutput, error) {
+	return &iam.TagPolicyOutput{}, nil
+}
+func (m *flexMockIAMService) UntagPolicy(_ string, _ *iam.UntagPolicyInput) (*iam.UntagPolicyOutput, error) {
+	return &iam.UntagPolicyOutput{}, nil
+}
+func (m *flexMockIAMService) ListPolicyTags(_ string, _ *iam.ListPolicyTagsInput) (*iam.ListPolicyTagsOutput, error) {
+	return &iam.ListPolicyTagsOutput{}, nil
+}
+func (m *flexMockIAMService) TagInstanceProfile(_ string, _ *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error) {
+	return &iam.TagInstanceProfileOutput{}, nil
+}
+func (m *flexMockIAMService) UntagInstanceProfile(_ string, _ *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error) {
+	return &iam.UntagInstanceProfileOutput{}, nil
+}
+func (m *flexMockIAMService) ListInstanceProfileTags(_ string, _ *iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error) {
+	return &iam.ListInstanceProfileTagsOutput{}, nil
+}
+func (m *flexMockIAMService) TagOpenIDConnectProvider(_ string, _ *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	return &iam.TagOpenIDConnectProviderOutput{}, nil
+}
+func (m *flexMockIAMService) UntagOpenIDConnectProvider(_ string, _ *iam.UntagOpenIDConnectProviderInput) (*iam.UntagOpenIDConnectProviderOutput, error) {
+	return &iam.UntagOpenIDConnectProviderOutput{}, nil
+}
+func (m *flexMockIAMService) ListOpenIDConnectProviderTags(_ string, _ *iam.ListOpenIDConnectProviderTagsInput) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	return &iam.ListOpenIDConnectProviderTagsOutput{}, nil
+}

--- a/spinifex/gateway/sts/handler_test.go
+++ b/spinifex/gateway/sts/handler_test.go
@@ -550,3 +550,49 @@ func TestGetSessionToken_PropagatesServiceError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
 }
+
+func (s *stubIAMService) TagUser(_ string, _ *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return &iam.TagUserOutput{}, nil
+}
+func (s *stubIAMService) UntagUser(_ string, _ *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
+	return &iam.UntagUserOutput{}, nil
+}
+func (s *stubIAMService) ListUserTags(_ string, _ *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
+	return &iam.ListUserTagsOutput{}, nil
+}
+func (s *stubIAMService) TagRole(_ string, _ *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
+	return &iam.TagRoleOutput{}, nil
+}
+func (s *stubIAMService) UntagRole(_ string, _ *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
+	return &iam.UntagRoleOutput{}, nil
+}
+func (s *stubIAMService) ListRoleTags(_ string, _ *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
+	return &iam.ListRoleTagsOutput{}, nil
+}
+func (s *stubIAMService) TagPolicy(_ string, _ *iam.TagPolicyInput) (*iam.TagPolicyOutput, error) {
+	return &iam.TagPolicyOutput{}, nil
+}
+func (s *stubIAMService) UntagPolicy(_ string, _ *iam.UntagPolicyInput) (*iam.UntagPolicyOutput, error) {
+	return &iam.UntagPolicyOutput{}, nil
+}
+func (s *stubIAMService) ListPolicyTags(_ string, _ *iam.ListPolicyTagsInput) (*iam.ListPolicyTagsOutput, error) {
+	return &iam.ListPolicyTagsOutput{}, nil
+}
+func (s *stubIAMService) TagInstanceProfile(_ string, _ *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error) {
+	return &iam.TagInstanceProfileOutput{}, nil
+}
+func (s *stubIAMService) UntagInstanceProfile(_ string, _ *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error) {
+	return &iam.UntagInstanceProfileOutput{}, nil
+}
+func (s *stubIAMService) ListInstanceProfileTags(_ string, _ *iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error) {
+	return &iam.ListInstanceProfileTagsOutput{}, nil
+}
+func (s *stubIAMService) TagOpenIDConnectProvider(_ string, _ *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	return &iam.TagOpenIDConnectProviderOutput{}, nil
+}
+func (s *stubIAMService) UntagOpenIDConnectProvider(_ string, _ *iam.UntagOpenIDConnectProviderInput) (*iam.UntagOpenIDConnectProviderOutput, error) {
+	return &iam.UntagOpenIDConnectProviderOutput{}, nil
+}
+func (s *stubIAMService) ListOpenIDConnectProviderTags(_ string, _ *iam.ListOpenIDConnectProviderTagsInput) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	return &iam.ListOpenIDConnectProviderTagsOutput{}, nil
+}

--- a/spinifex/handlers/iam/instance_profiles.go
+++ b/spinifex/handlers/iam/instance_profiles.go
@@ -290,6 +290,73 @@ func parseInstanceProfileARN(arn string) (accountID, name string, err error) {
 	return parts[4], name, nil
 }
 
+// TagInstanceProfile upserts tags on an instance profile. Blind
+// read-modify-write Put like the other instance-profile writers (no CAS).
+func (s *IAMServiceImpl) TagInstanceProfile(accountID string, input *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error) {
+	if err := validateTags(input.Tags); err != nil {
+		return nil, err
+	}
+
+	profileName := *input.InstanceProfileName
+	profile, err := s.getInstanceProfile(accountID, profileName)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeTags(profile.Tags, input.Tags)
+	if len(merged) > maxTagsPerResource {
+		return nil, errors.New(awserrors.ErrorIAMLimitExceeded)
+	}
+	profile.Tags = merged
+
+	data, err := json.Marshal(profile)
+	if err != nil {
+		return nil, fmt.Errorf("marshal instance profile: %w", err)
+	}
+	if _, err := s.instanceProfilesBucket.Put(accountID+"."+profileName, data); err != nil {
+		return nil, fmt.Errorf("update instance profile: %w", err)
+	}
+
+	slog.Info("IAM instance profile tagged", "accountID", accountID, "instanceProfileName", profileName)
+	return &iam.TagInstanceProfileOutput{}, nil
+}
+
+// UntagInstanceProfile removes the named tag keys from an instance profile;
+// unknown keys are a no-op.
+func (s *IAMServiceImpl) UntagInstanceProfile(accountID string, input *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error) {
+	profileName := *input.InstanceProfileName
+	profile, err := s.getInstanceProfile(accountID, profileName)
+	if err != nil {
+		return nil, err
+	}
+
+	profile.Tags = removeTagKeys(profile.Tags, input.TagKeys)
+
+	data, err := json.Marshal(profile)
+	if err != nil {
+		return nil, fmt.Errorf("marshal instance profile: %w", err)
+	}
+	if _, err := s.instanceProfilesBucket.Put(accountID+"."+profileName, data); err != nil {
+		return nil, fmt.Errorf("update instance profile: %w", err)
+	}
+
+	slog.Info("IAM instance profile untagged", "accountID", accountID, "instanceProfileName", profileName)
+	return &iam.UntagInstanceProfileOutput{}, nil
+}
+
+// ListInstanceProfileTags returns an instance profile's tags. Pagination is
+// not implemented: IsTruncated is always false.
+func (s *IAMServiceImpl) ListInstanceProfileTags(accountID string, input *iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error) {
+	profile, err := s.getInstanceProfile(accountID, *input.InstanceProfileName)
+	if err != nil {
+		return nil, err
+	}
+	return &iam.ListInstanceProfileTagsOutput{
+		Tags:        tagsToSDK(profile.Tags),
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
 func (s *IAMServiceImpl) getInstanceProfile(accountID, profileName string) (*InstanceProfile, error) {
 	entry, err := s.instanceProfilesBucket.Get(accountID + "." + profileName)
 	if err != nil {

--- a/spinifex/handlers/iam/oidc_providers.go
+++ b/spinifex/handlers/iam/oidc_providers.go
@@ -254,15 +254,3 @@ func (s *IAMServiceImpl) getOIDCProvider(accountID, arn string) (*OIDCProviderRe
 	}
 	return &record, nil
 }
-
-// tagsToSDK converts stored Tags into the SDK shape.
-func tagsToSDK(tags []Tag) []*iam.Tag {
-	if len(tags) == 0 {
-		return nil
-	}
-	out := make([]*iam.Tag, 0, len(tags))
-	for _, t := range tags {
-		out = append(out, &iam.Tag{Key: aws.String(t.Key), Value: aws.String(t.Value)})
-	}
-	return out
-}

--- a/spinifex/handlers/iam/oidc_providers.go
+++ b/spinifex/handlers/iam/oidc_providers.go
@@ -229,6 +229,85 @@ func (s *IAMServiceImpl) DeleteOpenIDConnectProvider(accountID string, input *ia
 	return &iam.DeleteOpenIDConnectProviderOutput{}, nil
 }
 
+// TagOpenIDConnectProvider upserts tags on an OIDC provider. Blind
+// read-modify-write Put like the other writers here (no CAS).
+func (s *IAMServiceImpl) TagOpenIDConnectProvider(accountID string, input *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	if err := validateTags(input.Tags); err != nil {
+		return nil, err
+	}
+
+	arn := aws.StringValue(input.OpenIDConnectProviderArn)
+	record, err := s.getOIDCProvider(accountID, arn)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeTags(record.Tags, input.Tags)
+	if len(merged) > maxTagsPerResource {
+		return nil, errors.New(awserrors.ErrorIAMLimitExceeded)
+	}
+	record.Tags = merged
+
+	if err := s.putOIDCProvider(accountID, record); err != nil {
+		return nil, err
+	}
+
+	slog.Info("IAM OIDC provider tagged", "accountID", accountID, "arn", arn)
+	return &iam.TagOpenIDConnectProviderOutput{}, nil
+}
+
+// UntagOpenIDConnectProvider removes the named tag keys from an OIDC provider;
+// unknown keys are a no-op.
+func (s *IAMServiceImpl) UntagOpenIDConnectProvider(accountID string, input *iam.UntagOpenIDConnectProviderInput) (*iam.UntagOpenIDConnectProviderOutput, error) {
+	arn := aws.StringValue(input.OpenIDConnectProviderArn)
+	record, err := s.getOIDCProvider(accountID, arn)
+	if err != nil {
+		return nil, err
+	}
+
+	record.Tags = removeTagKeys(record.Tags, input.TagKeys)
+
+	if err := s.putOIDCProvider(accountID, record); err != nil {
+		return nil, err
+	}
+
+	slog.Info("IAM OIDC provider untagged", "accountID", accountID, "arn", arn)
+	return &iam.UntagOpenIDConnectProviderOutput{}, nil
+}
+
+// ListOpenIDConnectProviderTags returns an OIDC provider's tags. Pagination is
+// not implemented: IsTruncated is always false.
+func (s *IAMServiceImpl) ListOpenIDConnectProviderTags(accountID string, input *iam.ListOpenIDConnectProviderTagsInput) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	record, err := s.getOIDCProvider(accountID, aws.StringValue(input.OpenIDConnectProviderArn))
+	if err != nil {
+		return nil, err
+	}
+	return &iam.ListOpenIDConnectProviderTagsOutput{
+		Tags:        tagsToSDK(record.Tags),
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
+// putOIDCProvider overwrites an existing provider record, keyed by its issuer
+// URL. The record must have been read from the bucket first.
+func (s *IAMServiceImpl) putOIDCProvider(accountID string, record *OIDCProviderRecord) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal OIDC provider: %w", err)
+	}
+	kv, err := s.js.KeyValue(IAMAccountBucketName(accountID))
+	if err != nil {
+		if errors.Is(err, nats.ErrBucketNotFound) {
+			return errors.New(awserrors.ErrorIAMNoSuchEntity)
+		}
+		return fmt.Errorf("open IAM account bucket: %w", err)
+	}
+	if _, err := kv.Put(OIDCProviderKey(record.Url), data); err != nil {
+		return fmt.Errorf("store OIDC provider: %w", err)
+	}
+	return nil
+}
+
 func (s *IAMServiceImpl) getOIDCProvider(accountID, arn string) (*OIDCProviderRecord, error) {
 	issuer, err := issuerFromOIDCProviderARN(arn)
 	if err != nil {

--- a/spinifex/handlers/iam/roles.go
+++ b/spinifex/handlers/iam/roles.go
@@ -428,6 +428,57 @@ func (s *IAMServiceImpl) ListRolePolicies(accountID string, input *iam.ListRoleP
 	}, nil
 }
 
+// TagRole upserts tags on a role under CAS, like the other role writers.
+func (s *IAMServiceImpl) TagRole(accountID string, input *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
+	if err := validateTags(input.Tags); err != nil {
+		return nil, err
+	}
+
+	roleName := *input.RoleName
+	err := s.updateRoleCAS(accountID, roleName, func(role *Role) (bool, error) {
+		merged := mergeTags(role.Tags, input.Tags)
+		if len(merged) > maxTagsPerResource {
+			return false, errors.New(awserrors.ErrorIAMLimitExceeded)
+		}
+		role.Tags = merged
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("IAM role tagged", "accountID", accountID, "roleName", roleName)
+	return &iam.TagRoleOutput{}, nil
+}
+
+// UntagRole removes the named tag keys from a role; unknown keys are a no-op.
+func (s *IAMServiceImpl) UntagRole(accountID string, input *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
+	roleName := *input.RoleName
+	err := s.updateRoleCAS(accountID, roleName, func(role *Role) (bool, error) {
+		role.Tags = removeTagKeys(role.Tags, input.TagKeys)
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("IAM role untagged", "accountID", accountID, "roleName", roleName)
+	return &iam.UntagRoleOutput{}, nil
+}
+
+// ListRoleTags returns a role's tags. Pagination is not implemented:
+// IsTruncated is always false.
+func (s *IAMServiceImpl) ListRoleTags(accountID string, input *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
+	role, err := s.getRole(accountID, *input.RoleName)
+	if err != nil {
+		return nil, err
+	}
+	return &iam.ListRoleTagsOutput{
+		Tags:        tagsToSDK(role.Tags),
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
 // GetRolePolicies resolves the managed and inline policy documents for a role.
 // Used by the gateway for policy evaluation. Fails closed: any unresolvable
 // policy returns an error so the caller denies access rather than using a partial set.

--- a/spinifex/handlers/iam/service.go
+++ b/spinifex/handlers/iam/service.go
@@ -95,6 +95,23 @@ type IAMService interface {
 	ListOpenIDConnectProviders(accountID string, input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error)
 	DeleteOpenIDConnectProvider(accountID string, input *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error)
 
+	// Resource tagging — account-scoped
+	TagUser(accountID string, input *iam.TagUserInput) (*iam.TagUserOutput, error)
+	UntagUser(accountID string, input *iam.UntagUserInput) (*iam.UntagUserOutput, error)
+	ListUserTags(accountID string, input *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error)
+	TagRole(accountID string, input *iam.TagRoleInput) (*iam.TagRoleOutput, error)
+	UntagRole(accountID string, input *iam.UntagRoleInput) (*iam.UntagRoleOutput, error)
+	ListRoleTags(accountID string, input *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error)
+	TagPolicy(accountID string, input *iam.TagPolicyInput) (*iam.TagPolicyOutput, error)
+	UntagPolicy(accountID string, input *iam.UntagPolicyInput) (*iam.UntagPolicyOutput, error)
+	ListPolicyTags(accountID string, input *iam.ListPolicyTagsInput) (*iam.ListPolicyTagsOutput, error)
+	TagInstanceProfile(accountID string, input *iam.TagInstanceProfileInput) (*iam.TagInstanceProfileOutput, error)
+	UntagInstanceProfile(accountID string, input *iam.UntagInstanceProfileInput) (*iam.UntagInstanceProfileOutput, error)
+	ListInstanceProfileTags(accountID string, input *iam.ListInstanceProfileTagsInput) (*iam.ListInstanceProfileTagsOutput, error)
+	TagOpenIDConnectProvider(accountID string, input *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error)
+	UntagOpenIDConnectProvider(accountID string, input *iam.UntagOpenIDConnectProviderInput) (*iam.UntagOpenIDConnectProviderOutput, error)
+	ListOpenIDConnectProviderTags(accountID string, input *iam.ListOpenIDConnectProviderTagsInput) (*iam.ListOpenIDConnectProviderTagsOutput, error)
+
 	// ResolveInstanceProfile dereferences a RunInstancesInput.IamInstanceProfile
 	// reference (name or ARN) to the canonical InstanceProfile record. Used by
 	// EC2 paths only. Cross-account ARNs are rejected as a defence-in-depth

--- a/spinifex/handlers/iam/service_impl.go
+++ b/spinifex/handlers/iam/service_impl.go
@@ -43,6 +43,9 @@ const (
 	KVBucketGroupsVersion           = 1
 
 	maxAccessKeysPerUser = 2
+	maxTagsPerResource   = 50
+	maxTagKeyLength      = 128
+	maxTagValueLength    = 256
 
 	// LongLivedAccessKeyIDPrefix is the AWS-defined prefix for long-lived IAM access keys.
 	// The access-keys bucket rejects writes with any other prefix to prevent silent privilege escalation.
@@ -225,6 +228,81 @@ func copyTags(tags []*iam.Tag) []Tag {
 	for _, tag := range tags {
 		if tag.Key != nil && tag.Value != nil {
 			out = append(out, Tag{Key: *tag.Key, Value: *tag.Value})
+		}
+	}
+	return out
+}
+
+// tagsToSDK converts stored Tags into the SDK shape.
+func tagsToSDK(tags []Tag) []*iam.Tag {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]*iam.Tag, 0, len(tags))
+	for _, t := range tags {
+		out = append(out, &iam.Tag{Key: aws.String(t.Key), Value: aws.String(t.Value)})
+	}
+	return out
+}
+
+// validateTags enforces the AWS IAM tag limits on request input: at most 50
+// tags, key length 1-128, value length 0-256, no duplicate keys.
+func validateTags(tags []*iam.Tag) error {
+	if len(tags) > maxTagsPerResource {
+		return errors.New(awserrors.ErrorIAMLimitExceeded)
+	}
+	seen := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		if tag == nil || tag.Key == nil {
+			return errors.New(awserrors.ErrorIAMInvalidInput)
+		}
+		key := *tag.Key
+		if len(key) < 1 || len(key) > maxTagKeyLength {
+			return errors.New(awserrors.ErrorIAMInvalidInput)
+		}
+		if tag.Value != nil && len(*tag.Value) > maxTagValueLength {
+			return errors.New(awserrors.ErrorIAMInvalidInput)
+		}
+		if _, dup := seen[key]; dup {
+			return errors.New(awserrors.ErrorIAMInvalidInput)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+// mergeTags upserts add into existing by key, matching AWS semantics: a
+// repeated key overwrites in place, new keys append in input order.
+func mergeTags(existing []Tag, add []*iam.Tag) []Tag {
+	out := slices.Clone(existing)
+	for _, tag := range add {
+		if tag.Key == nil {
+			continue
+		}
+		next := Tag{Key: *tag.Key, Value: aws.StringValue(tag.Value)}
+		idx := slices.IndexFunc(out, func(t Tag) bool { return t.Key == next.Key })
+		if idx >= 0 {
+			out[idx] = next
+		} else {
+			out = append(out, next)
+		}
+	}
+	return out
+}
+
+// removeTagKeys drops the named keys from existing; unknown keys are
+// silently ignored, matching AWS.
+func removeTagKeys(existing []Tag, keys []*string) []Tag {
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		if k != nil {
+			drop[*k] = struct{}{}
+		}
+	}
+	out := make([]Tag, 0, len(existing))
+	for _, t := range existing {
+		if _, gone := drop[t.Key]; !gone {
+			out = append(out, t)
 		}
 	}
 	return out

--- a/spinifex/handlers/iam/service_impl.go
+++ b/spinifex/handlers/iam/service_impl.go
@@ -1473,6 +1473,139 @@ func (s *IAMServiceImpl) ListUserPolicies(accountID string, input *iam.ListUserP
 	}, nil
 }
 
+// ---------------------------------------------------------------------------
+// User + policy tagging
+// ---------------------------------------------------------------------------
+
+// TagUser upserts tags on a user. Blind read-modify-write Put like the other
+// user writers (no CAS).
+func (s *IAMServiceImpl) TagUser(accountID string, input *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	if err := validateTags(input.Tags); err != nil {
+		return nil, err
+	}
+
+	userName := *input.UserName
+	user, err := s.getUser(accountID, userName)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeTags(user.Tags, input.Tags)
+	if len(merged) > maxTagsPerResource {
+		return nil, errors.New(awserrors.ErrorIAMLimitExceeded)
+	}
+	user.Tags = merged
+
+	data, err := json.Marshal(user)
+	if err != nil {
+		return nil, fmt.Errorf("marshal user: %w", err)
+	}
+	if _, err := s.usersBucket.Put(accountID+"."+userName, data); err != nil {
+		return nil, fmt.Errorf("update user: %w", err)
+	}
+
+	slog.Info("IAM user tagged", "accountID", accountID, "userName", userName)
+	return &iam.TagUserOutput{}, nil
+}
+
+// UntagUser removes the named tag keys from a user; unknown keys are a no-op.
+func (s *IAMServiceImpl) UntagUser(accountID string, input *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
+	userName := *input.UserName
+	user, err := s.getUser(accountID, userName)
+	if err != nil {
+		return nil, err
+	}
+
+	user.Tags = removeTagKeys(user.Tags, input.TagKeys)
+
+	data, err := json.Marshal(user)
+	if err != nil {
+		return nil, fmt.Errorf("marshal user: %w", err)
+	}
+	if _, err := s.usersBucket.Put(accountID+"."+userName, data); err != nil {
+		return nil, fmt.Errorf("update user: %w", err)
+	}
+
+	slog.Info("IAM user untagged", "accountID", accountID, "userName", userName)
+	return &iam.UntagUserOutput{}, nil
+}
+
+// ListUserTags returns a user's tags. Pagination is not implemented:
+// IsTruncated is always false.
+func (s *IAMServiceImpl) ListUserTags(accountID string, input *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
+	user, err := s.getUser(accountID, *input.UserName)
+	if err != nil {
+		return nil, err
+	}
+	return &iam.ListUserTagsOutput{
+		Tags:        tagsToSDK(user.Tags),
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
+// TagPolicy upserts tags on a customer-managed policy, resolved by ARN.
+func (s *IAMServiceImpl) TagPolicy(accountID string, input *iam.TagPolicyInput) (*iam.TagPolicyOutput, error) {
+	if err := validateTags(input.Tags); err != nil {
+		return nil, err
+	}
+
+	policy, err := s.getPolicyByARN(accountID, *input.PolicyArn)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeTags(policy.Tags, input.Tags)
+	if len(merged) > maxTagsPerResource {
+		return nil, errors.New(awserrors.ErrorIAMLimitExceeded)
+	}
+	policy.Tags = merged
+
+	data, err := json.Marshal(policy)
+	if err != nil {
+		return nil, fmt.Errorf("marshal policy: %w", err)
+	}
+	if _, err := s.policiesBucket.Put(accountID+"."+policy.PolicyName, data); err != nil {
+		return nil, fmt.Errorf("update policy: %w", err)
+	}
+
+	slog.Info("IAM policy tagged", "accountID", accountID, "policyName", policy.PolicyName)
+	return &iam.TagPolicyOutput{}, nil
+}
+
+// UntagPolicy removes the named tag keys from a policy; unknown keys are a no-op.
+func (s *IAMServiceImpl) UntagPolicy(accountID string, input *iam.UntagPolicyInput) (*iam.UntagPolicyOutput, error) {
+	policy, err := s.getPolicyByARN(accountID, *input.PolicyArn)
+	if err != nil {
+		return nil, err
+	}
+
+	policy.Tags = removeTagKeys(policy.Tags, input.TagKeys)
+
+	data, err := json.Marshal(policy)
+	if err != nil {
+		return nil, fmt.Errorf("marshal policy: %w", err)
+	}
+	if _, err := s.policiesBucket.Put(accountID+"."+policy.PolicyName, data); err != nil {
+		return nil, fmt.Errorf("update policy: %w", err)
+	}
+
+	slog.Info("IAM policy untagged", "accountID", accountID, "policyName", policy.PolicyName)
+	return &iam.UntagPolicyOutput{}, nil
+}
+
+// ListPolicyTags returns a policy's tags. Pagination is not implemented:
+// IsTruncated is always false.
+func (s *IAMServiceImpl) ListPolicyTags(accountID string, input *iam.ListPolicyTagsInput) (*iam.ListPolicyTagsOutput, error) {
+	policy, err := s.getPolicyByARN(accountID, *input.PolicyArn)
+	if err != nil {
+		return nil, err
+	}
+	return &iam.ListPolicyTagsOutput{
+		Tags:        tagsToSDK(policy.Tags),
+		IsTruncated: aws.Bool(false),
+	}, nil
+}
+
 // GetUserPolicies resolves all policy documents attached to a user.
 // Used internally by the gateway for policy evaluation.
 func (s *IAMServiceImpl) GetUserPolicies(accountID, userName string) ([]PolicyDocument, error) {

--- a/spinifex/handlers/iam/service_impl.go
+++ b/spinifex/handlers/iam/service_impl.go
@@ -386,6 +386,7 @@ func (s *IAMServiceImpl) GetUser(accountID string, input *iam.GetUserInput) (*ia
 			Arn:        aws.String(user.ARN),
 			Path:       aws.String(user.Path),
 			CreateDate: aws.Time(createdAt),
+			Tags:       tagsToSDK(user.Tags),
 		},
 	}, nil
 }

--- a/spinifex/handlers/iam/tags_test.go
+++ b/spinifex/handlers/iam/tags_test.go
@@ -1,0 +1,127 @@
+package handlers_iam
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sdkTag(key, value string) *iam.Tag {
+	return &iam.Tag{Key: aws.String(key), Value: aws.String(value)}
+}
+
+func TestValidateTags(t *testing.T) {
+	tooMany := make([]*iam.Tag, maxTagsPerResource+1)
+	for i := range tooMany {
+		tooMany[i] = sdkTag("key"+strings.Repeat("a", i%100+1), "v")
+	}
+
+	cases := []struct {
+		name    string
+		tags    []*iam.Tag
+		wantErr string
+	}{
+		{"nil slice", nil, ""},
+		{"valid tags", []*iam.Tag{sdkTag("env", "prod"), sdkTag("team", "")}, ""},
+		{"max key length", []*iam.Tag{sdkTag(strings.Repeat("k", maxTagKeyLength), "v")}, ""},
+		{"max value length", []*iam.Tag{sdkTag("k", strings.Repeat("v", maxTagValueLength))}, ""},
+		{"nil value allowed", []*iam.Tag{{Key: aws.String("k")}}, ""},
+		{"over 50 tags", tooMany, awserrors.ErrorIAMLimitExceeded},
+		{"nil tag entry", []*iam.Tag{nil}, awserrors.ErrorIAMInvalidInput},
+		{"nil key", []*iam.Tag{{Value: aws.String("v")}}, awserrors.ErrorIAMInvalidInput},
+		{"empty key", []*iam.Tag{sdkTag("", "v")}, awserrors.ErrorIAMInvalidInput},
+		{"over-length key", []*iam.Tag{sdkTag(strings.Repeat("k", maxTagKeyLength+1), "v")}, awserrors.ErrorIAMInvalidInput},
+		{"over-length value", []*iam.Tag{sdkTag("k", strings.Repeat("v", maxTagValueLength+1))}, awserrors.ErrorIAMInvalidInput},
+		{"duplicate keys", []*iam.Tag{sdkTag("k", "1"), sdkTag("k", "2")}, awserrors.ErrorIAMInvalidInput},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTags(tc.tags)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tc.wantErr, err.Error())
+		})
+	}
+}
+
+func TestMergeTags(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing []Tag
+		add      []*iam.Tag
+		want     []Tag
+	}{
+		{"append to empty", nil, []*iam.Tag{sdkTag("a", "1")}, []Tag{{Key: "a", Value: "1"}}},
+		{
+			"upsert preserves order",
+			[]Tag{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}},
+			[]*iam.Tag{sdkTag("a", "9"), sdkTag("c", "3")},
+			[]Tag{{Key: "a", Value: "9"}, {Key: "b", Value: "2"}, {Key: "c", Value: "3"}},
+		},
+		{
+			"nil key skipped",
+			[]Tag{{Key: "a", Value: "1"}},
+			[]*iam.Tag{{Value: aws.String("v")}},
+			[]Tag{{Key: "a", Value: "1"}},
+		},
+		{
+			"nil value stored empty",
+			nil,
+			[]*iam.Tag{{Key: aws.String("a")}},
+			[]Tag{{Key: "a", Value: ""}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeTags(tc.existing, tc.add)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMergeTags_DoesNotMutateExisting(t *testing.T) {
+	existing := []Tag{{Key: "a", Value: "1"}}
+	_ = mergeTags(existing, []*iam.Tag{sdkTag("a", "9")})
+	assert.Equal(t, []Tag{{Key: "a", Value: "1"}}, existing)
+}
+
+func TestRemoveTagKeys(t *testing.T) {
+	existing := []Tag{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}, {Key: "c", Value: "3"}}
+
+	cases := []struct {
+		name string
+		keys []*string
+		want []Tag
+	}{
+		{"remove one", []*string{aws.String("b")}, []Tag{{Key: "a", Value: "1"}, {Key: "c", Value: "3"}}},
+		{"unknown key ignored", []*string{aws.String("zzz")}, existing},
+		{"nil key ignored", []*string{nil, aws.String("a")}, []Tag{{Key: "b", Value: "2"}, {Key: "c", Value: "3"}}},
+		{"remove all", []*string{aws.String("a"), aws.String("b"), aws.String("c")}, []Tag{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := removeTagKeys(existing, tc.keys)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestTagsToSDK(t *testing.T) {
+	assert.Nil(t, tagsToSDK(nil))
+	assert.Nil(t, tagsToSDK([]Tag{}))
+	got := tagsToSDK([]Tag{{Key: "a", Value: "1"}})
+	require.Len(t, got, 1)
+	assert.Equal(t, "a", aws.StringValue(got[0].Key))
+	assert.Equal(t, "1", aws.StringValue(got[0].Value))
+}

--- a/spinifex/handlers/iam/tags_test.go
+++ b/spinifex/handlers/iam/tags_test.go
@@ -291,6 +291,21 @@ func TestResourceTagging_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestTagUser_GetUserSurfacesTags(t *testing.T) {
+	svc := setupTestIAMService(t)
+	user := createTestUser(t, svc, "tagme")
+
+	_, err := svc.TagUser(testAccountID, &iam.TagUserInput{
+		UserName: user.UserName,
+		Tags:     []*iam.Tag{sdkTag("env", "prod")},
+	})
+	require.NoError(t, err)
+
+	out, err := svc.GetUser(testAccountID, &iam.GetUserInput{UserName: user.UserName})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"env": "prod"}, tagsAsMap(out.User.Tags))
+}
+
 func TestResourceTagging_MissingEntity(t *testing.T) {
 	for _, ops := range allTagOps() {
 		t.Run(ops.resource, func(t *testing.T) {

--- a/spinifex/handlers/iam/tags_test.go
+++ b/spinifex/handlers/iam/tags_test.go
@@ -1,6 +1,7 @@
 package handlers_iam
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -115,6 +116,226 @@ func TestRemoveTagKeys(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// tagOps abstracts the per-resource tag/untag/list triple so the round-trip
+// behaviour is asserted identically for every taggable resource.
+type tagOps struct {
+	resource  string
+	create    func(t *testing.T, svc *IAMServiceImpl) string
+	missingID string
+	tag       func(svc *IAMServiceImpl, id string, tags []*iam.Tag) error
+	untag     func(svc *IAMServiceImpl, id string, keys []*string) error
+	list      func(svc *IAMServiceImpl, id string) ([]*iam.Tag, error)
+}
+
+func allTagOps() []tagOps {
+	return []tagOps{
+		{
+			resource: "user",
+			create: func(t *testing.T, svc *IAMServiceImpl) string {
+				return *createTestUser(t, svc, "tagme").UserName
+			},
+			missingID: "no-such-user",
+			tag: func(svc *IAMServiceImpl, id string, tags []*iam.Tag) error {
+				_, err := svc.TagUser(testAccountID, &iam.TagUserInput{UserName: aws.String(id), Tags: tags})
+				return err
+			},
+			untag: func(svc *IAMServiceImpl, id string, keys []*string) error {
+				_, err := svc.UntagUser(testAccountID, &iam.UntagUserInput{UserName: aws.String(id), TagKeys: keys})
+				return err
+			},
+			list: func(svc *IAMServiceImpl, id string) ([]*iam.Tag, error) {
+				out, err := svc.ListUserTags(testAccountID, &iam.ListUserTagsInput{UserName: aws.String(id)})
+				if err != nil {
+					return nil, err
+				}
+				return out.Tags, nil
+			},
+		},
+		{
+			resource: "role",
+			create: func(t *testing.T, svc *IAMServiceImpl) string {
+				return *createTestRole(t, svc, "tagme").RoleName
+			},
+			missingID: "no-such-role",
+			tag: func(svc *IAMServiceImpl, id string, tags []*iam.Tag) error {
+				_, err := svc.TagRole(testAccountID, &iam.TagRoleInput{RoleName: aws.String(id), Tags: tags})
+				return err
+			},
+			untag: func(svc *IAMServiceImpl, id string, keys []*string) error {
+				_, err := svc.UntagRole(testAccountID, &iam.UntagRoleInput{RoleName: aws.String(id), TagKeys: keys})
+				return err
+			},
+			list: func(svc *IAMServiceImpl, id string) ([]*iam.Tag, error) {
+				out, err := svc.ListRoleTags(testAccountID, &iam.ListRoleTagsInput{RoleName: aws.String(id)})
+				if err != nil {
+					return nil, err
+				}
+				return out.Tags, nil
+			},
+		},
+		{
+			resource: "policy",
+			create: func(t *testing.T, svc *IAMServiceImpl) string {
+				out, err := svc.CreatePolicy(testAccountID, &iam.CreatePolicyInput{
+					PolicyName:     aws.String("tagme"),
+					PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`),
+				})
+				require.NoError(t, err)
+				return *out.Policy.Arn
+			},
+			missingID: "arn:aws:iam::" + testAccountID + ":policy/no-such-policy",
+			tag: func(svc *IAMServiceImpl, id string, tags []*iam.Tag) error {
+				_, err := svc.TagPolicy(testAccountID, &iam.TagPolicyInput{PolicyArn: aws.String(id), Tags: tags})
+				return err
+			},
+			untag: func(svc *IAMServiceImpl, id string, keys []*string) error {
+				_, err := svc.UntagPolicy(testAccountID, &iam.UntagPolicyInput{PolicyArn: aws.String(id), TagKeys: keys})
+				return err
+			},
+			list: func(svc *IAMServiceImpl, id string) ([]*iam.Tag, error) {
+				out, err := svc.ListPolicyTags(testAccountID, &iam.ListPolicyTagsInput{PolicyArn: aws.String(id)})
+				if err != nil {
+					return nil, err
+				}
+				return out.Tags, nil
+			},
+		},
+		{
+			resource: "instance profile",
+			create: func(t *testing.T, svc *IAMServiceImpl) string {
+				return *createTestInstanceProfile(t, svc, "tagme").InstanceProfileName
+			},
+			missingID: "no-such-profile",
+			tag: func(svc *IAMServiceImpl, id string, tags []*iam.Tag) error {
+				_, err := svc.TagInstanceProfile(testAccountID, &iam.TagInstanceProfileInput{InstanceProfileName: aws.String(id), Tags: tags})
+				return err
+			},
+			untag: func(svc *IAMServiceImpl, id string, keys []*string) error {
+				_, err := svc.UntagInstanceProfile(testAccountID, &iam.UntagInstanceProfileInput{InstanceProfileName: aws.String(id), TagKeys: keys})
+				return err
+			},
+			list: func(svc *IAMServiceImpl, id string) ([]*iam.Tag, error) {
+				out, err := svc.ListInstanceProfileTags(testAccountID, &iam.ListInstanceProfileTagsInput{InstanceProfileName: aws.String(id)})
+				if err != nil {
+					return nil, err
+				}
+				return out.Tags, nil
+			},
+		},
+		{
+			resource: "OIDC provider",
+			create: func(t *testing.T, svc *IAMServiceImpl) string {
+				out, err := svc.CreateOpenIDConnectProvider(testAccountID, &iam.CreateOpenIDConnectProviderInput{
+					Url: aws.String("https://oidc.example.com/id/TAGME"),
+				})
+				require.NoError(t, err)
+				return *out.OpenIDConnectProviderArn
+			},
+			missingID: "arn:aws:iam::" + testAccountID + ":oidc-provider/oidc.example.com/id/MISSING",
+			tag: func(svc *IAMServiceImpl, id string, tags []*iam.Tag) error {
+				_, err := svc.TagOpenIDConnectProvider(testAccountID, &iam.TagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(id), Tags: tags})
+				return err
+			},
+			untag: func(svc *IAMServiceImpl, id string, keys []*string) error {
+				_, err := svc.UntagOpenIDConnectProvider(testAccountID, &iam.UntagOpenIDConnectProviderInput{OpenIDConnectProviderArn: aws.String(id), TagKeys: keys})
+				return err
+			},
+			list: func(svc *IAMServiceImpl, id string) ([]*iam.Tag, error) {
+				out, err := svc.ListOpenIDConnectProviderTags(testAccountID, &iam.ListOpenIDConnectProviderTagsInput{OpenIDConnectProviderArn: aws.String(id)})
+				if err != nil {
+					return nil, err
+				}
+				return out.Tags, nil
+			},
+		},
+	}
+}
+
+func tagsAsMap(tags []*iam.Tag) map[string]string {
+	m := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		m[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+	}
+	return m
+}
+
+func TestResourceTagging_RoundTrip(t *testing.T) {
+	for _, ops := range allTagOps() {
+		t.Run(ops.resource, func(t *testing.T) {
+			svc := setupTestIAMService(t)
+			id := ops.create(t, svc)
+
+			tags, err := ops.list(svc, id)
+			require.NoError(t, err)
+			assert.Empty(t, tags)
+
+			require.NoError(t, ops.tag(svc, id, []*iam.Tag{sdkTag("env", "prod"), sdkTag("team", "core")}))
+			tags, err = ops.list(svc, id)
+			require.NoError(t, err)
+			assert.Equal(t, map[string]string{"env": "prod", "team": "core"}, tagsAsMap(tags))
+
+			// Re-tagging an existing key upserts in place.
+			require.NoError(t, ops.tag(svc, id, []*iam.Tag{sdkTag("env", "staging")}))
+			tags, err = ops.list(svc, id)
+			require.NoError(t, err)
+			assert.Equal(t, map[string]string{"env": "staging", "team": "core"}, tagsAsMap(tags))
+
+			// Untag removes only the named keys; unknown keys are a no-op.
+			require.NoError(t, ops.untag(svc, id, []*string{aws.String("team"), aws.String("unknown")}))
+			tags, err = ops.list(svc, id)
+			require.NoError(t, err)
+			assert.Equal(t, map[string]string{"env": "staging"}, tagsAsMap(tags))
+		})
+	}
+}
+
+func TestResourceTagging_MissingEntity(t *testing.T) {
+	for _, ops := range allTagOps() {
+		t.Run(ops.resource, func(t *testing.T) {
+			svc := setupTestIAMService(t)
+
+			err := ops.tag(svc, ops.missingID, []*iam.Tag{sdkTag("env", "prod")})
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorIAMNoSuchEntity, err.Error())
+
+			err = ops.untag(svc, ops.missingID, []*string{aws.String("env")})
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorIAMNoSuchEntity, err.Error())
+
+			_, err = ops.list(svc, ops.missingID)
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorIAMNoSuchEntity, err.Error())
+		})
+	}
+}
+
+func TestTagUser_MergedLimitExceeded(t *testing.T) {
+	svc := setupTestIAMService(t)
+	createTestUser(t, svc, "taglimit")
+
+	fill := make([]*iam.Tag, maxTagsPerResource)
+	for i := range fill {
+		fill[i] = sdkTag(fmt.Sprintf("key-%02d", i), "v")
+	}
+	_, err := svc.TagUser(testAccountID, &iam.TagUserInput{UserName: aws.String("taglimit"), Tags: fill})
+	require.NoError(t, err)
+
+	// One more distinct key would push the merged set past the limit.
+	_, err = svc.TagUser(testAccountID, &iam.TagUserInput{
+		UserName: aws.String("taglimit"),
+		Tags:     []*iam.Tag{sdkTag("overflow", "v")},
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorIAMLimitExceeded, err.Error())
+
+	// Upserting an existing key does not grow the set and stays allowed.
+	_, err = svc.TagUser(testAccountID, &iam.TagUserInput{
+		UserName: aws.String("taglimit"),
+		Tags:     []*iam.Tag{sdkTag("key-00", "updated")},
+	})
+	require.NoError(t, err)
 }
 
 func TestTagsToSDK(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements the IAM resource tagging APIs that were previously `NOT STARTED`: `tag-*`, `untag-*`, and `list-*-tags` for users, roles, policies, instance profiles, and OIDC providers (15 actions). This closes the highest-leverage IAM compatibility gap for Terraform, which calls `ListRoleTags`/`ListUserTags`/`ListPolicyTags` on every plan and refresh.

## Changes

- **Shared helpers** (`handlers/iam/service_impl.go`): `validateTags` (max 50 tags, key 1-128, value 0-256, no duplicate keys), `mergeTags` (upsert by key, order-preserving), `removeTagKeys` (unknown keys are a no-op). `tagsToSDK` moved beside `copyTags`.
- **Service methods**: three read-modify-write methods per resource, following the existing group inline-policy writer shape. `IAMService` interface extended; the compile-time check enforces completeness.
- **Gateway validators** (`gateway/iam/*.go`): nil/empty checks on the name-or-ARN field plus required `Tags`/`TagKeys`.
- **Dispatch**: 15 entries added to `iamActions`.
- **GetUser** now emits `user.Tags`, mirroring `GetRole`/`GetInstanceProfile`.
- **Docs**: 15 rows flipped to `DONE` in `docs/COMMANDS.md`.

`List*Tags` returns `IsTruncated=false` with no `Marker`, consistent with the rest of IAM here. IAM groups are out of scope (AWS has no group tagging API). No evaluator or hot-path impact — tags are pure metadata.