### PR TITLE
feat(obs): emit OTLP spans from qmp-collector and spinifex-ui

### DIFF
--- a/spinifex/services/qmpcollector/poller.go
+++ b/spinifex/services/qmpcollector/poller.go
@@ -14,12 +14,19 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/qmp"
 	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // userHZ is the kernel jiffy rate exposed in /proc/<pid>/stat. USER_HZ is 100
 // on every Linux architecture spinifex targets (x86_64, aarch64).
 const userHZ = 100.0
+
+// pollerTracerName is the instrumentation scope for per-instance poll spans.
+const pollerTracerName = "github.com/mulgadc/spinifex/spinifex/services/qmpcollector"
 
 // sample is one raw counter snapshot; published values are deltas between
 // consecutive samples.
@@ -94,7 +101,7 @@ func (p *poller) run(ctx context.Context) {
 	ticker := time.NewTicker(period)
 	defer ticker.Stop()
 	for {
-		p.tick()
+		p.tick(ctx)
 		select {
 		case <-ctx.Done():
 			return
@@ -109,13 +116,20 @@ func (p *poller) run(ctx context.Context) {
 
 // tick takes a snapshot and publishes the delta against the previous one.
 // The first snapshot only primes counters; any error or counter regression
-// (QEMU restarted) re-primes instead of publishing garbage.
-func (p *poller) tick() {
+// (QEMU restarted) re-primes instead of publishing garbage. Each call opens a
+// root span so poll failures surface in APM alongside the journald warning.
+func (p *poller) tick(ctx context.Context) {
 	meta := p.snapshotMeta()
+	ctx, span := otel.Tracer(pollerTracerName).Start(ctx, "qmp.poll_instance",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attribute.String("instance.id", meta.InstanceID)))
+	defer span.End()
+
 	cur, err := p.collect(meta)
 	if err != nil {
-		slog.Warn("qmp-collector: collect failed, re-priming",
+		slog.WarnContext(ctx, "qmp-collector: collect failed, re-priming",
 			"instanceId", meta.InstanceID, "err", err)
+		utils.MarkSpanError(span, err)
 		p.mu.Lock()
 		p.prev = nil
 		p.mu.Unlock()
@@ -136,14 +150,16 @@ func (p *poller) tick() {
 	}
 	data, err := json.Marshal(batch)
 	if err != nil {
-		slog.Error("qmp-collector: marshal batch", "instanceId", meta.InstanceID, "err", err)
+		slog.ErrorContext(ctx, "qmp-collector: marshal batch", "instanceId", meta.InstanceID, "err", err)
+		utils.MarkSpanError(span, err)
 		return
 	}
 	if err := p.nc.Publish(types.MetricsEC2SubjectPrefix+meta.InstanceID, data); err != nil {
-		slog.Warn("qmp-collector: publish failed", "instanceId", meta.InstanceID, "err", err)
+		slog.WarnContext(ctx, "qmp-collector: publish failed", "instanceId", meta.InstanceID, "err", err)
+		utils.MarkSpanError(span, err)
 		return
 	}
-	slog.Debug("qmp-collector: published", "instanceId", meta.InstanceID, "series", len(batch.Series))
+	slog.DebugContext(ctx, "qmp-collector: published", "instanceId", meta.InstanceID, "series", len(batch.Series))
 }
 
 // collect dials the telemetry socket fresh each tick (no held connection to

--- a/spinifex/services/spinifexui/proxy.go
+++ b/spinifex/services/spinifexui/proxy.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // newProxyTransport creates an *http.Transport that trusts the given CA
@@ -40,7 +42,10 @@ func newProxyTransport(caCertPath string) (*http.Transport, error) {
 
 // newReverseProxy forwards requests to backendHost after stripping pathPrefix.
 // Sets req.Host to the backend so SigV4 canonical-host verification passes.
-func newReverseProxy(backendHost, pathPrefix string, transport *http.Transport) http.Handler {
+// The transport is wrapped with otelhttp so proxied requests inject
+// traceparent, letting a UI-initiated trace continue into awsgw/predastore
+// instead of stopping at spinifex-ui.
+func newReverseProxy(backendHost, pathPrefix string, transport http.RoundTripper) http.Handler {
 	target := &url.URL{
 		Scheme: "https",
 		Host:   backendHost,
@@ -57,7 +62,7 @@ func newReverseProxy(backendHost, pathPrefix string, transport *http.Transport) 
 				pr.Out.URL.Path = "/"
 			}
 		},
-		Transport: transport,
+		Transport: otelhttp.NewTransport(transport),
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			slog.Error("Proxy error", "backend", backendHost, "path", r.URL.Path, "error", err)
 			w.Header().Set("Content-Type", "application/xml")

--- a/spinifex/services/spinifexui/spinifexui.go
+++ b/spinifex/services/spinifexui/spinifexui.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/mulgadc/spinifex/internal/tlsconfig"
+	"github.com/mulgadc/spinifex/spinifex/otelsetup"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
@@ -219,7 +220,8 @@ func (svc *Service) launchService() error {
 	compressor := middleware.NewCompressor(5, "text/html", "text/css",
 		"application/javascript", "text/javascript", "application/json",
 		"image/svg+xml", "text/plain")
-	finalHandler := securityHeadersMiddleware(compressor.Handler(mux))
+	traced := otelsetup.HTTPMiddleware("spinifex-ui")(mux)
+	finalHandler := securityHeadersMiddleware(compressor.Handler(traced))
 
 	addr := fmt.Sprintf("%s:%d", svc.Config.Host, svc.Config.Port)
 


### PR DESCRIPTION
## Summary

The Kibana APM service map on wattle showed spans from only 5 services (predastore,
awsgw, spinifex-daemon, vpcd, viperblockd). nats, qmp-collector, spinifex-ui, and eks all
ship logs/metrics through the same `otelsetup.Init` bootstrap but never opened a span, so
they never appeared in the trace view.

- **qmp-collector**: opens a root span (`qmp.poll_instance`, attribute `instance.id`)
  around each per-VM poll tick in `poller.tick`, marking the span as an error on QMP
  collect/publish failure so poll failures are visible in APM, not only journald.
- **spinifex-ui**: wraps its HTTP handler chain with `otelsetup.HTTPMiddleware`, the same
  helper awsgw and spinifex-daemon already use, and wraps the reverse-proxy transport with
  `otelhttp.NewTransport` so proxied calls to awsgw/predastore carry `traceparent` — a
  UI-initiated action now continues as one trace instead of stopping at the UI hop.
- **nats / eks**: intentionally left uninstrumented, with rationale recorded in
  `docs/development/improvements/widen-spx-otlp-span-coverage.md` in the mulga repo. Short
  version: nats is the vendored broker process (traffic already traced end-to-end at its
  producer/consumer endpoints, no message-level hook to attach a span to); eks
  request/response calls already produce spans today under `service.name=spinifex-daemon`
  since the handlers run in that process — deep tracing of its async reconciler
  goroutines is a separate, much larger piece of work.
- northstar is out of scope (tracing not implemented there yet).

## Before / after (wattle APM service map, `service.name` terms agg over traces index)

- Before: `predastore`, `awsgw`, `spinifex-daemon`, `vpcd`, `viperblockd`
- After: same five, **plus `spinifex-ui`** (`GET /`, `GET /api/ca.pem` transactions
  observed) **and `qmp-collector`** (`qmp.poll_instance` transaction observed, trace_id
  correlated with the collector's WARN log line for a stale poller).

## Test plan

- [x] `make preflight` passes (tests, race tests, vet, lint, govulncheck).
- [x] `go build ./...` with `GOWORK=off` in an isolated worktree.
- [x] Deployed to wattle (`make wattle-deploy EXTRA_VARS="spinifex_root=..."`) and
      confirmed via `.ds-traces-apm-default-*` in Elasticsearch that `spinifex-ui` and
      `qmp-collector` now emit spans.