### PR TITLE
feat(spx): surface OVN NB/SB Raft roles in get nodes

### DIFF
--- a/cmd/spinifex/cmd/get.go
+++ b/cmd/spinifex/cmd/get.go
@@ -138,6 +138,12 @@ func formatRoles(resp types.NodeStatusResponse) string {
 	if resp.NATSRole != "" {
 		roles = append(roles, "nats:"+resp.NATSRole)
 	}
+	if resp.OVNNBRole != "" {
+		roles = append(roles, "ovn-nb:"+resp.OVNNBRole)
+	}
+	if resp.OVNSBRole != "" {
+		roles = append(roles, "ovn-sb:"+resp.OVNSBRole)
+	}
 	if resp.PredastoreRole != "" {
 		roles = append(roles, "predastore:"+resp.PredastoreRole)
 	}

--- a/cmd/spinifex/cmd/get_test.go
+++ b/cmd/spinifex/cmd/get_test.go
@@ -38,6 +38,26 @@ func TestFormatRoles(t *testing.T) {
 			resp: types.NodeStatusResponse{NATSRole: "leader", PredastoreRole: "leader"},
 			want: "nats:leader,predastore:leader",
 		},
+		{
+			name: "ovn roles only",
+			resp: types.NodeStatusResponse{OVNNBRole: "leader", OVNSBRole: "follower"},
+			want: "ovn-nb:leader,ovn-sb:follower",
+		},
+		{
+			name: "all four roles ordered",
+			resp: types.NodeStatusResponse{
+				NATSRole:       "leader",
+				OVNNBRole:      "leader",
+				OVNSBRole:      "follower",
+				PredastoreRole: "follower",
+			},
+			want: "nats:leader,ovn-nb:leader,ovn-sb:follower,predastore:follower",
+		},
+		{
+			name: "ovn-nb leader with nats, sb absent",
+			resp: types.NodeStatusResponse{NATSRole: "follower", OVNNBRole: "leader"},
+			want: "nats:follower,ovn-nb:leader",
+		},
 	}
 
 	for _, tt := range tests {

--- a/spinifex/daemon/daemon_handlers.go
+++ b/spinifex/daemon/daemon_handlers.go
@@ -312,19 +312,17 @@ func (d *Daemon) handleNodeStatus(msg *nats.Msg) {
 	}
 
 	// Query service roles concurrently to keep worst-case latency bounded.
-	ovnDBMember := d.isOVNDBQuorumMember()
+	// OVN roles are probed only on DB quorum members; compute-only nodes skip
+	// the shell-out entirely.
 	var wg sync.WaitGroup
-	wg.Add(4)
+	wg.Add(2)
 	go func() { defer wg.Done(); resp.NATSRole = d.queryNATSRole() }()
 	go func() { defer wg.Done(); resp.PredastoreRole = d.queryPredastoreRole() }()
-	go func() {
-		defer wg.Done()
-		resp.OVNNBRole = queryOVNRole(ovnDBMember, host.OVNNBTarget, host.OVNNBSchema)
-	}()
-	go func() {
-		defer wg.Done()
-		resp.OVNSBRole = queryOVNRole(ovnDBMember, host.OVNSBTarget, host.OVNSBSchema)
-	}()
+	if d.isOVNDBQuorumMember() {
+		wg.Add(2)
+		go func() { defer wg.Done(); resp.OVNNBRole = host.OVNDBRole(host.OVNNBTarget, host.OVNNBSchema) }()
+		go func() { defer wg.Done(); resp.OVNSBRole = host.OVNDBRole(host.OVNSBTarget, host.OVNSBSchema) }()
+	}
 	wg.Wait()
 
 	respondWithJSON(msg, resp)
@@ -367,16 +365,6 @@ func (d *Daemon) isOVNDBQuorumMember() bool {
 	}
 	names := slices.Collect(maps.Keys(d.clusterConfig.Nodes))
 	return slices.Contains(formation.OVNDBQuorumNames(names), d.node)
-}
-
-// queryOVNRole returns this node's OVN DB Raft role for the given ctl target and
-// schema, or "" when the node is not an OVN DB cluster member. A standalone OVN
-// or any appctl error fails soft to "".
-func queryOVNRole(dbMember bool, target, schema string) string {
-	if !dbMember {
-		return ""
-	}
-	return host.OVNDBRole(target, schema)
 }
 
 var roleHTTPClient = &http.Client{Timeout: 500 * time.Millisecond}

--- a/spinifex/daemon/daemon_handlers.go
+++ b/spinifex/daemon/daemon_handlers.go
@@ -366,7 +366,7 @@ func (d *Daemon) isOVNDBQuorumMember() bool {
 		return false
 	}
 	names := slices.Collect(maps.Keys(d.clusterConfig.Nodes))
-	return formation.IsOVNDBQuorumMember(names, d.node)
+	return slices.Contains(formation.OVNDBQuorumNames(names), d.node)
 }
 
 // queryOVNRole returns this node's OVN DB Raft role for the given ctl target and

--- a/spinifex/daemon/daemon_handlers.go
+++ b/spinifex/daemon/daemon_handlers.go
@@ -6,14 +6,18 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/formation"
 	"github.com/mulgadc/spinifex/spinifex/gpu"
+	"github.com/mulgadc/spinifex/spinifex/network/host"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/mulgadc/spinifex/spinifex/vm"
@@ -307,11 +311,20 @@ func (d *Daemon) handleNodeStatus(msg *nats.Msg) {
 		InstanceTypes:  caps,
 	}
 
-	// Query service roles concurrently to halve worst-case latency (500ms vs 1s).
+	// Query service roles concurrently to keep worst-case latency bounded.
+	ovnDBMember := d.isOVNDBQuorumMember()
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(4)
 	go func() { defer wg.Done(); resp.NATSRole = d.queryNATSRole() }()
 	go func() { defer wg.Done(); resp.PredastoreRole = d.queryPredastoreRole() }()
+	go func() {
+		defer wg.Done()
+		resp.OVNNBRole = queryOVNRole(ovnDBMember, host.OVNNBTarget, host.OVNNBSchema)
+	}()
+	go func() {
+		defer wg.Done()
+		resp.OVNSBRole = queryOVNRole(ovnDBMember, host.OVNSBTarget, host.OVNSBSchema)
+	}()
 	wg.Wait()
 
 	respondWithJSON(msg, resp)
@@ -343,6 +356,27 @@ func (d *Daemon) queryPredastoreRole() string {
 	}
 	url := "https://" + net.JoinHostPort(d.daemonIP(), strconv.Itoa(predastoreDBPort)) + "/status"
 	return fetchPredastoreRole(url, roleTLSHTTPClient)
+}
+
+// isOVNDBQuorumMember reports whether this node hosts the clustered OVN NB/SB
+// databases. Compute-only nodes short-circuit OVN role probes to "" without
+// shelling out to ovn-appctl.
+func (d *Daemon) isOVNDBQuorumMember() bool {
+	if d.clusterConfig == nil {
+		return false
+	}
+	names := slices.Collect(maps.Keys(d.clusterConfig.Nodes))
+	return formation.IsOVNDBQuorumMember(names, d.node)
+}
+
+// queryOVNRole returns this node's OVN DB Raft role for the given ctl target and
+// schema, or "" when the node is not an OVN DB cluster member. A standalone OVN
+// or any appctl error fails soft to "".
+func queryOVNRole(dbMember bool, target, schema string) string {
+	if !dbMember {
+		return ""
+	}
+	return host.OVNDBRole(target, schema)
 }
 
 var roleHTTPClient = &http.Client{Timeout: 500 * time.Millisecond}

--- a/spinifex/formation/helpers.go
+++ b/spinifex/formation/helpers.go
@@ -88,6 +88,17 @@ func BuildOVNDBAddrs(nodes map[string]NodeInfo) (nbAddr, sbAddr string) {
 	return strings.Join(nb, ","), strings.Join(sb, ",")
 }
 
+// IsOVNDBQuorumMember reports whether the named node hosts the clustered OVN
+// NB/SB databases: the RAFT quorum is the first ovnDBQuorum node names (sorted).
+// Every other node is OVN compute-only and does not run the DB servers.
+func IsOVNDBQuorumMember(nodeNames []string, name string) bool {
+	sorted := slices.Sorted(slices.Values(nodeNames))
+	if len(sorted) > ovnDBQuorum {
+		sorted = sorted[:ovnDBQuorum]
+	}
+	return slices.Contains(sorted, name)
+}
+
 // sortedNodes returns nodes sorted by name.
 func sortedNodes(nodes map[string]NodeInfo) []NodeInfo {
 	names := slices.Sorted(maps.Keys(nodes))

--- a/spinifex/formation/helpers.go
+++ b/spinifex/formation/helpers.go
@@ -70,33 +70,34 @@ func BuildPredastoreNodes(nodes map[string]NodeInfo) []admin.PredastoreNodeConfi
 	return out
 }
 
+// OVNDBQuorumNames returns the sorted names of the nodes that host the
+// clustered OVN NB/SB databases: the first ovnDBQuorum names (sorted). Every
+// other node is OVN compute-only and does not run the DB servers. Endpoint
+// construction (BuildOVNDBAddrs) and role probing both route through this so
+// they can never disagree on membership; callers test membership with
+// slices.Contains.
+func OVNDBQuorumNames(nodeNames []string) []string {
+	sorted := slices.Sorted(slices.Values(nodeNames))
+	if len(sorted) > ovnDBQuorum {
+		sorted = sorted[:ovnDBQuorum]
+	}
+	return sorted
+}
+
 // BuildOVNDBAddrs returns comma-separated OVN NB and SB endpoint lists for the
 // RAFT quorum nodes (first ovnDBQuorum by sorted name). Every node — quorum and
 // compute alike — points its OVN client at the full list so libovsdb fails over
 // across the cluster. BindIP is the cross-node dial address.
 func BuildOVNDBAddrs(nodes map[string]NodeInfo) (nbAddr, sbAddr string) {
-	sorted := sortedNodes(nodes)
-	if len(sorted) > ovnDBQuorum {
-		sorted = sorted[:ovnDBQuorum]
-	}
-	nb := make([]string, len(sorted))
-	sb := make([]string, len(sorted))
-	for i, n := range sorted {
+	members := OVNDBQuorumNames(slices.Collect(maps.Keys(nodes)))
+	nb := make([]string, len(members))
+	sb := make([]string, len(members))
+	for i, name := range members {
+		n := nodes[name]
 		nb[i] = fmt.Sprintf("tcp:%s:%d", n.BindIP, ovnNBPort)
 		sb[i] = fmt.Sprintf("tcp:%s:%d", n.BindIP, ovnSBPort)
 	}
 	return strings.Join(nb, ","), strings.Join(sb, ",")
-}
-
-// IsOVNDBQuorumMember reports whether the named node hosts the clustered OVN
-// NB/SB databases: the RAFT quorum is the first ovnDBQuorum node names (sorted).
-// Every other node is OVN compute-only and does not run the DB servers.
-func IsOVNDBQuorumMember(nodeNames []string, name string) bool {
-	sorted := slices.Sorted(slices.Values(nodeNames))
-	if len(sorted) > ovnDBQuorum {
-		sorted = sorted[:ovnDBQuorum]
-	}
-	return slices.Contains(sorted, name)
 }
 
 // sortedNodes returns nodes sorted by name.

--- a/spinifex/formation/helpers_test.go
+++ b/spinifex/formation/helpers_test.go
@@ -99,6 +99,23 @@ func TestBuildOVNDBAddrs_FewerThanQuorum(t *testing.T) {
 	assert.Equal(t, "tcp:10.0.0.1:6642,tcp:10.0.0.2:6642", sb)
 }
 
+func TestIsOVNDBQuorumMember(t *testing.T) {
+	t.Parallel()
+	names := []string{"node4", "node1", "node3", "node2", "node5"}
+	// Quorum = first ovnDBQuorum sorted names: node1, node2, node3.
+	assert.True(t, IsOVNDBQuorumMember(names, "node1"))
+	assert.True(t, IsOVNDBQuorumMember(names, "node3"))
+	assert.False(t, IsOVNDBQuorumMember(names, "node4"))
+	assert.False(t, IsOVNDBQuorumMember(names, "node5"))
+	assert.False(t, IsOVNDBQuorumMember(names, "absent"))
+
+	// Fewer than quorum: every node is a member.
+	small := []string{"a", "b"}
+	assert.True(t, IsOVNDBQuorumMember(small, "a"))
+	assert.True(t, IsOVNDBQuorumMember(small, "b"))
+	assert.False(t, IsOVNDBQuorumMember(nil, "a"))
+}
+
 func TestBuildClusterRoutes_MixedServicesAndEmpty(t *testing.T) {
 	t.Parallel()
 	nodes := map[string]NodeInfo{

--- a/spinifex/formation/helpers_test.go
+++ b/spinifex/formation/helpers_test.go
@@ -99,21 +99,15 @@ func TestBuildOVNDBAddrs_FewerThanQuorum(t *testing.T) {
 	assert.Equal(t, "tcp:10.0.0.1:6642,tcp:10.0.0.2:6642", sb)
 }
 
-func TestIsOVNDBQuorumMember(t *testing.T) {
+func TestOVNDBQuorumNames(t *testing.T) {
 	t.Parallel()
 	names := []string{"node4", "node1", "node3", "node2", "node5"}
 	// Quorum = first ovnDBQuorum sorted names: node1, node2, node3.
-	assert.True(t, IsOVNDBQuorumMember(names, "node1"))
-	assert.True(t, IsOVNDBQuorumMember(names, "node3"))
-	assert.False(t, IsOVNDBQuorumMember(names, "node4"))
-	assert.False(t, IsOVNDBQuorumMember(names, "node5"))
-	assert.False(t, IsOVNDBQuorumMember(names, "absent"))
+	assert.Equal(t, []string{"node1", "node2", "node3"}, OVNDBQuorumNames(names))
 
-	// Fewer than quorum: every node is a member.
-	small := []string{"a", "b"}
-	assert.True(t, IsOVNDBQuorumMember(small, "a"))
-	assert.True(t, IsOVNDBQuorumMember(small, "b"))
-	assert.False(t, IsOVNDBQuorumMember(nil, "a"))
+	// Fewer than quorum: every node is a member, still sorted.
+	assert.Equal(t, []string{"a", "b"}, OVNDBQuorumNames([]string{"b", "a"}))
+	assert.Empty(t, OVNDBQuorumNames(nil))
 }
 
 func TestBuildClusterRoutes_MixedServicesAndEmpty(t *testing.T) {

--- a/spinifex/network/host/ovn_raft.go
+++ b/spinifex/network/host/ovn_raft.go
@@ -2,9 +2,7 @@ package host
 
 import (
 	"context"
-	"errors"
 	"log/slog"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -28,29 +26,18 @@ const ovnAppctlTimeout = 500 * time.Millisecond
 
 // OVNDBRole reports this node's OVSDB Raft role for the given ctl target and
 // schema: "leader", "follower", or "" when OVN is standalone or unreachable.
-// Callers gate this on quorum membership, so an appctl error means a DB that
-// should be reachable is not — logged at Warn rather than silently dropped.
+// A standalone (non-clustered) DB or any appctl error fails soft to "" at Debug,
+// matching the NATS/Predastore role probes.
 func OVNDBRole(target, schema string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), ovnAppctlTimeout)
 	defer cancel()
 	out, err := utils.SudoCommandContext(ctx, "ovn-appctl", "-t", target, "cluster/status", schema).Output()
 	if err != nil {
-		slog.Warn("Failed to query OVN cluster/status on a quorum member",
-			"schema", schema, "target", target, "err", err, "stderr", commandStderr(err))
+		slog.Debug("Failed to query OVN cluster/status", "schema", schema, "err", err)
 		return ""
 	}
 	_, role := ParseClusterStatus(string(out))
 	return role
-}
-
-// commandStderr returns the subprocess stderr captured by exec.Cmd.Output for an
-// ExitError; err.Error() alone reports only the exit code.
-func commandStderr(err error) string {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return strings.TrimSpace(string(exitErr.Stderr))
-	}
-	return ""
 }
 
 // ParseClusterStatus extracts the quorum size and this server's role from ovs

--- a/spinifex/network/host/ovn_raft.go
+++ b/spinifex/network/host/ovn_raft.go
@@ -1,8 +1,12 @@
 package host
 
 import (
+	"context"
+	"errors"
 	"log/slog"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/utils"
 )
@@ -17,17 +21,36 @@ const (
 	OVNSBSchema = "OVN_Southbound"
 )
 
+// ovnAppctlTimeout bounds the cluster/status shell-out so a wedged ovsdb-server
+// cannot stall the node-status handler, matching the 500ms budget of the
+// sibling NATS/Predastore role probes.
+const ovnAppctlTimeout = 500 * time.Millisecond
+
 // OVNDBRole reports this node's OVSDB Raft role for the given ctl target and
 // schema: "leader", "follower", or "" when OVN is standalone or unreachable.
-// A standalone (non-clustered) DB or any appctl error fails soft to "".
+// Callers gate this on quorum membership, so an appctl error means a DB that
+// should be reachable is not — logged at Warn rather than silently dropped.
 func OVNDBRole(target, schema string) string {
-	out, err := utils.SudoCommand("ovn-appctl", "-t", target, "cluster/status", schema).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), ovnAppctlTimeout)
+	defer cancel()
+	out, err := utils.SudoCommandContext(ctx, "ovn-appctl", "-t", target, "cluster/status", schema).Output()
 	if err != nil {
-		slog.Debug("Failed to query OVN cluster/status", "schema", schema, "err", err)
+		slog.Warn("Failed to query OVN cluster/status on a quorum member",
+			"schema", schema, "target", target, "err", err, "stderr", commandStderr(err))
 		return ""
 	}
 	_, role := ParseClusterStatus(string(out))
 	return role
+}
+
+// commandStderr returns the subprocess stderr captured by exec.Cmd.Output for an
+// ExitError; err.Error() alone reports only the exit code.
+func commandStderr(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return strings.TrimSpace(string(exitErr.Stderr))
+	}
+	return ""
 }
 
 // ParseClusterStatus extracts the quorum size and this server's role from ovs

--- a/spinifex/network/host/ovn_raft.go
+++ b/spinifex/network/host/ovn_raft.go
@@ -1,0 +1,47 @@
+package host
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
+)
+
+// OVN DB ctl targets and schemas for cluster/status probes. The short "-t"
+// target lets ovn-appctl resolve the ctl socket via OVN_RUNDIR regardless of
+// the Trixie (/var/run/ovn) vs older (/var/run/openvswitch) layout.
+const (
+	OVNNBTarget = "ovnnb_db"
+	OVNSBTarget = "ovnsb_db"
+	OVNNBSchema = "OVN_Northbound"
+	OVNSBSchema = "OVN_Southbound"
+)
+
+// OVNDBRole reports this node's OVSDB Raft role for the given ctl target and
+// schema: "leader", "follower", or "" when OVN is standalone or unreachable.
+// A standalone (non-clustered) DB or any appctl error fails soft to "".
+func OVNDBRole(target, schema string) string {
+	out, err := utils.SudoCommand("ovn-appctl", "-t", target, "cluster/status", schema).Output()
+	if err != nil {
+		slog.Debug("Failed to query OVN cluster/status", "schema", schema, "err", err)
+		return ""
+	}
+	_, role := ParseClusterStatus(string(out))
+	return role
+}
+
+// ParseClusterStatus extracts the quorum size and this server's role from ovs
+// cluster/status output. Each member appears as a "<id> at tcp:<addr>" line
+// under Servers:; the "Role:" header reports the queried server's own role.
+func ParseClusterStatus(out string) (servers int, role string) {
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "Role:"); ok {
+			role = strings.TrimSpace(rest)
+		}
+		if strings.Contains(line, " at tcp:") {
+			servers++
+		}
+	}
+	return servers, role
+}

--- a/spinifex/network/host/ovn_raft_test.go
+++ b/spinifex/network/host/ovn_raft_test.go
@@ -1,0 +1,70 @@
+package host
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const clusterStatusLeader = `0f21
+Name: OVN_Northbound
+Cluster ID: c8f5 (c8f5b3e0-...)
+Server ID: 0f21 (0f21a1b2-...)
+Address: tcp:10.0.0.1:6643
+Status: cluster member
+Role: leader
+Term: 3
+Leader: self
+Vote: self
+
+Servers:
+    0f21 (0f21 at tcp:10.0.0.1:6643) (self)
+    8a8f (8a8f at tcp:10.0.0.2:6643)
+    abcd (abcd at tcp:10.0.0.3:6643)
+`
+
+const clusterStatusFollower = `8a8f
+Name: OVN_Southbound
+Cluster ID: c8f5 (c8f5b3e0-...)
+Server ID: 8a8f (8a8fc3d4-...)
+Address: tcp:10.0.0.2:6644
+Status: cluster member
+Role: follower
+Term: 3
+Leader: 0f21
+Vote: 0f21
+
+Servers:
+    0f21 (0f21 at tcp:10.0.0.1:6644)
+    8a8f (8a8f at tcp:10.0.0.2:6644) (self)
+    abcd (abcd at tcp:10.0.0.3:6644)
+`
+
+// A standalone (non-clustered) DB reports no Role: header and no Raft servers.
+const clusterStatusStandalone = `Name: OVN_Northbound
+Status: standalone
+`
+
+func TestParseClusterStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		out         string
+		wantServers int
+		wantRole    string
+	}{
+		{"leader", clusterStatusLeader, 3, "leader"},
+		{"follower", clusterStatusFollower, 3, "follower"},
+		{"standalone yields empty role", clusterStatusStandalone, 0, ""},
+		{"empty output", "", 0, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			servers, role := ParseClusterStatus(tt.out)
+			assert.Equal(t, tt.wantServers, servers)
+			assert.Equal(t, tt.wantRole, role)
+		})
+	}
+}

--- a/spinifex/types/node.go
+++ b/spinifex/types/node.go
@@ -64,6 +64,11 @@ type NodeStatusResponse struct {
 	// Leader roles for clustered services (empty string = service not running or not clustered)
 	NATSRole       string `json:"nats_role,omitempty"`       // "leader" or "follower"
 	PredastoreRole string `json:"predastore_role,omitempty"` // "leader" or "follower"
+
+	// OVN DB Raft roles ("leader"/"follower"/""); empty when the node is not an
+	// OVN DB cluster member or OVN is standalone.
+	OVNNBRole string `json:"ovn_nb_role,omitempty"`
+	OVNSBRole string `json:"ovn_sb_role,omitempty"`
 }
 
 // InstanceTypeCap describes available capacity for one instance type on a node.

--- a/spinifex/utils/sudo.go
+++ b/spinifex/utils/sudo.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"os"
 	"os/exec"
 )
@@ -18,6 +19,15 @@ var sudoCommand = func(name string, args ...string) *exec.Cmd {
 // dev environments may not.
 func SudoCommand(name string, args ...string) *exec.Cmd {
 	return sudoCommand(name, args...)
+}
+
+// SudoCommandContext is SudoCommand bound to a context so a wedged subprocess is
+// killed when the context is cancelled or its deadline elapses.
+func SudoCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	if os.Getuid() == 0 {
+		return exec.CommandContext(ctx, name, args...)
+	}
+	return exec.CommandContext(ctx, "sudo", append([]string{name}, args...)...)
 }
 
 // SetSudoCommandForTest swaps the command builder for a test, returning a restore func for t.Cleanup.

--- a/tests/e2e/multinode/ovn_raft_test.go
+++ b/tests/e2e/multinode/ovn_raft_test.go
@@ -15,10 +15,8 @@ import (
 )
 
 const (
-	ovnNBSock   = "/var/run/ovn/ovnnb_db.ctl"
-	ovnSBSock   = "/var/run/ovn/ovnsb_db.ctl"
-	ovnNBSchema = "OVN_Northbound"
-	ovnSBSchema = "OVN_Southbound"
+	ovnNBSock = "/var/run/ovn/ovnnb_db.ctl"
+	ovnSBSock = "/var/run/ovn/ovnsb_db.ctl"
 )
 
 // runOVNRaft asserts the clustered OVN control plane: every DB node's NB and SB
@@ -37,8 +35,8 @@ func runOVNRaft(t *testing.T, fix *Fixture) {
 
 	// 1. Quorum health: 3 servers + exactly one leader, per schema, per node.
 	for _, db := range []struct{ name, sock, schema string }{
-		{"NB", ovnNBSock, ovnNBSchema},
-		{"SB", ovnSBSock, ovnSBSchema},
+		{"NB", ovnNBSock, host.OVNNBSchema},
+		{"SB", ovnSBSock, host.OVNSBSchema},
 	} {
 		leaders := 0
 		for _, n := range dbNodes {
@@ -58,7 +56,7 @@ func runOVNRaft(t *testing.T, fix *Fixture) {
 	var leader harness.Node
 	var survivors []harness.Node
 	for _, n := range dbNodes {
-		if _, role := ovnClusterStatus(t, ssh, n, ovnNBSock, ovnNBSchema); role == "leader" {
+		if _, role := ovnClusterStatus(t, ssh, n, ovnNBSock, host.OVNNBSchema); role == "leader" {
 			leader = n
 		} else {
 			survivors = append(survivors, n)

--- a/tests/e2e/multinode/ovn_raft_test.go
+++ b/tests/e2e/multinode/ovn_raft_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/network/host"
 	"github.com/mulgadc/spinifex/tests/e2e/harness"
 	"github.com/stretchr/testify/require"
 )
@@ -125,23 +126,7 @@ func ovnClusterStatus(t *testing.T, ssh *harness.PeerSSH, n harness.Node, sock, 
 	defer cancel()
 	out, err := ssh.Run(ctx, n.Addr, fmt.Sprintf("sudo ovn-appctl -t %s cluster/status %s", sock, schema))
 	require.NoErrorf(t, err, "cluster/status %s on %s", schema, n.Name)
-	return parseClusterStatus(string(out))
-}
-
-// parseClusterStatus extracts the quorum size and this server's role from
-// ovs cluster/status output. Each member appears as a "<id> at tcp:<addr>" line
-// under Servers:; the "Role:" header reports the queried server's own role.
-func parseClusterStatus(out string) (servers int, role string) {
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "Role:") {
-			role = strings.TrimSpace(strings.TrimPrefix(line, "Role:"))
-		}
-		if strings.Contains(line, " at tcp:") {
-			servers++
-		}
-	}
-	return servers, role
+	return host.ParseClusterStatus(string(out))
 }
 
 // nbEndpointList builds the comma-separated NB client endpoint list used by


### PR DESCRIPTION
## Summary

Extends the `ROLES` column in `spx get nodes` to report OVN Northbound and Southbound OVSDB Raft leadership alongside the existing NATS and Predastore roles. This is a read-only observability change: no leadership is moved and no new control command is added.

Example output on a DB quorum node:

```
nats:leader,ovn-nb:leader,ovn-sb:follower,predastore:follower
```

## Changes

- `types/node.go` — add `OVNNBRole` / `OVNSBRole` to `NodeStatusResponse`.
- `network/host/ovn_raft.go` — new `OVNDBRole(target, schema)` probe and shared `ParseClusterStatus` parser. The probe uses the short `-t ovnnb_db` ctl target so `ovn-appctl` resolves the socket via `OVN_RUNDIR` across distro layouts (Trixie `/var/run/ovn` vs older `/var/run/openvswitch`), matching the existing `host.HealthStatus` probe. The shell-out is bounded by a 500ms context (via `utils.SudoCommandContext`) so a wedged `ovsdb-server` cannot stall the node-status handler, matching the NATS/Predastore probe budget.
- `formation/helpers.go` — `OVNDBQuorumNames` is the single sorted-first-N membership definition, shared by `BuildOVNDBAddrs` and the daemon so endpoint construction and role probing can never disagree. Compute-only nodes short-circuit to `""` without shelling out.
- `daemon/daemon_handlers.go` — `handleNodeStatus` probes NB/SB roles concurrently with the existing NATS/Predastore probes. Standalone OVN fails soft to `""`; a probe failure on a confirmed quorum member logs at `slog.Warn` with the ctl target and subprocess stderr (the probe is only reached once the node is known to host the clustered DB, so an error there is an operational problem, not a routine empty).
- `cmd/spinifex/cmd/get.go` — `formatRoles` renders `ovn-nb`/`ovn-sb` in stable order (nats, ovn-nb, ovn-sb, predastore), omitting empty values.
- `tests/e2e/multinode/ovn_raft_test.go` — switch to the shared `host.ParseClusterStatus` and the shared `host.OVN{NB,SB}Schema` constants (no behaviour change).
- Gateway fan-out (`gateway/spx`) re-serialises the whole `NodeStatusResponse` with no allow-list, so the new fields flow through automatically.
