### PR TITLE
feat(eks): expose NVIDIA GPUs to pods (Epic B) — VFIO QMP, worker registration, device-plugin GPU access

### DIFF
--- a/scripts/images/eks-node-gpu/k3s-agent.service
+++ b/scripts/images/eks-node-gpu/k3s-agent.service
@@ -23,6 +23,12 @@ LimitCORE=infinity
 # Cloud-init drops K3S_URL/K3S_TOKEN/K3S_NODE_NAME/K3S_NODE_LABEL here at
 # RunInstances time per the Nodegroup bootstrap flow.
 EnvironmentFile=-/etc/spinifex-eks/agent.env
+# Tee k3s (and its embedded kubelet's klog) stderr to the serial console as well
+# as journald: Ubuntu logs to journald only, which is off-box-invisible on a
+# worker in an isolated customer VPC, so a kubelet that fails to register the
+# Node leaves no trace. The serial console is captured per-VM by the daemon.
+StandardOutput=journal+console
+StandardError=journal+console
 ExecStartPre=-/sbin/modprobe overlay
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=/usr/local/sbin/k3s-agent-prestart

--- a/scripts/images/eks-node-gpu/k3s-agent.service
+++ b/scripts/images/eks-node-gpu/k3s-agent.service
@@ -9,9 +9,22 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+# k3s embeds containerd + kubelet in-process, so on a cgroup-v2 host the unit
+# must delegate a cgroup subtree or the kubelet cannot create /kubepods and
+# ContainerManager.Start fails before Node registration (OpenRC ran k3s in the
+# root cgroup, so this was implicit). overlay/br_netfilter feed the embedded
+# containerd snapshotter + kube-proxy.
+Delegate=yes
+KillMode=process
+TasksMax=infinity
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
 # Cloud-init drops K3S_URL/K3S_TOKEN/K3S_NODE_NAME/K3S_NODE_LABEL here at
 # RunInstances time per the Nodegroup bootstrap flow.
 EnvironmentFile=-/etc/spinifex-eks/agent.env
+ExecStartPre=-/sbin/modprobe overlay
+ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=/usr/local/sbin/k3s-agent-prestart
 ExecStart=/bin/sh -c '. /run/k3s-agent-extra-args.env 2>/dev/null || true; exec /usr/local/bin/k3s agent ${K3S_AGENT_EXTRA_ARGS:-}'
 Restart=on-failure

--- a/scripts/images/eks-node-gpu/manifest.conf
+++ b/scripts/images/eks-node-gpu/manifest.conf
@@ -16,6 +16,16 @@ IMAGE_SIZE="16G"
 # in setup.sh rather than here (see scripts/images/ubuntu-gpu-nvidia-setup.sh).
 APT_PACKAGES="ca-certificates curl jq iptables conntrack cgroup-tools initramfs-tools"
 
+# ecr-credential-provider is the ONLY server binary a GPU worker needs: the
+# nodegroup userdata points kubelet at it (image-credential-provider-config +
+# bin-dir=/usr/local/bin) for ECR pulls, and kubelet treats a referenced-but-
+# missing provider binary as a FATAL init error (RegisterCredentialProviderPlugins),
+# so the node never registers. The Alpine eks-node ships it; the GPU AMI must too.
+# Server-only binaries (token-webhook, gateway-*, konnectivity, k3s server) stay
+# omitted — GPU nodes are agent-only.
+BUILD_COMMANDS="CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o bin/ecr-credential-provider ./cmd/ecr-credential-provider"
+INSTALL_BINARIES="bin/ecr-credential-provider:/usr/local/bin/ecr-credential-provider"
+
 # Role-agnostic helper scripts are reused verbatim from scripts/images/eks-node/
 # (only the init wiring changes: OpenRC -> systemd). k3s-agent-prestart is new —
 # it reproduces the k3s-agent.initd start_pre logic (env require + IMDS

--- a/scripts/images/eks-node/addons/nvidia-device-plugin/0.17.4/10-daemonset.yaml
+++ b/scripts/images/eks-node/addons/nvidia-device-plugin/0.17.4/10-daemonset.yaml
@@ -1,8 +1,14 @@
 # nvidia-device-plugin 0.17.4 — CDI-mode DaemonSet exposing nvidia.com/gpu
 # allocatable on GPU-tainted nodes. Gated to GPU nodes via nodeSelector on the
 # K3S_NODE_LABEL nvidia.com/gpu.present=true (nodegroup_userdata.go); inert
-# elsewhere. --device-list-strategy=cdi-cri consumes /etc/cdi/nvidia.yaml
-# (mulga-cdi-generate.service), no nvidia-container-runtime class needed.
+# elsewhere. --device-list-strategy=cdi-cri makes the plugin generate a CDI spec
+# for GPU workloads (containerd 2.x resolves the CRI-passed CDI devices; no
+# enable_cdi drop-in needed on k3s v1.32.5). The plugin's OWN container needs
+# NVML + the driver tree to run nvml.Init and generate that spec, so it runs
+# under the k3s-auto-configured "nvidia" runtimeClass with the host root mounted
+# at /driver-root and the host /var/run/cdi mounted writable so the generated
+# spec is visible to containerd. GPU workloads themselves need only
+# resources.limits nvidia.com/gpu — no runtimeClass.
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -29,6 +35,7 @@ spec:
         operator: Exists
         effect: NoSchedule
       priorityClassName: "system-node-critical"
+      runtimeClassName: nvidia
       containers:
       - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.4
         name: nvidia-device-plugin-ctr
@@ -37,6 +44,10 @@ spec:
         env:
           - name: FAIL_ON_INIT_ERROR
             value: "false"
+          - name: NVIDIA_VISIBLE_DEVICES
+            value: all
+          - name: NVIDIA_DRIVER_CAPABILITIES
+            value: all
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -44,8 +55,20 @@ spec:
         volumeMounts:
         - name: kubelet-device-plugins-dir
           mountPath: /var/lib/kubelet/device-plugins
+        - name: driver-root
+          mountPath: /driver-root
+          readOnly: true
+        - name: cdi-root
+          mountPath: /var/run/cdi
       volumes:
       - name: kubelet-device-plugins-dir
         hostPath:
           path: /var/lib/kubelet/device-plugins
           type: Directory
+      - name: driver-root
+        hostPath:
+          path: /
+      - name: cdi-root
+        hostPath:
+          path: /var/run/cdi
+          type: DirectoryOrCreate

--- a/scripts/images/eks-node/addons/nvidia-device-plugin/0.17.4/10-daemonset.yaml
+++ b/scripts/images/eks-node/addons/nvidia-device-plugin/0.17.4/10-daemonset.yaml
@@ -1,0 +1,51 @@
+# nvidia-device-plugin 0.17.4 — CDI-mode DaemonSet exposing nvidia.com/gpu
+# allocatable on GPU-tainted nodes. Gated to GPU nodes via nodeSelector on the
+# K3S_NODE_LABEL nvidia.com/gpu.present=true (nodegroup_userdata.go); inert
+# elsewhere. --device-list-strategy=cdi-cri consumes /etc/cdi/nvidia.yaml
+# (mulga-cdi-generate.service), no nvidia-container-runtime class needed.
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-device-plugin
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      priorityClassName: "system-node-critical"
+      containers:
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.4
+        name: nvidia-device-plugin-ctr
+        args:
+        - --device-list-strategy=cdi-cri
+        env:
+          - name: FAIL_ON_INIT_ERROR
+            value: "false"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: kubelet-device-plugins-dir
+          mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+      - name: kubelet-device-plugins-dir
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+          type: Directory

--- a/scripts/images/eks-node/manifest.conf
+++ b/scripts/images/eks-node/manifest.conf
@@ -61,6 +61,7 @@ scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/00-rbac.yaml:/usr/share
 scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml:/usr/share/spinifex-eks/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml \
 scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml:/usr/share/spinifex-eks/addons/aws-ebs-csi-driver/1.40.1/20-node.yaml \
 scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/30-storageclass.yaml:/usr/share/spinifex-eks/addons/aws-ebs-csi-driver/1.40.1/30-storageclass.yaml \
+scripts/images/eks-node/addons/nvidia-device-plugin/0.17.4/10-daemonset.yaml:/usr/share/spinifex-eks/addons/nvidia-device-plugin/0.17.4/10-daemonset.yaml \
 scripts/images/eks-node/coredns/coredns-mulga.yaml:/usr/share/spinifex-eks/coredns/coredns-mulga.yaml \
 scripts/images/eks-node/cloud-init-ec2.cfg:/etc/cloud/cloud.cfg.d/90-spinifex-ec2-imds.cfg \
 scripts/images/eks-node/mulga-eks-etcd-snapshot.sh:/etc/periodic/daily/mulga-eks-etcd-snapshot \

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -3807,22 +3806,4 @@ func TestPrepareRunInstances_PreCreatedENIAttachErrorSurfaced(t *testing.T) {
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 	assert.Equal(t, 1, eni.attachCalls)
 	assert.Equal(t, 0, eni.createCalls)
-}
-
-// TestRestoreSlogDefault verifies the Info-level handler is reinstalled after
-// viperblock.New resets the global logger to LevelError: Info/Warn must be
-// enabled again and Debug must stay off.
-func TestRestoreSlogDefault(t *testing.T) {
-	prev := slog.Default()
-	t.Cleanup(func() { slog.SetDefault(prev) })
-
-	slog.SetDefault(slog.New(slog.DiscardHandler))
-	require.False(t, slog.Default().Enabled(context.Background(), slog.LevelInfo))
-
-	restoreSlogDefault()
-
-	got := slog.Default()
-	assert.True(t, got.Enabled(context.Background(), slog.LevelInfo), "Info must be enabled after restore")
-	assert.True(t, got.Enabled(context.Background(), slog.LevelWarn), "Warn must be enabled after restore")
-	assert.False(t, got.Enabled(context.Background(), slog.LevelDebug), "Debug must stay off")
 }

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -3806,4 +3807,22 @@ func TestPrepareRunInstances_PreCreatedENIAttachErrorSurfaced(t *testing.T) {
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 	assert.Equal(t, 1, eni.attachCalls)
 	assert.Equal(t, 0, eni.createCalls)
+}
+
+// TestRestoreSlogDefault verifies the Info-level handler is reinstalled after
+// viperblock.New resets the global logger to LevelError: Info/Warn must be
+// enabled again and Debug must stay off.
+func TestRestoreSlogDefault(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+	require.False(t, slog.Default().Enabled(context.Background(), slog.LevelInfo))
+
+	restoreSlogDefault()
+
+	got := slog.Default()
+	assert.True(t, got.Enabled(context.Background(), slog.LevelInfo), "Info must be enabled after restore")
+	assert.True(t, got.Enabled(context.Background(), slog.LevelWarn), "Warn must be enabled after restore")
+	assert.False(t, got.Enabled(context.Background(), slog.LevelDebug), "Debug must stay off")
 }

--- a/spinifex/handlers/eks/addon_catalog.go
+++ b/spinifex/handlers/eks/addon_catalog.go
@@ -2,6 +2,10 @@ package handlers_eks
 
 import "slices"
 
+// nvidiaDevicePluginAddonName is auto-staged on GPU nodegroup create (see
+// stageGPUDeviceAddon in nodegroup.go), never user-requested directly.
+const nvidiaDevicePluginAddonName = "nvidia-device-plugin"
+
 // AddonSpec describes one Spinifex-supported managed add-on in the static
 // in-binary catalog. DescribeAddonVersions and CreateAddon validate against it.
 type AddonSpec struct {
@@ -30,6 +34,12 @@ var addonCatalog = buildAddonCatalog(
 	newAddonSpec("aws-ebs-csi-driver", true,
 		"Container Storage Interface driver for Amazon EBS (Viperblock) volumes.",
 		"1.40.1"),
+	// nvidia-device-plugin is auto-staged (never user-requested) on GPU
+	// nodegroup create, so it is hidden from the public catalog like
+	// spinifex-noop but still creatable by name.
+	hiddenAddonSpec(newAddonSpec(nvidiaDevicePluginAddonName, false,
+		"NVIDIA device plugin exposing nvidia.com/gpu allocatable via CDI on GPU-tainted nodes.",
+		"0.17.4")),
 	// spinifex-noop is the delivery-transport fixture: a trivial bundle
 	// (Namespace + ConfigMap) used by the addon e2e to prove stage → render →
 	// auto-deploy → ACTIVE → delete round-trips end-to-end without depending on

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -33,9 +33,11 @@ const defaultNodegroupInstanceType = "t3.medium"
 // defaultNodegroupReadyTimeout / defaultNodegroupReadyPoll bound how long
 // launchNodegroupInfra waits for its workers to register Ready (observed via the
 // CP state report's Ready-node count, refreshed at the reconcile cadence) before
-// marking the nodegroup CREATE_FAILED.
+// marking the nodegroup CREATE_FAILED. GPU workers spend ~7min on first-boot
+// driver + CDI work before k3s-agent even starts, so the budget must clear that
+// plus the join.
 const (
-	defaultNodegroupReadyTimeout = 10 * time.Minute
+	defaultNodegroupReadyTimeout = 20 * time.Minute
 	defaultNodegroupReadyPoll    = 15 * time.Second
 )
 

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -300,6 +300,21 @@ func gpuFieldsForInstanceTypes(instanceTypes []string) (gpuEnabled bool, gpuVend
 	return false, ""
 }
 
+// stageGPUDeviceAddon idempotently stages nvidia-device-plugin for a GPU
+// nodegroup's cluster via the normal CreateAddon path. Already-staged
+// (ResourceInUse) is expected on scale-up/repeat nodegroups, not an error;
+// any other failure only logs — a GPU nodegroup must still come up even if
+// addon staging fails.
+func (s *EKSServiceImpl) stageGPUDeviceAddon(ctx context.Context, accountID, cluster string) {
+	_, err := s.CreateAddon(ctx, &eks.CreateAddonInput{
+		ClusterName: aws.String(cluster),
+		AddonName:   aws.String(nvidiaDevicePluginAddonName),
+	}, accountID)
+	if err != nil && err.Error() != awserrors.ErrorEKSResourceInUse {
+		slog.WarnContext(ctx, "createNodegroup: stage nvidia-device-plugin addon", "cluster", cluster, "err", err)
+	}
+}
+
 // resolveWorkerAMI resolves the worker AMI for a nodegroup: the GPU node AMI
 // when rec is GPU-enabled, otherwise the default eks-node AMI. A GPU nodegroup
 // with no matching GPU AMI errors rather than silently falling back to the
@@ -352,6 +367,10 @@ func (s *EKSServiceImpl) launchNodegroupInfra(ctx context.Context, lc nodegroupL
 	if err != nil {
 		s.markNodegroupFailed(acctKV, cluster, ng, "resolve eks-node AMI: "+err.Error())
 		return
+	}
+
+	if rec.GPUEnabled {
+		s.stageGPUDeviceAddon(ctx, accountID, cluster)
 	}
 
 	if _, err := s.launchWorkers(ctx, acctKV, accountID, rec, meta, ngSGID, amiID, token, lc.desired); err != nil {
@@ -477,6 +496,8 @@ func (s *EKSServiceImpl) launchOneWorker(ctx context.Context, rec *NodegroupReco
 		AccountID:     accountID,
 		RegistryHost:  registryHost,
 		GatewayIP:     gatewayIP,
+		GPUEnabled:    rec.GPUEnabled,
+		GPUVendor:     rec.GPUVendor,
 	})
 	runInput := &ec2.RunInstancesInput{
 		ImageId:          aws.String(amiID),

--- a/spinifex/handlers/eks/nodegroup_test.go
+++ b/spinifex/handlers/eks/nodegroup_test.go
@@ -379,6 +379,42 @@ func TestCreateNodegroup_GPUInstanceTypeSetsGPUFields(t *testing.T) {
 	f.svc.WaitLaunches()
 }
 
+// A GPU nodegroup create must auto-stage the nvidia-device-plugin addon so
+// GPU-tainted nodes get nvidia.com/gpu allocatable without a manual CreateAddon.
+func TestCreateNodegroup_GPUNodegroupStagesDevicePluginAddon(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	seedActiveClusterWithToken(t, f, "c1")
+
+	in := createNGInput("c1", "ng-gpu", 1)
+	in.InstanceTypes = aws.StringSlice([]string{"g5.xlarge"})
+
+	_, err := f.svc.CreateNodegroup(context.Background(), in, testAccountID)
+	require.NoError(t, err)
+
+	markWorkersReady(t, f, "c1", 1)
+	f.svc.WaitLaunches()
+
+	rec, err := GetAddonRecord(f.kv, "c1", nvidiaDevicePluginAddonName)
+	require.NoError(t, err, "nvidia-device-plugin must be staged for a GPU nodegroup")
+	assert.Equal(t, "0.17.4", rec.AddonVersion)
+}
+
+// A non-GPU nodegroup create must not stage nvidia-device-plugin — it stays
+// dormant on non-GPU clusters, and it isn't user-visible in the catalog.
+func TestCreateNodegroup_NonGPUNodegroupDoesNotStageDevicePluginAddon(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	seedActiveClusterWithToken(t, f, "c1")
+
+	_, err := f.svc.CreateNodegroup(context.Background(), createNGInput("c1", "ng1", 1), testAccountID)
+	require.NoError(t, err)
+
+	markWorkersReady(t, f, "c1", 1)
+	f.svc.WaitLaunches()
+
+	_, err = GetAddonRecord(f.kv, "c1", nvidiaDevicePluginAddonName)
+	require.ErrorIs(t, err, ErrAddonNotFound)
+}
+
 // A non-GPU instance type must leave the record's GPU fields unset, so the
 // worker-launch path keeps resolving the default eks-node AMI.
 func TestCreateNodegroup_NonGPUInstanceTypeClearsGPUFields(t *testing.T) {

--- a/spinifex/handlers/eks/nodegroup_userdata.go
+++ b/spinifex/handlers/eks/nodegroup_userdata.go
@@ -28,6 +28,11 @@ type agentUserDataInput struct {
 	AccountID     string
 	RegistryHost  string
 	GatewayIP     string
+
+	// GPUEnabled/GPUVendor gate the GPU node label + default scheduling taint;
+	// set from the owning NodegroupRecord (see gpuFieldsForInstanceTypes).
+	GPUEnabled bool
+	GPUVendor  string
 }
 
 // registryMirrorHosts returns the distinct registry hosts a worker must accept on
@@ -51,6 +56,9 @@ func buildAgentUserData(in agentUserDataInput) string {
 	// lives in the unpeered managed CP VPC and is unreachable from the worker VPC.
 	k3sURL := in.ServerURL
 	nodeLabel := "eks.amazonaws.com/nodegroup=" + in.NodegroupName
+	if in.GPUEnabled {
+		nodeLabel += ",nvidia.com/gpu.present=true"
+	}
 
 	envBody := strings.Join([]string{
 		"SPINIFEX_K3S_ROLE=agent",
@@ -127,6 +135,19 @@ func buildAgentUserData(in agentUserDataInput) string {
 		{Path: "/etc/rancher/k3s/registries.yaml", Perms: "0644", Body: registriesYAML},
 		{Path: "/etc/rancher/k3s/config.yaml.d/20-ecr-credential-provider.yaml", Perms: "0644", Body: credProviderDropin},
 		{Path: "/etc/spinifex-eks/credential-provider-config.yaml", Perms: "0644", Body: credProviderConfig},
+	}
+
+	// Default GPU nodes to NoSchedule so ordinary workloads don't consume scarce
+	// GPU capacity; the device plugin and GPU pods tolerate it. Non-GPU
+	// nodegroups get no drop-in, keeping their user-data byte-identical.
+	if in.GPUEnabled {
+		gpuTaintDropin := strings.Join([]string{
+			"node-taint:",
+			"  - \"nvidia.com/gpu=present:NoSchedule\"",
+		}, "\n")
+		files = append(files, userDataFile{
+			Path: "/etc/rancher/k3s/config.yaml.d/20-gpu-taint.yaml", Perms: "0644", Body: gpuTaintDropin,
+		})
 	}
 
 	var buf strings.Builder

--- a/spinifex/handlers/eks/nodegroup_userdata.go
+++ b/spinifex/handlers/eks/nodegroup_userdata.go
@@ -56,9 +56,6 @@ func buildAgentUserData(in agentUserDataInput) string {
 	// lives in the unpeered managed CP VPC and is unreachable from the worker VPC.
 	k3sURL := in.ServerURL
 	nodeLabel := "eks.amazonaws.com/nodegroup=" + in.NodegroupName
-	if in.GPUEnabled {
-		nodeLabel += ",nvidia.com/gpu.present=true"
-	}
 
 	envBody := strings.Join([]string{
 		"SPINIFEX_K3S_ROLE=agent",
@@ -137,16 +134,21 @@ func buildAgentUserData(in agentUserDataInput) string {
 		{Path: "/etc/spinifex-eks/credential-provider-config.yaml", Perms: "0644", Body: credProviderConfig},
 	}
 
-	// Default GPU nodes to NoSchedule so ordinary workloads don't consume scarce
-	// GPU capacity; the device plugin and GPU pods tolerate it. Non-GPU
-	// nodegroups get no drop-in, keeping their user-data byte-identical.
+	// GPU nodes advertise nvidia.com/gpu.present=true (so the device-plugin
+	// DaemonSet nodeSelector matches) and default to NoSchedule so ordinary
+	// workloads don't consume scarce GPU capacity. Both must come from k3s
+	// config keys — k3s has no K3S_NODE_LABEL env, so the label rides a
+	// node-label drop-in, not agent.env. Non-GPU nodegroups get no drop-in,
+	// keeping their user-data byte-identical.
 	if in.GPUEnabled {
-		gpuTaintDropin := strings.Join([]string{
+		gpuDropin := strings.Join([]string{
+			"node-label:",
+			"  - \"nvidia.com/gpu.present=true\"",
 			"node-taint:",
 			"  - \"nvidia.com/gpu=present:NoSchedule\"",
 		}, "\n")
 		files = append(files, userDataFile{
-			Path: "/etc/rancher/k3s/config.yaml.d/20-gpu-taint.yaml", Perms: "0644", Body: gpuTaintDropin,
+			Path: "/etc/rancher/k3s/config.yaml.d/20-gpu.yaml", Perms: "0644", Body: gpuDropin,
 		})
 	}
 

--- a/spinifex/handlers/eks/nodegroup_userdata_test.go
+++ b/spinifex/handlers/eks/nodegroup_userdata_test.go
@@ -103,14 +103,20 @@ func TestBuildAgentUserData_GPUEnabledAddsLabelAndTaint(t *testing.T) {
 
 	got := buildAgentUserData(in)
 
-	if !strings.Contains(got, "K3S_NODE_LABEL=eks.amazonaws.com/nodegroup=ng-1,nvidia.com/gpu.present=true") {
-		t.Errorf("expected GPU node label, got:\n%s", got)
+	// The label must ride a node-label config drop-in, not K3S_NODE_LABEL (k3s
+	// has no such env var — it would be a no-op and the device-plugin
+	// nodeSelector would never match).
+	if !strings.Contains(got, "/etc/rancher/k3s/config.yaml.d/20-gpu.yaml") {
+		t.Errorf("expected GPU drop-in path, got:\n%s", got)
 	}
-	if !strings.Contains(got, "/etc/rancher/k3s/config.yaml.d/20-gpu-taint.yaml") {
-		t.Errorf("expected GPU taint drop-in path, got:\n%s", got)
+	if !strings.Contains(got, "node-label:") || !strings.Contains(got, "nvidia.com/gpu.present=true") {
+		t.Errorf("expected GPU node-label drop-in value, got:\n%s", got)
 	}
 	if !strings.Contains(got, "nvidia.com/gpu=present:NoSchedule") {
 		t.Errorf("expected GPU taint value, got:\n%s", got)
+	}
+	if strings.Contains(got, "K3S_NODE_LABEL=eks.amazonaws.com/nodegroup=ng-1,nvidia.com/gpu.present=true") {
+		t.Errorf("GPU label must not ride the no-op K3S_NODE_LABEL env, got:\n%s", got)
 	}
 }
 
@@ -122,8 +128,8 @@ func TestBuildAgentUserData_NonGPUHasNoLabelOrTaint(t *testing.T) {
 	if strings.Contains(got, "nvidia.com/gpu") {
 		t.Errorf("non-GPU nodegroup user-data must not reference nvidia.com/gpu, got:\n%s", got)
 	}
-	if strings.Contains(got, "20-gpu-taint.yaml") {
-		t.Errorf("non-GPU nodegroup user-data must not carry the GPU taint drop-in, got:\n%s", got)
+	if strings.Contains(got, "20-gpu.yaml") {
+		t.Errorf("non-GPU nodegroup user-data must not carry the GPU drop-in, got:\n%s", got)
 	}
 	if !strings.Contains(got, "K3S_NODE_LABEL=eks.amazonaws.com/nodegroup=ng-1") {
 		t.Errorf("expected plain nodegroup label, got:\n%s", got)

--- a/spinifex/handlers/eks/nodegroup_userdata_test.go
+++ b/spinifex/handlers/eks/nodegroup_userdata_test.go
@@ -82,3 +82,50 @@ func TestBuildAgentUserData_NoGatewayIPUsesHostnameEndpoint(t *testing.T) {
 		t.Errorf("expected hostname:port tls config key when GatewayIP is empty\n%s", got)
 	}
 }
+
+func baseTestInput() agentUserDataInput {
+	return agentUserDataInput{
+		ClusterName:   "alpha",
+		NodegroupName: "ng-1",
+		ServerURL:     "https://10.0.0.1:443",
+		JoinToken:     "jointoken",
+		NodeName:      "alpha-ng-1-abcd1234",
+		Region:        "ap-southeast-2",
+		AccountID:     "123456789012",
+		RegistryHost:  "123456789012.dkr.ecr.ap-southeast-2.spinifex.internal",
+	}
+}
+
+func TestBuildAgentUserData_GPUEnabledAddsLabelAndTaint(t *testing.T) {
+	in := baseTestInput()
+	in.GPUEnabled = true
+	in.GPUVendor = "nvidia"
+
+	got := buildAgentUserData(in)
+
+	if !strings.Contains(got, "K3S_NODE_LABEL=eks.amazonaws.com/nodegroup=ng-1,nvidia.com/gpu.present=true") {
+		t.Errorf("expected GPU node label, got:\n%s", got)
+	}
+	if !strings.Contains(got, "/etc/rancher/k3s/config.yaml.d/20-gpu-taint.yaml") {
+		t.Errorf("expected GPU taint drop-in path, got:\n%s", got)
+	}
+	if !strings.Contains(got, "nvidia.com/gpu=present:NoSchedule") {
+		t.Errorf("expected GPU taint value, got:\n%s", got)
+	}
+}
+
+func TestBuildAgentUserData_NonGPUHasNoLabelOrTaint(t *testing.T) {
+	in := baseTestInput()
+
+	got := buildAgentUserData(in)
+
+	if strings.Contains(got, "nvidia.com/gpu") {
+		t.Errorf("non-GPU nodegroup user-data must not reference nvidia.com/gpu, got:\n%s", got)
+	}
+	if strings.Contains(got, "20-gpu-taint.yaml") {
+		t.Errorf("non-GPU nodegroup user-data must not carry the GPU taint drop-in, got:\n%s", got)
+	}
+	if !strings.Contains(got, "K3S_NODE_LABEL=eks.amazonaws.com/nodegroup=ng-1") {
+		t.Errorf("expected plain nodegroup label, got:\n%s", got)
+	}
+}

--- a/spinifex/qmp/qmp.go
+++ b/spinifex/qmp/qmp.go
@@ -149,14 +149,27 @@ type QMPClient struct {
 	Dead bool
 }
 
+// DefaultGreetingTimeout bounds the wait for QEMU's QMP greeting on a plain VM.
+// A VFIO/GPU guest must lock+DMA-map its entire RAM before the monitor answers,
+// which exceeds this — such callers pass a larger value via
+// NewQMPClientWithGreetingTimeout.
+const DefaultGreetingTimeout = 30 * time.Second
+
 func NewQMPClient(path string) (*QMPClient, error) {
+	return NewQMPClientWithGreetingTimeout(path, DefaultGreetingTimeout)
+}
+
+// NewQMPClientWithGreetingTimeout is NewQMPClient with an explicit deadline for
+// the QMP greeting. VFIO passthrough guests pin all guest RAM before the monitor
+// responds, so the greeting can take far longer than DefaultGreetingTimeout.
+func NewQMPClientWithGreetingTimeout(path string, greetingTimeout time.Duration) (*QMPClient, error) {
 	conn, err := net.Dial("unix", path)
 	if err != nil {
 		return nil, err
 	}
 
 	// Deadline prevents a hung QEMU from blocking forever.
-	if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+	if err := conn.SetReadDeadline(time.Now().Add(greetingTimeout)); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("set read deadline: %w", err)
 	}

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -661,6 +661,22 @@ const (
 // seam overrides it to keep dial-failure tests off the wall clock.
 var qmpSocketWaitTimeout = 3 * time.Second
 
+// qmpVFIOGreetingTimeout is the QMP greeting wait for a VFIO passthrough guest.
+// QEMU must lock+DMA-map the entire guest RAM through the IOMMU before the
+// monitor answers, which scales with RAM and far exceeds the plain-VM default
+// (a 16GB EKS GPU worker takes >30s on wattle). Generous to cover larger guests
+// and a loaded host.
+const qmpVFIOGreetingTimeout = 180 * time.Second
+
+// qmpGreetingTimeout picks the QMP greeting deadline for a VM: the plain default
+// unless the guest has GPU/VFIO passthrough, whose RAM pinning delays the monitor.
+func qmpGreetingTimeout(v *VM) time.Duration {
+	if len(v.GPUAttachments) > 0 {
+		return qmpVFIOGreetingTimeout
+	}
+	return qmp.DefaultGreetingTimeout
+}
+
 // removeStaleQMPSocket unlinks a leftover QMP socket inode from a prior QEMU so
 // the startup probe and QMP dial cannot race a dead listener. A missing file is
 // not an error.
@@ -677,10 +693,10 @@ func removeStaleQMPSocket(path string) error {
 // first connect; a single dial then loses the race. Only transient connect
 // errors are retried — a greeting/handshake failure means we reached a listener,
 // so it surfaces immediately.
-func dialQMPWithRetry(path string) (*qmp.QMPClient, error) {
+func dialQMPWithRetry(path string, greetingTimeout time.Duration) (*qmp.QMPClient, error) {
 	deadline := time.Now().Add(qmpDialTimeout)
 	for {
-		client, err := qmp.NewQMPClient(path)
+		client, err := qmp.NewQMPClientWithGreetingTimeout(path, greetingTimeout)
 		if err == nil {
 			return client, nil
 		}
@@ -706,7 +722,7 @@ func newQMPClientWithHandshake(ctx context.Context, v *VM) (*qmp.QMPClient, erro
 	if err := utils.WaitForUnixSocket(v.Config.QMPSocket, qmpSocketWaitTimeout); err != nil {
 		return nil, fmt.Errorf("connect QMP socket %s: %w", v.Config.QMPSocket, err)
 	}
-	client, err := dialQMPWithRetry(v.Config.QMPSocket)
+	client, err := dialQMPWithRetry(v.Config.QMPSocket, qmpGreetingTimeout(v))
 	if err != nil {
 		return nil, fmt.Errorf("connect QMP socket %s: %w", v.Config.QMPSocket, err)
 	}
@@ -885,7 +901,9 @@ func reconnectQMP(q *qmp.QMPClient, instanceID string) error {
 		_ = q.Conn.Close()
 	}
 
-	fresh, err := dialQMPWithRetry(q.Path)
+	// A reconnect targets an already-running QEMU whose RAM is long pinned, so
+	// the greeting returns promptly — the plain default deadline is enough.
+	fresh, err := dialQMPWithRetry(q.Path, qmp.DefaultGreetingTimeout)
 	if err != nil {
 		return fmt.Errorf("redial QMP socket %s: %w", q.Path, err)
 	}

--- a/spinifex/vm/lifecycle_test.go
+++ b/spinifex/vm/lifecycle_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/gpu"
 	"github.com/mulgadc/spinifex/spinifex/qmp"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/stretchr/testify/assert"
@@ -1103,6 +1104,21 @@ func TestSendQMPCommand_ReconnectsAgainstSingleClientServer(t *testing.T) {
 
 	_, err = sendQMPCommand(t.Context(), client, qmp.QMPCommand{Execute: "query-status"}, "i-single-client")
 	require.NoError(t, err, "a second command must succeed over the reconnected stream")
+}
+
+// TestQMPGreetingTimeout pins the VFIO scaling: a GPU passthrough guest must
+// pin all its RAM through the IOMMU before the monitor answers, so it gets the
+// larger greeting deadline; a plain VM keeps the default.
+func TestQMPGreetingTimeout(t *testing.T) {
+	plain := &VM{}
+	assert.Equal(t, qmp.DefaultGreetingTimeout, qmpGreetingTimeout(plain),
+		"a plain VM keeps the default greeting deadline")
+
+	gpuVM := &VM{GPUAttachments: []gpu.GPUAttachment{{PCIAddress: "0000:5e:00.0"}}}
+	assert.Equal(t, qmpVFIOGreetingTimeout, qmpGreetingTimeout(gpuVM),
+		"a VFIO passthrough VM gets the larger greeting deadline")
+	assert.Greater(t, qmpVFIOGreetingTimeout, qmp.DefaultGreetingTimeout,
+		"the VFIO deadline must exceed the plain default")
 }
 
 // TestRemoveStaleQMPSocket covers the SIGKILL-leftover unlink: a stale socket

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -620,20 +619,13 @@ func waitPodReady(t *testing.T, kc *harness.Kubectl, pod string) {
 // --- Fixture --------------------------------------------------------------
 
 type clusterFixture struct {
-	ClusterName     string
-	AccountID       string
-	VPCID           string
-	SubnetID        string // worker (private) subnet
-	IGWID           string
-	PubSubnetID     string
-	PubRTID         string
-	PubRTAssocID    string
-	EIPAllocID      string
-	NATGWID         string
-	WorkerRTID      string
-	WorkerRTAssocID string
-	Cluster         *eks.Cluster
-	Deleted         bool
+	ClusterName string
+	AccountID   string
+	VPCID       string
+	SubnetID    string // worker (private) subnet
+	Egress      *harness.WorkerEgress
+	Cluster     *eks.Cluster
+	Deleted     bool
 }
 
 func setupClusterFixture(t *testing.T, c *harness.AWSClient, env *harness.Env, artifacts string) *clusterFixture {
@@ -647,12 +639,12 @@ func setupClusterFixture(t *testing.T, c *harness.AWSClient, env *harness.Env, a
 	t.Logf("account: %s", fx.AccountID)
 
 	harness.Phase(t, "Creating VPC topology (%s)", eksVPCCIDR)
-	createVPC(t, c, fx)
-	t.Cleanup(func() { deleteVPC(t, c, fx) })
-	createSubnet(t, c, fx)
-	t.Cleanup(func() { deleteSubnet(t, c, fx) })
-	createWorkerEgress(t, c, fx)
-	t.Cleanup(func() { deleteWorkerEgress(t, c, fx) })
+	fx.VPCID = harness.CreateVPC(t, c, eksVPCCIDR)
+	t.Cleanup(func() { harness.DeleteVPC(t, c, fx.VPCID) })
+	fx.SubnetID = harness.CreateSubnet(t, c, fx.VPCID, eksSubnetCIDR)
+	t.Cleanup(func() { harness.DeleteSubnet(t, c, fx.SubnetID) })
+	fx.Egress = harness.CreateWorkerEgress(t, c, fx.VPCID, fx.SubnetID, eksPublicSubnetCIDR)
+	t.Cleanup(func() { harness.DeleteWorkerEgress(t, c, fx.Egress) })
 
 	harness.Phase(t, "Creating cluster %q", fx.ClusterName)
 	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s-role", fx.AccountID, fx.ClusterName)
@@ -678,236 +670,6 @@ func requireClusterReady(t *testing.T, fx *clusterFixture) {
 	t.Helper()
 	if fx.Cluster == nil {
 		t.Skip("cluster never reached ACTIVE (CreateCluster subtest failed)")
-	}
-}
-
-// --- VPC / Subnet ---------------------------------------------------------
-
-func createVPC(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
-	t.Helper()
-	out, err := c.EC2.CreateVpc(&ec2.CreateVpcInput{CidrBlock: aws.String(eksVPCCIDR)})
-	require.NoError(t, err, "create-vpc")
-	fx.VPCID = aws.StringValue(out.Vpc.VpcId)
-	t.Logf("VPC: %s", fx.VPCID)
-}
-
-func deleteVPC(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
-	if fx.VPCID == "" {
-		return
-	}
-	if _, err := c.EC2.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String(fx.VPCID)}); err != nil {
-		t.Logf("delete VPC %s: %v", fx.VPCID, err)
-	}
-}
-
-func createSubnet(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
-	t.Helper()
-	out, err := c.EC2.CreateSubnet(&ec2.CreateSubnetInput{
-		VpcId:     aws.String(fx.VPCID),
-		CidrBlock: aws.String(eksSubnetCIDR),
-	})
-	require.NoError(t, err, "create-subnet")
-	fx.SubnetID = aws.StringValue(out.Subnet.SubnetId)
-	t.Logf("subnet: %s", fx.SubnetID)
-}
-
-func deleteSubnet(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
-	if fx.SubnetID == "" {
-		return
-	}
-	if _, err := c.EC2.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(fx.SubnetID)}); err != nil {
-		t.Logf("delete subnet %s: %v", fx.SubnetID, err)
-	}
-}
-
-// createWorkerEgress gives the customer VPC the egress a real customer VPC
-// needs for private workers: an IGW-fronted public subnet hosting a NAT
-// Gateway, with the worker subnet default-routed to that NAT Gateway. AttachIGW
-// deliberately programs no SNAT (mirrors AWS: an IGW serves only public-IP
-// instances), so a private worker reaches the public NLB endpoint and pulls
-// public CSI images only through the NAT Gateway's subnet-wide SNAT.
-func createWorkerEgress(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
-	t.Helper()
-
-	igwOut, err := c.EC2.CreateInternetGateway(&ec2.CreateInternetGatewayInput{}) // e2e:allow-create
-	require.NoError(t, err, "create-internet-gateway")
-	fx.IGWID = aws.StringValue(igwOut.InternetGateway.InternetGatewayId)
-	_, err = c.EC2.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
-		InternetGatewayId: aws.String(fx.IGWID),
-		VpcId:             aws.String(fx.VPCID),
-	})
-	require.NoError(t, err, "attach-internet-gateway")
-
-	// Public subnet routed straight to the IGW; the NAT Gateway lives here.
-	pubOut, err := c.EC2.CreateSubnet(&ec2.CreateSubnetInput{ // e2e:allow-create
-		VpcId:     aws.String(fx.VPCID),
-		CidrBlock: aws.String(eksPublicSubnetCIDR),
-	})
-	require.NoError(t, err, "create-public-subnet")
-	fx.PubSubnetID = aws.StringValue(pubOut.Subnet.SubnetId)
-
-	pubRT, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{VpcId: aws.String(fx.VPCID)}) // e2e:allow-create
-	require.NoError(t, err, "create-public-route-table")
-	fx.PubRTID = aws.StringValue(pubRT.RouteTable.RouteTableId)
-	_, err = c.EC2.CreateRoute(&ec2.CreateRouteInput{
-		RouteTableId:         aws.String(fx.PubRTID),
-		DestinationCidrBlock: aws.String("0.0.0.0/0"),
-		GatewayId:            aws.String(fx.IGWID),
-	})
-	require.NoError(t, err, "create-public-route")
-	pubAssoc, err := c.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
-		RouteTableId: aws.String(fx.PubRTID),
-		SubnetId:     aws.String(fx.PubSubnetID),
-	})
-	require.NoError(t, err, "associate-public-route-table")
-	fx.PubRTAssocID = aws.StringValue(pubAssoc.AssociationId)
-
-	// Elastic IP + NAT Gateway in the public subnet.
-	eip, err := c.EC2.AllocateAddress(&ec2.AllocateAddressInput{Domain: aws.String("vpc")}) // e2e:allow-create
-	require.NoError(t, err, "allocate-address")
-	fx.EIPAllocID = aws.StringValue(eip.AllocationId)
-	natOut, err := c.EC2.CreateNatGateway(&ec2.CreateNatGatewayInput{ // e2e:allow-create
-		SubnetId:     aws.String(fx.PubSubnetID),
-		AllocationId: aws.String(fx.EIPAllocID),
-	})
-	require.NoError(t, err, "create-nat-gateway")
-	fx.NATGWID = aws.StringValue(natOut.NatGateway.NatGatewayId)
-	waitNatGatewayAvailable(t, c, fx.NATGWID)
-
-	// Worker (private) subnet default-routes to the NAT Gateway; associating
-	// the route table triggers the subnet-wide SNAT egress reroute.
-	workerRT, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{VpcId: aws.String(fx.VPCID)}) // e2e:allow-create
-	require.NoError(t, err, "create-worker-route-table")
-	fx.WorkerRTID = aws.StringValue(workerRT.RouteTable.RouteTableId)
-	_, err = c.EC2.CreateRoute(&ec2.CreateRouteInput{
-		RouteTableId:         aws.String(fx.WorkerRTID),
-		DestinationCidrBlock: aws.String("0.0.0.0/0"),
-		NatGatewayId:         aws.String(fx.NATGWID),
-	})
-	require.NoError(t, err, "create-worker-route")
-	workerAssoc, err := c.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
-		RouteTableId: aws.String(fx.WorkerRTID),
-		SubnetId:     aws.String(fx.SubnetID),
-	})
-	require.NoError(t, err, "associate-worker-route-table")
-	fx.WorkerRTAssocID = aws.StringValue(workerAssoc.AssociationId)
-	t.Logf("egress: igw=%s nat=%s eip=%s pubrt=%s workerrt=%s",
-		fx.IGWID, fx.NATGWID, fx.EIPAllocID, fx.PubRTID, fx.WorkerRTID)
-}
-
-// waitNatGatewayAvailable blocks until the NAT Gateway reports "available";
-// SNAT is not programmed on the VPC router until then.
-func waitNatGatewayAvailable(t *testing.T, c *harness.AWSClient, natID string) {
-	t.Helper()
-	const timeout = 3 * time.Minute
-	deadline := time.Now().Add(timeout)
-	for {
-		out, err := c.EC2.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
-			NatGatewayIds: aws.StringSlice([]string{natID}),
-		})
-		if err == nil && len(out.NatGateways) > 0 {
-			switch aws.StringValue(out.NatGateways[0].State) {
-			case "available":
-				return
-			case "failed", "deleted":
-				t.Fatalf("nat gateway %s entered terminal state %q", natID, aws.StringValue(out.NatGateways[0].State))
-			}
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("nat gateway %s not available within %s", natID, timeout)
-		}
-		time.Sleep(3 * time.Second)
-	}
-}
-
-// deleteWorkerEgress tears the egress topology down in reverse: the worker
-// route table releases the private subnet, then the NAT Gateway is deleted and
-// drained before the public subnet + EIP it pins can be removed.
-func deleteWorkerEgress(t *testing.T, c *harness.AWSClient, fx *clusterFixture) {
-	if fx.WorkerRTAssocID != "" {
-		if _, err := c.EC2.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
-			AssociationId: aws.String(fx.WorkerRTAssocID),
-		}); err != nil {
-			t.Logf("disassociate worker route table %s: %v", fx.WorkerRTAssocID, err)
-		}
-	}
-	if fx.WorkerRTID != "" {
-		if _, err := c.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{
-			RouteTableId: aws.String(fx.WorkerRTID),
-		}); err != nil {
-			t.Logf("delete worker route table %s: %v", fx.WorkerRTID, err)
-		}
-	}
-	if fx.NATGWID != "" {
-		if _, err := c.EC2.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
-			NatGatewayId: aws.String(fx.NATGWID),
-		}); err != nil {
-			t.Logf("delete nat gateway %s: %v", fx.NATGWID, err)
-		}
-		waitNatGatewayDeleted(t, c, fx.NATGWID)
-	}
-	if fx.EIPAllocID != "" {
-		if _, err := c.EC2.ReleaseAddress(&ec2.ReleaseAddressInput{
-			AllocationId: aws.String(fx.EIPAllocID),
-		}); err != nil {
-			t.Logf("release address %s: %v", fx.EIPAllocID, err)
-		}
-	}
-	if fx.PubRTAssocID != "" {
-		if _, err := c.EC2.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
-			AssociationId: aws.String(fx.PubRTAssocID),
-		}); err != nil {
-			t.Logf("disassociate public route table %s: %v", fx.PubRTAssocID, err)
-		}
-	}
-	if fx.PubRTID != "" {
-		if _, err := c.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{
-			RouteTableId: aws.String(fx.PubRTID),
-		}); err != nil {
-			t.Logf("delete public route table %s: %v", fx.PubRTID, err)
-		}
-	}
-	if fx.PubSubnetID != "" {
-		if _, err := c.EC2.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(fx.PubSubnetID)}); err != nil {
-			t.Logf("delete public subnet %s: %v", fx.PubSubnetID, err)
-		}
-	}
-	if fx.IGWID != "" {
-		if _, err := c.EC2.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
-			InternetGatewayId: aws.String(fx.IGWID),
-			VpcId:             aws.String(fx.VPCID),
-		}); err != nil {
-			t.Logf("detach igw %s: %v", fx.IGWID, err)
-		}
-		if _, err := c.EC2.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
-			InternetGatewayId: aws.String(fx.IGWID),
-		}); err != nil {
-			t.Logf("delete igw %s: %v", fx.IGWID, err)
-		}
-	}
-}
-
-// waitNatGatewayDeleted blocks until the NAT Gateway drains to "deleted" so the
-// public subnet + EIP it holds can be released; best-effort on timeout.
-func waitNatGatewayDeleted(t *testing.T, c *harness.AWSClient, natID string) {
-	t.Helper()
-	const timeout = 3 * time.Minute
-	deadline := time.Now().Add(timeout)
-	for {
-		out, err := c.EC2.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
-			NatGatewayIds: aws.StringSlice([]string{natID}),
-		})
-		if err != nil || len(out.NatGateways) == 0 {
-			return
-		}
-		if aws.StringValue(out.NatGateways[0].State) == "deleted" {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Logf("nat gateway %s not deleted within %s; continuing teardown", natID, timeout)
-			return
-		}
-		time.Sleep(3 * time.Second)
 	}
 }
 

--- a/tests/e2e/gpu/eks_gpu_test.go
+++ b/tests/e2e/gpu/eks_gpu_test.go
@@ -1,0 +1,480 @@
+//go:build e2e
+
+package gpu
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// eksGPUInstanceType is the single worker instance type for the GPU
+	// nodegroup — must be advertised with GpuInfo (see requireEKSGPUFixture).
+	eksGPUInstanceType = "g5.xlarge"
+	// eksGPUVPCCIDR / eksGPUSubnetCIDR / eksGPUPublicSubnetCIDR build a
+	// dedicated VPC + private worker subnet + NAT-gateway egress topology
+	// (mirrors eks_test.go's setupClusterFixture), on a CIDR range disjoint
+	// from the eks suite's 10.210.0.0/16 so the two suites never collide.
+	eksGPUVPCCIDR          = "10.212.0.0/16"
+	eksGPUSubnetCIDR       = "10.212.1.0/24"
+	eksGPUPublicSubnetCIDR = "10.212.2.0/24"
+	eksGPUClusterPfx       = "eks-gpu-e2e"
+
+	// eksNodeAMIName / eksNodeGPUAMIName are the registered EKS node AMI
+	// names (see spinifex/spinifex/utils/images.go). Both must be imported —
+	// the base image for control-plane parity checks, the GPU variant for
+	// resolveWorkerAMI's GPU branch.
+	eksNodeAMIName    = "spinifex-eks-node"
+	eksNodeGPUAMIName = "spinifex-eks-node-gpu"
+
+	// nvidiaDevicePluginDaemonSet is the DaemonSet name from the bundled
+	// addon manifest (scripts/images/eks-node/addons/nvidia-device-plugin).
+	nvidiaDevicePluginDaemonSet = "nvidia-device-plugin-daemonset"
+
+	// nvidiaSmiPodImage carries the nvidia-smi CLI; pulled directly (not
+	// through the ECR mirror path), matching the busybox pattern EBS CSI e2e
+	// uses for its non-ECR test images.
+	nvidiaSmiPodImage = "nvidia/cuda:12.4.1-base-ubuntu22.04"
+)
+
+// eksGPUFixture bundles the environment + AWS client resolved once every
+// requireEKSGPUFixture guard condition passes.
+type eksGPUFixture struct {
+	Env *harness.Env
+	AWS *harness.AWSClient
+}
+
+// requireEKSGPUFixture skips the calling test unless every precondition for
+// exercising Epic B (EKS: expose GPU to pods) is met:
+//   - SPINIFEX_E2E is set
+//   - SPINIFEX_MODE is single (this suite only targets a single-node dev box)
+//   - g5.xlarge is advertised with GPU capability by DescribeInstanceTypes
+//   - both EKS node AMIs (spinifex-eks-node, spinifex-eks-node-gpu) are imported
+func requireEKSGPUFixture(t *testing.T) *eksGPUFixture {
+	t.Helper()
+	if os.Getenv("SPINIFEX_E2E") == "" {
+		t.Skip("SPINIFEX_E2E unset")
+	}
+	env := harness.LoadEnv(t)
+	if env.Mode != harness.ModeSingle {
+		t.Skip("eks gpu suite requires SPINIFEX_MODE=single")
+	}
+	// Give a clean skip rather than letting NewAWSClient t.Fatal when no
+	// Spinifex node is running (ResolveCACert uses the same candidate paths).
+	if _, err := harness.ResolveCACert(env); err != nil {
+		t.Skip("no Spinifex node running — provision first: ansible-playbook ansible/playbooks/dev-reset.yml")
+	}
+	awsCli := harness.NewAWSClient(t, env)
+
+	if reason := discoverEKSGPUPrereqs(awsCli); reason != "" {
+		t.Skip(reason)
+	}
+	return &eksGPUFixture{Env: env, AWS: awsCli}
+}
+
+// discoverEKSGPUPrereqs returns a non-empty skip reason unless g5.xlarge is
+// advertised with GPU capability AND both EKS node AMIs are imported.
+func discoverEKSGPUPrereqs(c *harness.AWSClient) string {
+	typesOut, err := c.EC2.DescribeInstanceTypes(&ec2.DescribeInstanceTypesInput{
+		InstanceTypes: aws.StringSlice([]string{eksGPUInstanceType}),
+	})
+	if err != nil {
+		return "DescribeInstanceTypes: " + err.Error()
+	}
+	gpuAdvertised := false
+	for _, it := range typesOut.InstanceTypes {
+		if aws.StringValue(it.InstanceType) == eksGPUInstanceType && it.GpuInfo != nil && len(it.GpuInfo.Gpus) > 0 {
+			gpuAdvertised = true
+			break
+		}
+	}
+	if !gpuAdvertised {
+		return fmt.Sprintf("instance type %s not advertised with GPU capability — node has no GPU or gpu_passthrough is disabled", eksGPUInstanceType)
+	}
+
+	imgsOut, err := c.EC2.DescribeImages(&ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{Name: aws.String("name"), Values: aws.StringSlice([]string{eksNodeAMIName, eksNodeGPUAMIName})},
+			{Name: aws.String("state"), Values: []*string{aws.String("available")}},
+		},
+	})
+	if err != nil {
+		return "DescribeImages: " + err.Error()
+	}
+	seen := make(map[string]bool, len(imgsOut.Images))
+	for _, img := range imgsOut.Images {
+		seen[aws.StringValue(img.Name)] = true
+	}
+	var missing []string
+	for _, name := range []string{eksNodeAMIName, eksNodeGPUAMIName} {
+		if !seen[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Sprintf("EKS node AMI(s) not imported: %s — run: spx admin images import --name <ami>", strings.Join(missing, ", "))
+	}
+	return ""
+}
+
+// TestEKSGPUPodExposure drives Epic B end-to-end: a minimal EKS cluster plus a
+// 1-node GPU nodegroup, then asserts the GPU is actually visible to a pod —
+// node Ready, gpu.present label + scheduling taint, device-plugin DaemonSet
+// rollout, nvidia.com/gpu allocatable, and a tolerating pod running
+// nvidia-smi against the passed-through device.
+func TestEKSGPUPodExposure(t *testing.T) {
+	fx := requireEKSGPUFixture(t)
+	env, c := fx.Env, fx.AWS
+	artifacts := harness.ArtifactDir(t, env)
+
+	harness.Phase(t, "EKS GPU — resolving caller account")
+	ident, err := c.STS.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	require.NoError(t, err, "sts get-caller-identity")
+	accountID := aws.StringValue(ident.Account)
+
+	harness.Phase(t, "Creating VPC topology (%s)", eksGPUVPCCIDR)
+	vpcID := harness.CreateVPC(t, c, eksGPUVPCCIDR)
+	t.Cleanup(func() { harness.DeleteVPC(t, c, vpcID) })
+	subnetID := harness.CreateSubnet(t, c, vpcID, eksGPUSubnetCIDR)
+	t.Cleanup(func() { harness.DeleteSubnet(t, c, subnetID) })
+	egress := harness.CreateWorkerEgress(t, c, vpcID, subnetID, eksGPUPublicSubnetCIDR)
+	t.Cleanup(func() { harness.DeleteWorkerEgress(t, c, egress) })
+
+	clusterName := fmt.Sprintf("%s-%d", eksGPUClusterPfx, time.Now().Unix())
+	harness.Phase(t, "Creating cluster %q", clusterName)
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s-role", accountID, clusterName)
+	// e2e:allow-create — the GPU cluster is the subject under test (GPU worker join + device-plugin exposure).
+	_, err = c.EKS.CreateCluster(&eks.CreateClusterInput{
+		Name:    aws.String(clusterName),
+		RoleArn: aws.String(roleArn),
+		ResourcesVpcConfig: &eks.VpcConfigRequest{
+			SubnetIds: aws.StringSlice([]string{subnetID}),
+			// Public access (default). The dedicated VPC has a NAT Gateway
+			// (harness.CreateWorkerEgress), so the private GPU worker SNATs
+			// out to reach the internet-facing NLB endpoint and pull images.
+			EndpointPublicAccess: aws.Bool(true),
+		},
+	})
+	require.NoError(t, err, "create-cluster")
+	t.Cleanup(func() { deleteEKSGPUClusterBestEffort(t, c, clusterName) })
+
+	cl := harness.WaitForEKSClusterActive(t, c, clusterName)
+	require.Equal(t, eks.ClusterStatusActive, aws.StringValue(cl.Status))
+
+	kcPath := writeEKSGPUKubeconfig(t, artifacts, cl)
+	kc := harness.NewKubectl(t, kcPath, eksGPUTokenEnv(t, env))
+
+	nodeRoleName := fmt.Sprintf("%s-node", clusterName)
+	harness.Phase(t, "Creating node IAM role %s", nodeRoleName)
+	const nodeTrustPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+	_, err = c.IAM.CreateRole(&iam.CreateRoleInput{
+		RoleName:                 aws.String(nodeRoleName),
+		AssumeRolePolicyDocument: aws.String(nodeTrustPolicy),
+		Description:              aws.String("E2E GPU node role"),
+	})
+	require.NoError(t, err, "create-role (node)")
+	t.Cleanup(func() { deleteEKSGPUNodeRoleBestEffort(t, c, nodeRoleName) })
+
+	const nodegroup = "gpu-e2e-ng"
+	harness.Phase(t, "Creating GPU nodegroup %s (%s)", nodegroup, eksGPUInstanceType)
+	// e2e:allow-create — the GPU nodegroup is the subject under test (GPU worker join + device-plugin exposure).
+	_, err = c.EKS.CreateNodegroup(&eks.CreateNodegroupInput{
+		ClusterName:   aws.String(clusterName),
+		NodegroupName: aws.String(nodegroup),
+		Subnets:       aws.StringSlice([]string{subnetID}),
+		NodeRole:      aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, nodeRoleName)),
+		InstanceTypes: aws.StringSlice([]string{eksGPUInstanceType}),
+		ScalingConfig: &eks.NodegroupScalingConfig{
+			MinSize:     aws.Int64(1),
+			MaxSize:     aws.Int64(1),
+			DesiredSize: aws.Int64(1),
+		},
+	})
+	require.NoError(t, err, "create-nodegroup")
+	t.Cleanup(func() { deleteEKSGPUNodegroupBestEffort(t, c, clusterName, nodegroup) })
+
+	harness.Phase(t, "Waiting for nodegroup ACTIVE")
+	harness.EventuallyErr(t, func() error {
+		out, derr := c.EKS.DescribeNodegroup(&eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(clusterName),
+			NodegroupName: aws.String(nodegroup),
+		})
+		if derr != nil {
+			return fmt.Errorf("describe-nodegroup: %w", derr)
+		}
+		if s := aws.StringValue(out.Nodegroup.Status); s != eks.NodegroupStatusActive {
+			return fmt.Errorf("nodegroup status %q, want ACTIVE", s)
+		}
+		return nil
+	}, 10*time.Minute, 10*time.Second)
+
+	// (a) the GPU worker node becomes Ready.
+	var nodeName string
+	harness.Phase(t, "Waiting for GPU worker node Ready")
+	harness.EventuallyErr(t, func() error {
+		out, kerr := kc.Run(30*time.Second, "get", "nodes",
+			"-l", "eks.amazonaws.com/nodegroup="+nodegroup,
+			"-o", `jsonpath={range .items[*]}{.metadata.name}{"="}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}`)
+		if kerr != nil {
+			return fmt.Errorf("kubectl get nodes: %v\n%s", kerr, out)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			name, ready, ok := strings.Cut(line, "=")
+			if ok && ready == "True" {
+				nodeName = name
+				return nil
+			}
+		}
+		return fmt.Errorf("no Ready GPU node yet:\n%s", out)
+	}, 8*time.Minute, 5*time.Second)
+	require.NotEmpty(t, nodeName, "GPU worker node name resolved")
+	harness.Detail(t, "node", nodeName)
+
+	// (b) node carries the GPU label and scheduling taint.
+	labelOut, err := kc.Run(30*time.Second, "get", "node", nodeName, "-o",
+		`jsonpath={.metadata.labels['nvidia\.com/gpu\.present']}`)
+	require.NoErrorf(t, err, "get node labels:\n%s", labelOut)
+	assert.Equal(t, "true", strings.TrimSpace(labelOut), "node must carry nvidia.com/gpu.present=true")
+
+	taintsOut, err := kc.Run(30*time.Second, "get", "node", nodeName, "-o",
+		`jsonpath={range .spec.taints[*]}{.key}={.value}:{.effect}{"\n"}{end}`)
+	require.NoErrorf(t, err, "get node taints:\n%s", taintsOut)
+	assert.Contains(t, taintsOut, "nvidia.com/gpu=present:NoSchedule", "node must carry the GPU scheduling taint")
+
+	// (c) nvidia-device-plugin-daemonset reports desired=1/ready=1.
+	harness.Phase(t, "Waiting for %s rollout", nvidiaDevicePluginDaemonSet)
+	harness.EventuallyErr(t, func() error {
+		out, kerr := kc.Run(30*time.Second, "-n", "kube-system", "get", "daemonset", nvidiaDevicePluginDaemonSet,
+			"-o", `jsonpath={.status.desiredNumberScheduled}={.status.numberReady}`)
+		if kerr != nil {
+			return fmt.Errorf("get daemonset: %v\n%s", kerr, out)
+		}
+		if strings.TrimSpace(out) != "1=1" {
+			return fmt.Errorf("daemonset desired=ready %q, want 1=1", strings.TrimSpace(out))
+		}
+		return nil
+	}, 5*time.Minute, 5*time.Second)
+
+	// (d) node.status.allocatable["nvidia.com/gpu"] == "1".
+	allocOut, err := kc.Run(30*time.Second, "get", "node", nodeName, "-o",
+		`jsonpath={.status.allocatable['nvidia\.com/gpu']}`)
+	require.NoErrorf(t, err, "get node allocatable:\n%s", allocOut)
+	assert.Equal(t, "1", strings.TrimSpace(allocOut), "node must expose exactly 1 allocatable nvidia.com/gpu")
+
+	// (e) a pod tolerating the taint and requesting nvidia.com/gpu runs
+	// nvidia-smi and observes the passed-through device.
+	const podName = "nvidia-smi-e2e"
+	podPath := filepath.Join(artifacts, "nvidia-smi-pod.yaml")
+	require.NoError(t, os.WriteFile(podPath, []byte(nvidiaSmiPodManifest(podName)), 0o600))
+	t.Cleanup(func() {
+		_, _ = kc.Run(60*time.Second, "delete", "-f", podPath, "--ignore-not-found", "--wait=false")
+	})
+
+	harness.Phase(t, "Applying nvidia-smi pod")
+	out, err := kc.Run(60*time.Second, "apply", "-f", podPath)
+	require.NoErrorf(t, err, "apply nvidia-smi pod:\n%s", out)
+
+	harness.EventuallyErr(t, func() error {
+		phase, kerr := kc.Run(30*time.Second, "get", "pod", podName, "-o", `jsonpath={.status.phase}`)
+		if kerr != nil {
+			return fmt.Errorf("get pod phase: %v\n%s", kerr, phase)
+		}
+		switch strings.TrimSpace(phase) {
+		case "Succeeded":
+			return nil
+		case "Failed":
+			desc, _ := kc.Run(30*time.Second, "describe", "pod", podName)
+			return fmt.Errorf("pod %s failed:\n%s", podName, desc)
+		default:
+			return fmt.Errorf("pod %s phase=%q, want Succeeded", podName, strings.TrimSpace(phase))
+		}
+	}, 5*time.Minute, 5*time.Second)
+
+	logs, err := kc.Run(30*time.Second, "logs", podName)
+	require.NoErrorf(t, err, "pod logs:\n%s", logs)
+	assert.Contains(t, logs, "NVIDIA RTX A1000", "nvidia-smi output must report the passed-through GPU model")
+}
+
+// nvidiaSmiPodManifest renders a Never-restart pod that tolerates the GPU
+// scheduling taint, requests one nvidia.com/gpu, and runs nvidia-smi once.
+func nvidiaSmiPodManifest(name string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: default
+spec:
+  restartPolicy: Never
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Equal
+    value: present
+    effect: NoSchedule
+  containers:
+  - name: nvidia-smi
+    image: %s
+    command: ["nvidia-smi"]
+    resources:
+      limits:
+        nvidia.com/gpu: "1"
+`, name, nvidiaSmiPodImage)
+}
+
+// writeEKSGPUKubeconfig builds a kubeconfig from DescribeCluster output,
+// mirroring eks_test.go's writeKubeconfig (unexported there, so reimplemented
+// locally for this package).
+func writeEKSGPUKubeconfig(t *testing.T, artifacts string, cl *eks.Cluster) string {
+	t.Helper()
+	name := aws.StringValue(cl.Name)
+	kc := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: %[1]s
+  cluster:
+    server: %[2]s
+    certificate-authority-data: %[3]s
+contexts:
+- name: %[1]s
+  context:
+    cluster: %[1]s
+    user: %[1]s
+current-context: %[1]s
+users:
+- name: %[1]s
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+      args:
+      - eks
+      - get-token
+      - --cluster-name
+      - %[1]s
+`, name, aws.StringValue(cl.Endpoint), aws.StringValue(cl.CertificateAuthority.Data))
+
+	path := filepath.Join(artifacts, "kubeconfig-"+name+".yaml")
+	require.NoError(t, os.WriteFile(path, []byte(kc), 0o600), "write kubeconfig")
+	t.Logf("kubeconfig: %s", path)
+	return path
+}
+
+// eksGPUTokenEnv builds the environment kubectl's `aws eks get-token` exec
+// block needs, mirroring eks_test.go's getTokenEnv.
+func eksGPUTokenEnv(t *testing.T, env *harness.Env) []string {
+	t.Helper()
+	e := os.Environ()
+	if os.Getenv("AWS_PROFILE") == "" {
+		e = append(e, "AWS_PROFILE="+eksGPUEnvOr("SPINIFEX_AWS_PROFILE", "spinifex"))
+	}
+	if os.Getenv("AWS_REGION") == "" {
+		e = append(e, "AWS_REGION="+eksGPUEnvOr("SPINIFEX_AWS_REGION", "ap-southeast-2"))
+	}
+	if os.Getenv("AWS_CA_BUNDLE") == "" && os.Getenv("SPINIFEX_AWS_INSECURE") != "1" {
+		if ca, err := harness.ResolveCACert(env); err == nil {
+			e = append(e, "AWS_CA_BUNDLE="+ca)
+		}
+	}
+	return e
+}
+
+func eksGPUEnvOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// deleteEKSGPUNodegroupBestEffort deletes the nodegroup and waits for it to
+// clear, logging (not failing) on error so cluster teardown still proceeds.
+func deleteEKSGPUNodegroupBestEffort(t *testing.T, c *harness.AWSClient, cluster, nodegroup string) {
+	t.Helper()
+	if _, err := c.EKS.DeleteNodegroup(&eks.DeleteNodegroupInput{
+		ClusterName:   aws.String(cluster),
+		NodegroupName: aws.String(nodegroup),
+	}); err != nil {
+		if !isEKSResourceNotFound(err) {
+			t.Logf("cleanup delete-nodegroup %s/%s: %v", cluster, nodegroup, err)
+		}
+		return
+	}
+	harness.EventuallyErr(t, func() error {
+		_, err := c.EKS.DescribeNodegroup(&eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(cluster),
+			NodegroupName: aws.String(nodegroup),
+		})
+		if err == nil {
+			return fmt.Errorf("nodegroup %s/%s still exists", cluster, nodegroup)
+		}
+		if isEKSResourceNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("describe-nodegroup %s/%s: %w", cluster, nodegroup, err)
+	}, 5*time.Minute, 5*time.Second)
+}
+
+// deleteEKSGPUNodeRoleBestEffort detaches the node role from the instance
+// profile ensureNodeInstanceProfile created for it (see nodegroup.go), then
+// deletes the profile and the role, logging (not failing) on error. Cleanups
+// run LIFO, so this fires after the nodegroup cleanup has already terminated
+// the worker that held the instance profile.
+func deleteEKSGPUNodeRoleBestEffort(t *testing.T, c *harness.AWSClient, roleName string) {
+	t.Helper()
+	if _, err := c.IAM.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{
+		InstanceProfileName: aws.String(roleName),
+		RoleName:            aws.String(roleName),
+	}); err != nil {
+		t.Logf("cleanup remove-role-from-instance-profile %s: %v", roleName, err)
+	}
+	if _, err := c.IAM.DeleteInstanceProfile(&iam.DeleteInstanceProfileInput{
+		InstanceProfileName: aws.String(roleName),
+	}); err != nil {
+		t.Logf("cleanup delete-instance-profile %s: %v", roleName, err)
+	}
+	if _, err := c.IAM.DeleteRole(&iam.DeleteRoleInput{RoleName: aws.String(roleName)}); err != nil {
+		t.Logf("cleanup delete-role %s: %v", roleName, err)
+	}
+}
+
+// deleteEKSGPUClusterBestEffort deletes the cluster and waits for it to be
+// gone. Registered after the nodegroup cleanup (LIFO), so the worker is
+// already reclaimed before the control plane tears down.
+func deleteEKSGPUClusterBestEffort(t *testing.T, c *harness.AWSClient, cluster string) {
+	t.Helper()
+	if _, err := c.EKS.DeleteCluster(&eks.DeleteClusterInput{Name: aws.String(cluster)}); err != nil {
+		if !isEKSResourceNotFound(err) {
+			t.Logf("cleanup delete-cluster %s: %v", cluster, err)
+		}
+		return
+	}
+	harness.WaitForEKSClusterDeleted(t, c, cluster)
+}
+
+// isEKSResourceNotFound reports whether err is the EKS "gone" error. The SDK
+// constant is "ResourceNotFoundException" but awsgw emits the doubled
+// "ResourceNotFoundExceptionException" on the wire, so match by substring
+// (mirrors harness.isClusterNotFound).
+func isEKSResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var aerr awserr.Error
+	if errors.As(err, &aerr) {
+		return strings.Contains(aerr.Code(), "ResourceNotFound")
+	}
+	return false
+}

--- a/tests/e2e/harness/vpc_egress.go
+++ b/tests/e2e/harness/vpc_egress.go
@@ -1,0 +1,269 @@
+//go:build e2e
+
+package harness
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/require"
+)
+
+// CreateVPC creates a VPC with the given CIDR and returns its ID.
+func CreateVPC(t *testing.T, c *AWSClient, cidr string) string {
+	t.Helper()
+	out, err := c.EC2.CreateVpc(&ec2.CreateVpcInput{CidrBlock: aws.String(cidr)}) // e2e:allow-create
+	require.NoError(t, err, "create-vpc")
+	vpcID := aws.StringValue(out.Vpc.VpcId)
+	t.Logf("VPC: %s", vpcID)
+	return vpcID
+}
+
+// DeleteVPC deletes vpcID, logging (not failing) on error so teardown proceeds.
+func DeleteVPC(t *testing.T, c *AWSClient, vpcID string) {
+	t.Helper()
+	if vpcID == "" {
+		return
+	}
+	if _, err := c.EC2.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String(vpcID)}); err != nil {
+		t.Logf("delete VPC %s: %v", vpcID, err)
+	}
+}
+
+// CreateSubnet creates a subnet in vpcID with the given CIDR and returns its ID.
+func CreateSubnet(t *testing.T, c *AWSClient, vpcID, cidr string) string {
+	t.Helper()
+	out, err := c.EC2.CreateSubnet(&ec2.CreateSubnetInput{ // e2e:allow-create
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String(cidr),
+	})
+	require.NoError(t, err, "create-subnet")
+	subnetID := aws.StringValue(out.Subnet.SubnetId)
+	t.Logf("subnet: %s", subnetID)
+	return subnetID
+}
+
+// DeleteSubnet deletes subnetID, logging (not failing) on error so teardown proceeds.
+func DeleteSubnet(t *testing.T, c *AWSClient, subnetID string) {
+	t.Helper()
+	if subnetID == "" {
+		return
+	}
+	if _, err := c.EC2.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(subnetID)}); err != nil {
+		t.Logf("delete subnet %s: %v", subnetID, err)
+	}
+}
+
+// WorkerEgress bundles the IGW/public-subnet/NAT-gateway resources that give a
+// private worker subnet internet egress, plus the IDs needed to tear it down.
+type WorkerEgress struct {
+	VPCID           string
+	WorkerSubnetID  string
+	IGWID           string
+	PubSubnetID     string
+	PubRTID         string
+	PubRTAssocID    string
+	EIPAllocID      string
+	NATGWID         string
+	WorkerRTID      string
+	WorkerRTAssocID string
+}
+
+// CreateWorkerEgress gives vpcID the egress a real customer VPC needs for
+// private workers: an IGW-fronted public subnet (pubCIDR) hosting a NAT
+// Gateway, with workerSubnetID default-routed to that NAT Gateway. AttachIGW
+// deliberately programs no SNAT (mirrors AWS: an IGW serves only public-IP
+// instances), so a private worker reaches a public NLB endpoint and pulls
+// public images only through the NAT Gateway's subnet-wide SNAT.
+func CreateWorkerEgress(t *testing.T, c *AWSClient, vpcID, workerSubnetID, pubCIDR string) *WorkerEgress {
+	t.Helper()
+	eg := &WorkerEgress{VPCID: vpcID, WorkerSubnetID: workerSubnetID}
+
+	igwOut, err := c.EC2.CreateInternetGateway(&ec2.CreateInternetGatewayInput{}) // e2e:allow-create
+	require.NoError(t, err, "create-internet-gateway")
+	eg.IGWID = aws.StringValue(igwOut.InternetGateway.InternetGatewayId)
+	_, err = c.EC2.AttachInternetGateway(&ec2.AttachInternetGatewayInput{
+		InternetGatewayId: aws.String(eg.IGWID),
+		VpcId:             aws.String(vpcID),
+	})
+	require.NoError(t, err, "attach-internet-gateway")
+
+	// Public subnet routed straight to the IGW; the NAT Gateway lives here.
+	pubOut, err := c.EC2.CreateSubnet(&ec2.CreateSubnetInput{ // e2e:allow-create
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String(pubCIDR),
+	})
+	require.NoError(t, err, "create-public-subnet")
+	eg.PubSubnetID = aws.StringValue(pubOut.Subnet.SubnetId)
+
+	pubRT, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{VpcId: aws.String(vpcID)}) // e2e:allow-create
+	require.NoError(t, err, "create-public-route-table")
+	eg.PubRTID = aws.StringValue(pubRT.RouteTable.RouteTableId)
+	_, err = c.EC2.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         aws.String(eg.PubRTID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String(eg.IGWID),
+	})
+	require.NoError(t, err, "create-public-route")
+	pubAssoc, err := c.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(eg.PubRTID),
+		SubnetId:     aws.String(eg.PubSubnetID),
+	})
+	require.NoError(t, err, "associate-public-route-table")
+	eg.PubRTAssocID = aws.StringValue(pubAssoc.AssociationId)
+
+	// Elastic IP + NAT Gateway in the public subnet.
+	eip, err := c.EC2.AllocateAddress(&ec2.AllocateAddressInput{Domain: aws.String("vpc")}) // e2e:allow-create
+	require.NoError(t, err, "allocate-address")
+	eg.EIPAllocID = aws.StringValue(eip.AllocationId)
+	natOut, err := c.EC2.CreateNatGateway(&ec2.CreateNatGatewayInput{ // e2e:allow-create
+		SubnetId:     aws.String(eg.PubSubnetID),
+		AllocationId: aws.String(eg.EIPAllocID),
+	})
+	require.NoError(t, err, "create-nat-gateway")
+	eg.NATGWID = aws.StringValue(natOut.NatGateway.NatGatewayId)
+	waitNatGatewayAvailable(t, c, eg.NATGWID)
+
+	// Worker (private) subnet default-routes to the NAT Gateway; associating
+	// the route table triggers the subnet-wide SNAT egress reroute.
+	workerRT, err := c.EC2.CreateRouteTable(&ec2.CreateRouteTableInput{VpcId: aws.String(vpcID)}) // e2e:allow-create
+	require.NoError(t, err, "create-worker-route-table")
+	eg.WorkerRTID = aws.StringValue(workerRT.RouteTable.RouteTableId)
+	_, err = c.EC2.CreateRoute(&ec2.CreateRouteInput{
+		RouteTableId:         aws.String(eg.WorkerRTID),
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		NatGatewayId:         aws.String(eg.NATGWID),
+	})
+	require.NoError(t, err, "create-worker-route")
+	workerAssoc, err := c.EC2.AssociateRouteTable(&ec2.AssociateRouteTableInput{
+		RouteTableId: aws.String(eg.WorkerRTID),
+		SubnetId:     aws.String(workerSubnetID),
+	})
+	require.NoError(t, err, "associate-worker-route-table")
+	eg.WorkerRTAssocID = aws.StringValue(workerAssoc.AssociationId)
+	t.Logf("egress: igw=%s nat=%s eip=%s pubrt=%s workerrt=%s",
+		eg.IGWID, eg.NATGWID, eg.EIPAllocID, eg.PubRTID, eg.WorkerRTID)
+	return eg
+}
+
+// waitNatGatewayAvailable blocks until the NAT Gateway reports "available";
+// SNAT is not programmed on the VPC router until then.
+func waitNatGatewayAvailable(t *testing.T, c *AWSClient, natID string) {
+	t.Helper()
+	const timeout = 3 * time.Minute
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := c.EC2.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
+			NatGatewayIds: aws.StringSlice([]string{natID}),
+		})
+		if err == nil && len(out.NatGateways) > 0 {
+			switch aws.StringValue(out.NatGateways[0].State) {
+			case "available":
+				return
+			case "failed", "deleted":
+				t.Fatalf("nat gateway %s entered terminal state %q", natID, aws.StringValue(out.NatGateways[0].State))
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nat gateway %s not available within %s", natID, timeout)
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// DeleteWorkerEgress tears the egress topology down in reverse: the worker
+// route table releases the private subnet, then the NAT Gateway is deleted and
+// drained before the public subnet + EIP it pins can be removed.
+func DeleteWorkerEgress(t *testing.T, c *AWSClient, eg *WorkerEgress) {
+	t.Helper()
+	if eg == nil {
+		return
+	}
+	if eg.WorkerRTAssocID != "" {
+		if _, err := c.EC2.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
+			AssociationId: aws.String(eg.WorkerRTAssocID),
+		}); err != nil {
+			t.Logf("disassociate worker route table %s: %v", eg.WorkerRTAssocID, err)
+		}
+	}
+	if eg.WorkerRTID != "" {
+		if _, err := c.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+			RouteTableId: aws.String(eg.WorkerRTID),
+		}); err != nil {
+			t.Logf("delete worker route table %s: %v", eg.WorkerRTID, err)
+		}
+	}
+	if eg.NATGWID != "" {
+		if _, err := c.EC2.DeleteNatGateway(&ec2.DeleteNatGatewayInput{
+			NatGatewayId: aws.String(eg.NATGWID),
+		}); err != nil {
+			t.Logf("delete nat gateway %s: %v", eg.NATGWID, err)
+		}
+		waitNatGatewayDeleted(t, c, eg.NATGWID)
+	}
+	if eg.EIPAllocID != "" {
+		if _, err := c.EC2.ReleaseAddress(&ec2.ReleaseAddressInput{
+			AllocationId: aws.String(eg.EIPAllocID),
+		}); err != nil {
+			t.Logf("release address %s: %v", eg.EIPAllocID, err)
+		}
+	}
+	if eg.PubRTAssocID != "" {
+		if _, err := c.EC2.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
+			AssociationId: aws.String(eg.PubRTAssocID),
+		}); err != nil {
+			t.Logf("disassociate public route table %s: %v", eg.PubRTAssocID, err)
+		}
+	}
+	if eg.PubRTID != "" {
+		if _, err := c.EC2.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+			RouteTableId: aws.String(eg.PubRTID),
+		}); err != nil {
+			t.Logf("delete public route table %s: %v", eg.PubRTID, err)
+		}
+	}
+	if eg.PubSubnetID != "" {
+		if _, err := c.EC2.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(eg.PubSubnetID)}); err != nil {
+			t.Logf("delete public subnet %s: %v", eg.PubSubnetID, err)
+		}
+	}
+	if eg.IGWID != "" {
+		if _, err := c.EC2.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
+			InternetGatewayId: aws.String(eg.IGWID),
+			VpcId:             aws.String(eg.VPCID),
+		}); err != nil {
+			t.Logf("detach igw %s: %v", eg.IGWID, err)
+		}
+		if _, err := c.EC2.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+			InternetGatewayId: aws.String(eg.IGWID),
+		}); err != nil {
+			t.Logf("delete igw %s: %v", eg.IGWID, err)
+		}
+	}
+}
+
+// waitNatGatewayDeleted blocks until the NAT Gateway drains to "deleted" so the
+// public subnet + EIP it holds can be released; best-effort on timeout.
+func waitNatGatewayDeleted(t *testing.T, c *AWSClient, natID string) {
+	t.Helper()
+	const timeout = 3 * time.Minute
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := c.EC2.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{
+			NatGatewayIds: aws.StringSlice([]string{natID}),
+		})
+		if err != nil || len(out.NatGateways) == 0 {
+			return
+		}
+		if aws.StringValue(out.NatGateways[0].State) == "deleted" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Logf("nat gateway %s not deleted within %s; continuing teardown", natID, timeout)
+			return
+		}
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/tests/e2e/manifest-lint/baseline.txt
+++ b/tests/e2e/manifest-lint/baseline.txt
@@ -2,8 +2,6 @@
 # Regenerate with: make manifest-lint-update. Migrate entries away over time.
 # Lines: "create\t<file>\t<API>\t#<n>" or "subject\t<file>\t<subject>".
 create	tests/e2e/eks/eks_test.go	CreateCluster	#1
-create	tests/e2e/eks/eks_test.go	CreateSubnet	#1
-create	tests/e2e/eks/eks_test.go	CreateVpc	#1
 create	tests/e2e/gpu/gpu_test.go	RunInstances	#1
 create	tests/e2e/gpu/gpu_test.go	RunInstances	#2
 create	tests/e2e/gpu/helpers_test.go	RunInstances	#1


### PR DESCRIPTION
## Summary
Completes GPU Epic B: an EKS GPU nodegroup worker registers, is Ready, advertises `nvidia.com/gpu`, and runs GPU pods. Live-validated end-to-end on the single-GPU host (NVIDIA RTX A1000) from a clean baked control-plane AMI with zero manual intervention — a `nvidia-smi` pod printed `NVIDIA RTX A1000` (driver 595.71.05).

## What's here
- **VFIO QMP greeting deadline** (`72709f37`): scaled to 180s for passthrough guests — QEMU locks + DMA-maps all guest RAM through the IOMMU before the QMP monitor answers, exceeding the 30s default and SIGKILLing 16GB GPU VMs at launch.
- **Worker registration** (`cf004ce2`, `92c512d0`): `Delegate=yes` so k3s-agent can create `/kubepods` on cgroup-v2; `ecr-credential-provider` baked into the GPU AMI (kubelet treats a referenced-but-missing provider as a fatal init error → Node never registers); GPU node label `nvidia.com/gpu.present=true` + default taint `nvidia.com/gpu=present:NoSchedule`.
- **Device-plugin GPU access** (`3f89ab7a`): the CDI-mode `nvidia-device-plugin` must run `nvml.Init` and generate the CDI spec in its own container. It now runs under the k3s-auto-configured `nvidia` runtimeClass with `NVIDIA_VISIBLE_DEVICES/CAPABILITIES=all`, host root mounted read-only at `/driver-root` (locate driver libs + `ld.so.cache`), and `/var/run/cdi` writable (publish the generated spec). No `enable_cdi` containerd drop-in is needed — k3s v1.32.5 / containerd 2.0.5 resolve CRI-passed CDI natively. GPU workload pods need only `resources.limits nvidia.com/gpu`.

## Testing
- `make preflight` green (diff coverage 68.6%). Unit tests for the VFIO QMP greeting timeout + GPU bootstrap gating.
- Live 6/6 e2e on wattle (single-node GPU cluster), clean-baked-AMI path, cleaned up (cluster/VPC/IAM torn down, GPU released, co-tenants untouched).

## Follow-ups (separate)
- `konnectivity-agent` DaemonSet does not tolerate the GPU `NoSchedule` taint → `kubectl logs/exec` fail on GPU-only clusters (mulga-yufch).