### PR TITLE
fix(ovn): recover ovn-controller from stale-SB RAFT wedge

### DIFF
--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -70,6 +70,32 @@ func (p *GatewayClaimProber) NudgeRecompute(_ context.Context) error {
 	return nil
 }
 
+// SBConnectionState returns ovn-controller's Southbound OVSDB connection status.
+// It is `connected` when the controller is synced with the SB RAFT cluster; a
+// sustained non-`connected` status (typically looping on "clustered database
+// server has stale data") is the stale-index wedge that stops the controller
+// realising new Port_Bindings. Output() not CombinedOutput(): sudo PAM noise on
+// stderr must not be misread as the status token.
+func (p *GatewayClaimProber) SBConnectionState(_ context.Context) (string, error) {
+	out, err := utils.SudoCommand("ovn-appctl", "-t", "ovn-controller", "connection-status").Output()
+	if err != nil {
+		return "", fmt.Errorf("ovn-appctl connection-status: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ResetSBClusterState forces ovn-controller to drop its cached SB cluster state
+// and re-sync against the SB RAFT cluster, clearing a stale-index wedge without a
+// process restart or a flow wipe. Targeted equivalent of the manual
+// `systemctl restart ovn-controller` recovery.
+func (p *GatewayClaimProber) ResetSBClusterState(_ context.Context) error {
+	out, err := utils.SudoCommand("ovn-appctl", "-t", "ovn-controller", "sb-cluster-state-reset").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ovn-appctl sb-cluster-state-reset: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 // RepairDatapath re-asserts the WAN-glue veth admin state, then forces a recompute.
 // A post-reboot boot race (ovs-vswitchd/ovn-controller start after the passive
 // network.target, concurrently with systemd-networkd) can leave veth-wan-ovs

--- a/spinifex/network/host/health.go
+++ b/spinifex/network/host/health.go
@@ -1,7 +1,6 @@
 package host
 
 import (
-	"os"
 	"strings"
 
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -24,14 +23,18 @@ func HealthStatus() OVNHealth {
 		status.BrIntExists = true
 	}
 
-	// Trixie OVN moved the pid file to /var/run/ovn/; older installs use
-	// /var/run/openvswitch/. Probe at runtime so the same binary works on both.
-	ovnTarget := "ovn-controller"
-	if _, err := os.Stat("/var/run/ovn/ovn-controller.pid"); err == nil {
-		ovnTarget = "/var/run/ovn/ovn-controller"
-	}
-	if out, err := utils.SudoCommand("ovs-appctl", "-t", ovnTarget, "version").CombinedOutput(); err == nil && len(out) > 0 {
-		status.OVNControllerUp = true
+	// Report OVN readiness from the controller's SB connection, not bare process
+	// liveness. `ovn-appctl -t ovn-controller` resolves the ctl socket via OVN_RUNDIR
+	// regardless of the Trixie (/var/run/ovn) vs older (/var/run/openvswitch) layout;
+	// the previous `ovs-appctl -t /var/run/ovn/ovn-controller version` passed a slashed
+	// target that ovs-appctl treats as a literal socket path — the real socket is
+	// ovn-controller.<pid>.ctl — so it always failed and healthy nodes falsely read
+	// not_running. connection-status == "connected" is the meaningful signal: it is
+	// true only when the process is up AND synced with the SB RAFT cluster, so a
+	// stale-SB wedge correctly surfaces as not_running instead of hiding behind a
+	// process-alive check.
+	if out, err := utils.SudoCommand("ovn-appctl", "-t", "ovn-controller", "connection-status").Output(); err == nil {
+		status.OVNControllerUp = strings.TrimSpace(string(out)) == "connected"
 	}
 
 	if out, err := utils.SudoCommand("ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:system-id").CombinedOutput(); err == nil {

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -33,6 +33,13 @@ var (
 	guestPortDatapathInterval = 5 * time.Second
 )
 
+// After this many recompute misses with a binding still down, the readiness loops
+// check SB connectivity and, if the local ovn-controller is not "connected",
+// escalate once to sb-cluster-state-reset. A recompute re-evaluates flows from the
+// controller's current SB view, so it is a no-op against a stale-SB wedge — the
+// reset re-syncs that view. Package var so tests can shrink it.
+var sbResetEscalateAfter = 3
+
 // applyVPCs ensures every intent VPC has a LogicalRouter. Stray OVN-only
 // routers are left alone.
 func (r *reconciler) applyVPCs(ctx context.Context, intent IntentState, actual ActualState) {
@@ -390,6 +397,29 @@ func (r *reconciler) ensureGatewayDatapath(ctx context.Context, vpcID, gwIP, eip
 	}
 }
 
+// escalateSBReset issues a one-shot sb-cluster-state-reset when the local
+// ovn-controller's SB client is wedged (status not "connected"). A recompute nudge
+// cannot clear a stale-SB wedge — it re-evaluates flows from the same stale SB view
+// — so a readiness loop that keeps missing checks connectivity and resets once.
+// Returns true when a reset was issued (caller stops escalating); false when the SB
+// is connected (recompute is the right tool) or the probe failed (retry next miss).
+func (r *reconciler) escalateSBReset(ctx context.Context, logKV ...any) bool {
+	status, err := r.gwClaim.SBConnectionState(ctx)
+	if err != nil {
+		slog.Warn("reconcile/apply: SB connection-status probe failed during escalation", append(logKV, "err", err)...)
+		return false
+	}
+	if status == "connected" {
+		return false
+	}
+	slog.Warn("reconcile/apply: recompute not converging and SB not connected; escalating to sb-cluster-state-reset",
+		append(logKV, "sb_status", status)...)
+	if err := r.gwClaim.ResetSBClusterState(ctx); err != nil {
+		slog.Warn("reconcile/apply: sb-cluster-state-reset failed", append(logKV, "err", err)...)
+	}
+	return true
+}
+
 // ensureGatewayClaimed polls the SB chassisredirect binding after SetGatewayChassis.
 // An unclaimed binding after reboot makes floating IPs unreachable. Recompute on
 // every miss, not once: after a fresh-VPC bring-up or a chassis flap a single early
@@ -402,6 +432,8 @@ func (r *reconciler) ensureGatewayClaimed(ctx context.Context, crPortName string
 	}
 	deadline := time.Now().Add(gatewayClaimTimeout)
 	nudged := false
+	misses := 0
+	resetEscalated := false
 	for {
 		claimed, err := r.gwClaim.GatewayPortClaimed(ctx, crPortName)
 		if err != nil {
@@ -419,6 +451,10 @@ func (r *reconciler) ensureGatewayClaimed(ctx context.Context, crPortName string
 			slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "port", crPortName, "err", err)
 		}
 		nudged = true
+		misses++
+		if !resetEscalated && misses >= sbResetEscalateAfter {
+			resetEscalated = r.escalateSBReset(ctx, "port", crPortName)
+		}
 		if time.Now().After(deadline) {
 			slog.Error("reconcile/apply: gateway SB chassis claim did not converge; floating IPs may be unreachable",
 				"port", crPortName, "timeout", gatewayClaimTimeout)
@@ -512,6 +548,8 @@ func (r *reconciler) ensureGuestPortDatapath(ctx context.Context, vpcID, lspName
 	}
 	deadline := time.Now().Add(guestPortDatapathTimeout)
 	nudged := false
+	misses := 0
+	resetEscalated := false
 	for {
 		up, err := r.gwClaim.GuestPortUp(ctx, lspName)
 		if err != nil {
@@ -530,6 +568,10 @@ func (r *reconciler) ensureGuestPortDatapath(ctx context.Context, vpcID, lspName
 			slog.Warn("reconcile/apply: ovn-controller recompute nudge failed", "vpc_id", vpcID, "lsp", lspName, "err", err)
 		}
 		nudged = true
+		misses++
+		if !resetEscalated && misses >= sbResetEscalateAfter {
+			resetEscalated = r.escalateSBReset(ctx, "vpc_id", vpcID, "lsp", lspName)
+		}
 		if time.Now().After(deadline) {
 			slog.Error("reconcile/apply: guest port datapath did not converge; EIP ingress may be unreachable",
 				"vpc_id", vpcID, "lsp", lspName, "timeout", guestPortDatapathTimeout)

--- a/spinifex/network/reconcile/apply_gateway_claim_test.go
+++ b/spinifex/network/reconcile/apply_gateway_claim_test.go
@@ -19,11 +19,16 @@ type fakeClaimVerifier struct {
 	nudgeErr       error
 	reachErr       error
 	guestErr       error
+	sbNotConnected bool  // SBConnectionState reports the wedge ("not connected")
+	sbStateErr     error // SBConnectionState probe error
+	sbResetErr     error // ResetSBClusterState error
 	checks         int
 	nudges         int
 	repairs        int
 	reachChecks    int
 	guestChecks    int
+	sbChecks       int
+	sbResets       int
 	lastPort       string // most recent port name passed to GatewayPortClaimed
 	lastGwIP       string // most recent IP passed to GatewayReachable
 	lastEIP        string // most recent IP passed to EIPReachable
@@ -95,6 +100,23 @@ func (f *fakeClaimVerifier) GuestPortUp(_ context.Context, lspName string) (bool
 		return false, nil
 	}
 	return f.nudges >= f.guestUpAfter, nil
+}
+
+// SBConnectionState reports "connected" by default; sbNotConnected scripts the wedge.
+func (f *fakeClaimVerifier) SBConnectionState(_ context.Context) (string, error) {
+	f.sbChecks++
+	if f.sbStateErr != nil {
+		return "", f.sbStateErr
+	}
+	if f.sbNotConnected {
+		return "not connected", nil
+	}
+	return "connected", nil
+}
+
+func (f *fakeClaimVerifier) ResetSBClusterState(_ context.Context) error {
+	f.sbResets++
+	return f.sbResetErr
 }
 
 func withFastGuestPortBounds(t *testing.T) {
@@ -467,5 +489,82 @@ func TestEnsureGuestPortDatapath_ContextCancelStops(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("ensureGuestPortDatapath ignored context cancellation")
+	}
+}
+
+func withSmallSBResetThreshold(t *testing.T) {
+	t.Helper()
+	prev := sbResetEscalateAfter
+	sbResetEscalateAfter = 2
+	t.Cleanup(func() { sbResetEscalateAfter = prev })
+}
+
+func runToDeadline(t *testing.T, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { fn(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readiness loop did not return within deadline; blocking reconcile")
+	}
+}
+
+func TestEnsureGatewayClaimed_WedgedSBEscalatesResetOnce(t *testing.T) {
+	withFastClaimBounds(t)
+	withSmallSBResetThreshold(t)
+	// Never claims AND the SB is wedged: recompute cannot converge a stale-SB wedge,
+	// so after the miss threshold the loop escalates to exactly one reset.
+	f := &fakeClaimVerifier{claimedAfter: -1, sbNotConnected: true}
+	r := &reconciler{gwClaim: f}
+
+	runToDeadline(t, func() { r.ensureGatewayClaimed(context.Background(), "gw-vpc-a") })
+
+	if f.sbResets != 1 {
+		t.Errorf("sbResets = %d, want exactly 1 (escalate once, then stop resetting)", f.sbResets)
+	}
+	if f.nudges < 2 {
+		t.Errorf("nudges = %d, want >=2 (recompute still runs each miss)", f.nudges)
+	}
+}
+
+func TestEnsureGatewayClaimed_ConnectedSBNeverResets(t *testing.T) {
+	withFastClaimBounds(t)
+	withSmallSBResetThreshold(t)
+	// Never claims but SB is connected: the miss is not a wedge, so no reset —
+	// recompute is the right tool and a reset would needlessly churn the SB sync.
+	f := &fakeClaimVerifier{claimedAfter: -1, sbNotConnected: false}
+	r := &reconciler{gwClaim: f}
+
+	runToDeadline(t, func() { r.ensureGatewayClaimed(context.Background(), "gw-vpc-a") })
+
+	if f.sbResets != 0 {
+		t.Errorf("sbResets = %d, want 0 (connected SB must never be reset)", f.sbResets)
+	}
+}
+
+func TestEnsureGuestPortDatapath_WedgedSBEscalatesResetOnce(t *testing.T) {
+	withFastGuestPortBounds(t)
+	withSmallSBResetThreshold(t)
+	f := &fakeClaimVerifier{guestUpAfter: -1, sbNotConnected: true}
+	r := &reconciler{gwClaim: f}
+
+	runToDeadline(t, func() { r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1") })
+
+	if f.sbResets != 1 {
+		t.Errorf("sbResets = %d, want exactly 1 (escalate once on a wedged SB)", f.sbResets)
+	}
+}
+
+func TestEnsureGuestPortDatapath_ConnectedSBNeverResets(t *testing.T) {
+	withFastGuestPortBounds(t)
+	withSmallSBResetThreshold(t)
+	f := &fakeClaimVerifier{guestUpAfter: -1, sbNotConnected: false}
+	r := &reconciler{gwClaim: f}
+
+	runToDeadline(t, func() { r.ensureGuestPortDatapath(context.Background(), "vpc-a", "port-eni-1") })
+
+	if f.sbResets != 0 {
+		t.Errorf("sbResets = %d, want 0 (connected SB must never be reset)", f.sbResets)
 	}
 }

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -60,6 +60,15 @@ type GatewayClaimVerifier interface {
 	// blackholes after DNAT and the public IP is dark against an otherwise-running
 	// instance — the post-reboot state until an ovn-controller recompute binds it.
 	GuestPortUp(ctx context.Context, lspName string) (bool, error)
+	// SBConnectionState returns ovn-controller's Southbound OVSDB connection status
+	// ("connected" when healthy). A sustained non-"connected" status is the stale-SB
+	// RAFT wedge that stops new Port_Binding realisation; a recompute cannot clear it
+	// because it re-evaluates flows from the same stale SB view.
+	SBConnectionState(ctx context.Context) (string, error)
+	// ResetSBClusterState forces ovn-controller to re-sync its SB cluster state,
+	// clearing a stale-index wedge without a process restart or a flow wipe. Escalated
+	// to when a recompute nudge cannot converge a binding and the SB is not connected.
+	ResetSBClusterState(ctx context.Context) error
 }
 
 // Config is the construction-time bag for the reconciler. All fields except

--- a/spinifex/vpcd/ovn_controller_watchdog.go
+++ b/spinifex/vpcd/ovn_controller_watchdog.go
@@ -1,0 +1,107 @@
+package vpcd
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/host"
+)
+
+// Compile-time check: the gateway-claim prober satisfies the watchdog's needs.
+var _ sbStateProber = (*host.GatewayClaimProber)(nil)
+
+// Tunables for the ovn-controller wedge watchdog. Package vars so tests can shrink
+// them. staleAfter must exceed a normal reconnect blip so a transient
+// non-"connected" status does not trip a reset; cooldown bounds the reset rate so a
+// genuinely-down SB does not induce a tight reset loop.
+var (
+	ovnWatchdogInterval   = 15 * time.Second
+	ovnWatchdogStaleAfter = 45 * time.Second
+	ovnWatchdogCooldown   = 60 * time.Second
+)
+
+// sbStateProber is the slice of the gateway-claim prober the watchdog needs.
+// *host.GatewayClaimProber satisfies it; tests supply a fake.
+type sbStateProber interface {
+	SBConnectionState(ctx context.Context) (string, error)
+	ResetSBClusterState(ctx context.Context) error
+}
+
+// ovnWatchdog detects a wedged local ovn-controller — one whose SB OVSDB client is
+// stuck on stale RAFT cluster state and has stopped realising Port_Bindings — and
+// clears it with sb-cluster-state-reset. It is per host, not leader-gated: the wedge
+// is local to a chassis and usually strikes a non-leader placement host, so a
+// leader-only recovery would never fire on the wedged node.
+type ovnWatchdog struct {
+	prober     sbStateProber
+	staleAfter time.Duration
+	cooldown   time.Duration
+
+	// nonConnectedSince marks when the status first went non-"connected"; zero while
+	// connected. lastReset gates the cooldown; zero until the first reset.
+	nonConnectedSince time.Time
+	lastReset         time.Time
+}
+
+func newOVNWatchdog(prober sbStateProber) *ovnWatchdog {
+	return &ovnWatchdog{
+		prober:     prober,
+		staleAfter: ovnWatchdogStaleAfter,
+		cooldown:   ovnWatchdogCooldown,
+	}
+}
+
+// evaluate runs one watchdog decision at time now and reports whether it issued a
+// reset. Pure of wall-clock (now is injected) so tests drive it deterministically.
+// A probe error is treated as unknown — no reset — so a flaky appctl never forces a
+// reset on a healthy SB.
+func (w *ovnWatchdog) evaluate(ctx context.Context, now time.Time) bool {
+	status, err := w.prober.SBConnectionState(ctx)
+	if err != nil {
+		slog.Warn("ovn-controller watchdog: SB connection-status probe failed", "err", err)
+		return false
+	}
+	if status == "connected" {
+		w.nonConnectedSince = time.Time{}
+		return false
+	}
+
+	if w.nonConnectedSince.IsZero() {
+		w.nonConnectedSince = now
+	}
+	if now.Sub(w.nonConnectedSince) < w.staleAfter {
+		return false
+	}
+	if !w.lastReset.IsZero() && now.Sub(w.lastReset) < w.cooldown {
+		return false
+	}
+
+	slog.Warn("ovn-controller watchdog: SB wedge detected, resetting SB cluster state",
+		"status", status, "stale_for", now.Sub(w.nonConnectedSince).Round(time.Second))
+	if err := w.prober.ResetSBClusterState(ctx); err != nil {
+		slog.Warn("ovn-controller watchdog: sb-cluster-state-reset failed", "err", err)
+		// Still record the attempt so the cooldown throttles retries.
+	}
+	w.lastReset = now
+	// Re-arm the stale timer: give the reset a full staleAfter window to take
+	// effect before the next reset is even considered.
+	w.nonConnectedSince = time.Time{}
+	return true
+}
+
+// runOVNControllerWatchdog ticks the watchdog until ctx is cancelled.
+func runOVNControllerWatchdog(ctx context.Context, w *ovnWatchdog) {
+	ticker := time.NewTicker(ovnWatchdogInterval)
+	defer ticker.Stop()
+	slog.Info("ovn-controller wedge watchdog started",
+		"interval", ovnWatchdogInterval, "stale_after", w.staleAfter, "cooldown", w.cooldown)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.evaluate(ctx, time.Now())
+		}
+	}
+}

--- a/spinifex/vpcd/ovn_controller_watchdog_test.go
+++ b/spinifex/vpcd/ovn_controller_watchdog_test.go
@@ -1,0 +1,165 @@
+package vpcd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeSBProber scripts SBConnectionState and counts resets.
+type fakeSBProber struct {
+	status    string
+	statusErr error
+	resetErr  error
+	resets    int
+	calls     int
+}
+
+func (f *fakeSBProber) SBConnectionState(_ context.Context) (string, error) {
+	f.calls++
+	return f.status, f.statusErr
+}
+
+func (f *fakeSBProber) ResetSBClusterState(_ context.Context) error {
+	f.resets++
+	return f.resetErr
+}
+
+func newTestWatchdog(f *fakeSBProber) *ovnWatchdog {
+	return &ovnWatchdog{prober: f, staleAfter: 10 * time.Second, cooldown: 60 * time.Second}
+}
+
+func TestOVNWatchdog_ConnectedNeverResets(t *testing.T) {
+	f := &fakeSBProber{status: "connected"}
+	w := newTestWatchdog(f)
+	base := time.Unix(1_000_000, 0)
+	for i := range 5 {
+		if w.evaluate(context.Background(), base.Add(time.Duration(i)*time.Minute)) {
+			t.Fatalf("evaluate reset while connected (tick %d)", i)
+		}
+	}
+	if f.resets != 0 {
+		t.Errorf("resets = %d, want 0 (connected status must never reset)", f.resets)
+	}
+}
+
+func TestOVNWatchdog_StaleUnderThresholdNoReset(t *testing.T) {
+	f := &fakeSBProber{status: "not connected"}
+	w := newTestWatchdog(f)
+	base := time.Unix(1_000_000, 0)
+	w.evaluate(context.Background(), base)                    // arm at t0
+	w.evaluate(context.Background(), base.Add(9*time.Second)) // still under staleAfter (10s)
+	if f.resets != 0 {
+		t.Errorf("resets = %d, want 0 (a sub-threshold blip must not reset)", f.resets)
+	}
+}
+
+func TestOVNWatchdog_StalePastThresholdResetsOnce(t *testing.T) {
+	f := &fakeSBProber{status: "not connected"}
+	w := newTestWatchdog(f)
+	base := time.Unix(1_000_000, 0)
+	w.evaluate(context.Background(), base) // arm at t0
+	if !w.evaluate(context.Background(), base.Add(11*time.Second)) {
+		t.Fatal("evaluate did not reset past the stale threshold")
+	}
+	if f.resets != 1 {
+		t.Errorf("resets = %d, want 1", f.resets)
+	}
+}
+
+func TestOVNWatchdog_CooldownBlocksTightLoop(t *testing.T) {
+	f := &fakeSBProber{status: "not connected"}
+	w := newTestWatchdog(f)
+	base := time.Unix(1_000_000, 0)
+	w.evaluate(context.Background(), base)                     // arm
+	w.evaluate(context.Background(), base.Add(11*time.Second)) // reset #1 (lastReset=+11s)
+	// Re-arm and cross the stale threshold again, but stay within the 60s cooldown:
+	w.evaluate(context.Background(), base.Add(12*time.Second)) // re-arm at +12s
+	w.evaluate(context.Background(), base.Add(30*time.Second)) // stale (18s) but cooldown (19s<60s)
+	if f.resets != 1 {
+		t.Errorf("resets = %d, want 1 (cooldown must block a second reset)", f.resets)
+	}
+	// Past the cooldown, a still-wedged SB resets again.
+	if !w.evaluate(context.Background(), base.Add(80*time.Second)) {
+		t.Fatal("evaluate did not reset after the cooldown elapsed")
+	}
+	if f.resets != 2 {
+		t.Errorf("resets = %d, want 2 (reset resumes after cooldown)", f.resets)
+	}
+}
+
+func TestOVNWatchdog_RecoveryClearsStaleTimer(t *testing.T) {
+	f := &fakeSBProber{status: "not connected"}
+	w := newTestWatchdog(f)
+	base := time.Unix(1_000_000, 0)
+	w.evaluate(context.Background(), base) // arm at t0
+	f.status = "connected"
+	w.evaluate(context.Background(), base.Add(5*time.Second)) // recovered; stale timer cleared
+	f.status = "not connected"
+	w.evaluate(context.Background(), base.Add(6*time.Second))  // re-arm at +6s
+	w.evaluate(context.Background(), base.Add(12*time.Second)) // only 6s stale (< 10s) -> no reset
+	if f.resets != 0 {
+		t.Errorf("resets = %d, want 0 (a recovery must reset the stale clock)", f.resets)
+	}
+}
+
+func TestOVNWatchdog_ProbeErrorNoReset(t *testing.T) {
+	f := &fakeSBProber{statusErr: errors.New("appctl unavailable")}
+	w := newTestWatchdog(f)
+	base := time.Unix(1_000_000, 0)
+	w.evaluate(context.Background(), base)
+	w.evaluate(context.Background(), base.Add(time.Hour))
+	if f.resets != 0 {
+		t.Errorf("resets = %d, want 0 (a probe error is unknown, not a wedge)", f.resets)
+	}
+}
+
+// TestOVNWatchdog_ResetErrorRecordsAttempt covers the reset-failure branch: even
+// when sb-cluster-state-reset errors, evaluate reports the attempt and records it so
+// the cooldown throttles retries rather than hammering a genuinely-down SB.
+func TestOVNWatchdog_ResetErrorRecordsAttempt(t *testing.T) {
+	f := &fakeSBProber{status: "not connected", resetErr: errors.New("appctl boom")}
+	w := newTestWatchdog(f)
+	base := time.Unix(1_000_000, 0)
+	w.evaluate(context.Background(), base) // arm
+	if !w.evaluate(context.Background(), base.Add(11*time.Second)) {
+		t.Fatal("evaluate must report a reset attempt even when the reset errors")
+	}
+	if f.resets != 1 {
+		t.Errorf("resets = %d, want 1 (attempt recorded despite the error)", f.resets)
+	}
+}
+
+func withFastWatchdogInterval(t *testing.T) {
+	t.Helper()
+	prev := ovnWatchdogInterval
+	ovnWatchdogInterval = time.Millisecond
+	t.Cleanup(func() { ovnWatchdogInterval = prev })
+}
+
+// TestOVNWatchdog_LoopPollsAndStopsOnCancel drives runOVNControllerWatchdog (and the
+// newOVNWatchdog constructor): it must poll on each tick and return promptly on
+// context cancel.
+func TestOVNWatchdog_LoopPollsAndStopsOnCancel(t *testing.T) {
+	withFastWatchdogInterval(t)
+	f := &fakeSBProber{status: "connected"}
+	w := newOVNWatchdog(f)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		runOVNControllerWatchdog(ctx, w)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runOVNControllerWatchdog did not return on context cancel")
+	}
+	if f.calls == 0 {
+		t.Error("watchdog loop never polled SBConnectionState")
+	}
+}

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -644,6 +644,12 @@ func launchService(cfg *Config) error {
 		close(loopDone)
 	}()
 
+	// Per-host ovn-controller wedge watchdog. Not leader-gated: a stale-SB wedge is
+	// local to this chassis and usually strikes a non-leader placement host, so the
+	// recovery must run on every node. Backstops the bring-up settle pass for runtime
+	// SB re-bootstraps (snapshot install / compaction) with no deploy in flight.
+	go runOVNControllerWatchdog(loopCtx, newOVNWatchdog(host.NewGatewayClaimProber(cfg.OVNSBAddr)))
+
 	slog.Info("vpcd service started, waiting for VPC lifecycle events",
 		"subscriptions", len(subs))
 


### PR DESCRIPTION
## Problem

On a fresh cluster (or any SB re-bootstrap), a node's `ovn-controller` could latch its OVSDB client on **stale Southbound RAFT cluster state** and loop on `clustered database server has stale data; trying another server` — silently no longer realising new `Port_Bindings`. Cross-host EKS control-plane data-NICs then never bind: no DHCP → no IMDS → member boots degraded. Only a manual `systemctl restart ovn-controller` recovered it.

**Root cause is deterministic, not random:** `setup-ovn.sh` restarts `ovn-controller` per node *as each RAFT member forms*, so a controller started for the creator/early joiner is already running when a later `join` mutates SB RAFT membership — the exact condition that strands the SB client on a stale index. `.20` (slow joiner + SB leader placement) is the one that wedges.

Confirmed live on env19: the cross-host CP member on `.20` never leased in the 600s budget; a manual `sb-cluster-state-reset` on `.20` flipped `connection-status` from `not connected` → `connected`, geneve tunnels reformed, and a fresh EKS cluster then reached ACTIVE.

## Changes (this repo)

- **Per-host wedge watchdog** (`vpcd/ovn_controller_watchdog.go`) — not leader-gated (the wedge is per chassis and usually strikes a non-leader host). Polls SB `connection-status`; after a 45s stale threshold issues `sb-cluster-state-reset`, throttled by a 60s cooldown. Decision logic takes an injected clock → deterministic unit tests.
- **Reconcile-loop escalation** — `ensureGatewayClaimed` / `ensureGuestPortDatapath` escalate to **one** `sb-cluster-state-reset` after repeated recompute misses, **only when SB is not connected** (a recompute re-evaluates flows from the same stale SB view, so it can't clear a wedge).
- **Prober primitives** — `SBConnectionState` / `ResetSBClusterState` on `GatewayClaimProber` + `GatewayClaimVerifier` interface extension (compile-time check in vpcd).
- **awsgw health probe fix** (`network/host/health.go`) — the old probe passed a slashed `-t /var/run/ovn/ovn-controller` socket path that never resolves, so every healthy node reported `ovn-controller: not_running`. Now probes `connection-status`: `OVNControllerUp` is true only when `connected` — healthy nodes read `ok`, a real wedge correctly reads `not_running`.

## Companion change (mulga repo, separate PR)

The **primary, deterministic** fix — a bring-up settle pass in `cluster-bootstrap.yml` + `cluster-ovn-reset.yml` that resets every controller once after RAFT membership is final and **gates on `connection-status == connected`** — lands in the mulga repo (ansible + plan doc). The watchdog here is the runtime backstop for SB re-bootstraps with no deploy in flight.

## Testing

- `make preflight` passes (tests, race, vet, lint, govulncheck).
- New: watchdog `evaluate()` unit tests (healthy → stale → reset → cooldown → recovery → probe-error); reconcile escalation tests (wedged SB resets once, connected SB never resets).
- Live recovery verified on env19 (above). Live E2E of the watchdog auto-firing intentionally deferred.

Tracked in `mulga-bjktm`; health-probe fix in `mulga-f18xj`.