### PR TITLE
refactor: drop restoreSlogDefault workaround (viperblock no longer mutates global slog)

### DIFF
--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -1385,16 +1385,7 @@ func (s *InstanceServiceImpl) newViperblock(volumeName string, size int, volumeC
 	}
 
 	vb, err := viperblock.New(&vbconfig, "s3", cfg)
-	restoreSlogDefault()
 	return vb, err
-}
-
-// restoreSlogDefault re-installs the Info-level slog handler after viperblock.New
-// resets it to LevelError via SetDebug, silencing all Info/Warn globally.
-func restoreSlogDefault() {
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	})))
 }
 
 // prepareRootVolume handles creation/cloning of the root volume


### PR DESCRIPTION
## Summary
- viperblock's `New()` used to call `slog.SetDefault(...)` internally, clobbering the spinifex daemon's global logger, so `newViperblock` re-installed an Info-level handler via `restoreSlogDefault()` after every call as a workaround.
- viperblock PR #31 (merged to dev, now bumped in mulga) fixed the root cause: viperblock now uses an instance logger and never touches `slog.SetDefault`.
- This removes the now-dead workaround call and helper function from `spinifex/handlers/ec2/instance/service_impl.go`. No other references to `restoreSlogDefault` exist in the repo. The `os` import is still required elsewhere in the file (os.ErrNotExist checks, os.ReadFile), so it was left in place.

## Test plan
- [x] `GOWORK=off make preflight` passes (manifest-check, manifest-lint, golangci-lint, govulncheck, tests w/ race detector, e2e harness unit tests)