### PR TITLE
fix: stabilise OVN UUIDs on Ensure* insert + SG ACL reconcile (siv-501, siv-502)

### DIFF
--- a/spinifex/network/external/igw.go
+++ b/spinifex/network/external/igw.go
@@ -217,7 +217,7 @@ func (m *igwManager) ensureSharedExternal(ctx context.Context, switchName, portN
 		Name:        switchName,
 		ExternalIDs: map[string]string{"spinifex:role": "external"},
 	}
-	if _, err := m.ovn.EnsureLogicalSwitch(ctx, extSwitch); err != nil {
+	if _, _, err := m.ovn.EnsureLogicalSwitch(ctx, extSwitch); err != nil {
 		return fmt.Errorf("ensure shared external switch %s: %w", switchName, err)
 	}
 	if _, err := m.ovn.GetLogicalSwitchPort(ctx, portName); err == nil {

--- a/spinifex/network/ovn/acl_diff.go
+++ b/spinifex/network/ovn/acl_diff.go
@@ -1,0 +1,50 @@
+package ovn
+
+import (
+	"fmt"
+
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+)
+
+// aclKey builds a content-addressable key covering every semantic ACL field so a
+// current NB row set can be compared against desired specs without minting UUIDs.
+func aclKey(direction string, priority int, match, action string, log bool, name, severity string) string {
+	return fmt.Sprintf("%s\x1f%d\x1f%s\x1f%s\x1f%t\x1f%s\x1f%s",
+		direction, priority, match, action, log, name, severity)
+}
+
+func aclRowKey(a *nbdb.ACL) string {
+	name, severity := "", ""
+	if a.Name != nil {
+		name = *a.Name
+	}
+	if a.Severity != nil {
+		severity = *a.Severity
+	}
+	return aclKey(a.Direction, a.Priority, a.Match, a.Action, a.Log, name, severity)
+}
+
+func aclSpecKey(s ACLSpec) string {
+	return aclKey(s.Direction, s.Priority, s.Match, s.Action, s.Log, s.Name, s.Severity)
+}
+
+// ACLSetEqual reports whether rows and specs describe the same ACL multiset by
+// semantic content (ignoring UUID and ExternalIDs). Shared by LiveClient and the
+// mock so both no-op an unchanged ReplaceACLs instead of churning row UUIDs.
+func ACLSetEqual(rows []nbdb.ACL, specs []ACLSpec) bool {
+	if len(rows) != len(specs) {
+		return false
+	}
+	counts := make(map[string]int, len(specs))
+	for _, s := range specs {
+		counts[aclSpecKey(s)]++
+	}
+	for i := range rows {
+		k := aclRowKey(&rows[i])
+		if counts[k] == 0 {
+			return false
+		}
+		counts[k]--
+	}
+	return true
+}

--- a/spinifex/network/ovn/client.go
+++ b/spinifex/network/ovn/client.go
@@ -38,8 +38,10 @@ type Client interface {
 	// Logical Switch (subnet)
 	CreateLogicalSwitch(ctx context.Context, ls *nbdb.LogicalSwitch) error
 	// EnsureLogicalSwitch atomically creates a logical switch or returns the existing
-	// row. Uses an OVSDB wait-op (see EnsureLogicalRouter for rationale).
-	EnsureLogicalSwitch(ctx context.Context, ls *nbdb.LogicalSwitch) (*nbdb.LogicalSwitch, error)
+	// row. Uses an OVSDB wait-op (see EnsureLogicalRouter for rationale). The returned
+	// row always carries the real persisted UUID; created reports whether this call
+	// inserted the row (false when an existing row was reused).
+	EnsureLogicalSwitch(ctx context.Context, ls *nbdb.LogicalSwitch) (row *nbdb.LogicalSwitch, created bool, err error)
 	DeleteLogicalSwitch(ctx context.Context, name string) error
 	GetLogicalSwitch(ctx context.Context, name string) (*nbdb.LogicalSwitch, error)
 	ListLogicalSwitches(ctx context.Context) ([]nbdb.LogicalSwitch, error)
@@ -61,8 +63,10 @@ type Client interface {
 	CreateLogicalRouter(ctx context.Context, lr *nbdb.LogicalRouter) error
 	// EnsureLogicalRouter atomically creates a logical router or returns the existing
 	// row. OVSDB wait-op serialises concurrent writers — NB has no unique-Name
-	// constraint, so without it concurrent vpc.create calls produce duplicates.
-	EnsureLogicalRouter(ctx context.Context, lr *nbdb.LogicalRouter) (*nbdb.LogicalRouter, error)
+	// constraint, so without it concurrent vpc.create calls produce duplicates. The
+	// returned row always carries the real persisted UUID; created reports whether
+	// this call inserted the row.
+	EnsureLogicalRouter(ctx context.Context, lr *nbdb.LogicalRouter) (row *nbdb.LogicalRouter, created bool, err error)
 	DeleteLogicalRouter(ctx context.Context, name string) error
 	GetLogicalRouter(ctx context.Context, name string) (*nbdb.LogicalRouter, error)
 	ListLogicalRouters(ctx context.Context) ([]nbdb.LogicalRouter, error)
@@ -108,8 +112,9 @@ type Client interface {
 	// Port Groups (security group enforcement)
 	CreatePortGroup(ctx context.Context, name string, ports []string) error
 	// EnsurePortGroup atomically creates a port group or returns the existing row.
-	// See EnsureLogicalRouter for the wait-op rationale.
-	EnsurePortGroup(ctx context.Context, name string, ports []string) (*nbdb.PortGroup, error)
+	// See EnsureLogicalRouter for the wait-op rationale. The returned row always
+	// carries the real persisted UUID; created reports whether this call inserted it.
+	EnsurePortGroup(ctx context.Context, name string, ports []string) (row *nbdb.PortGroup, created bool, err error)
 	DeletePortGroup(ctx context.Context, name string) error
 	// UpdatePortGroupMemberships applies all port-group joins and leaves for an LSP
 	// in one transaction, preventing an intermediate state with fewer groups

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -180,26 +180,32 @@ func (c *LiveClient) CreateLogicalSwitch(ctx context.Context, ls *nbdb.LogicalSw
 	return nil
 }
 
-func (c *LiveClient) EnsureLogicalSwitch(ctx context.Context, ls *nbdb.LogicalSwitch) (*nbdb.LogicalSwitch, error) {
+func (c *LiveClient) EnsureLogicalSwitch(ctx context.Context, ls *nbdb.LogicalSwitch) (*nbdb.LogicalSwitch, bool, error) {
 	if existing, err := c.GetLogicalSwitch(ctx, ls.Name); err == nil {
-		return existing, nil
+		return existing, false, nil
 	}
 	if ls.UUID == "" {
 		ls.UUID = namedUUID("ls_", ls.Name)
 	}
 	ops, err := c.ensureNamedRowOps("Logical_Switch", ls.Name, ls)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := c.transactOps(ctx, ops); err != nil {
 		if existing, refErr := c.waitForCachedSwitch(ctx, ls.Name); refErr == nil {
 			slog.Info("ovn: EnsureLogicalSwitch lost race, reusing existing",
 				"name", ls.Name, "existing_uuid", existing.UUID)
-			return existing, nil
+			return existing, false, nil
 		}
-		return nil, fmt.Errorf("ensure logical switch %q: %w", ls.Name, err)
+		return nil, false, fmt.Errorf("ensure logical switch %q: %w", ls.Name, err)
 	}
-	return ls, nil
+	// The insert path returns a client-side named-uuid; resolve the persisted
+	// server UUID from the monitored cache before returning.
+	created, refErr := c.waitForCachedSwitch(ctx, ls.Name)
+	if refErr != nil {
+		return nil, false, fmt.Errorf("resolve logical switch %q uuid after insert: %w", ls.Name, refErr)
+	}
+	return created, true, nil
 }
 
 func (c *LiveClient) waitForCachedSwitch(ctx context.Context, name string) (*nbdb.LogicalSwitch, error) {
@@ -429,26 +435,32 @@ func (c *LiveClient) CreateLogicalRouter(ctx context.Context, lr *nbdb.LogicalRo
 	return nil
 }
 
-func (c *LiveClient) EnsureLogicalRouter(ctx context.Context, lr *nbdb.LogicalRouter) (*nbdb.LogicalRouter, error) {
+func (c *LiveClient) EnsureLogicalRouter(ctx context.Context, lr *nbdb.LogicalRouter) (*nbdb.LogicalRouter, bool, error) {
 	if existing, err := c.GetLogicalRouter(ctx, lr.Name); err == nil {
-		return existing, nil
+		return existing, false, nil
 	}
 	if lr.UUID == "" {
 		lr.UUID = namedUUID("lr_", lr.Name)
 	}
 	ops, err := c.ensureNamedRowOps("Logical_Router", lr.Name, lr)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := c.transactOps(ctx, ops); err != nil {
 		if existing, refErr := c.waitForCachedRouter(ctx, lr.Name); refErr == nil {
 			slog.Info("ovn: EnsureLogicalRouter lost race, reusing existing",
 				"name", lr.Name, "existing_uuid", existing.UUID)
-			return existing, nil
+			return existing, false, nil
 		}
-		return nil, fmt.Errorf("ensure logical router %q: %w", lr.Name, err)
+		return nil, false, fmt.Errorf("ensure logical router %q: %w", lr.Name, err)
 	}
-	return lr, nil
+	// The insert path returns a client-side named-uuid; resolve the persisted
+	// server UUID from the monitored cache before returning.
+	created, refErr := c.waitForCachedRouter(ctx, lr.Name)
+	if refErr != nil {
+		return nil, false, fmt.Errorf("resolve logical router %q uuid after insert: %w", lr.Name, refErr)
+	}
+	return created, true, nil
 }
 
 func (c *LiveClient) UpdateLogicalRouterExternalIDs(ctx context.Context, name string, externalIDs map[string]string) error {
@@ -1284,9 +1296,9 @@ func (c *LiveClient) CreatePortGroup(ctx context.Context, name string, ports []s
 	return nil
 }
 
-func (c *LiveClient) EnsurePortGroup(ctx context.Context, name string, ports []string) (*nbdb.PortGroup, error) {
+func (c *LiveClient) EnsurePortGroup(ctx context.Context, name string, ports []string) (*nbdb.PortGroup, bool, error) {
 	if existing, err := c.getPortGroup(ctx, name); err == nil {
-		return existing, nil
+		return existing, false, nil
 	}
 	pg := &nbdb.PortGroup{
 		UUID:        namedUUID("pg_", name),
@@ -1296,17 +1308,23 @@ func (c *LiveClient) EnsurePortGroup(ctx context.Context, name string, ports []s
 	}
 	ops, err := c.ensureNamedRowOps("Port_Group", name, pg)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := c.transactOps(ctx, ops); err != nil {
 		if existing, refErr := c.waitForCachedPortGroup(ctx, name); refErr == nil {
 			slog.Info("ovn: EnsurePortGroup lost race, reusing existing",
 				"name", name, "existing_uuid", existing.UUID)
-			return existing, nil
+			return existing, false, nil
 		}
-		return nil, fmt.Errorf("ensure port group %q: %w", name, err)
+		return nil, false, fmt.Errorf("ensure port group %q: %w", name, err)
 	}
-	return pg, nil
+	// The insert path returns a client-side named-uuid; resolve the persisted
+	// server UUID from the monitored cache before returning.
+	created, refErr := c.waitForCachedPortGroup(ctx, name)
+	if refErr != nil {
+		return nil, false, fmt.Errorf("resolve port group %q uuid after insert: %w", name, refErr)
+	}
+	return created, true, nil
 }
 
 func (c *LiveClient) waitForCachedPortGroup(ctx context.Context, name string) (*nbdb.PortGroup, error) {
@@ -1526,12 +1544,37 @@ func (c *LiveClient) ClearACLs(ctx context.Context, portGroupName string) error 
 	return nil
 }
 
+// aclSetUnchanged reports whether the port group's current ACL rows are the same
+// multiset as the desired specs, so ReplaceACLs can no-op and avoid UUID churn.
+func (c *LiveClient) aclSetUnchanged(ctx context.Context, pg *nbdb.PortGroup, specs []ACLSpec) (bool, error) {
+	if len(pg.ACLs) != len(specs) {
+		return false, nil
+	}
+	rows := make([]nbdb.ACL, 0, len(pg.ACLs))
+	for _, aclUUID := range pg.ACLs {
+		acl := &nbdb.ACL{UUID: aclUUID}
+		if err := c.client.Get(ctx, acl); err != nil {
+			return false, fmt.Errorf("get ACL %s: %w", aclUUID, err)
+		}
+		rows = append(rows, *acl)
+	}
+	return ACLSetEqual(rows, specs), nil
+}
+
 // ReplaceACLs atomically swaps the port group's ACL set in one transaction.
 // Avoids the zero-ACL window that ClearACLs+AddACLs would expose (default-drop).
+// No-ops when the current ACL set already matches specs, so an unchanged SG does
+// not churn NB rows (and force ovn-northd flow recompute) on every drift tick.
 func (c *LiveClient) ReplaceACLs(ctx context.Context, portGroupName string, specs []ACLSpec) error {
 	pg, err := c.getPortGroup(ctx, portGroupName)
 	if err != nil {
 		return fmt.Errorf("replace ACLs port group lookup: %w", err)
+	}
+
+	if unchanged, uErr := c.aclSetUnchanged(ctx, pg, specs); uErr != nil {
+		return fmt.Errorf("replace ACLs diff on %s: %w", portGroupName, uErr)
+	} else if unchanged {
+		return nil
 	}
 
 	var ops []ovsdb.Operation

--- a/spinifex/network/ovn/live_ensure_test.go
+++ b/spinifex/network/ovn/live_ensure_test.go
@@ -1,0 +1,138 @@
+package ovn_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/ovn"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/ovntest"
+)
+
+func liveClient(t *testing.T) (*ovn.LiveClient, context.Context) {
+	t.Helper()
+	nb := ovntest.StartNB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cli := ovn.NewLiveClient(nb.Endpoint)
+	if err := cli.Connect(ctx); err != nil {
+		t.Fatalf("LiveClient.Connect: %v", err)
+	}
+	t.Cleanup(cli.Close)
+	return cli, ctx
+}
+
+// EnsureLogicalRouter must return the persisted UUID (not the client-side
+// named-uuid) on the insert path and report created; a second call reuses it.
+func TestEnsureLogicalRouter_InsertResolvesRealUUID(t *testing.T) {
+	cli, ctx := liveClient(t)
+
+	got, created, err := cli.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{Name: "lr-x"})
+	if err != nil {
+		t.Fatalf("EnsureLogicalRouter #1: %v", err)
+	}
+	if !created {
+		t.Fatalf("first call: created = false, want true")
+	}
+	if got.UUID == "" || got.UUID == "lr_lr_x" {
+		t.Fatalf("insert returned non-persisted UUID %q", got.UUID)
+	}
+
+	again, created, err := cli.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{Name: "lr-x"})
+	if err != nil {
+		t.Fatalf("EnsureLogicalRouter #2: %v", err)
+	}
+	if created {
+		t.Fatalf("second call: created = true, want false")
+	}
+	if again.UUID != got.UUID {
+		t.Fatalf("second call UUID %q != first %q", again.UUID, got.UUID)
+	}
+}
+
+func TestEnsurePortGroup_InsertResolvesRealUUID(t *testing.T) {
+	cli, ctx := liveClient(t)
+
+	got, created, err := cli.EnsurePortGroup(ctx, "pg-x", nil)
+	if err != nil {
+		t.Fatalf("EnsurePortGroup #1: %v", err)
+	}
+	if !created {
+		t.Fatalf("first call: created = false, want true")
+	}
+	if got.UUID == "" || got.UUID == "pg_pg_x" {
+		t.Fatalf("insert returned non-persisted UUID %q", got.UUID)
+	}
+
+	_, created, err = cli.EnsurePortGroup(ctx, "pg-x", nil)
+	if err != nil {
+		t.Fatalf("EnsurePortGroup #2: %v", err)
+	}
+	if created {
+		t.Fatalf("second call: created = true, want false")
+	}
+}
+
+// ReplaceACLs must no-op when the desired set already matches, keeping ACL row
+// UUIDs stable, and swap when the set changes.
+func TestReplaceACLs_IdempotentNoChurn(t *testing.T) {
+	cli, ctx := liveClient(t)
+
+	if _, _, err := cli.EnsurePortGroup(ctx, "pg-acl", nil); err != nil {
+		t.Fatalf("EnsurePortGroup: %v", err)
+	}
+	specs := []ovn.ACLSpec{
+		{Direction: "to-lport", Priority: 1001, Match: "ip4", Action: "allow-related"},
+		{Direction: "from-lport", Priority: 1002, Match: "ip4", Action: "allow-related"},
+	}
+
+	if err := cli.ReplaceACLs(ctx, "pg-acl", specs); err != nil {
+		t.Fatalf("ReplaceACLs #1: %v", err)
+	}
+	before := aclUUIDs(t, ctx, cli, "pg-acl")
+	if len(before) != len(specs) {
+		t.Fatalf("expected %d ACLs, got %d", len(specs), len(before))
+	}
+
+	if err := cli.ReplaceACLs(ctx, "pg-acl", specs); err != nil {
+		t.Fatalf("ReplaceACLs #2 (identical): %v", err)
+	}
+	after := aclUUIDs(t, ctx, cli, "pg-acl")
+	if !equalStringSet(before, after) {
+		t.Fatalf("identical ReplaceACLs churned ACL UUIDs: %v → %v", before, after)
+	}
+
+	changed := append(specs, ovn.ACLSpec{Direction: "to-lport", Priority: 2000, Match: "ip6", Action: "drop"})
+	if err := cli.ReplaceACLs(ctx, "pg-acl", changed); err != nil {
+		t.Fatalf("ReplaceACLs #3 (changed): %v", err)
+	}
+	if got := aclUUIDs(t, ctx, cli, "pg-acl"); len(got) != len(changed) {
+		t.Fatalf("changed ReplaceACLs: expected %d ACLs, got %d", len(changed), len(got))
+	}
+}
+
+func aclUUIDs(t *testing.T, ctx context.Context, cli *ovn.LiveClient, pgName string) map[string]struct{} {
+	t.Helper()
+	pg, err := cli.GetPortGroup(ctx, pgName)
+	if err != nil {
+		t.Fatalf("GetPortGroup: %v", err)
+	}
+	out := make(map[string]struct{}, len(pg.ACLs))
+	for _, u := range pg.ACLs {
+		out[u] = struct{}{}
+	}
+	return out
+}
+
+func equalStringSet(a, b map[string]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/spinifex/network/ovn/live_test.go
+++ b/spinifex/network/ovn/live_test.go
@@ -1,6 +1,35 @@
 package ovn
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestACLSetEqual(t *testing.T) {
+	specs := []ACLSpec{
+		{Direction: "to-lport", Priority: 1001, Match: "ip4", Action: "allow-related", Name: "a", Severity: "info"},
+		{Direction: "from-lport", Priority: 1002, Match: "ip6", Action: "drop"},
+	}
+	rows := []nbdb.ACL{
+		{Direction: "from-lport", Priority: 1002, Match: "ip6", Action: "drop"},
+		{Direction: "to-lport", Priority: 1001, Match: "ip4", Action: "allow-related", Name: ptr("a"), Severity: ptr("info")},
+	}
+
+	if !ACLSetEqual(rows, specs) {
+		t.Errorf("reordered equal set reported unequal")
+	}
+	if ACLSetEqual(rows[:1], specs) {
+		t.Errorf("count mismatch reported equal")
+	}
+
+	diff := []nbdb.ACL{rows[0], {Direction: "to-lport", Priority: 1001, Match: "ip4", Action: "drop"}}
+	if ACLSetEqual(diff, specs) {
+		t.Errorf("content mismatch reported equal")
+	}
+}
 
 func TestNamedUUID(t *testing.T) {
 	tests := []struct {

--- a/spinifex/network/ovn/mock/mock.go
+++ b/spinifex/network/ovn/mock/mock.go
@@ -102,12 +102,12 @@ func (m *Client) CreateLogicalSwitch(_ context.Context, ls *nbdb.LogicalSwitch) 
 
 // EnsureLogicalSwitch mirrors the live client's wait-op semantics under the
 // mock's single mutex: concurrent callers see the row on the second arrival.
-func (m *Client) EnsureLogicalSwitch(_ context.Context, ls *nbdb.LogicalSwitch) (*nbdb.LogicalSwitch, error) {
+func (m *Client) EnsureLogicalSwitch(_ context.Context, ls *nbdb.LogicalSwitch) (*nbdb.LogicalSwitch, bool, error) {
 	m.Mu.Lock()
 	defer m.Mu.Unlock()
 	if existing, ok := m.Switches[ls.Name]; ok {
 		result := *existing
-		return &result, nil
+		return &result, false, nil
 	}
 	if ls.UUID == "" {
 		ls.UUID = utils.GenerateResourceID("ovn")
@@ -115,7 +115,7 @@ func (m *Client) EnsureLogicalSwitch(_ context.Context, ls *nbdb.LogicalSwitch) 
 	stored := *ls
 	m.Switches[ls.Name] = &stored
 	result := stored
-	return &result, nil
+	return &result, true, nil
 }
 
 func (m *Client) DeleteLogicalSwitch(_ context.Context, name string) error {
@@ -283,12 +283,12 @@ func (m *Client) CreateLogicalRouter(_ context.Context, lr *nbdb.LogicalRouter) 
 
 // EnsureLogicalRouter mirrors the live client's wait-op semantics under the
 // mock's single mutex.
-func (m *Client) EnsureLogicalRouter(_ context.Context, lr *nbdb.LogicalRouter) (*nbdb.LogicalRouter, error) {
+func (m *Client) EnsureLogicalRouter(_ context.Context, lr *nbdb.LogicalRouter) (*nbdb.LogicalRouter, bool, error) {
 	m.Mu.Lock()
 	defer m.Mu.Unlock()
 	if existing, ok := m.Routers[lr.Name]; ok {
 		result := *existing
-		return &result, nil
+		return &result, false, nil
 	}
 	if lr.UUID == "" {
 		lr.UUID = utils.GenerateResourceID("ovn")
@@ -296,7 +296,7 @@ func (m *Client) EnsureLogicalRouter(_ context.Context, lr *nbdb.LogicalRouter) 
 	stored := *lr
 	m.Routers[lr.Name] = &stored
 	result := stored
-	return &result, nil
+	return &result, true, nil
 }
 
 func (m *Client) DeleteLogicalRouter(_ context.Context, name string) error {
@@ -790,12 +790,12 @@ func (m *Client) CreatePortGroup(_ context.Context, name string, ports []string)
 }
 
 // EnsurePortGroup mirrors the live client's wait-op semantics.
-func (m *Client) EnsurePortGroup(_ context.Context, name string, ports []string) (*nbdb.PortGroup, error) {
+func (m *Client) EnsurePortGroup(_ context.Context, name string, ports []string) (*nbdb.PortGroup, bool, error) {
 	m.Mu.Lock()
 	defer m.Mu.Unlock()
 	if existing, ok := m.PortGroups[name]; ok {
 		result := *existing
-		return &result, nil
+		return &result, false, nil
 	}
 	pg := &nbdb.PortGroup{
 		UUID:  utils.GenerateResourceID("pg"),
@@ -804,7 +804,7 @@ func (m *Client) EnsurePortGroup(_ context.Context, name string, ports []string)
 	}
 	m.PortGroups[name] = pg
 	result := *pg
-	return &result, nil
+	return &result, true, nil
 }
 
 func (m *Client) DeletePortGroup(_ context.Context, name string) error {
@@ -946,6 +946,23 @@ func (m *Client) ClearACLs(_ context.Context, portGroupName string) error {
 	return nil
 }
 
+// aclSetUnchangedLocked reports whether pg's current ACL rows are the same
+// multiset as specs. Caller holds m.Mu.
+func (m *Client) aclSetUnchangedLocked(pg *nbdb.PortGroup, specs []ovn.ACLSpec) bool {
+	if len(pg.ACLs) != len(specs) {
+		return false
+	}
+	rows := make([]nbdb.ACL, 0, len(pg.ACLs))
+	for _, aclUUID := range pg.ACLs {
+		acl, ok := m.ACLs[aclUUID]
+		if !ok {
+			return false
+		}
+		rows = append(rows, *acl)
+	}
+	return ovn.ACLSetEqual(rows, specs)
+}
+
 // ReplaceACLs atomically swaps the port group's ACL set under a single mutex
 // hold — semantically equivalent to ClearACLs+AddACLs but with no observable
 // mid-flight window where pg.ACLs is empty.
@@ -960,6 +977,11 @@ func (m *Client) ReplaceACLs(_ context.Context, portGroupName string, specs []ov
 	pg, exists := m.PortGroups[portGroupName]
 	if !exists {
 		return fmt.Errorf("port group %q not found", portGroupName)
+	}
+	// No-op when the current ACL set already matches specs, mirroring LiveClient:
+	// unchanged SGs must not churn ACL UUIDs on every reconcile pass.
+	if m.aclSetUnchangedLocked(pg, specs) {
+		return nil
 	}
 	for _, aclUUID := range pg.ACLs {
 		delete(m.ACLs, aclUUID)

--- a/spinifex/network/ovn/mock/mock_test.go
+++ b/spinifex/network/ovn/mock/mock_test.go
@@ -5,8 +5,50 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/mulgadc/spinifex/spinifex/network/ovn"
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
 )
+
+// ReplaceACLs must no-op on an unchanged set (stable ACL UUIDs) and swap on a
+// changed set, mirroring LiveClient.
+func TestMockReplaceACLs_IdempotentNoChurn(t *testing.T) {
+	m := New()
+	_ = m.Connect(context.Background())
+	ctx := context.Background()
+
+	if _, _, err := m.EnsurePortGroup(ctx, "pg-acl", nil); err != nil {
+		t.Fatalf("EnsurePortGroup: %v", err)
+	}
+	specs := []ovn.ACLSpec{
+		{Direction: "to-lport", Priority: 1001, Match: "ip4", Action: "allow-related"},
+		{Direction: "from-lport", Priority: 1002, Match: "ip4", Action: "allow-related"},
+	}
+
+	if err := m.ReplaceACLs(ctx, "pg-acl", specs); err != nil {
+		t.Fatalf("ReplaceACLs #1: %v", err)
+	}
+	before := append([]string(nil), m.PortGroups["pg-acl"].ACLs...)
+
+	if err := m.ReplaceACLs(ctx, "pg-acl", specs); err != nil {
+		t.Fatalf("ReplaceACLs #2 (identical): %v", err)
+	}
+	after := m.PortGroups["pg-acl"].ACLs
+	if len(before) != len(after) {
+		t.Fatalf("ACL count changed on identical ReplaceACLs: %d → %d", len(before), len(after))
+	}
+	for i := range before {
+		if before[i] != after[i] {
+			t.Fatalf("identical ReplaceACLs churned ACL UUID: %q → %q", before[i], after[i])
+		}
+	}
+
+	if err := m.ReplaceACLs(ctx, "pg-acl", specs[:1]); err != nil {
+		t.Fatalf("ReplaceACLs #3 (changed): %v", err)
+	}
+	if got := len(m.PortGroups["pg-acl"].ACLs); got != 1 {
+		t.Fatalf("changed ReplaceACLs: ACL count = %d, want 1", got)
+	}
+}
 
 func TestClient_DeleteAllNATsByExternalIP(t *testing.T) {
 	m := New()
@@ -176,7 +218,7 @@ func TestEnsureLogicalRouter_ConcurrentSingleSurvivor(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			lr, err := m.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{
+			lr, _, err := m.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{
 				Name:        "vpc-vpc-X",
 				ExternalIDs: map[string]string{"spinifex:vpc_id": "vpc-X"},
 			})
@@ -216,19 +258,25 @@ func TestEnsureLogicalRouter_ReturnsExistingOnSecondCall(t *testing.T) {
 	_ = m.Connect(context.Background())
 	ctx := context.Background()
 
-	first, err := m.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{
+	first, created, err := m.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{
 		Name:        "vpc-vpc-Y",
 		ExternalIDs: map[string]string{"spinifex:vpc_id": "vpc-Y", "spinifex:cidr": ""},
 	})
 	if err != nil {
 		t.Fatalf("EnsureLogicalRouter first call: %v", err)
 	}
-	second, err := m.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{
+	if !created {
+		t.Errorf("first call should report created=true")
+	}
+	second, created, err := m.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{
 		Name:        "vpc-vpc-Y",
 		ExternalIDs: map[string]string{"spinifex:vpc_id": "vpc-Y", "spinifex:cidr": "10.0.0.0/16"},
 	})
 	if err != nil {
 		t.Fatalf("EnsureLogicalRouter second call: %v", err)
+	}
+	if created {
+		t.Errorf("second call should report created=false")
 	}
 	if first.UUID != second.UUID {
 		t.Errorf("second call returned different UUID: %q vs %q", second.UUID, first.UUID)
@@ -249,7 +297,7 @@ func TestEnsureLogicalSwitch_ConcurrentSingleSurvivor(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			ls, err := m.EnsureLogicalSwitch(ctx, &nbdb.LogicalSwitch{
+			ls, _, err := m.EnsureLogicalSwitch(ctx, &nbdb.LogicalSwitch{
 				Name:        "subnet-subnet-Z",
 				ExternalIDs: map[string]string{"spinifex:subnet_id": "subnet-Z"},
 			})
@@ -292,7 +340,7 @@ func TestEnsurePortGroup_ConcurrentSingleSurvivor(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			pg, err := m.EnsurePortGroup(ctx, "sg-pg-A", nil)
+			pg, _, err := m.EnsurePortGroup(ctx, "sg-pg-A", nil)
 			if err != nil {
 				t.Errorf("EnsurePortGroup[%d]: %v", i, err)
 				return

--- a/spinifex/network/ovn/ovntest/encoding_test.go
+++ b/spinifex/network/ovn/ovntest/encoding_test.go
@@ -25,15 +25,18 @@ func TestStartNB_ColumnEncoding(t *testing.T) {
 	defer cli.Close()
 
 	// EnsureLogicalSwitch twice must converge to a single row, not insert a
-	// duplicate. UUID equality is not asserted: the insert path returns a
-	// client-side named UUID while the existing-row path returns the persisted
-	// one, so identity is checked via the row count and name instead.
+	// duplicate. The insert path reports created=true and the second call
+	// created=false; both return the persisted UUID.
 	ls := &nbdb.LogicalSwitch{Name: "ls-enc"}
-	if _, err := cli.EnsureLogicalSwitch(ctx, ls); err != nil {
+	if _, created, err := cli.EnsureLogicalSwitch(ctx, ls); err != nil {
 		t.Fatalf("EnsureLogicalSwitch #1: %v", err)
+	} else if !created {
+		t.Fatalf("EnsureLogicalSwitch #1: created = false, want true")
 	}
-	if _, err := cli.EnsureLogicalSwitch(ctx, &nbdb.LogicalSwitch{Name: "ls-enc"}); err != nil {
+	if _, created, err := cli.EnsureLogicalSwitch(ctx, &nbdb.LogicalSwitch{Name: "ls-enc"}); err != nil {
 		t.Fatalf("EnsureLogicalSwitch #2: %v", err)
+	} else if created {
+		t.Fatalf("EnsureLogicalSwitch #2: created = true, want false")
 	}
 	switches, err := cli.ListLogicalSwitches(ctx)
 	if err != nil {

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -46,7 +46,7 @@ func (r *reconciler) applyVPCs(ctx context.Context, intent IntentState, actual A
 					"spinifex:cidr":   spec.CIDR.String(),
 				},
 			}
-			if _, err := r.ovn.EnsureLogicalRouter(ctx, lr); err != nil {
+			if _, _, err := r.ovn.EnsureLogicalRouter(ctx, lr); err != nil {
 				slog.Error("reconcile/apply: ensure VPC router failed", "vpc_id", vpcID, "err", err)
 				continue
 			}
@@ -81,7 +81,7 @@ func (r *reconciler) applySubnets(ctx context.Context, intent IntentState, actua
 					"spinifex:vpc_id":    spec.VPCID,
 				},
 			}
-			if _, err := r.ovn.EnsureLogicalSwitch(ctx, ls); err != nil {
+			if _, _, err := r.ovn.EnsureLogicalSwitch(ctx, ls); err != nil {
 				slog.Error("reconcile/apply: ensure subnet switch failed", "subnet_id", subnetID, "err", err)
 				continue
 			}

--- a/spinifex/network/reconcile/apply_test.go
+++ b/spinifex/network/reconcile/apply_test.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"maps"
 	"net"
 	"net/netip"
 	"slices"
@@ -110,7 +111,7 @@ func TestReconcile_Idempotent(t *testing.T) {
 	switchCountBefore := len(m.Switches)
 	portCountBefore := len(m.Ports)
 	pgCountBefore := len(m.PortGroups)
-	addACLsBefore := m.AddACLCalls
+	aclUUIDsBefore := aclUUIDSet(m)
 
 	if err := rec.Reconcile(ctx, intent); err != nil {
 		t.Fatalf("Reconcile #2: %v", err)
@@ -128,10 +129,24 @@ func TestReconcile_Idempotent(t *testing.T) {
 	if len(m.PortGroups) != pgCountBefore {
 		t.Errorf("second reconcile created duplicate port groups: %d → %d", pgCountBefore, len(m.PortGroups))
 	}
-	// EnsureSG has replace-all semantics: AddACL count must grow each pass.
-	if m.AddACLCalls < addACLsBefore {
-		t.Errorf("second reconcile fewer AddACL calls than first — replace-all semantics regressed")
+	// An unchanged SG must not churn ACL rows: ReplaceACLs no-ops, so every ACL
+	// UUID from the first pass survives the second identical reconcile.
+	aclUUIDsAfter := aclUUIDSet(m)
+	if !maps.Equal(aclUUIDsBefore, aclUUIDsAfter) {
+		t.Errorf("second reconcile churned ACL UUIDs: %v → %v", aclUUIDsBefore, aclUUIDsAfter)
 	}
+}
+
+// aclUUIDSet snapshots the mock's current ACL UUIDs so idempotency can assert no
+// churn across reconciles.
+func aclUUIDSet(m *mock.Client) map[string]struct{} {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	out := make(map[string]struct{}, len(m.ACLs))
+	for uuid := range m.ACLs {
+		out[uuid] = struct{}{}
+	}
+	return out
 }
 
 func TestReconcile_OrphanPortGroupRemoved(t *testing.T) {

--- a/spinifex/network/reconcile/scenario_live_test.go
+++ b/spinifex/network/reconcile/scenario_live_test.go
@@ -175,6 +175,20 @@ func snapshotNB(t *testing.T, ctx context.Context, cli ovn.Client) string {
 		tokens[d.UUID] = "dhcp:" + d.CIDR
 	}
 
+	// OVN returns set columns (Ports) in an unstable order; sort by token so the
+	// snapshot is deterministic across runs.
+	sortByToken := func(uuids []string) {
+		slices.SortFunc(uuids, func(a, b string) int {
+			return strings.Compare(tokens[a]+a, tokens[b]+b)
+		})
+	}
+	for i := range switches {
+		sortByToken(switches[i].Ports)
+	}
+	for i := range pgs {
+		sortByToken(pgs[i].Ports)
+	}
+
 	var lines []string
 	add := func(kind string, rows []string) {
 		for i := range rows {

--- a/spinifex/network/reconcile/testdata/kitchen_sink_nb.golden
+++ b/spinifex/network/reconcile/testdata/kitchen_sink_nb.golden
@@ -11,8 +11,8 @@ port {UUID:lsp:port-eni-priv Name:port-eni-priv Type: Addresses:[02:00:00:00:00:
 port {UUID:lsp:port-eni-pub Name:port-eni-pub Type: Addresses:[02:00:00:00:00:01 10.0.1.10] PortSecurity:[02:00:00:00:00:01 10.0.1.10] DHCPv4Options:PTR Enabled:<nil> Up:<nil> ExternalIDs:map[spinifex:eni_id:eni-pub spinifex:subnet_id:subnet-pub spinifex:vpc_id:vpc-a] Options:map[]}
 port {UUID:lsp:rtr-port-subnet-priv Name:rtr-port-subnet-priv Type:router Addresses:[router] PortSecurity:[] DHCPv4Options:<nil> Enabled:<nil> Up:<nil> ExternalIDs:map[spinifex:subnet_id:subnet-priv spinifex:vpc_id:vpc-a] Options:map[router-port:rtr-subnet-priv]}
 port {UUID:lsp:rtr-port-subnet-pub Name:rtr-port-subnet-pub Type:router Addresses:[router] PortSecurity:[] DHCPv4Options:<nil> Enabled:<nil> Up:<nil> ExternalIDs:map[spinifex:subnet_id:subnet-pub spinifex:vpc_id:vpc-a] Options:map[router-port:rtr-subnet-pub]}
-portgroup {UUID:pg:sg_a Name:sg_a Ports:[lsp:port-eni-pub lsp:port-eni-priv] ACLs:[X X X X X X X] ExternalIDs:map[]}
+portgroup {UUID:pg:sg_a Name:sg_a Ports:[lsp:port-eni-priv lsp:port-eni-pub] ACLs:[X X X X X X X] ExternalIDs:map[]}
 router {UUID:lr:vpc-vpc-a Name:vpc-vpc-a Ports:[X X X] StaticRoutes:[X] NAT:[X X] Policies:[X X X X X] Enabled:<nil> ExternalIDs:map[spinifex:cidr:10.0.0.0/16 spinifex:vpc_id:vpc-a] Options:map[]}
 switch {UUID:ls:ext-shared Name:ext-shared Ports:[lsp:ext-port-shared lsp:gw-port-vpc-a] ACLs:[] DNSRecords:[] ExternalIDs:map[spinifex:role:external] OtherConfig:map[]}
-switch {UUID:ls:subnet-subnet-priv Name:subnet-subnet-priv Ports:[lsp:rtr-port-subnet-priv lsp:port-eni-priv] ACLs:[] DNSRecords:[] ExternalIDs:map[spinifex:subnet_id:subnet-priv spinifex:vpc_id:vpc-a] OtherConfig:map[]}
-switch {UUID:ls:subnet-subnet-pub Name:subnet-subnet-pub Ports:[lsp:rtr-port-subnet-pub lsp:port-eni-pub] ACLs:[] DNSRecords:[] ExternalIDs:map[spinifex:subnet_id:subnet-pub spinifex:vpc_id:vpc-a] OtherConfig:map[]}
+switch {UUID:ls:subnet-subnet-priv Name:subnet-subnet-priv Ports:[lsp:port-eni-priv lsp:rtr-port-subnet-priv] ACLs:[] DNSRecords:[] ExternalIDs:map[spinifex:subnet_id:subnet-priv spinifex:vpc_id:vpc-a] OtherConfig:map[]}
+switch {UUID:ls:subnet-subnet-pub Name:subnet-subnet-pub Ports:[lsp:port-eni-pub lsp:rtr-port-subnet-pub] ACLs:[] DNSRecords:[] ExternalIDs:map[spinifex:subnet_id:subnet-pub spinifex:vpc_id:vpc-a] OtherConfig:map[]}

--- a/spinifex/network/topology/manager_live.go
+++ b/spinifex/network/topology/manager_live.go
@@ -65,11 +65,11 @@ func (m *liveManager) EnsureVPC(ctx context.Context, spec VPCSpec) error {
 			"spinifex:cidr":   cidr,
 		},
 	}
-	existing, err := m.ovn.EnsureLogicalRouter(ctx, lr)
+	existing, created, err := m.ovn.EnsureLogicalRouter(ctx, lr)
 	if err != nil {
 		return fmt.Errorf("ensure logical router %q: %w", routerName, err)
 	}
-	if existing.UUID == lr.UUID {
+	if created {
 		slog.Info("topology: EnsureVPC created router", "router", routerName, "vpc_id", spec.VPCID, "cidr", cidr)
 		return nil
 	}
@@ -184,11 +184,11 @@ func (m *liveManager) EnsureSubnet(ctx context.Context, spec SubnetSpec) error {
 			"spinifex:vpc_id":    spec.VPCID,
 		},
 	}
-	existingSwitch, err := m.ovn.EnsureLogicalSwitch(ctx, ls)
+	_, created, err := m.ovn.EnsureLogicalSwitch(ctx, ls)
 	if err != nil {
 		return fmt.Errorf("ensure logical switch %q: %w", switchName, err)
 	}
-	if existingSwitch.UUID != ls.UUID {
+	if !created {
 		return nil
 	}
 
@@ -362,7 +362,7 @@ func (m *liveManager) EnsureSGPortGroup(ctx context.Context, groupID string) err
 		return fmt.Errorf("EnsureSGPortGroup: empty groupID")
 	}
 	pgName := SecurityGroupPortGroup(groupID)
-	if _, err := m.ovn.EnsurePortGroup(ctx, pgName, nil); err != nil {
+	if _, _, err := m.ovn.EnsurePortGroup(ctx, pgName, nil); err != nil {
 		return fmt.Errorf("ensure port group %s: %w", pgName, err)
 	}
 	slog.Info("topology: ensured SG port group", "pg", pgName, "group_id", groupID)


### PR DESCRIPTION
## Summary

Two related OVN NB UUID-stability defects surfaced by the in-process reconcile harness.

### siv-501 — Ensure* insert path returns named-uuid
`EnsureLogicalSwitch` (and siblings `EnsureLogicalRouter`, `EnsurePortGroup`)
returned the client-side named-uuid (e.g. `ls_ls_enc`) on the fresh-insert path,
but the real server uuid when the row already existed. A caller storing the
returned uuid after a create then doing `Where(uuid)` would miss.

- Resolve the persisted server uuid from the monitored cache after insert.
- Add an explicit `created bool` return to the three `Ensure*` primitives.
- `topology/manager_live.go` callers now branch on `created` instead of the
  fragile `existing.UUID == passed.UUID` sentinel.

### siv-502 — SG ACLs rewritten with fresh UUIDs every reconcile
`ReplaceACLs` deleted and recreated the whole ACL set every reconcile, minting new
ACL row uuids even for an unchanged SG. Against real OVN this churns NB and forces
`ovn-northd` flow recompute on every 5-min drift tick for idle SGs.

- Diff current vs desired ACLs by content key (direction, priority, match, action,
  log, name, severity) and no-op when unchanged (live + mock).

## Testing
- `TestReconcile_Idempotent` flipped to assert ACL uuid stability across a second
  identical reconcile (previously asserted the churn).
- `network/invariants` baseline green.
- `make preflight` passes.

Closes siv-501, siv-502.