### PR TITLE
fix(sysinstance): don't wire a phantom mgmt NIC when br-mgmt is absent (single-node)

### DIFF
--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -757,9 +757,17 @@ func (d *Daemon) buildDirectBootConfig(instanceID string, input *handlers_elbv2.
 	//   i8042.no{pnp,aux,kbd}   — microvm has no PS/2; skip i8042 probe timeouts
 	var sb strings.Builder
 	sb.WriteString("console=ttyS0 quiet loglevel=3 mitigations=off tsc=reliable no_timer_check reboot=t i8042.nopnp i8042.noaux i8042.nokbd")
-	for i := range input.NICs {
+	// Slots must stay packed in the same order QEMU actually creates
+	// -device entries (buildNICNetdevs), so an unprovisioned mgmt NIC
+	// (skipped there) must not reserve a slot here either.
+	slot := 0
+	for i, nic := range input.NICs {
+		if !nicProvisioned(i, nic) {
+			continue
+		}
 		fmt.Fprintf(&sb, " virtio_mmio.device=0x200@0x%x:%d",
-			0xfeb00000+i*0x200, 5+i)
+			0xfeb00000+slot*0x200, 5+slot)
+		slot++
 	}
 	cmdline := sb.String()
 
@@ -805,11 +813,15 @@ func microvmMachineType() string {
 // buildNICNetdevs produces QEMU -netdev and -device entries for each NIC in
 // input. The NIC order determines the netdev IDs: net0 = primary ENI,
 // net1 = mgmt (if present), net2+ = extra ENIs. Extra ENIs beyond the primary
-// are only included when corresponding ExtraENIs entries exist.
+// are only included when corresponding ExtraENIs entries exist. A gap at
+// net1 (single-node hosts with no br-mgmt) is expected and fine for QEMU.
 func buildNICNetdevs(instanceID string, input *handlers_elbv2.SystemInstanceInput, machineType string) nicNetdevResult {
 	var res nicNetdevResult
 
 	for i, nic := range input.NICs {
+		if !nicProvisioned(i, nic) {
+			continue
+		}
 		netID := fmt.Sprintf("net%d", i)
 		// Resolve the tap name from the corresponding ENI.
 		tapName := tapNameForNIC(i, nic, instanceID, input)
@@ -820,6 +832,15 @@ func buildNICNetdevs(instanceID string, input *handlers_elbv2.SystemInstanceInpu
 	}
 
 	return res
+}
+
+// nicProvisioned reports whether NIC[i] has a real tap/device behind it.
+// The mgmt NIC (index 1) is only wired when br-mgmt allocated it a MAC at
+// launch (LaunchSystemInstance); single-node hosts without br-mgmt leave it
+// blank, so it must be excluded from netdevs, mmio slots, and guest config —
+// not just any empty-MAC NIC, only this specific, expected slot.
+func nicProvisioned(i int, nic handlers_elbv2.NICConfig) bool {
+	return i != 1 || nic.MAC != ""
 }
 
 // tapNameForNIC returns the Linux tap device name for a NIC at the given index.
@@ -850,7 +871,17 @@ func (d *Daemon) writeFwCfgBlobs(instanceID string, input *handlers_elbv2.System
 	lbenvPath := filepath.Join(runtimeDir, fmt.Sprintf("fwcfg-%s-lbenv.tmp", instanceID))
 	cacertPath := filepath.Join(runtimeDir, fmt.Sprintf("fwcfg-%s-cacert.tmp", instanceID))
 
-	netcfg, err := buildNetcfgBlob(input.NICs)
+	// Exclude any unprovisioned mgmt NIC so the guest is only ever told about
+	// interfaces that physically exist — mirrors the netdev/mmio-slot skip
+	// in buildNICNetdevs/buildDirectBootConfig.
+	provisionedNICs := make([]handlers_elbv2.NICConfig, 0, len(input.NICs))
+	for i, nic := range input.NICs {
+		if nicProvisioned(i, nic) {
+			provisionedNICs = append(provisionedNICs, nic)
+		}
+	}
+
+	netcfg, err := buildNetcfgBlob(provisionedNICs)
 	if err != nil {
 		return nil, err
 	}

--- a/spinifex/daemon/daemon_system_instance_test.go
+++ b/spinifex/daemon/daemon_system_instance_test.go
@@ -251,6 +251,87 @@ func TestBuildNICNetdevs_EmptyNICs(t *testing.T) {
 	assert.Empty(t, res.devices)
 }
 
+func TestBuildNICNetdevs_UnprovisionedMgmtNIC_Skipped(t *testing.T) {
+	// Single-node host with no br-mgmt: NIC[1] (mgmt) never got a MAC/tap.
+	input := &handlers_elbv2.SystemInstanceInput{
+		ENIID: "eni-000000000000000c",
+		NICs: []handlers_elbv2.NICConfig{
+			{MAC: "02:aa:bb:cc:dd:01", IsDefault: true},
+			{MAC: ""},
+		},
+	}
+	res := buildNICNetdevs("i-test3", input, microvmMachineType())
+	require.Len(t, res.netdevs, 1)
+	require.Len(t, res.devices, 1)
+	assert.Contains(t, res.netdevs[0].Value, "id=net0,")
+	assert.Contains(t, res.devices[0].Value, "netdev=net0")
+}
+
+func TestBuildNICNetdevs_ProvisionedMgmtNIC_Included(t *testing.T) {
+	// Multi-node host with br-mgmt: NIC[1] (mgmt) has a real MAC/tap.
+	input := &handlers_elbv2.SystemInstanceInput{
+		ENIID: "eni-000000000000000d",
+		NICs: []handlers_elbv2.NICConfig{
+			{MAC: "02:aa:bb:cc:dd:01", IsDefault: true},
+			{MAC: "02:aa:bb:cc:dd:02"},
+		},
+	}
+	res := buildNICNetdevs("i-test4", input, microvmMachineType())
+	require.Len(t, res.netdevs, 2)
+	require.Len(t, res.devices, 2)
+	assert.Contains(t, res.netdevs[0].Value, "id=net0,")
+	assert.Contains(t, res.netdevs[1].Value, "id=net1,")
+	assert.Contains(t, res.devices[1].Value, "netdev=net1")
+}
+
+func TestBuildNICNetdevs_UnprovisionedMgmtNIC_ExtraENIUnaffected(t *testing.T) {
+	// NIC[1] mgmt unprovisioned + NIC[2] extra ENI provisioned: net1 must be
+	// skipped but the extra ENI's tap name resolution (index-based) must not
+	// be shifted/renumbered.
+	input := &handlers_elbv2.SystemInstanceInput{
+		ENIID: "eni-primary000000000",
+		ExtraENIs: []handlers_elbv2.ExtraENIInput{
+			{ENIID: "eni-extra000000000000"},
+		},
+		NICs: []handlers_elbv2.NICConfig{
+			{MAC: "02:aa:bb:cc:dd:01", IsDefault: true},
+			{MAC: ""},
+			{MAC: "02:aa:bb:cc:dd:03"},
+		},
+	}
+	res := buildNICNetdevs("i-test5", input, microvmMachineType())
+	require.Len(t, res.netdevs, 2)
+	require.Len(t, res.devices, 2)
+	assert.Contains(t, res.netdevs[0].Value, "id=net0,")
+	// net1 (mgmt) skipped entirely — net2 (extra ENI) keeps its own ID.
+	assert.Contains(t, res.netdevs[1].Value, "id=net2,")
+	assert.Contains(t, res.devices[1].Value, "netdev=net2")
+	assert.Contains(t, res.devices[1].Value, "02:aa:bb:cc:dd:03")
+	// Extra ENI's tap name must still resolve against ExtraENIs[0], not be
+	// mis-mapped by the gap at index 1.
+	assert.Equal(t, vm.TapDeviceName("eni-extra000000000000"), tapNameForNIC(2, input.NICs[2], "i-test5", input))
+}
+
+// ---------------------------------------------------------------------------
+// nicProvisioned
+// ---------------------------------------------------------------------------
+
+func TestNicProvisioned_MgmtSlotEmptyMAC(t *testing.T) {
+	assert.False(t, nicProvisioned(1, handlers_elbv2.NICConfig{MAC: ""}))
+}
+
+func TestNicProvisioned_MgmtSlotWithMAC(t *testing.T) {
+	assert.True(t, nicProvisioned(1, handlers_elbv2.NICConfig{MAC: "02:aa:bb:cc:dd:02"}))
+}
+
+func TestNicProvisioned_NonMgmtSlotsAlwaysTrue(t *testing.T) {
+	// Only the mgmt slot (index 1) is ever gated on MAC presence — an empty
+	// MAC anywhere else (e.g. primary, not expected in practice) is not
+	// treated as "unprovisioned" by this guard.
+	assert.True(t, nicProvisioned(0, handlers_elbv2.NICConfig{MAC: ""}))
+	assert.True(t, nicProvisioned(2, handlers_elbv2.NICConfig{MAC: ""}))
+}
+
 // ---------------------------------------------------------------------------
 // microvmMachineType
 // ---------------------------------------------------------------------------
@@ -308,6 +389,65 @@ func TestWriteFwCfgBlobs_HappyPath(t *testing.T) {
 	}
 }
 
+func TestWriteFwCfgBlobs_UnprovisionedMgmtNIC_ExcludedFromGuestConfig(t *testing.T) {
+	// Single-node host with no br-mgmt: the mgmt NIC (index 1) never got a
+	// MAC/CIDR. The guest netcfg blob must not carry a NIC1 entry at all.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	d := &Daemon{}
+	instanceID := "i-fwcfg-nomgmt"
+	input := &handlers_elbv2.SystemInstanceInput{
+		NICs: []handlers_elbv2.NICConfig{
+			{MAC: "02:aa:bb:cc:dd:01", CIDR: "10.0.1.5/24", Gateway: "10.0.1.1", IsDefault: true},
+			{MAC: ""},
+		},
+	}
+
+	entries, err := d.writeFwCfgBlobs(instanceID, input)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+
+	netcfgData, err := os.ReadFile(entries[0].File)
+	require.NoError(t, err)
+	assert.Contains(t, string(netcfgData), "NIC0_MAC=02:aa:bb:cc:dd:01")
+	// The unprovisioned mgmt NIC must not appear as NIC1 (nor anywhere else).
+	assert.NotContains(t, string(netcfgData), "NIC1_")
+	assert.NotContains(t, string(netcfgData), "MAC=\n")
+
+	for _, e := range entries {
+		assert.NoError(t, os.Remove(e.File))
+	}
+}
+
+func TestWriteFwCfgBlobs_ProvisionedMgmtNIC_IncludedInGuestConfig(t *testing.T) {
+	// Multi-node host with br-mgmt: mgmt NIC has a real MAC/CIDR and must
+	// still be wired into the guest config exactly as today.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	d := &Daemon{}
+	instanceID := "i-fwcfg-mgmt"
+	input := &handlers_elbv2.SystemInstanceInput{
+		NICs: []handlers_elbv2.NICConfig{
+			{MAC: "02:aa:bb:cc:dd:01", CIDR: "10.0.1.5/24", Gateway: "10.0.1.1", IsDefault: true},
+			{MAC: "02:aa:bb:cc:dd:02", CIDR: "192.168.100.5/24"},
+		},
+	}
+
+	entries, err := d.writeFwCfgBlobs(instanceID, input)
+	require.NoError(t, err)
+
+	netcfgData, err := os.ReadFile(entries[0].File)
+	require.NoError(t, err)
+	assert.Contains(t, string(netcfgData), "NIC0_MAC=02:aa:bb:cc:dd:01")
+	assert.Contains(t, string(netcfgData), "NIC1_MAC=02:aa:bb:cc:dd:02")
+
+	for _, e := range entries {
+		assert.NoError(t, os.Remove(e.File))
+	}
+}
+
 func TestWriteFwCfgBlobs_InvalidNICs_NoDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
@@ -328,6 +468,73 @@ func TestWriteFwCfgBlobs_InvalidNICs_NoDefault(t *testing.T) {
 	for _, e := range entries {
 		assert.False(t, strings.HasPrefix(e.Name(), "fwcfg-i-bad-nics"),
 			"unexpected tmpfile left behind: %s", e.Name())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildDirectBootConfig — mmio slot packing
+// ---------------------------------------------------------------------------
+
+func TestBuildDirectBootConfig_MmioSlotsPacked_MgmtSkipped(t *testing.T) {
+	// NIC[1] (mgmt) unprovisioned (no br-mgmt) must not reserve an mmio slot;
+	// remaining NICs (primary, extra ENI) get packed, contiguous slots.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	d := &Daemon{resourceMgr: &ResourceManager{instanceTypes: map[string]*ec2.InstanceTypeInfo{}}}
+	input := &handlers_elbv2.SystemInstanceInput{
+		ENIID: "eni-mmio000000000001",
+		ExtraENIs: []handlers_elbv2.ExtraENIInput{
+			{ENIID: "eni-mmio-extra00000001"},
+		},
+		NICs: []handlers_elbv2.NICConfig{
+			{MAC: "02:aa:bb:cc:dd:01", IsDefault: true},
+			{MAC: ""},
+			{MAC: "02:aa:bb:cc:dd:03"},
+		},
+	}
+
+	cfg, err := d.buildDirectBootConfig("i-mmio-test", input)
+	require.NoError(t, err)
+
+	// Only 2 real devices (mgmt skipped) → slots packed at 0 and 1, not 0 and 2.
+	assert.Contains(t, cfg.KernelCmdline, "virtio_mmio.device=0x200@0xfeb00000:5")
+	assert.Contains(t, cfg.KernelCmdline, "virtio_mmio.device=0x200@0xfeb00200:6")
+	assert.NotContains(t, cfg.KernelCmdline, "virtio_mmio.device=0x200@0xfeb00400:7")
+
+	require.Len(t, cfg.NetDevs, 2)
+	require.Len(t, cfg.Devices, 2)
+
+	for _, e := range cfg.FwCfg {
+		assert.NoError(t, os.Remove(e.File))
+	}
+}
+
+func TestBuildDirectBootConfig_MmioSlotsUnchanged_MgmtProvisioned(t *testing.T) {
+	// Multi-node host with br-mgmt: all NICs provisioned, slots stay 1:1
+	// with NIC index as before this fix.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	d := &Daemon{resourceMgr: &ResourceManager{instanceTypes: map[string]*ec2.InstanceTypeInfo{}}}
+	input := &handlers_elbv2.SystemInstanceInput{
+		ENIID: "eni-mmio000000000002",
+		NICs: []handlers_elbv2.NICConfig{
+			{MAC: "02:aa:bb:cc:dd:01", IsDefault: true},
+			{MAC: "02:aa:bb:cc:dd:02"},
+		},
+	}
+
+	cfg, err := d.buildDirectBootConfig("i-mmio-test2", input)
+	require.NoError(t, err)
+
+	assert.Contains(t, cfg.KernelCmdline, "virtio_mmio.device=0x200@0xfeb00000:5")
+	assert.Contains(t, cfg.KernelCmdline, "virtio_mmio.device=0x200@0xfeb00200:6")
+	require.Len(t, cfg.NetDevs, 2)
+	require.Len(t, cfg.Devices, 2)
+
+	for _, e := range cfg.FwCfg {
+		assert.NoError(t, os.Remove(e.File))
 	}
 }
 


### PR DESCRIPTION
## Summary
On a single-node deployment with no `br-mgmt` bridge, system-instance launch wired a phantom management NIC, breaking control-plane system-instance launch (surfaced while standing up EKS clusters on the single-GPU host). This skips the mgmt NIC when the mgmt bridge is absent.

## Testing
- `make preflight` green.
- Live-validated on wattle: `CreateCluster` + control-plane system-instance launch succeed; single-node GPU EKS clusters stand up end-to-end.