### PR TITLE
fix(eks): deflake reconciler boot-scan resume

### DIFF
--- a/spinifex/handlers/eks/delete_cluster_test.go
+++ b/spinifex/handlers/eks/delete_cluster_test.go
@@ -109,6 +109,9 @@ func newEKSServiceFixture(t *testing.T) *eksServiceFixture {
 	// quickly instead of against the production 5m/10s budget.
 	svc.workerLaunchRetryTimeout = 100 * time.Millisecond
 	svc.workerLaunchRetryBackoff = 20 * time.Millisecond
+	// Tight boot-scan re-scan backoff so the eventually-consistent JetStream
+	// enumeration settles fast in tests instead of the production 100ms.
+	svc.spawnScanRetryBackoff = 2 * time.Millisecond
 	t.Cleanup(svc.Shutdown)
 
 	return &eksServiceFixture{svc: svc, kv: kv, nlb: nlb, inst: inst, vpc: vpc, ami: ami, eip: eip, sg: sg, worker: worker, vpcMgr: vpcMgr, igw: igw, ngw: ngw, rt: rt}

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -52,6 +52,16 @@ const (
 	defaultWorkerLaunchRetryBackoff = 10 * time.Second
 )
 
+// spawnScanMaxAttempts / defaultSpawnScanRetryBackoff bound the boot-time
+// reconciler scan. JetStream bucket/key enumeration is eventually consistent, so
+// a single scan right after connect can miss a bucket or a just-committed cluster
+// key and silently skip resuming its reconciler. The scan re-runs until the
+// observed cluster count stops growing (Spawn is idempotent) or the cap is hit.
+const (
+	spawnScanMaxAttempts         = 5
+	defaultSpawnScanRetryBackoff = 100 * time.Millisecond
+)
+
 // ngCASMaxRetries bounds the compare-and-swap retry loop that serializes
 // concurrent nodegroup-record mutations (overlapping UpdateNodegroupConfig).
 const ngCASMaxRetries = 16

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -249,6 +249,10 @@ type EKSServiceImpl struct {
 	// giving up and marking the nodegroup CREATE_FAILED. Tests inject small values.
 	workerLaunchRetryTimeout time.Duration
 	workerLaunchRetryBackoff time.Duration
+
+	// spawnScanRetryBackoff paces the boot-time reconciler re-scan when JetStream
+	// enumeration is still catching up. Tests inject a small value.
+	spawnScanRetryBackoff time.Duration
 }
 
 var _ EKSService = (*EKSServiceImpl)(nil)
@@ -282,6 +286,7 @@ func NewEKSServiceImpl(deps EKSServiceDeps) (*EKSServiceImpl, error) {
 		nodegroupReadyPoll:       defaultNodegroupReadyPoll,
 		workerLaunchRetryTimeout: defaultWorkerLaunchRetryTimeout,
 		workerLaunchRetryBackoff: defaultWorkerLaunchRetryBackoff,
+		spawnScanRetryBackoff:    defaultSpawnScanRetryBackoff,
 	}, nil
 }
 
@@ -297,7 +302,12 @@ func (s *EKSServiceImpl) Shutdown() {
 	s.registry.StopAll()
 }
 
-// SpawnRegisteredReconcilers resumes reconciler goroutines for all CREATING/ACTIVE clusters on daemon boot.
+// SpawnRegisteredReconcilers resumes reconciler goroutines for all CREATING/ACTIVE
+// clusters on daemon boot. JetStream bucket/key enumeration is eventually
+// consistent, so the scan is retried until the observed cluster count stops
+// growing across two passes (Spawn is idempotent, so re-runs only pick up
+// stragglers a lagging enumeration first missed), capped to return promptly on a
+// genuinely empty daemon.
 func (s *EKSServiceImpl) SpawnRegisteredReconcilers() error {
 	if !s.depsReadyForOrchestration() {
 		slog.Debug("SpawnRegisteredReconcilers: deps not ready, skipping")
@@ -307,6 +317,25 @@ func (s *EKSServiceImpl) SpawnRegisteredReconcilers() error {
 	if err != nil {
 		return fmt.Errorf("jetstream: %w", err)
 	}
+	prev := -1
+	for attempt := range spawnScanMaxAttempts {
+		observed := s.spawnRegisteredReconcilersScan(js)
+		if observed <= prev {
+			break
+		}
+		prev = observed
+		if attempt < spawnScanMaxAttempts-1 {
+			time.Sleep(s.spawnScanRetryBackoff)
+		}
+	}
+	return nil
+}
+
+// spawnRegisteredReconcilersScan runs one enumeration pass and resumes reconcilers
+// for every CREATING/ACTIVE cluster it can see, returning the count observed so the
+// caller can detect when a lagging JetStream enumeration has settled.
+func (s *EKSServiceImpl) spawnRegisteredReconcilersScan(js nats.JetStreamContext) int {
+	observed := 0
 	buckets := js.KeyValueStoreNames()
 	for name := range buckets {
 		if !strings.HasPrefix(name, KVBucketEKSAccountPrefix) {
@@ -331,6 +360,7 @@ func (s *EKSServiceImpl) SpawnRegisteredReconcilers() error {
 			if meta.Status != ClusterStatusCreating && meta.Status != ClusterStatusActive {
 				continue
 			}
+			observed++
 			// Reclaim any nodegroup workers stranded by the restart: a launch that
 			// was in flight when the prior process died left a CREATING (or
 			// partially-launched CREATE_FAILED) record whose workers nothing else
@@ -347,7 +377,7 @@ func (s *EKSServiceImpl) SpawnRegisteredReconcilers() error {
 			s.spawnReconciler(accountID, cluster, meta)
 		}
 	}
-	return nil
+	return observed
 }
 
 func (s *EKSServiceImpl) depsReadyForOrchestration() bool {

--- a/spinifex/handlers/eks/spawn_registered_reconcilers_test.go
+++ b/spinifex/handlers/eks/spawn_registered_reconcilers_test.go
@@ -2,6 +2,7 @@ package handlers_eks
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,9 +19,13 @@ func TestSpawnRegisteredReconcilers_ResumesNonTerminal(t *testing.T) {
 	active.Status = ClusterStatusActive
 	require.NoError(t, PutClusterMeta(f.kv, active))
 
-	// CREATING resumes both the bootstrap re-subscribe and the reconciler.
+	// CREATING resumes both the bootstrap re-subscribe and the reconciler. Stamp a
+	// recent CreatedAt so the resumed reconciler stays CREATING (the shared fixture
+	// meta is weeks old, which trips the CREATE timeout and self-deregisters before
+	// the assertion — the race this test previously flaked on).
 	creating := sampleClusterMeta("beta")
 	creating.Status = ClusterStatusCreating
+	creating.CreatedAt = time.Now()
 	require.NoError(t, PutClusterMeta(f.kv, creating))
 
 	failed := sampleClusterMeta("zeta")


### PR DESCRIPTION
## Summary

Deflakes `TestSpawnRegisteredReconcilers_ResumesNonTerminal` (mulga-7fd7c) and closes a latent prod gap in the daemon boot-time reconciler resume.

### Root cause (two modes)

1. **Reconciler self-removal.** The shared fixture meta stamps a weeks-old `CreatedAt`, so a resumed CREATING reconciler instantly trips the CREATE timeout, marks the cluster FAILED and deregisters — before the `registry.Has("beta")` assert. The test was racing a self-removal (reproduced locally under `-count=20` full-package `-race` at `spawn_registered_reconcilers_test.go:33`). Fix: stamp a recent `CreatedAt` so the reconciler stays CREATING.

2. **Boot-scan enumeration lag.** `SpawnRegisteredReconcilers` ran a one-shot JetStream enumeration (`KeyValueStoreNames` + `kv.Keys`), which is eventually consistent. Under load a just-committed cluster can be missing and never resumed — silently, on a real daemon. Fix: re-scan until the observed CREATING/ACTIVE count stops growing (capped, short backoff; `Spawn` is idempotent so re-runs only pick up stragglers).

### Also

Closes mulga-42dbw by verification — the `concurrent map writes` panic no longer reproduces on dev (mutex-guarded fake worker launcher + registry, per-test real JetStream KV). No code change needed there.

## Testing

- 300x `TestSpawnRegisteredReconcilers` + 15x full `handlers/eks` package under `-race` — green.
- `make preflight` — passed.

Closes mulga-7fd7c, mulga-42dbw.