### PR TITLE
feat(dns): resolvable DNS names for ALB/NLB and EKS endpoints

### DIFF
--- a/spinifex/handlers/dns/naming.go
+++ b/spinifex/handlers/dns/naming.go
@@ -70,6 +70,50 @@ func EC2Changes(action Action, region, baseDomain, internalDomain, publicIP, pri
 	return changes
 }
 
+// ELBName is the AWS-shaped DNS name for a load balancer's frontend:
+// {prefix}{name}-{lbID}.{region}.elb.{baseDomain}. prefix is "internal-" for
+// internal-scheme balancers (AWS convention), "" for internet-facing.
+func ELBName(prefix, name, lbID, region, baseDomain string) string {
+	return fmt.Sprintf("%s%s-%s.%s.elb.%s", prefix, name, lbID, region, baseDomain)
+}
+
+// ELBChanges builds the record-set change for a load balancer's frontend
+// address. Returns no change when the name, zone, or IP is unavailable (e.g. a
+// launcher-less LB with no allocated frontend IP).
+func ELBChanges(action Action, dnsName, baseDomain, frontendIP string) []Change {
+	if dnsName == "" || baseDomain == "" || frontendIP == "" {
+		return nil
+	}
+	return []Change{{
+		Action: action,
+		Zone:   baseDomain,
+		Name:   dnsName,
+		Type:   "A",
+		Value:  frontendIP,
+	}}
+}
+
+// EKSName is the AWS-shaped DNS name for a cluster's apiserver endpoint:
+// {cluster}.{region}.eks.{baseDomain}.
+func EKSName(cluster, region, baseDomain string) string {
+	return fmt.Sprintf("%s.%s.eks.%s", cluster, region, baseDomain)
+}
+
+// EKSChanges builds the record-set change for a cluster's apiserver endpoint.
+// Returns no change when the name, zone, or IP is unavailable.
+func EKSChanges(action Action, dnsName, baseDomain, endpointIP string) []Change {
+	if dnsName == "" || baseDomain == "" || endpointIP == "" {
+		return nil
+	}
+	return []Change{{
+		Action: action,
+		Zone:   baseDomain,
+		Name:   dnsName,
+		Type:   "A",
+		Value:  endpointIP,
+	}}
+}
+
 // privateZoneOrDefault returns the configured internal domain or the
 // compute.internal default when unset.
 func privateZoneOrDefault(internalDomain string) string {

--- a/spinifex/handlers/dns/naming_test.go
+++ b/spinifex/handlers/dns/naming_test.go
@@ -41,6 +41,36 @@ func TestEC2Changes(t *testing.T) {
 	assert.Empty(t, EC2Changes(ActionUpsert, "", "spx3.net", "", "1.2.3.4", "172.31.26.216"))
 }
 
+func TestELBNameAndChanges(t *testing.T) {
+	assert.Equal(t, "web-lb-abc123.ap-southeast-2.elb.spx3.net",
+		ELBName("", "web-lb", "abc123", "ap-southeast-2", "spx3.net"))
+	assert.Equal(t, "internal-web-lb-abc123.ap-southeast-2.elb.spx3.net",
+		ELBName("internal-", "web-lb", "abc123", "ap-southeast-2", "spx3.net"))
+
+	changes := ELBChanges(ActionUpsert, "internal-web-lb-abc123.ap-southeast-2.elb.spx3.net", "spx3.net", "10.0.0.5")
+	require.Len(t, changes, 1)
+	assert.Equal(t, "spx3.net", changes[0].Zone)
+	assert.Equal(t, "A", changes[0].Type)
+	assert.Equal(t, "10.0.0.5", changes[0].Value)
+
+	// Missing zone or frontend IP → no change (launcher-less LB, northstar off).
+	assert.Empty(t, ELBChanges(ActionUpsert, "web-lb-abc123.ap-southeast-2.elb.spx3.net", "", "10.0.0.5"))
+	assert.Empty(t, ELBChanges(ActionUpsert, "web-lb-abc123.ap-southeast-2.elb.spx3.net", "spx3.net", ""))
+}
+
+func TestEKSNameAndChanges(t *testing.T) {
+	assert.Equal(t, "my-cluster.ap-southeast-2.eks.spx3.net",
+		EKSName("my-cluster", "ap-southeast-2", "spx3.net"))
+
+	changes := EKSChanges(ActionDelete, "my-cluster.ap-southeast-2.eks.spx3.net", "spx3.net", "10.0.0.9")
+	require.Len(t, changes, 1)
+	assert.Equal(t, ActionDelete, changes[0].Action)
+	assert.Equal(t, "spx3.net", changes[0].Zone)
+	assert.Equal(t, "10.0.0.9", changes[0].Value)
+
+	assert.Empty(t, EKSChanges(ActionUpsert, "my-cluster.ap-southeast-2.eks.spx3.net", "spx3.net", ""))
+}
+
 func TestRelativeLabel(t *testing.T) {
 	assert.Equal(t, "", relativeLabel("spx3.net", "spx3.net"))
 	assert.Equal(t, "", relativeLabel("spx3.net.", "spx3.net"))

--- a/spinifex/handlers/eks/cluster_state.go
+++ b/spinifex/handlers/eks/cluster_state.go
@@ -44,6 +44,10 @@ type ClusterMeta struct {
 	// EndpointIP is the NLB front-end IP (external-pool for public, VPC IP for private).
 	// The apiserver serving cert SANs this IP for TLS verification.
 	EndpointIP string `json:"endpointIp,omitempty"`
+	// EndpointDNSName is the AWS-shaped apiserver DNS name ({cluster}.{region}.eks.
+	// {baseDomain}) registered with northstar → EndpointIP; published as Endpoint
+	// when northstar is configured and SANed on the apiserver cert. Empty otherwise.
+	EndpointDNSName string `json:"endpointDnsName,omitempty"`
 	// PrivateEndpointIP is the customer-VPC (Set A) IP of the ENI threaded onto the
 	// cluster NLB's LB VM when EndpointPrivateAccess is on. In-VPC workers + kubectl
 	// reach the control plane here on :443 (no public hairpin / NAT GW). SANed on

--- a/spinifex/handlers/eks/k3s_server_vm.go
+++ b/spinifex/handlers/eks/k3s_server_vm.go
@@ -119,6 +119,10 @@ type K3sServerInput struct {
 	// EndpointIP is the NLB front-end IP added to the apiserver cert SANs for TLS.
 	// Empty for an internal endpoint with no front-end IP.
 	EndpointIP string
+	// EndpointDNS is the AWS-shaped apiserver DNS name ({cluster}.{region}.eks.
+	// {baseDomain}) added to the cert SANs so kubectl/SDK clients validate TLS when
+	// connecting via the published DNS endpoint. Empty when northstar is unconfigured.
+	EndpointDNS string
 	// PrivateEndpointIP is the customer-VPC (Set A) private-endpoint IP added to the
 	// apiserver cert SANs so in-VPC clients validate TLS via https://<ip>:443.
 	// Empty when private access is off.
@@ -478,7 +482,7 @@ func buildK3sUserData(in K3sServerInput) string {
 	if konnHost == "" {
 		konnHost = in.EndpointIP
 	}
-	konnSANs := dedupeNonEmpty([]string{in.PrivateEndpointIP, in.EndpointIP, in.NLBDNS})
+	konnSANs := dedupeNonEmpty([]string{in.PrivateEndpointIP, in.EndpointIP, in.NLBDNS, in.EndpointDNS})
 	konnCount := max(in.KonnServerCount, 1)
 
 	envLines := []string{
@@ -549,6 +553,11 @@ func buildK3sUserData(in K3sServerInput) string {
 	// EndpointIP must be a cert SAN for TLS validation via https://<EndpointIP>:443.
 	if in.EndpointIP != "" {
 		configLines = append(configLines, "  - "+in.EndpointIP)
+	}
+	// EndpointDNS (the published AWS-shaped endpoint) must be SANed so kubectl/SDK
+	// clients validate TLS when connecting via the DNS name.
+	if in.EndpointDNS != "" {
+		configLines = append(configLines, "  - "+in.EndpointDNS)
 	}
 	// The Set A private-endpoint IP is what in-VPC clients connect to; SAN it too.
 	if in.PrivateEndpointIP != "" && in.PrivateEndpointIP != in.EndpointIP {

--- a/spinifex/handlers/eks/private_endpoint_test.go
+++ b/spinifex/handlers/eks/private_endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 	"github.com/mulgadc/spinifex/spinifex/handlers/sysinstance"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,29 @@ func TestClusterJoinEndpoint_PublicOnlyUsesPublished(t *testing.T) {
 		},
 	}
 	assert.Equal(t, "https://203.0.113.9:443", clusterJoinEndpoint(meta))
+}
+
+func TestClusterJoinEndpoint_PublicJoinsByEndpointIP(t *testing.T) {
+	// With northstar on, meta.Endpoint is the DNS name but workers join by IP so
+	// cluster bring-up never depends on DNS resolution of the published name.
+	meta := &ClusterMeta{
+		Endpoint:   "https://my-cluster.ap-southeast-2.eks.spx3.net:443",
+		EndpointIP: "203.0.113.9",
+		ResourcesVpcConfig: &ClusterVpcConfig{
+			EndpointPublicAccess:  true,
+			EndpointPrivateAccess: false,
+		},
+	}
+	assert.Equal(t, "https://203.0.113.9:443", clusterJoinEndpoint(meta))
+}
+
+func TestPublishEKSDNS_NoopWhenDisabledOrIncomplete(t *testing.T) {
+	// baseDomain empty → no-op (and must not panic on a nil NATS conn).
+	s := &EKSServiceImpl{}
+	s.publishEKSDNS("acct", &ClusterMeta{EndpointDNSName: "c.r.eks.spx3.net", EndpointIP: "10.0.0.1"}, handlers_dns.ActionDelete)
+	// baseDomain set but no DNS name resolved → still a no-op.
+	s.baseDomain = "spx3.net"
+	s.publishEKSDNS("acct", &ClusterMeta{EndpointIP: "10.0.0.1"}, handlers_dns.ActionUpsert)
 }
 
 func TestEnsurePrivateEndpointSG_AuthorizesVPCCIDROnAPIServerPorts(t *testing.T) {

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/admin"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
+	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/handlers/sysinstance"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -155,6 +156,10 @@ type EKSServiceImpl struct {
 	// launchWG tracks in-flight async create launches for test determinism (WaitLaunches).
 	launchWG sync.WaitGroup
 
+	// baseDomain is the northstar default_domain; "" disables endpoint DNS naming
+	// (the cluster then publishes its bare IP:port endpoint as before).
+	baseDomain string
+
 	// nodegroupReadyTimeout / nodegroupReadyPoll bound how long launchNodegroupInfra
 	// waits for its workers to register Ready before marking the nodegroup
 	// CREATE_FAILED. Tests inject small values.
@@ -189,6 +194,7 @@ func NewEKSServiceImpl(deps EKSServiceDeps) (*EKSServiceImpl, error) {
 		registry:              NewReconcilerRegistry(),
 		bgCtx:                 ctx,
 		bgCancel:              cancel,
+		baseDomain:            handlers_dns.ResolveBaseDomain(deps.Config),
 		nodegroupReadyTimeout: defaultNodegroupReadyTimeout,
 		nodegroupReadyPoll:    defaultNodegroupReadyPoll,
 	}, nil
@@ -582,18 +588,32 @@ func (s *EKSServiceImpl) launchClusterInfra(lc clusterLaunchCtx) {
 		s.failClusterLaunch(acctKV, name, accountID, meta, "ensure cluster NLB", err)
 		return
 	}
-	// Endpoint resolution (301): publish the reachable front-end. With public access
-	// on (public-only or public+private) that is the NLB's public front-end IP. A
-	// private-only cluster publishes its Set A private endpoint instead — the
-	// internal NLB's Set B IP is unreachable from the customer VPC. Either way the
-	// host is a cert SAN, so TLS validates with verification on.
+	// Endpoint resolution (301): resolve the reachable front-end IP. With public
+	// access on (public-only or public+private) that is the NLB's public front-end
+	// IP. A private-only cluster uses its Set A private endpoint instead — the
+	// internal NLB's Set B IP is unreachable from the customer VPC.
 	if publicAccess {
-		meta.Endpoint = "https://" + net.JoinHostPort(nlb.FrontendIP, strconv.FormatInt(clusterNLBListenPort, 10))
 		meta.EndpointIP = nlb.FrontendIP
 	} else {
-		meta.Endpoint = "https://" + net.JoinHostPort(meta.PrivateEndpointIP, strconv.FormatInt(clusterNLBListenPort, 10))
 		meta.EndpointIP = meta.PrivateEndpointIP
 	}
+	// With northstar configured, publish an AWS-shaped DNS endpoint
+	// ({cluster}.{region}.eks.{baseDomain}) that resolves to EndpointIP and is
+	// SANed on the apiserver cert (below), so TLS validates. Without northstar the
+	// bare IP endpoint is published as before. Workers still join by IP
+	// (clusterJoinEndpoint), so cluster bring-up never waits on DNS propagation —
+	// only external SDK/kubectl clients use the name.
+	meta.EndpointDNSName = ""
+	if s.baseDomain != "" {
+		meta.EndpointDNSName = handlers_dns.EKSName(name, region, s.baseDomain)
+	}
+	endpointHost := meta.EndpointIP
+	if meta.EndpointDNSName != "" {
+		endpointHost = meta.EndpointDNSName
+	}
+	meta.Endpoint = "https://" + net.JoinHostPort(endpointHost, strconv.FormatInt(clusterNLBListenPort, 10))
+	// Register the endpoint A record (best-effort; reconcile repairs a miss).
+	s.publishEKSDNS(accountID, meta, handlers_dns.ActionUpsert)
 	meta.NLBArn = nlb.LoadBalancerArn
 	meta.NLBTargetGroupArn = nlb.TargetGroupArn
 	meta.KonnTargetGroupArn = nlb.KonnTargetGroupArn
@@ -646,6 +666,7 @@ func (s *EKSServiceImpl) launchClusterInfra(lc clusterLaunchCtx) {
 		ControlPlaneSGID:  cpSG,
 		NLBDNS:            nlb.DNSName,
 		EndpointIP:        nlb.FrontendIP,
+		EndpointDNS:       meta.EndpointDNSName,
 		PrivateEndpointIP: meta.PrivateEndpointIP,
 		OIDCIssuer:        oidcIssuer,
 		OIDCPrivateKeyPEM: privPEM,
@@ -989,6 +1010,9 @@ func (s *EKSServiceImpl) purgeClusterInfra(accountID, name string, meta *Cluster
 	if err := ZeroizeClusterOIDCKey(acctKV, name); err != nil {
 		teardownErrs = append(teardownErrs, fmt.Errorf("zeroize OIDC key: %w", err))
 	}
+
+	// Withdraw the endpoint A record alongside the NLB teardown (best-effort).
+	s.publishEKSDNS(accountID, meta, handlers_dns.ActionDelete)
 
 	if meta.NLBArn != "" {
 		// Deregister is best-effort: DeleteClusterNLB tears down the whole NLB
@@ -1811,7 +1835,24 @@ func clusterJoinEndpoint(meta *ClusterMeta) string {
 	if meta.ResourcesVpcConfig != nil && meta.ResourcesVpcConfig.EndpointPrivateAccess && meta.PrivateEndpointIP != "" {
 		return "https://" + net.JoinHostPort(meta.PrivateEndpointIP, strconv.FormatInt(clusterNLBListenPort, 10))
 	}
+	// Workers join by IP so cluster bring-up never waits on DNS resolution of the
+	// published endpoint name (EndpointIP is a cert SAN like the DNS name).
+	if meta.EndpointIP != "" {
+		return "https://" + net.JoinHostPort(meta.EndpointIP, strconv.FormatInt(clusterNLBListenPort, 10))
+	}
 	return meta.Endpoint
+}
+
+// publishEKSDNS registers or withdraws the cluster's apiserver endpoint A record
+// ({cluster}.{region}.eks.{baseDomain} → EndpointIP) with the control-plane DNS
+// writer. Best-effort and a no-op when northstar is not configured; the reconcile
+// loop repairs any miss and it never blocks the cluster operation.
+func (s *EKSServiceImpl) publishEKSDNS(accountID string, meta *ClusterMeta, action handlers_dns.Action) {
+	if s.baseDomain == "" || meta == nil || meta.EndpointDNSName == "" {
+		return
+	}
+	changes := handlers_dns.EKSChanges(action, meta.EndpointDNSName, s.baseDomain, meta.EndpointIP)
+	handlers_dns.PublishChangesBestEffort(s.deps.NATSConn, accountID, changes)
 }
 
 func (s *EKSServiceImpl) markFailed(kv nats.KeyValue, name string) {

--- a/spinifex/handlers/elbv2/dns_register_test.go
+++ b/spinifex/handlers/elbv2/dns_register_test.go
@@ -1,0 +1,47 @@
+package handlers_elbv2
+
+import (
+	"testing"
+
+	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLBFrontendIP(t *testing.T) {
+	// internet-facing → the AZ-0 public IP.
+	inet := &LoadBalancerRecord{
+		Scheme:     SchemeInternetFacing,
+		VPCIP:      "10.0.0.5",
+		AvailZones: []AvailZoneInfo{{PublicIP: "203.0.113.7"}},
+	}
+	assert.Equal(t, "203.0.113.7", lbFrontendIP(inet))
+
+	// internet-facing before the public IP is allocated → VPC IP fallback.
+	inetNoPub := &LoadBalancerRecord{
+		Scheme:     SchemeInternetFacing,
+		VPCIP:      "10.0.0.5",
+		AvailZones: []AvailZoneInfo{{}},
+	}
+	assert.Equal(t, "10.0.0.5", lbFrontendIP(inetNoPub))
+
+	// internal → VPC IP even if a public IP is somehow present.
+	internal := &LoadBalancerRecord{
+		Scheme:     SchemeInternal,
+		VPCIP:      "10.0.0.9",
+		AvailZones: []AvailZoneInfo{{PublicIP: "203.0.113.7"}},
+	}
+	assert.Equal(t, "10.0.0.9", lbFrontendIP(internal))
+}
+
+func TestPublishLBDNS_NoopWhenDisabled(t *testing.T) {
+	rec := &LoadBalancerRecord{
+		Scheme:    SchemeInternal,
+		DNSName:   "internal-web-abc.ap-southeast-2.elb.spx3.net",
+		VPCIP:     "10.0.0.1",
+		AccountID: "000000000000",
+	}
+	// No base domain → no-op; must not panic on the nil NATS connection.
+	(&ELBv2ServiceImpl{}).publishLBDNS(rec, handlers_dns.ActionUpsert)
+	// Base domain set but nil NATS conn → PublishChangesBestEffort tolerates it.
+	(&ELBv2ServiceImpl{dnsBaseDomain: "spx3.net"}).publishLBDNS(rec, handlers_dns.ActionDelete)
+}

--- a/spinifex/handlers/elbv2/service_impl.go
+++ b/spinifex/handlers/elbv2/service_impl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	handlers_acm "github.com/mulgadc/spinifex/spinifex/handlers/acm"
+	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
@@ -111,6 +112,7 @@ type ELBv2ServiceImpl struct {
 	CACert                     string // PEM-encoded CA certificate delivered to microvm guests via fw_cfg
 	nodeID                     string
 	region                     string
+	dnsBaseDomain              string        // northstar default_domain; "" disables DNS registration (falls back to spinifex.local naming)
 	systemInstanceType         string        // instance type for system VMs; resolved lazily via systemInstanceTypeFunc
 	systemInstanceTypeFunc     func() string // returns the smallest available instance type
 	systemInstanceTypeMu       sync.Mutex    // guards lazy resolution of systemInstanceType
@@ -159,15 +161,16 @@ func NewELBv2ServiceImplWithNATS(cfg *config.Config, nc *nats.Conn) (*ELBv2Servi
 	hc := newHealthChecker(store)
 
 	return &ELBv2ServiceImpl{
-		config:   cfg,
-		store:    store,
-		acmStore: acmStore,
-		nc:       nc,
-		nodeID:   nodeID,
-		region:   region,
-		ctx:      ctx,
-		cancel:   cancel,
-		hc:       hc,
+		config:        cfg,
+		store:         store,
+		acmStore:      acmStore,
+		nc:            nc,
+		nodeID:        nodeID,
+		region:        region,
+		dnsBaseDomain: handlers_dns.ResolveBaseDomain(cfg),
+		ctx:           ctx,
+		cancel:        cancel,
+		hc:            hc,
 	}, nil
 }
 
@@ -1139,7 +1142,13 @@ func (s *ELBv2ServiceImpl) createLoadBalancer(input *elbv2.CreateLoadBalancerInp
 	if scheme == SchemeInternal {
 		dnsPrefix = "internal-"
 	}
-	dnsName := fmt.Sprintf("%s%s-%s.%s.elb.spinifex.local", dnsPrefix, name, lbID, s.region)
+	// Under the northstar base domain when configured so the DNSName actually
+	// resolves; otherwise the legacy spinifex.local suffix (not northstar-served).
+	elbZone := s.dnsBaseDomain
+	if elbZone == "" {
+		elbZone = "spinifex.local"
+	}
+	dnsName := handlers_dns.ELBName(dnsPrefix, name, lbID, s.region, elbZone)
 
 	// Atomically claim the name before ENI/VM work. SDK retries lose the claim;
 	// orphaned claims from crashed creates are reclaimed. Every failure releases it.
@@ -1369,7 +1378,30 @@ func (s *ELBv2ServiceImpl) provisionLBDataPlane(lc lbLaunchCtx) error {
 	if putErr := s.store.PutLoadBalancer(record); putErr != nil {
 		return fmt.Errorf("persist launch result for %s: %w", lc.lbArn, putErr)
 	}
+	// Register the frontend A record now that the serving IP is allocated.
+	s.publishLBDNS(record, handlers_dns.ActionUpsert)
 	return nil
+}
+
+// lbFrontendIP is the address the load balancer's DNS name should resolve to:
+// the public IP for an internet-facing LB, the VPC IP for an internal one.
+func lbFrontendIP(r *LoadBalancerRecord) string {
+	if r.Scheme != SchemeInternal && len(r.AvailZones) > 0 && r.AvailZones[0].PublicIP != "" {
+		return r.AvailZones[0].PublicIP
+	}
+	return r.VPCIP
+}
+
+// publishLBDNS registers or withdraws the load balancer's frontend A record with
+// the control-plane DNS writer. Best-effort and a no-op when northstar is not
+// configured or no frontend IP has been allocated; the reconcile loop repairs
+// any miss and never blocks the LB operation.
+func (s *ELBv2ServiceImpl) publishLBDNS(record *LoadBalancerRecord, action handlers_dns.Action) {
+	if s.dnsBaseDomain == "" || record == nil {
+		return
+	}
+	changes := handlers_dns.ELBChanges(action, record.DNSName, s.dnsBaseDomain, lbFrontendIP(record))
+	handlers_dns.PublishChangesBestEffort(s.nc, record.AccountID, changes)
 }
 
 // launchLBVMAsync runs provisionLBDataPlane on the background goroutine spawned
@@ -1474,6 +1506,9 @@ func (s *ELBv2ServiceImpl) DeleteLoadBalancer(input *elbv2.DeleteLoadBalancerInp
 	// Release the name claim so the name is reusable. Idempotent on a missing
 	// key, so a delete that races the record removal still converges.
 	s.releaseLBNameClaim(lb.Name, accountID)
+
+	// Withdraw the frontend A record (best-effort; reconcile repairs a miss).
+	s.publishLBDNS(lb, handlers_dns.ActionDelete)
 
 	slog.Info("DeleteLoadBalancer completed", "lbArn", *input.LoadBalancerArn, "enis", len(lb.ENIs), "accountID", accountID)
 

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,6 +60,7 @@ func TestEKS(t *testing.T) {
 		ca, err := base64.StdEncoding.DecodeString(aws.StringValue(cl.CertificateAuthority.Data))
 		require.NoError(t, err, "certificateAuthority.data must be base64")
 		assert.Contains(t, string(ca), "BEGIN CERTIFICATE", "CA data must be a PEM cert")
+		assertEKSEndpointResolves(t, aws.StringValue(cl.Endpoint))
 		fx.Cluster = cl
 	})
 
@@ -930,6 +933,35 @@ func deleteClusterBestEffort(t *testing.T, c *harness.AWSClient, fx *clusterFixt
 }
 
 // --- kubeconfig artifact --------------------------------------------------
+
+// assertEKSEndpointResolves confirms the DescribeCluster endpoint is an
+// AWS-shaped DNS name that resolves through the host resolver (the path a
+// kubectl/AWS SDK client uses), matching real EKS. Skipped when northstar is not
+// configured and the endpoint is still a bare IP. Retries because the endpoint A
+// record is published asynchronously by the control-plane writer.
+func assertEKSEndpointResolves(t *testing.T, endpoint string) {
+	t.Helper()
+	require.NotEmpty(t, endpoint, "cluster endpoint must be set")
+	u, err := url.Parse(endpoint)
+	require.NoErrorf(t, err, "parse cluster endpoint %q", endpoint)
+	host := u.Hostname()
+	if net.ParseIP(host) != nil {
+		t.Logf("endpoint %q is a bare IP — DNS registration off, skipping resolution check", endpoint)
+		return
+	}
+	deadline := time.Now().Add(90 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if addrs, lerr := net.LookupHost(host); lerr == nil && len(addrs) > 0 {
+			t.Logf("EKS endpoint %s resolved to %v (northstar path)", host, addrs)
+			return
+		} else {
+			lastErr = lerr
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("EKS endpoint host %q never resolved within 90s (last err=%v) — northstar did not serve the A record", host, lastErr)
+}
 
 // writeKubeconfig builds a kubeconfig from DescribeCluster output and writes it to the artifact
 // dir. Avoids shelling to `aws eks update-kubeconfig` so the structure assertion is hermetic.

--- a/tests/e2e/lb/lb_test.go
+++ b/tests/e2e/lb/lb_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -523,6 +524,7 @@ func runLBSuite(t *testing.T, c *harness.AWSClient, f *sharedFixture, kind lbKin
 	if scheme == "internet-facing" {
 		ip := publicIP(eni)
 		require.NotEmpty(t, ip, label+" needs public IP")
+		assertLBDNSResolves(t, lb.DNSName, ip, label)
 		runInternetFacingTrafficSingle(t, kind, ssh, peer, ip)
 		if kind == kindNLB {
 			runNLBDeregisterDraining(t, c, tgArn, f.AppInstanceIDs[0])
@@ -535,6 +537,7 @@ func runLBSuite(t *testing.T, c *harness.AWSClient, f *sharedFixture, kind lbKin
 	priv := privateIP(eni)
 	require.NotEmpty(t, priv, label+" needs private IP")
 	assertInternalDNS(t, c, lb.ARN, label)
+	assertLBDNSResolves(t, lb.DNSName, priv, label)
 	runInternalTrafficViaClient(t, c, f, kind, priv)
 }
 
@@ -830,7 +833,7 @@ func deregisterTargets(t *testing.T, c *harness.AWSClient, tgArn string, instanc
 }
 
 type lbInfo struct {
-	ARN, ID, Scheme, Type string
+	ARN, ID, Scheme, Type, DNSName string
 }
 
 func createLB(t *testing.T, c *harness.AWSClient, f *sharedFixture, name, lbType, scheme string) lbInfo {
@@ -850,12 +853,13 @@ func createLB(t *testing.T, c *harness.AWSClient, f *sharedFixture, name, lbType
 	arn := aws.StringValue(lb.LoadBalancerArn)
 	parts := strings.Split(arn, "/")
 	info := lbInfo{
-		ARN:    arn,
-		ID:     parts[len(parts)-1],
-		Scheme: aws.StringValue(lb.Scheme),
-		Type:   aws.StringValue(lb.Type),
+		ARN:     arn,
+		ID:      parts[len(parts)-1],
+		Scheme:  aws.StringValue(lb.Scheme),
+		Type:    aws.StringValue(lb.Type),
+		DNSName: aws.StringValue(lb.DNSName),
 	}
-	t.Logf("LB %s: %s (scheme=%s type=%s)", name, info.ARN, info.Scheme, info.Type)
+	t.Logf("LB %s: %s (scheme=%s type=%s dns=%s)", name, info.ARN, info.Scheme, info.Type, info.DNSName)
 	return info
 }
 
@@ -1465,6 +1469,36 @@ func assertInternalDNS(t *testing.T, c *harness.AWSClient, lbArn, label string) 
 	require.NotEmpty(t, out.LoadBalancers)
 	dns := aws.StringValue(out.LoadBalancers[0].DNSName)
 	assert.True(t, strings.HasPrefix(dns, "internal-"), "%s internal DNS missing internal- prefix: %s", label, dns)
+}
+
+// assertLBDNSResolves confirms the SDK-returned DNSName resolves to the LB's
+// frontend IP through the host resolver (the same path an AWS SDK/CLI client
+// uses). Skipped when northstar is not configured (legacy .spinifex.local
+// naming, which northstar does not serve). Retries because the control-plane
+// writer publishes the record asynchronously (best-effort + reconcile).
+func assertLBDNSResolves(t *testing.T, dnsName, wantIP, label string) {
+	t.Helper()
+	if dnsName == "" || strings.HasSuffix(dnsName, ".spinifex.local") {
+		t.Logf("%s: DNS registration off (dns=%q) — skipping resolution check", label, dnsName)
+		return
+	}
+	harness.Step(t, "resolve LB DNS %s → %s (northstar path)", dnsName, wantIP)
+	deadline := time.Now().Add(90 * time.Second)
+	var last []string
+	for time.Now().Before(deadline) {
+		addrs, err := net.LookupHost(dnsName)
+		if err == nil {
+			last = addrs
+			for _, a := range addrs {
+				if a == wantIP {
+					return
+				}
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("%s: LB DNS %q never resolved to frontend IP %s within 90s (last=%v) — northstar did not serve the A record",
+		label, dnsName, wantIP, last)
 }
 
 // --- Internet-facing traffic ---------------------------------------------


### PR DESCRIPTION
## Summary

Adds AWS-parity, resolvable DNS names for load balancers and EKS clusters, matching what AWS returns via the SDK/CLI. Everything is gated on northstar being configured (`ResolveBaseDomain(cfg)`), so legacy behavior is preserved when DNS is off.

- **ELB/NLB**: `{name}-{lbID}.{region}.elb.{base}` — published on data-plane provision, withdrawn on delete. DNSName moves under the northstar-served zone (falls back to `spinifex.local` when northstar is off).
- **EKS**: `{cluster}.{region}.eks.{base}` → apiserver endpoint IP — published on cluster create, withdrawn on teardown. The DNS name is returned as the cluster endpoint via the SDK/CLI.

Records are published best-effort to the control-plane DNS writer (`dns.recordset.change`), consistent with the existing EC2 path.

## EKS join safety

Worker joins stay on the endpoint **IP** (`clusterJoinEndpoint`), so cluster bring-up never depends on DNS resolution of the published name. The DNS name is added to the k3s apiserver cert SANs (`tls-san` + konnectivity) so TLS validates for `kubectl`/SDK clients that use the name.

## Tests

- Unit: `ELBName`/`ELBChanges`, `EKSName`/`EKSChanges`, `lbFrontendIP`, no-op-when-disabled guards for both publishers, and `clusterJoinEndpoint` joins-by-IP.
- E2E: `tests/e2e/lb` and `tests/e2e/eks` now assert the generated hostnames resolve to the expected frontend/endpoint IPs (retry loop, skips the `spinifex.local` fallback), mirroring the existing EC2 guest-DNS resolution test.

`make preflight` passes.