### PR TITLE
fix(network): re-point EIP and flush stale OVN L2 state on IP reuse

### DIFF
--- a/spinifex/handlers/imds/tap_responder.go
+++ b/spinifex/handlers/imds/tap_responder.go
@@ -23,6 +23,11 @@ type tapListenFunc func(ctx context.Context, endpoint string) (net.Listener, err
 // responder manager is unit-testable without a live ENI bucket.
 type resolveENIFunc func(ctx context.Context, eniID string) (*eniFacts, error)
 
+// errENIRecordGone marks a start failure caused by a definitively absent ENI
+// record (as opposed to a transient resolve error). reconcile suspends retries
+// for such ENIs so a torn-down instance does not churn the log every pass.
+var errENIRecordGone = errors.New("ENI record gone")
+
 // ifindexFunc resolves an endpoint device's current kernel ifindex. Injected so
 // the recreated-endpoint check is unit-testable without real devices.
 type ifindexFunc func(dev string) (int, error)
@@ -47,8 +52,9 @@ type tapResponderManager struct {
 	listen  tapListenFunc
 	ifindex ifindexFunc
 
-	mu     sync.Mutex
-	active map[string]*activeTapResponder // eniID → responder
+	mu      sync.Mutex
+	active  map[string]*activeTapResponder // eniID → responder
+	missing map[string]struct{}            // eniID → record gone, retries suspended
 }
 
 func newTapResponderManager(handler http.Handler, resolve resolveENIFunc, listen tapListenFunc) *tapResponderManager {
@@ -58,6 +64,7 @@ func newTapResponderManager(handler http.Handler, resolve resolveENIFunc, listen
 		listen:  listen,
 		ifindex: deviceIfindex,
 		active:  make(map[string]*activeTapResponder),
+		missing: make(map[string]struct{}),
 	}
 }
 
@@ -89,7 +96,7 @@ func (m *tapResponderManager) start(ctx context.Context, eniID, endpoint string)
 		return fmt.Errorf("resolve eni %s: %w", eniID, err)
 	}
 	if eni == nil {
-		return fmt.Errorf("no ENI record for %s", eniID)
+		return fmt.Errorf("no ENI record for %s: %w", eniID, errENIRecordGone)
 	}
 
 	listener, err := m.listen(ctx, endpoint)
@@ -158,7 +165,23 @@ func (m *tapResponderManager) endpointRecreated(cur *activeTapResponder, endpoin
 // failure is logged and retried next reconcile so one stalled tap can't block the rest.
 func (m *tapResponderManager) reconcile(ctx context.Context, live map[string]string) {
 	for eniID, endpoint := range live {
+		m.mu.Lock()
+		_, suspended := m.missing[eniID]
+		m.mu.Unlock()
+		if suspended {
+			continue
+		}
 		if err := m.start(ctx, eniID, endpoint); err != nil {
+			if errors.Is(err, errENIRecordGone) {
+				// The ENI record is gone but its tap lingers. Retrying every pass just
+				// churns the log; suspend until the tap leaves the live set.
+				m.mu.Lock()
+				m.missing[eniID] = struct{}{}
+				m.mu.Unlock()
+				slog.InfoContext(ctx, "IMDS: ENI record gone; suspending tap responder retries until tap is removed",
+					"eni_id", eniID, "endpoint", endpoint)
+				continue
+			}
 			slog.WarnContext(ctx, "IMDS: tap responder start failed during reconcile", "eni_id", eniID, "endpoint", endpoint, "err", err)
 		}
 	}
@@ -168,6 +191,12 @@ func (m *tapResponderManager) reconcile(ctx context.Context, live map[string]str
 	for eniID := range m.active {
 		if _, ok := live[eniID]; !ok {
 			stale = append(stale, eniID)
+		}
+	}
+	// Clear suspensions whose tap has gone so a re-created ENI retries next pass.
+	for eniID := range m.missing {
+		if _, ok := live[eniID]; !ok {
+			delete(m.missing, eniID)
 		}
 	}
 	m.mu.Unlock()

--- a/spinifex/handlers/imds/tap_responder_test.go
+++ b/spinifex/handlers/imds/tap_responder_test.go
@@ -339,3 +339,41 @@ func tapGet(t *testing.T, addr, path, token string) tapResult {
 	_ = resp.Body.Close()
 	return tapResult{code: resp.StatusCode, body: string(body)}
 }
+
+// A tap whose ENI record is gone must be retried once then suspended, not churned
+// every reconcile pass; once the tap leaves the live set the suspension clears so a
+// re-created ENI resumes retrying.
+func TestTapResponder_ReconcileSuspendsRetriesForGoneENI(t *testing.T) {
+	const (
+		eniID    = "eni-gone1234"
+		endpoint = "ime-gone1234"
+	)
+	var mu sync.Mutex
+	var resolveCalls int
+	resolve := func(_ context.Context, _ string) (*eniFacts, error) {
+		mu.Lock()
+		resolveCalls++
+		mu.Unlock()
+		return nil, nil // record definitively gone
+	}
+	m := newTapResponderManager(http.NewServeMux(), resolve, loopbackTapListen(&sync.Map{}))
+	ctx := context.Background()
+	live := map[string]string{eniID: endpoint}
+
+	m.reconcile(ctx, live)
+	m.reconcile(ctx, live)
+	m.reconcile(ctx, live)
+
+	mu.Lock()
+	got := resolveCalls
+	mu.Unlock()
+	assert.Equal(t, 1, got, "a gone ENI record must be resolved once then suspended, not retried each pass")
+
+	// Tap leaves the live set: the suspension must clear so a re-created ENI retries.
+	m.reconcile(ctx, map[string]string{})
+	m.reconcile(ctx, live)
+	mu.Lock()
+	got = resolveCalls
+	mu.Unlock()
+	assert.Equal(t, 2, got, "a re-created tap must resume retrying after the suspension clears")
+}

--- a/spinifex/network/host/gateway_claim.go
+++ b/spinifex/network/host/gateway_claim.go
@@ -96,6 +96,37 @@ func (p *GatewayClaimProber) ResetSBClusterState(_ context.Context) error {
 	return nil
 }
 
+// FlushMACBinding removes SB MAC_Binding rows resolving ip so a reused private IP
+// re-resolves to the new owner's MAC rather than a terminated instance's. OVN
+// re-learns the binding on the next ARP, so an over-broad flush is self-healing.
+// Best-effort: an absent binding is success. Output() not CombinedOutput(): sudo
+// PAM noise on stderr must not be misread as a row UUID.
+func (p *GatewayClaimProber) FlushMACBinding(_ context.Context, ip string) error {
+	if ip == "" {
+		return nil
+	}
+	findArgs := []string{"--no-leader-only"}
+	if p.sbAddr != "" {
+		findArgs = append(findArgs, "--db="+p.sbAddr)
+	}
+	findArgs = append(findArgs, "--bare", "--columns=_uuid", "find", "MAC_Binding", "ip="+ip)
+	out, err := utils.SudoCommand("ovn-sbctl", findArgs...).Output()
+	if err != nil {
+		return fmt.Errorf("ovn-sbctl find MAC_Binding ip=%s: %w", ip, err)
+	}
+	for uuid := range strings.FieldsSeq(string(out)) {
+		delArgs := []string{"--no-leader-only"}
+		if p.sbAddr != "" {
+			delArgs = append(delArgs, "--db="+p.sbAddr)
+		}
+		delArgs = append(delArgs, "--if-exists", "destroy", "MAC_Binding", uuid)
+		if dout, derr := utils.SudoCommand("ovn-sbctl", delArgs...).CombinedOutput(); derr != nil {
+			return fmt.Errorf("ovn-sbctl destroy MAC_Binding %s: %s: %w", uuid, strings.TrimSpace(string(dout)), derr)
+		}
+	}
+	return nil
+}
+
 // RepairDatapath re-asserts the WAN-glue veth admin state, then forces a recompute.
 // A post-reboot boot race (ovs-vswitchd/ovn-controller start after the passive
 // network.target, concurrently with systemd-networkd) can leave veth-wan-ovs

--- a/spinifex/network/ovn/client.go
+++ b/spinifex/network/ovn/client.go
@@ -98,6 +98,9 @@ type Client interface {
 	DeleteAllNATsByExternalIP(ctx context.Context, natType, externalIP string) (int, error)
 	FindNATByExternalIP(ctx context.Context, natType, externalIP string) (*nbdb.NAT, error)
 	FindNATByLogicalIP(ctx context.Context, routerName, natType, logicalIP string) (*nbdb.NAT, error)
+	// ListNATs returns every NAT row in OVN NB. The reconciler uses it to prune
+	// orphan dnat_and_snat rows whose stamped owning ENI is gone from intent.
+	ListNATs(ctx context.Context) ([]nbdb.NAT, error)
 	// SetNATExemptedExtIPs updates exempted_ext_ips in place on the NAT rule
 	// matching (natType, logicalIP) on routerName — no delete/re-add flow gap.
 	// nil clears the ref. Returns ErrNATNotFound when the rule is absent.

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -1018,6 +1018,15 @@ func (c *LiveClient) DeleteAllNATsByExternalIP(ctx context.Context, natType, ext
 	return len(nats), nil
 }
 
+// ListNATs returns every NAT row in OVN NB.
+func (c *LiveClient) ListNATs(ctx context.Context) ([]nbdb.NAT, error) {
+	var nats []nbdb.NAT
+	if err := c.client.List(ctx, &nats); err != nil {
+		return nil, fmt.Errorf("list NATs: %w", err)
+	}
+	return nats, nil
+}
+
 // FindNATByExternalIP returns the first NAT rule matching (natType, externalIP), or nil.
 func (c *LiveClient) FindNATByExternalIP(ctx context.Context, natType, externalIP string) (*nbdb.NAT, error) {
 	var nats []nbdb.NAT

--- a/spinifex/network/ovn/mock/mock.go
+++ b/spinifex/network/ovn/mock/mock.go
@@ -594,6 +594,16 @@ func (m *Client) DeleteAllNATsByExternalIP(_ context.Context, natType, externalI
 	return len(foundUUIDs), nil
 }
 
+func (m *Client) ListNATs(_ context.Context) ([]nbdb.NAT, error) {
+	m.Mu.Lock()
+	defer m.Mu.Unlock()
+	result := make([]nbdb.NAT, 0, len(m.NATs))
+	for _, n := range m.NATs {
+		result = append(result, *n)
+	}
+	return result, nil
+}
+
 func (m *Client) FindNATByExternalIP(_ context.Context, natType, externalIP string) (*nbdb.NAT, error) {
 	m.Mu.Lock()
 	defer m.Mu.Unlock()

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -49,6 +49,13 @@ type NATManager interface {
 	// identically. Idempotent.
 	DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP, portName string) error
 
+	// PruneOrphanEIPs deletes every dnat_and_snat row whose stamped
+	// spinifex:logical_port owning ENI is absent from livePorts (the set of live
+	// intent port names), flushing the host ARP entry and unbinding routed-mode
+	// host state for each. Rows with no stamped logical port are left untouched
+	// (owner undeterminable). Returns the number of rows removed.
+	PruneOrphanEIPs(ctx context.Context, livePorts map[string]struct{}) (int, error)
+
 	// AddNATGateway installs the (snat, SubnetCIDR) rule; rejects overlap.
 	AddNATGateway(ctx context.Context, gw NATGWSpec) error
 
@@ -231,11 +238,22 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 		natRule.LogicalPort = &port
 	}
 
-	// Skip when the existing row already matches; avoids the
-	// delete-then-add flow-install gap on duplicate publishes.
-	if existing, err := m.ovn.FindNATByExternalIP(ctx, "dnat_and_snat", eip.ExternalIP); err != nil {
-		slog.Warn("policy: AddEIP idempotency lookup failed", "external_ip", eip.ExternalIP, "err", err)
-	} else if existing != nil && existing.LogicalIP == eip.LogicalIP &&
+	// Look up the existing row to decide between an idempotent skip and a re-point.
+	existing, lookupErr := m.ovn.FindNATByExternalIP(ctx, "dnat_and_snat", eip.ExternalIP)
+	if lookupErr != nil {
+		slog.Warn("policy: AddEIP idempotency lookup failed", "external_ip", eip.ExternalIP, "err", lookupErr)
+	}
+	// A changed owning ENI must force a re-point even when external+logical IP are
+	// unchanged. The spinifex:logical_port external-id is stamped in both NAT modes
+	// (the native LogicalPort column is empty in centralised mode), so it is the
+	// portable discriminator when a recycled IP pair is taken over by a new ENI —
+	// without it the datapath keeps targeting the dead predecessor's port.
+	ownerChanged := existing != nil && eip.PortName != "" &&
+		existing.ExternalIDs["spinifex:logical_port"] != eip.PortName
+
+	// Skip when the existing row already matches; avoids the delete-then-add
+	// flow-install gap on duplicate publishes. Never skip on an owner change.
+	if existing != nil && !ownerChanged && existing.LogicalIP == eip.LogicalIP &&
 		existing.ExternalIDs["spinifex:vpc_id"] == eip.VPCID &&
 		(!distributed ||
 			(existing.ExternalMAC != nil && *existing.ExternalMAC == eip.MAC &&
@@ -257,6 +275,11 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 		// Host state (routes, proxy-ARP) is volatile even when the OVN row
 		// survives — reconcile lands here after a reboot, so re-bind.
 		return m.bindHostEIP(ctx, eip)
+	}
+	if ownerChanged {
+		slog.Info("policy: AddEIP re-pointing dnat_and_snat — owning ENI changed",
+			"router", router, "external_ip", eip.ExternalIP, "logical_ip", eip.LogicalIP,
+			"old_port", existing.ExternalIDs["spinifex:logical_port"], "new_port", eip.PortName)
 	}
 
 	// Search every router for stale rules — vpc.delete-nat is fire-and-forget.
@@ -396,6 +419,52 @@ func (m *natManager) DeleteEIP(ctx context.Context, vpcID, externalIP, logicalIP
 		}
 	}
 	return nil
+}
+
+func (m *natManager) PruneOrphanEIPs(ctx context.Context, livePorts map[string]struct{}) (int, error) {
+	nats, err := m.ovn.ListNATs(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list NATs for orphan EIP prune: %w", err)
+	}
+	pruned := 0
+	for i := range nats {
+		n := nats[i]
+		if n.Type != "dnat_and_snat" {
+			continue
+		}
+		port := n.ExternalIDs["spinifex:logical_port"]
+		// No stamp: owner undeterminable (legacy row). Leave it so a live EIP
+		// whose owner cannot be proven absent is never swept.
+		if port == "" {
+			continue
+		}
+		if _, live := livePorts[port]; live {
+			continue
+		}
+		removed, derr := m.ovn.DeleteAllNATsByExternalIP(ctx, "dnat_and_snat", n.ExternalIP)
+		if derr != nil {
+			slog.Warn("policy: orphan EIP prune delete failed",
+				"external_ip", n.ExternalIP, "logical_port", port, "err", derr)
+			continue
+		}
+		if removed == 0 {
+			continue
+		}
+		pruned += removed
+		// Flush host ARP so the freed external IP is not shadowed by the dead
+		// owner's MAC, and tear down routed-mode host plumbing. Best-effort.
+		if err := m.neigh(n.ExternalIP); err != nil {
+			slog.Warn("policy: orphan EIP prune neighbour flush failed", "external_ip", n.ExternalIP, "err", err)
+		}
+		if m.mode == NATModeRouted && m.hostBinder != nil {
+			if err := m.hostBinder.Unbind(n.ExternalIP); err != nil {
+				slog.Warn("policy: orphan EIP prune host unbind failed", "external_ip", n.ExternalIP, "err", err)
+			}
+		}
+		slog.Info("policy: pruned orphan dnat_and_snat — owning ENI absent from intent",
+			"external_ip", n.ExternalIP, "logical_ip", n.LogicalIP, "logical_port", port)
+	}
+	return pruned, nil
 }
 
 func (m *natManager) AddNATGateway(ctx context.Context, gw NATGWSpec) error {

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -320,6 +320,107 @@ func TestNATManager_AddEIP_RemovesStaleRuleOnOtherRouter(t *testing.T) {
 	assert.Equal(t, "10.1.0.7", matching[0].LogicalIP)
 }
 
+// A NEW ENI taking over the same external+logical IP (private-IP reuse) must
+// re-point the dnat_and_snat row even in centralised mode, where the native
+// LogicalPort column is empty so only the spinifex:logical_port external-id can
+// discriminate the owner. Without the re-point the datapath targets the dead port.
+func TestNATManager_AddEIP_RePointsOnOwnerChange_Centralized(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	seedGatewayPort(t, m, "vpc-1", "aa:bb:cc:00:00:01")
+	var barrierCalls int
+	var primed []EIPSpec
+	nm, err := NewNATManager(m, NATModeCentralized,
+		WithFlowsBarrier(func() error { barrierCalls++; return nil }),
+		WithNeighPrimer(func(eip EIPSpec) error { primed = append(primed, eip); return nil }))
+	require.NoError(t, err)
+
+	base := EIPSpec{VPCID: "vpc-1", ExternalIP: "192.168.1.147", LogicalIP: "172.31.0.4"}
+	old := base
+	old.PortName = "port-eni-old"
+	require.NoError(t, nm.AddEIP(ctx, old))
+	require.Equal(t, 1, barrierCalls)
+	firstUUID := findNAT(m, "dnat_and_snat", base.LogicalIP).UUID
+
+	// Successor reuses BOTH IPs on a new ENI.
+	newer := base
+	newer.PortName = "port-eni-new"
+	require.NoError(t, nm.AddEIP(ctx, newer))
+
+	got := findNAT(m, "dnat_and_snat", base.LogicalIP)
+	require.NotNil(t, got)
+	assert.Equal(t, "port-eni-new", got.ExternalIDs["spinifex:logical_port"],
+		"row must be re-pointed to the new owning ENI")
+	assert.NotEqual(t, firstUUID, got.UUID, "owner change must replace the row, not skip")
+	assert.Equal(t, 2, barrierCalls, "re-point must fire the flows barrier (not an idempotent skip)")
+	assert.Len(t, primed, 2, "re-point must re-prime reachability")
+}
+
+// The genuine idempotent case — same ENI, same external+logical IP — must still
+// skip the delete-then-add churn in centralised mode.
+func TestNATManager_AddEIP_IdempotentSkip_SameOwner_Centralized(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-1")
+	seedGatewayPort(t, m, "vpc-1", "aa:bb:cc:00:00:01")
+	var barrierCalls int
+	nm, err := NewNATManager(m, NATModeCentralized,
+		WithFlowsBarrier(func() error { barrierCalls++; return nil }))
+	require.NoError(t, err)
+
+	spec := EIPSpec{VPCID: "vpc-1", ExternalIP: "192.168.1.147", LogicalIP: "172.31.0.4", PortName: "port-eni-same"}
+	require.NoError(t, nm.AddEIP(ctx, spec))
+	require.Equal(t, 1, barrierCalls)
+	firstUUID := findNAT(m, "dnat_and_snat", spec.LogicalIP).UUID
+
+	require.NoError(t, nm.AddEIP(ctx, spec))
+	assert.Equal(t, firstUUID, findNAT(m, "dnat_and_snat", spec.LogicalIP).UUID,
+		"same-ENI re-add must reuse the existing row")
+	assert.Equal(t, 1, barrierCalls, "same-ENI re-add must not fire the barrier")
+}
+
+func TestNATManager_PruneOrphanEIPs(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-live")
+	seedRouter(t, m, "vpc-dead")
+	var flushed []string
+	nm, err := NewNATManager(m, NATModeDistributed,
+		WithNeighFlusher(func(ip string) error { flushed = append(flushed, ip); return nil }))
+	require.NoError(t, err)
+
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-live", ExternalIP: "192.168.1.10", LogicalIP: "172.31.0.5",
+		PortName: "port-eni-live", MAC: "aa:aa:aa:aa:aa:aa",
+	}))
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-dead", ExternalIP: "192.168.1.11", LogicalIP: "172.31.0.4",
+		PortName: "port-eni-orphan", MAC: "bb:bb:bb:bb:bb:bb",
+	}))
+	// A legacy row with no stamped logical_port must survive (owner undeterminable).
+	require.NoError(t, m.AddNAT(ctx, topology.VPCRouter("vpc-dead"), &nbdb.NAT{
+		Type: "dnat_and_snat", ExternalIP: "192.168.1.12", LogicalIP: "172.31.0.9",
+		ExternalIDs: map[string]string{"spinifex:vpc_id": "vpc-dead"},
+	}))
+	// A snat row with an orphan stamp must survive (type filter excludes it).
+	require.NoError(t, m.AddNAT(ctx, topology.VPCRouter("vpc-dead"), &nbdb.NAT{
+		Type: "snat", ExternalIP: "192.168.1.13", LogicalIP: "172.31.0.0/24",
+		ExternalIDs: map[string]string{"spinifex:logical_port": "port-eni-gone"},
+	}))
+
+	live := map[string]struct{}{"port-eni-live": {}}
+	pruned, err := nm.PruneOrphanEIPs(ctx, live)
+	require.NoError(t, err)
+	assert.Equal(t, 1, pruned, "exactly the stamped orphan dnat_and_snat must be pruned")
+
+	assert.NotNil(t, findNAT(m, "dnat_and_snat", "172.31.0.5"), "live EIP row must survive")
+	assert.Nil(t, findNAT(m, "dnat_and_snat", "172.31.0.4"), "orphan EIP row must be pruned")
+	assert.NotNil(t, findNAT(m, "dnat_and_snat", "172.31.0.9"), "unstamped legacy row must survive")
+	assert.NotNil(t, findNAT(m, "snat", "172.31.0.0/24"), "snat row must survive the dnat_and_snat prune")
+	assert.Contains(t, flushed, "192.168.1.11", "orphan external IP ARP must be flushed on prune")
+}
+
 func TestNATManager_DeleteEIP_IdempotentOnMissing(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()

--- a/spinifex/network/reconcile/apply.go
+++ b/spinifex/network/reconcile/apply.go
@@ -482,6 +482,28 @@ func (r *reconciler) applyEIPs(ctx context.Context, intent IntentState, _ Actual
 	}
 }
 
+// pruneOrphanEIPs sweeps dnat_and_snat rows whose stamped owning ENI is gone from
+// intent. vpc.delete-nat is fire-and-forget and can be lost, leaking rows across
+// dead VPCs; NATManager.PruneOrphanEIPs deletes any row whose spinifex:logical_port
+// is absent from the live-port set. Runs only on the prune pass (drift), so an
+// in-flight association whose port event has not converged is never swept.
+func (r *reconciler) pruneOrphanEIPs(ctx context.Context, intent IntentState) {
+	live := make(map[string]struct{}, len(intent.Ports)+len(intent.EIPs))
+	for portID := range intent.Ports {
+		live[topology.Port(portID)] = struct{}{}
+	}
+	for _, e := range intent.EIPs {
+		if e.PortName != "" {
+			live[e.PortName] = struct{}{}
+		}
+	}
+	if pruned, err := r.nat.PruneOrphanEIPs(ctx, live); err != nil {
+		slog.Warn("reconcile/apply: orphan EIP prune failed", "err", err)
+	} else if pruned > 0 {
+		slog.Info("reconcile/apply: pruned orphan dnat_and_snat rows", "count", pruned)
+	}
+}
+
 // applyPublicInstanceEgress exempts every public-IP instance from its subnet egress
 // drop gate. Public IPs come from two disjoint sources: auto-assigned and ELB
 // addresses recorded on the ENI (intent.Ports) and user EIPs in the EIP bucket

--- a/spinifex/network/reconcile/apply_test.go
+++ b/spinifex/network/reconcile/apply_test.go
@@ -565,6 +565,56 @@ func freshIntent(t *testing.T) IntentState {
 	}
 }
 
+// The prune pass must sweep dnat_and_snat rows whose stamped owning ENI is absent
+// from intent (leaked across dead VPCs by a lost vpc.delete-nat), keying on the
+// union of intent port names and EIP port names, while leaving live rows intact.
+func TestReconcile_PruneOrphanEIPs_SweepsAbsentOwners(t *testing.T) {
+	r, m := newTestReconciler(t)
+	ctx := context.Background()
+
+	deadRouter := topology.VPCRouter("vpc-dead")
+	if err := m.CreateLogicalRouter(ctx, &nbdb.LogicalRouter{Name: deadRouter}); err != nil {
+		t.Fatalf("CreateLogicalRouter: %v", err)
+	}
+	if err := m.CreateLogicalRouter(ctx, &nbdb.LogicalRouter{Name: topology.VPCRouter("vpc-a")}); err != nil {
+		t.Fatalf("CreateLogicalRouter live: %v", err)
+	}
+	// Live row: owned by an ENI present in intent.Ports.
+	if err := m.AddNAT(ctx, topology.VPCRouter("vpc-a"), &nbdb.NAT{
+		Type: "dnat_and_snat", ExternalIP: "192.168.1.10", LogicalIP: "10.0.1.10",
+		ExternalIDs: map[string]string{"spinifex:logical_port": topology.Port("eni-a")},
+	}); err != nil {
+		t.Fatalf("AddNAT live: %v", err)
+	}
+	// Orphan row: owner ENI is gone from intent.
+	if err := m.AddNAT(ctx, deadRouter, &nbdb.NAT{
+		Type: "dnat_and_snat", ExternalIP: "192.168.1.11", LogicalIP: "172.31.0.4",
+		ExternalIDs: map[string]string{"spinifex:logical_port": topology.Port("eni-dead")},
+	}); err != nil {
+		t.Fatalf("AddNAT orphan: %v", err)
+	}
+
+	intent := freshIntent(t) // Ports has eni-a only
+	r.pruneOrphanEIPs(ctx, intent)
+
+	if findNATByExternal(m, "dnat_and_snat", "192.168.1.10") == nil {
+		t.Errorf("live EIP row must survive the prune")
+	}
+	if findNATByExternal(m, "dnat_and_snat", "192.168.1.11") != nil {
+		t.Errorf("orphan EIP row must be pruned")
+	}
+}
+
+// findNATByExternal returns the first NAT row matching (type, externalIP), or nil.
+func findNATByExternal(m *mock.Client, natType, externalIP string) *nbdb.NAT {
+	for _, n := range m.NATs {
+		if n.Type == natType && n.ExternalIP == externalIP {
+			return n
+		}
+	}
+	return nil
+}
+
 func sortedCopy(in []string) []string {
 	out := append([]string(nil), in...)
 	slices.Sort(out)

--- a/spinifex/network/reconcile/reconcile.go
+++ b/spinifex/network/reconcile/reconcile.go
@@ -183,6 +183,9 @@ func (r *reconciler) reconcile(ctx context.Context, intent IntentState, pruneOrp
 	r.applyPorts(ctx, intent, actual, pruneOrphans)
 	r.applyIGWs(ctx, intent, actual)
 	r.applyEIPs(ctx, intent, actual)
+	if pruneOrphans {
+		r.pruneOrphanEIPs(ctx, intent)
+	}
 	r.applyNATGWs(ctx, intent, actual)
 	r.applyIGWRoutes(ctx, intent, actual)
 	r.applyNATGWRoutes(ctx, intent, actual)

--- a/spinifex/network/subscribers/subscribers.go
+++ b/spinifex/network/subscribers/subscribers.go
@@ -3,6 +3,7 @@
 package subscribers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,13 @@ import (
 // QueueGroup ensures one vpcd processes each event (shared OVN NB DB).
 const QueueGroup = "vpcd-workers"
 
+// MACBindingFlusher removes stale SB MAC_Binding rows resolving a private IP so a
+// reused address re-resolves to the new owner's MAC rather than the terminated
+// instance's. Optional dependency; a nil flusher makes the flush a no-op.
+type MACBindingFlusher interface {
+	FlushMACBinding(ctx context.Context, ip string) error
+}
+
 // Subscriber wires VPC lifecycle NATS topics to the network managers.
 type Subscriber struct {
 	topology topology.Manager
@@ -23,15 +31,17 @@ type Subscriber struct {
 	eip      external.EIPManager
 	natgw    external.NATGWManager
 	igw      external.IGWManager
+	mac      MACBindingFlusher
 }
 
-// Config: all fields required.
+// Config: all manager fields required. MAC is optional (nil disables the flush).
 type Config struct {
 	Topology topology.Manager
 	SG       policy.SecurityGroupManager
 	EIP      external.EIPManager
 	NATGW    external.NATGWManager
 	IGW      external.IGWManager
+	MAC      MACBindingFlusher
 }
 
 // New constructs a Subscriber, returning an error when any manager is nil.
@@ -54,6 +64,7 @@ func New(cfg Config) (*Subscriber, error) {
 		eip:      cfg.EIP,
 		natgw:    cfg.NATGW,
 		igw:      cfg.IGW,
+		mac:      cfg.MAC,
 	}, nil
 }
 

--- a/spinifex/network/subscribers/subscribers_test.go
+++ b/spinifex/network/subscribers/subscribers_test.go
@@ -3,9 +3,12 @@ package subscribers
 import (
 	"context"
 	"encoding/json"
+	"net/netip"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -574,4 +577,110 @@ func TestBadJSON_AllRequestReplies(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeMACFlusher records the IPs it was asked to flush.
+type fakeMACFlusher struct {
+	mu      sync.Mutex
+	flushed []string
+	err     error
+}
+
+func (f *fakeMACFlusher) FlushMACBinding(_ context.Context, ip string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.flushed = append(f.flushed, ip)
+	return f.err
+}
+
+func (f *fakeMACFlusher) calls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.flushed...)
+}
+
+// newTestSubscriberWithMAC mirrors newTestSubscriber but injects a MAC flusher and
+// returns the shared topology manager so tests can seed the VPC/subnet.
+func newTestSubscriberWithMAC(t *testing.T, mac MACBindingFlusher) (*Subscriber, topology.Manager) {
+	t.Helper()
+	m := mock.New()
+	_ = m.Connect(context.Background())
+
+	topo := topology.NewLiveManager(m)
+	sg := policy.NewSecurityGroupManager(m)
+	nat, err := policy.NewNATManager(m, policy.NATModeDistributed)
+	if err != nil {
+		t.Fatalf("NewNATManager: %v", err)
+	}
+	routes := policy.NewRouteManager(m)
+	igw, err := external.NewIGWManager(external.IGWManagerConfig{
+		OVN: m, Routes: routes, NAT: nat,
+		Allocator: external.NewStaticRangeAllocator(m), Chassis: []string{"hv1"},
+		NATMode: policy.NATModeDistributed,
+	})
+	if err != nil {
+		t.Fatalf("NewIGWManager: %v", err)
+	}
+	eip, err := external.NewEIPManager(nat, nil)
+	if err != nil {
+		t.Fatalf("NewEIPManager: %v", err)
+	}
+	natgw, err := external.NewNATGWManager(nat)
+	if err != nil {
+		t.Fatalf("NewNATGWManager: %v", err)
+	}
+	s, err := New(Config{Topology: topo, SG: sg, EIP: eip, NATGW: natgw, IGW: igw, MAC: mac})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s, topo
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// A successor reusing a private IP must get a clean SB MAC_Binding: both the
+// create-port (successor bind) and delete-port (predecessor teardown) handlers
+// flush the private IP so OVN re-resolves it to the live owner's MAC.
+func TestHandlePort_FlushesStaleMACBinding(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeMACFlusher{}
+	sub, topo := newTestSubscriberWithMAC(t, fake)
+
+	require.NoError(t, topo.EnsureVPC(ctx, topology.VPCSpec{VPCID: "vpc-a", CIDR: netip.MustParsePrefix("172.31.0.0/16")}))
+	require.NoError(t, topo.EnsureSubnet(ctx, topology.SubnetSpec{SubnetID: "subnet-a", VPCID: "vpc-a", CIDR: netip.MustParsePrefix("172.31.0.0/24")}))
+
+	evt := PortEvent{
+		NetworkInterfaceId: "eni-new", SubnetId: "subnet-a", VpcId: "vpc-a",
+		PrivateIpAddress: "172.31.0.4", MacAddress: "02:00:00:00:00:aa",
+	}
+
+	sub.handleCreatePort(&nats.Msg{Data: mustJSON(t, evt)})
+	assert.Contains(t, fake.calls(), "172.31.0.4", "create-port must flush the private IP's mac_binding")
+
+	sub.handleDeletePort(&nats.Msg{Data: mustJSON(t, evt)})
+	assert.Equal(t, 2, len(fake.calls()), "delete-port must also flush the freed private IP's mac_binding")
+}
+
+// A nil flusher must be a no-op (the dependency is optional).
+func TestHandlePort_NilFlusherIsNoop(t *testing.T) {
+	ctx := context.Background()
+	sub, topo := newTestSubscriberWithMAC(t, nil)
+
+	require.NoError(t, topo.EnsureVPC(ctx, topology.VPCSpec{VPCID: "vpc-a", CIDR: netip.MustParsePrefix("172.31.0.0/16")}))
+	require.NoError(t, topo.EnsureSubnet(ctx, topology.SubnetSpec{SubnetID: "subnet-a", VPCID: "vpc-a", CIDR: netip.MustParsePrefix("172.31.0.0/24")}))
+
+	evt := PortEvent{
+		NetworkInterfaceId: "eni-new", SubnetId: "subnet-a", VpcId: "vpc-a",
+		PrivateIpAddress: "172.31.0.4", MacAddress: "02:00:00:00:00:aa",
+	}
+	// Reaching here without panic is the assertion.
+	sub.handleCreatePort(&nats.Msg{Data: mustJSON(t, evt)})
+	sub.handleDeletePort(&nats.Msg{Data: mustJSON(t, evt)})
 }

--- a/spinifex/network/subscribers/topology.go
+++ b/spinifex/network/subscribers/topology.go
@@ -142,7 +142,21 @@ func (s *Subscriber) handleCreatePort(msg *nats.Msg) {
 		respond(msg, err)
 		return
 	}
+	// Clear any stale SB MAC_Binding for the private IP so a reused address
+	// resolves to this port's MAC, not a terminated predecessor's.
+	s.flushMACBinding(evt.NetworkInterfaceId, evt.PrivateIpAddress)
 	respond(msg, nil)
+}
+
+// flushMACBinding drops stale SB MAC_Binding rows for ip. Best-effort: the flush
+// never fails the handler, and OVN re-learns the binding on the next ARP.
+func (s *Subscriber) flushMACBinding(eniID, ip string) {
+	if s.mac == nil || ip == "" {
+		return
+	}
+	if err := s.mac.FlushMACBinding(context.Background(), ip); err != nil {
+		slog.Warn("subscribers: flush stale mac_binding failed", "eni_id", eniID, "ip", ip, "err", err)
+	}
 }
 
 func (s *Subscriber) handleDeletePort(msg *nats.Msg) {
@@ -161,6 +175,9 @@ func (s *Subscriber) handleDeletePort(msg *nats.Msg) {
 		respond(msg, err)
 		return
 	}
+	// Flush the freed private IP's SB MAC_Binding so a successor reusing the address
+	// is not resolved to this now-dead port's MAC.
+	s.flushMACBinding(evt.NetworkInterfaceId, evt.PrivateIpAddress)
 	respond(msg, nil)
 }
 

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -76,6 +76,9 @@ var serviceName = "vpcd"
 // Compile-time check: host.GatewayClaimProber implements reconcile.GatewayClaimVerifier.
 var _ reconcile.GatewayClaimVerifier = (*host.GatewayClaimProber)(nil)
 
+// Compile-time check: host.GatewayClaimProber implements subscribers.MACBindingFlusher.
+var _ subscribers.MACBindingFlusher = (*host.GatewayClaimProber)(nil)
+
 // BootstrapVPC holds the default VPC IDs from spinifex.toml used to seed OVN topology on first boot.
 type BootstrapVPC struct {
 	AccountID  string
@@ -596,6 +599,7 @@ func launchService(cfg *Config) error {
 		EIP:      eipMgr,
 		NATGW:    natgwMgr,
 		IGW:      igwMgr,
+		MAC:      host.NewGatewayClaimProber(cfg.OVNSBAddr),
 	})
 	if err != nil {
 		return fmt.Errorf("construct subscriber: %w", err)


### PR DESCRIPTION
## Problem

When an instance is terminated and a new instance reuses BOTH the freed floating (public) IP and the freed private IP (e.g. 172.31.0.4, the first-free address in a single-tenant subnet), the successor was unreachable on its EIP — SSH/TCP timed out — even though the guest booted healthy, cloud-init imported its key, and sshd was listening. IMDS (link-local) worked; only the br-wan/br-int EIP ingress datapath was broken. Root cause: stale OVN L2/L3 state from the released instance shadowing the reused IPs.

Exposed by the GPU e2e suite (all subtests recycle the same floating + private IP): Launch PASS, DeviceVisible/DriverAccess FAIL with `SSH to <ip>:22 not ready after 5m0s`.

## Fix (three parts)

1. **AddEIP re-point** (`network/policy/nat.go`) — the idempotent-skip guard now also requires the owning ENI to be unchanged (compares the `spinifex:logical_port` external-id, portable across centralised/distributed NAT). When a new ENI takes over the same external+logical IP, AddEIP falls through to delete-all + AddNAT + barrier + re-prime + host-rebind instead of skipping and leaving the datapath pointed at the dead port. Genuine same-ENI re-add still skips.

2. **Stale MAC_Binding flush** (`subscribers` + `host/gateway_claim.go` + `vpcd.go`) — on port delete (teardown, freed IP) and port create (successor bind), flush the private IP's SB `MAC_Binding` (`ovn-sbctl find/destroy`) so OVN re-learns the successor's MAC on next ARP instead of resolving to the dead instance's MAC.

3. **Orphan NAT prune + tap-responder churn stop** (`network/reconcile` + `tap_responder.go`) — reconciler prunes `dnat_and_snat` rows whose stamped `spinifex:logical_port` ENI is absent from the live-port set (fixes leaked rows from fire-and-forget vpc.delete-nat); the IMDS tap responder suspends retries for a vanished ENI record instead of looping every 15s.

Plan doc: `docs/development/bugs/ip-reuse-ovn-datapath-staleness.md` (mulga).

## Testing

- Unit tests: AddEIP re-points on owner change / preserves same-ENI skip (centralised); `PruneOrphanEIPs` prunes stamped orphans, keeps live/unstamped/snat rows; reconciler prune sweep; subscriber create/delete-port flush; tap-responder suspend/resume. Invariants (I1, RLC5) kept green. `make preflight` passes.
- Live-verified on wattle (spx v1.11.0-35-g20ca4088): non-GPU repro — instance A on 192.168.1.147/172.31.0.4 SSH OK; terminate→B reused same public+private IP SSH OK; terminate→C reused again SSH OK. Post-teardown: 0 orphan `dnat_and_snat`, tap-responder churn eliminated, MAC_Binding + neigh flush firing.
- Regression e2e (e2e.yml): Multi-Node PASS; the single Single-Node failure (`TestNATGateway` 8.8.8.8 egress) is a pre-existing env flake reproduced identically on fix-free dev — not a regression.

## Notes

- No submodule pointer bumped. Changes key on the `spinifex:logical_port` external-id (stamped on both dev and feat/gpu-e2e-main) so they merge cleanly alongside the gpu-e2e work.
- MAC_Binding flush is keyed by IP alone; in multi-VPC overlapping CIDRs this could over-flush a same-numbered IP in another VPC — self-healing (OVN re-ARPs), noted in the plan doc.