### PR TITLE
chore(deps): bump viperblock to dev (parallel chunk upload + backpressure)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20260407060928-11b94ed970f2
 	github.com/klauspost/cpuid/v2 v2.4.0
 	github.com/mulgadc/predastore v1.11.1-0.20260711123238-92a0009c2769
-	github.com/mulgadc/viperblock v1.11.1-0.20260711235849-9ae04258c43a
+	github.com/mulgadc/viperblock v1.11.1-0.20260713024608-eb4a376becc8
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1317,8 +1317,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/mulgadc/predastore v1.11.1-0.20260711123238-92a0009c2769 h1:JzOa3FMZnQg2WjkSsSgmQkS0v1wxJ2Zxbwz0EWFfmdA=
 github.com/mulgadc/predastore v1.11.1-0.20260711123238-92a0009c2769/go.mod h1:ZCuQ8zFVUxaR32UoQzIr3xCCi8I8uYDTyD2wqWvV/IY=
-github.com/mulgadc/viperblock v1.11.1-0.20260711235849-9ae04258c43a h1:Ghh4MBA77Ms853EBgG+toirG9f1zmKGMv+rFVJLwfe8=
-github.com/mulgadc/viperblock v1.11.1-0.20260711235849-9ae04258c43a/go.mod h1:S4jx9L98vVP4kRL8NRCpAQEH8MsOt/nmxsvsnHBuy64=
+github.com/mulgadc/viperblock v1.11.1-0.20260713024608-eb4a376becc8 h1:QlSs/heYbRdX+D5JS1KWykL5fgM/jRDwcZMmxGOH+ZM=
+github.com/mulgadc/viperblock v1.11.1-0.20260713024608-eb4a376becc8/go.mod h1:S4jx9L98vVP4kRL8NRCpAQEH8MsOt/nmxsvsnHBuy64=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
Bumps `github.com/mulgadc/viperblock` `v1.11.1-0.…-9ae0425` → `v1.11.1-0.20260713024608-eb4a376becc8` (dev tip through viperblock **#34**).

Picks up:
- **#34** — bounded parallel chunk upload + coalesced checkpoint (`mulga-edou7` §7 items 2/9). Isolated A/B: 2.3× drain, ~130× worst-case write latency, half RSS vs serial; validated in-situ (VM boots on an encrypted volume served by the new plugin).
- **#33** — guest-write buffer backpressure (was already merged in viperblock but the require was pinned back at #32).

The nbdkit **plugin** (the VM write plane) is built from the viperblock submodule source, so this require bump aligns the `viperblock` library that `spx`/`viperblockd` link. Additive API change only — `go build ./...` clean.

Companion: the mulga superproject viperblock submodule pointer should bump to `eb4a376` in the same change set so `make dev-deploy` builds the parallel plugin from source.