### PR TITLE
fix(ci): upload full tofu apply/destroy log as an artifact after teardown

### DIFF
--- a/.github/workflows/e2e-ddil.yml
+++ b/.github/workflows/e2e-ddil.yml
@@ -208,3 +208,12 @@ jobs:
           quiet_run "tofu destroy"          "$TOFU_LOG" tofu destroy -var-file=envs/${SPINIFEX_CI_ENV}.tfvars -auto-approve -input=false
           quiet_run "scrub-env"             "$TOFU_LOG" ./scrub-env.sh "${SPINIFEX_CI_ENV}" || true
           ok "teardown complete"
+
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-ddil-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -348,6 +348,15 @@ jobs:
           tofu destroy -var-file=envs/${SPINIFEX_CI_ENV}.tfvars ${TOFU_VAR_ARGS} -auto-approve -input=false >> "$TOFU_LOG" 2>&1
           ./scrub-env.sh "${SPINIFEX_CI_ENV}" >> "$TOFU_LOG" 2>&1 || true
 
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-cell-${{ matrix.cell }}-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 14
+
   # Bare-metal single-node suite. Doesn't fit the tofu matrix shape, so it
   # runs as a sibling job via the reusable e2e-baremetal workflow. Gated like a
   # matrix cell ("cell 20"): every weeknight cron, or dispatch with 20 selected

--- a/.github/workflows/e2e-suites.yml
+++ b/.github/workflows/e2e-suites.yml
@@ -267,6 +267,15 @@ jobs:
             "$VM":/tmp/start-net-capture.sh
           ssh "${SSH_OPTS[@]}" "$VM" "bash /tmp/start-net-capture.sh" || true
 
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-single-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 14
+
   single_suite:
     name: Single env · suite
     needs: single_provision
@@ -467,6 +476,15 @@ jobs:
           quiet_run "scrub-env"             "$TOFU_LOG" ./scrub-env.sh "${SPINIFEX_CI_ENV}"
           ok "teardown complete"
 
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-single-td-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 14
+
   # ---------------------------------------------------------------------------
   # Multinode env
   # ---------------------------------------------------------------------------
@@ -616,6 +634,15 @@ jobs:
               tf-user@"$ip":/tmp/start-net-capture.sh
             ssh "${SSH_OPTS[@]}" tf-user@"$ip" "bash /tmp/start-net-capture.sh" || true
           done
+
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-multi-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 14
 
   multi_suite:
     name: Multi env · suite
@@ -788,6 +815,15 @@ jobs:
           quiet_run "tofu destroy"          "$TOFU_LOG" timeout 600 tofu destroy -var-file=envs/${SPINIFEX_CI_ENV}.tfvars -auto-approve -input=false
           quiet_run "scrub-env"             "$TOFU_LOG" ./scrub-env.sh "${SPINIFEX_CI_ENV}"
           ok "teardown complete"
+
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-multi-td-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 14
 
   e2e_suites_status:
     name: E2E suite blocks · summary

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -466,6 +466,15 @@ jobs:
           quiet_run "scrub-env"             "$TOFU_LOG" ./scrub-env.sh "${SPINIFEX_CI_ENV}"
           ok "teardown complete"
 
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-single-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Fail job if any suite failed
         if: always()
         run: |
@@ -880,6 +889,15 @@ jobs:
           quiet_run "tofu destroy"          "$TOFU_LOG" timeout 600 tofu destroy -var-file=envs/${SPINIFEX_CI_ENV}.tfvars -auto-approve -input=false
           quiet_run "scrub-env"             "$TOFU_LOG" ./scrub-env.sh "${SPINIFEX_CI_ENV}"
           ok "teardown complete"
+
+      - name: Upload tofu log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tofu-log-multi-${{ github.run_id }}
+          path: ${{ env.TOFU_LOG }}
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Fail job if any suite failed
         if: always()


### PR DESCRIPTION
## Summary

- Every tofu-based e2e workflow (`e2e.yml`, `e2e-suites.yml`, `e2e-nightly.yml`, `e2e-ddil.yml`) sets `TOFU_LOG` to a `/tmp` path outside `ARTIFACT_DIR`. The `ci-fmt.sh` `quiet_run` helper appends all `tofu init/apply/destroy` output to that file and only tails the last 80 lines to the live log on failure.
- The `Teardown` step (which runs `tofu destroy`, also appended to the same `$TOFU_LOG`) always ran *after* the existing `actions/upload-artifact` step, so the full apply+destroy log — including destroy-time failures — was silently lost on every run.
- Adds a new `if: always()` `actions/upload-artifact@v7` step positioned after `Teardown` in each affected job, uploading `$TOFU_LOG` directly. Since `quiet_run` appends both apply and destroy output to one file, a single upload after `Teardown` now captures everything.
- Existing pre-teardown bundle upload steps are unchanged.

Jobs touched:
- `e2e.yml`: `e2e_single`, `e2e_multi`
- `e2e-suites.yml`: `single_provision`, `single_teardown`, `multi_provision`, `multi_teardown`
- `e2e-nightly.yml`: `matrix` (per-cell, artifact name includes `matrix.cell`)
- `e2e-ddil.yml`: `ddil`

Shipping this log to Elasticsearch/OTLP is explicitly out of scope here and deferred to mulga-5n7fe, which will consume this new artifact.

## Test plan
- [x] `python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" ...` — all four files parse cleanly (exit 0)
- [ ] `actionlint` not available on this machine, skipped
- [x] Manual grep confirms one new `if: always()` upload step per job with a `TOFU_LOG`, correct `${{ env.TOFU_LOG }}` reference, and unique artifact names within each file
- [ ] Verify on next scheduled/dispatched run that the `tofu-log-*` artifacts appear even when destroy fails