### PR TITLE
fix(e2e): hard-cap runSSHQuiet ssh process to stop EIP probe hang

### DIFF
--- a/tests/e2e/single/natgw_test.go
+++ b/tests/e2e/single/natgw_test.go
@@ -3,6 +3,7 @@
 package single
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -443,6 +444,12 @@ func scpKey(t *testing.T, keyPath, host string) {
 	}
 }
 
+// sshQuietHardTimeout hard-caps one runSSHQuiet call. ConnectTimeout bounds only
+// the TCP connect; a post-connect banner/kex wedge (e.g. probing an EIP whose
+// DNAT was just torn down) is otherwise unbounded and can outlast the caller's
+// EventuallyErr budget. The ctx deadline kills ssh regardless of which phase hangs.
+const sshQuietHardTimeout = 30 * time.Second
+
 // runSSHQuiet is the EventuallyErr-friendly variant of runSSH: it returns
 // stdout+stderr and the error rather than calling t.Fatal, so polling
 // loops can iterate on transient failures (cloud-init not done, OVN
@@ -459,6 +466,14 @@ func runSSHQuiet(tgt harness.SSHTarget, command string) (string, error) {
 		tgt.User + "@" + tgt.Host,
 		command,
 	}
-	out, err := exec.Command("ssh", args...).CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), sshQuietHardTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd.WaitDelay = 5 * time.Second // return even if ssh ignores the kill
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return string(out), fmt.Errorf("ssh %s@%s:%d timed out after %s: %w",
+			tgt.User, tgt.Host, tgt.Port, sshQuietHardTimeout, ctx.Err())
+	}
 	return string(out), err
 }


### PR DESCRIPTION
## Problem

On the single-node E2E run, `TestInstanceEIP` panicked at the 30-minute test-binary timeout. The goroutine dump from CI run 28842614192 pins the hang to `os/exec.(*Cmd).Wait` inside `runSSHQuiet` at `eip_test.go:138` — the test goroutine sat there for 14m26s because the `ssh` child never exited.

The EIP "verify guest unreachable after disassociate" step polls `runSSHQuiet(tgt, "true")` inside `harness.EventuallyErr(90s)`. `ssh -o ConnectTimeout=5` bounds only the connect (and, on newer OpenSSH, the banner exchange), but on the CI runner the ssh process wedged post-connect and never returned. `EventuallyErr` cannot interrupt an in-flight `CombinedOutput`, so a single probe consumed the entire 30-minute budget and panicked.

A Go test-timeout panic does not run `t.Cleanup`/defer, so the suite's EIP and NAT-gateway VMs leaked (never terminated). Those held single-node capacity, which then starved the `lb` suite: the daemon capacity-gates its `system.LaunchInstance.sys.micro` subscription and unsubscribes when full, so the ALB micro launch got `nats: no responders` on all three retries. One unbounded ssh probe reddened both the `single` and `lb` suites.

## Fix

`runSSHQuiet` now runs ssh under `exec.CommandContext` with a 30s hard deadline plus `cmd.WaitDelay`, returning a descriptive timeout error on `DeadlineExceeded`. The bound is applied at the Go/process layer, so it holds regardless of ssh version or which phase wedges — unlike ssh's own `ConnectTimeout`. 30s is safe for every caller (the worst legitimate call is a `ping -c2 -W5` probe at roughly 10-15s) and well under the 90s `EventuallyErr` budget, so a wedged probe now yields a clean bounded failure with `t.Cleanup` intact.

## Verification

- Compiles under `-tags e2e` (`go test -tags e2e -c ./tests/e2e/single/`), `gofmt` clean, `go vet -tags e2e` clean.
- Root cause confirmed against the CI panic goroutine dump: the hang is in the exact function this PR bounds.
- Not run: the live e2e EIP path, which needs a pool-mode + OVN stack. `make preflight` does not exercise this file (`test-harness` runs only `./tests/e2e/harness/...`; race/coverage run `./spinifex/...` non-e2e; lint has no e2e build-tags), so the `-tags e2e` compile/vet above is the applicable static gate and the E2E job is the runtime gate.