### PR TITLE
fix(viperblock): stop chunk-uploader goroutine leak at all VB call sites

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20260407060928-11b94ed970f2
 	github.com/klauspost/cpuid/v2 v2.3.0
 	github.com/mulgadc/predastore v1.11.0-dev
-	github.com/mulgadc/viperblock v1.10.1-0.20260703054738-6af89855f547
+	github.com/mulgadc/viperblock v1.10.1-0.20260706044126-01a7e686fcae
 	github.com/nats-io/nats-server/v2 v2.14.2
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1301,8 +1301,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/mulgadc/predastore v1.11.0-dev h1:GMkwHWEANG9Oazf5Fxk8IATDNlNLcbJ15/tJ0JrdIeE=
 github.com/mulgadc/predastore v1.11.0-dev/go.mod h1:j2DOdAOj/c42MRI6SkZrfh9KFbIyDDJLmf63SJ2yizw=
-github.com/mulgadc/viperblock v1.10.1-0.20260703054738-6af89855f547 h1:wq8oLYxyZLly31R8FcyeFSm7f3Gr9VgbH3b3l+tK60k=
-github.com/mulgadc/viperblock v1.10.1-0.20260703054738-6af89855f547/go.mod h1:2ArCxLXJjSN4Idx9g8Pdq5n1Kp7HFHs2vWMZgKJT9dI=
+github.com/mulgadc/viperblock v1.10.1-0.20260706044126-01a7e686fcae h1:5tscnBmYgClla4897booPnnAGjvcuY0JiOmAOBhpjtc=
+github.com/mulgadc/viperblock v1.10.1-0.20260706044126-01a7e686fcae/go.mod h1:2ArCxLXJjSN4Idx9g8Pdq5n1Kp7HFHs2vWMZgKJT9dI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/spinifex/handlers/ec2/image/service_impl.go
+++ b/spinifex/handlers/ec2/image/service_impl.go
@@ -509,6 +509,10 @@ func (s *ImageServiceImpl) snapshotRunningVolume(volumeID, snapshotID string) er
 		slog.Error("snapshotRunningVolume: failed to create viperblock instance", "volumeId", volumeID, "err", err)
 		return errors.New(awserrors.ErrorServerInternal)
 	}
+	defer func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}()
 
 	if err := vb.Backend.Init(); err != nil {
 		slog.Error("snapshotRunningVolume: failed to init backend", "volumeId", volumeID, "err", err)
@@ -578,6 +582,10 @@ func (s *ImageServiceImpl) snapshotStoppedVolume(volumeID, snapshotID string) er
 		slog.Error("snapshotStoppedVolume: failed to create viperblock instance", "volumeId", volumeID, "err", err)
 		return errors.New(awserrors.ErrorServerInternal)
 	}
+	defer func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}()
 
 	if err := vb.Backend.Init(); err != nil {
 		slog.Error("snapshotStoppedVolume: failed to init backend", "volumeId", volumeID, "err", err)

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -1389,6 +1389,10 @@ func (s *InstanceServiceImpl) prepareRootVolume(input *ec2.RunInstancesInput, im
 		slog.Error("Failed to connect to Viperblock store", "err", err)
 		return errors.New(awserrors.ErrorServerInternal)
 	}
+	defer func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}()
 
 	// Initialize the backend
 	err = vb.Backend.Init()

--- a/spinifex/handlers/ec2/snapshot/service_impl.go
+++ b/spinifex/handlers/ec2/snapshot/service_impl.go
@@ -324,6 +324,11 @@ func (s *SnapshotServiceImpl) snapshotVolume(volumeID, snapshotID string, volume
 	if err != nil {
 		return fmt.Errorf("new viperblock: %w", err)
 	}
+	defer func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}()
+
 	if err := vb.Backend.Init(); err != nil {
 		return fmt.Errorf("backend init: %w", err)
 	}

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -223,6 +223,10 @@ func (s *VolumeServiceImpl) CreateVolume(input *ec2.CreateVolumeInput, accountID
 		slog.Error("CreateVolume failed to create viperblock instance", "err", err)
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
+	defer func() {
+		vb.StopChunkUploader()
+		vb.StopWALSyncer()
+	}()
 
 	vb.SetDebug(false)
 

--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -391,8 +391,9 @@ func launchService(cfg *Config) (err error) {
 					slog.Error("Failed to unsubscribe config topic", "volume", ebsRequest.Volume, "err", err)
 				}
 			}
-			// Stop WAL syncer and kill nbdkit process
+			// Stop background goroutines and kill nbdkit process
 			if matched.VB != nil {
+				matched.VB.StopChunkUploader()
 				matched.VB.StopWALSyncer()
 			}
 			if err := utils.KillProcess(matched.PID); err != nil {
@@ -469,9 +470,11 @@ func launchService(cfg *Config) (err error) {
 				}
 			}
 
-			// Clean up the VB instance's background goroutine.
-			// This VB is state-only (LoadState/sync) — actual I/O is in the nbdkit plugin process.
+			// Stop background goroutines on the state-tracking VB.
+			// Actual I/O is in the nbdkit plugin process; sealVolumeVB below
+			// opens a fresh VB and calls Close() for the proper seal.
 			if matched.VB != nil {
+				matched.VB.StopChunkUploader()
 				matched.VB.StopWALSyncer()
 			}
 
@@ -909,6 +912,7 @@ func launchService(cfg *Config) (err error) {
 func shutdownVolumes(volumes []MountedVolume, inUse func(MountedVolume) bool) {
 	for _, volume := range volumes {
 		if volume.VB != nil {
+			volume.VB.StopChunkUploader()
 			volume.VB.StopWALSyncer()
 		}
 		if inUse(volume) {


### PR DESCRIPTION
## Summary

- **7 leak sites patched**: every `viperblock.New()` call site that creates a short-lived or state-only VB now calls `StopChunkUploader()` alongside the existing `StopWALSyncer()` before the VB goes out of scope. The `feat/snapshot-ami` merge introduced an unconditional background uploader goroutine (30s timer) stopped only by `Close()`; none of the seven spinifex call sites called `Close()`, so every instance launch and every mount/unmount cycle leaked an uploader that PUT `checkpoints/blocks.live.bin` to predastore every 30s forever.
- **Sites**: `prepareRootVolume` (defer pattern — `Close()` unsafe here as `cloneAMIToVolume` already removes local WAL files), `viperblockd` `ebs.unmount` / `ebs.delete` / `shutdownVolumes`, `snapshotVolume`, `CreateVolume`, `snapshotRunningVolume`, `snapshotStoppedVolume`.

Fixes: mulga-0zzci (goroutine leak / memory exhaustion), mulga-ji5fi (volumes stuck in-use on terminate)
Runtime cause of mulga-be2ev AEAD failures also eliminated (leaked `prepareRootVolume` goroutine was overwriting the live checkpoint with clone-point seqNums every 30s).
Companion PR: viperblock fix/viperblock-regressions (mulgadc/viperblock#28)

## Test plan

- [x] `make preflight` passes (lint, govulncheck, tests, race detector)
- [x] Runtime: zero `blocks.live.bin` PUTs across 7 instance terminations (3+1+3) with 4+ full 30s uploader intervals post-terminate — confirmed on `tom-banksia` single-node dev with spinifex `v1.10.0-59-g5ad66078`
- [x] predastore RSS returned below baseline after termination (500 MB vs 718 MB baseline)
- [x] No `DeleteVolume: volume is in use` or `blockdev-del` failures on any termination
- [x] lb-suite instances launched and terminated cleanly