### PR TITLE
fix(daemon): silence benign NATS unsubscribe noise on shutdown

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -2192,7 +2192,11 @@ func (d *Daemon) setupShutdown() {
 		for _, sub := range d.natsSubscriptions {
 			slog.Info("Unsubscribing from NATS", "subject", sub.Subject)
 			if err := sub.Unsubscribe(); err != nil {
-				slog.Error("Error unsubscribing from NATS", "err", err)
+				if errors.Is(err, nats.ErrBadSubscription) {
+					slog.Debug("NATS subscription already invalid during shutdown", "subject", sub.Subject)
+				} else {
+					slog.Error("Error unsubscribing from NATS", "err", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
Graceful spinifex-daemon shutdown emitted a burst of ERROR-level `Error unsubscribing from NATS err='nats: invalid subscription'` (observed env19 bottlebrush restart, 2026-07-09). Cosmetic cleanup race — unsubscribe of an already-drained/closed subscription. No functional impact.

## Change
Shutdown unsubscribe loop now checks `errors.Is(err, nats.ErrBadSubscription)`: already-invalid subscriptions log at debug; real errors still log at error.

## Testing
`make preflight` green (diff coverage 72.6%, race ok, govulncheck ok).

Closes mulga-hjti7.