### PR TITLE
fix(e2e): fail fast on reaped instance launch + emit APM error on MarkFailed

### DIFF
--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -472,7 +472,7 @@ func (d *Daemon) launchAMISystemInstance(input *sysinstance.SystemInstanceInput)
 	// Management NIC must be set before LaunchRunInstances so the fw_cfg netcfg
 	// blob (built during launch) carries the static mgmt0 address.
 	if err := d.attachSystemMgmtNIC(inst); err != nil {
-		d.vmMgr.MarkFailed(inst, "mgmt_nic_setup_failed")
+		d.vmMgr.MarkFailed(context.Background(), inst, "mgmt_nic_setup_failed")
 		return nil, err
 	}
 
@@ -485,7 +485,7 @@ func (d *Daemon) launchAMISystemInstance(input *sysinstance.SystemInstanceInput)
 			extraAccount := resolveENIAccount(extra.AccountID, input.AccountID)
 			if _, attachErr := d.vpcService.AttachENI(extraAccount, extra.ENIID, inst.ID, int64(idx+1)); attachErr != nil {
 				slog.Error("launchAMISystemInstance: failed to attach extra ENI", "eniId", extra.ENIID, "instanceId", inst.ID, "err", attachErr)
-				d.vmMgr.MarkFailed(inst, "extra_eni_attach_failed")
+				d.vmMgr.MarkFailed(context.Background(), inst, "extra_eni_attach_failed")
 				return nil, fmt.Errorf("attach extra ENI %s: %w", extra.ENIID, attachErr)
 			}
 		}
@@ -684,7 +684,7 @@ func (d *Daemon) releaseSystemInstanceEIP(instance *vm.VM) {
 // state migration to terminated KV).
 func (d *Daemon) cleanupFailedSystemInstance(instance *vm.VM, _ *ec2.InstanceTypeInfo) {
 	d.releaseSystemInstanceEIP(instance)
-	d.vmMgr.MarkFailed(instance, "system_instance_launch_failed")
+	d.vmMgr.MarkFailed(context.Background(), instance, "system_instance_launch_failed")
 }
 
 // WaitForSystemInstance polls until the instance reaches running state or times out.

--- a/spinifex/daemon/state_test.go
+++ b/spinifex/daemon/state_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -1025,7 +1026,7 @@ func TestPendingWatchdog_MarksStuckInstanceFailed(t *testing.T) {
 	stuckBefore, _ := daemon.vmMgr.Get("i-stuck")
 	require.NotNil(t, stuckBefore)
 	for _, instance := range stuck {
-		daemon.vmMgr.MarkFailed(instance, "launch_timeout")
+		daemon.vmMgr.MarkFailed(context.Background(), instance, "launch_timeout")
 	}
 
 	// MarkFailed sets the StateReason synchronously, then runs the cleanup
@@ -1123,7 +1124,7 @@ func TestMarkInstanceFailed_AlreadyShuttingDown(t *testing.T) {
 	daemon.vmMgr.Insert(instance)
 
 	// Should be a no-op — instance is already being cleaned up
-	daemon.vmMgr.MarkFailed(instance, "test_reason")
+	daemon.vmMgr.MarkFailed(context.Background(), instance, "test_reason")
 
 	// Status should not change
 	assert.Equal(t, vm.StateShuttingDown, instance.Status)
@@ -1139,7 +1140,7 @@ func TestMarkInstanceFailed_AlreadyTerminated(t *testing.T) {
 	}
 	daemon.vmMgr.Insert(instance)
 
-	daemon.vmMgr.MarkFailed(instance, "test_reason")
+	daemon.vmMgr.MarkFailed(context.Background(), instance, "test_reason")
 
 	// Status should not change
 	assert.Equal(t, vm.StateTerminated, instance.Status)

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -846,7 +846,7 @@ func (s *InstanceServiceImpl) LaunchRunInstances(ctx context.Context, instances 
 		volumeInfos, err := s.GenerateVolumes(ctx, input, instance)
 		if err != nil {
 			slog.ErrorContext(ctx, "LaunchRunInstances: GenerateVolumes failed", "instanceId", instance.ID, "err", err)
-			s.vmMgr.MarkFailed(instance, "volume_preparation_failed")
+			s.vmMgr.MarkFailed(ctx, instance, "volume_preparation_failed")
 			continue
 		}
 
@@ -867,7 +867,7 @@ func (s *InstanceServiceImpl) LaunchRunInstances(ctx context.Context, instances 
 			att, gpuErr := s.gpuClaimer.Claim(instance.ID, profileName)
 			if gpuErr != nil {
 				slog.ErrorContext(ctx, "LaunchRunInstances: GPU claim failed", "instanceId", instance.ID, "err", gpuErr)
-				s.vmMgr.MarkFailed(instance, "gpu_claim_failed")
+				s.vmMgr.MarkFailed(ctx, instance, "gpu_claim_failed")
 				continue
 			}
 			instance.GPUAttachments = []gpu.GPUAttachment{*att}
@@ -883,7 +883,7 @@ func (s *InstanceServiceImpl) LaunchRunInstances(ctx context.Context, instances 
 						"instanceId", instance.ID, "err", releaseErr)
 				}
 			}
-			s.vmMgr.MarkFailed(instance, "launch_failed")
+			s.vmMgr.MarkFailed(ctx, instance, "launch_failed")
 			continue
 		}
 

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -43,6 +43,21 @@ func endSpanWithError(span trace.Span, err error) {
 	span.End()
 }
 
+// recordInstanceFailure surfaces a reaped-launch as an APM error event on the
+// active span so the failure reason is queryable in the error stream,
+// correlated by trace id. No-op when ctx carries no recording span.
+func recordInstanceFailure(ctx context.Context, instanceID, reason string) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	span.RecordError(fmt.Errorf("instance %s launch failed: %s", instanceID, reason),
+		trace.WithAttributes(
+			attribute.String("instance.id", instanceID),
+			attribute.String("failure.reason", reason),
+		))
+}
+
 // RG-4 guest OOM tiers: user guests are reaped first; system instances (ELBv2,
 // EKS) rank above user guests but below infra (OOMScoreAdjust=-500).
 const (

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -147,7 +147,7 @@ func (m *Manager) Terminate(id string) error {
 // MarkFailed sets a failure reason, transitions to shutting-down synchronously,
 // then runs the cleanup chain in a goroutine so callers return immediately.
 // Tolerates instances already in a cleanup state (no-op).
-func (m *Manager) MarkFailed(instance *VM, reason string) {
+func (m *Manager) MarkFailed(ctx context.Context, instance *VM, reason string) {
 	skip := false
 	var observed InstanceState
 	m.Inspect(instance, func(v *VM) {
@@ -177,7 +177,8 @@ func (m *Manager) MarkFailed(instance *VM, reason string) {
 			return
 		}
 	}
-	slog.Info("Instance marked as failed", "instanceId", instance.ID, "reason", reason)
+	recordInstanceFailure(ctx, instance.ID, reason)
+	slog.ErrorContext(ctx, "Instance marked as failed", "instanceId", instance.ID, "reason", reason)
 
 	m.goroutineWg.Go(func() {
 		m.terminateCleanup(instance)

--- a/spinifex/vm/shutdown_test.go
+++ b/spinifex/vm/shutdown_test.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"context"
 	"errors"
 	"os"
 	"sync"
@@ -69,7 +70,7 @@ func TestMarkFailed_TransitionsToTerminated(t *testing.T) {
 	m.Insert(instance)
 
 	terminated := rt.waitFor(instance.ID, StateTerminated)
-	m.MarkFailed(instance, "volume_preparation_failed")
+	m.MarkFailed(context.Background(), instance, "volume_preparation_failed")
 
 	require.NotNil(t, instance.Instance.StateReason,
 		"MarkFailed must populate StateReason synchronously")
@@ -108,7 +109,7 @@ func TestMarkFailed_NilInstance(t *testing.T) {
 
 	terminated := rt.waitFor(instance.ID, StateTerminated)
 	require.NotPanics(t, func() {
-		m.MarkFailed(instance, "test_failure")
+		m.MarkFailed(context.Background(), instance, "test_failure")
 	})
 
 	select {
@@ -132,7 +133,7 @@ func TestMarkFailed_AlreadyShuttingDown_NoOp(t *testing.T) {
 	}
 	m.Insert(instance)
 
-	m.MarkFailed(instance, "duplicate_call")
+	m.MarkFailed(context.Background(), instance, "duplicate_call")
 
 	assert.Empty(t, rt.snapshot(),
 		"MarkFailed must not transition an already-shutting-down instance")
@@ -152,7 +153,7 @@ func TestMarkFailed_AlreadyTerminated_NoOp(t *testing.T) {
 	}
 	m.Insert(instance)
 
-	m.MarkFailed(instance, "duplicate_call")
+	m.MarkFailed(context.Background(), instance, "duplicate_call")
 
 	assert.Empty(t, rt.snapshot(),
 		"MarkFailed must not transition an already-terminated instance")

--- a/spinifex/vm/watchdog.go
+++ b/spinifex/vm/watchdog.go
@@ -48,6 +48,6 @@ func (m *Manager) scanAndMarkStuckPending(now time.Time) {
 		slog.Warn("Instance stuck in pending, marking failed",
 			"instanceId", instance.ID, "status", instance.Status,
 			"elapsed", now.Sub(*instance.Instance.LaunchTime))
-		m.MarkFailed(instance, "launch_timeout")
+		m.MarkFailed(context.Background(), instance, "launch_timeout")
 	}
 }

--- a/tests/e2e/harness/poll.go
+++ b/tests/e2e/harness/poll.go
@@ -47,6 +47,13 @@ func applyOpts(def pollCfg, opts ...PollOpt) pollCfg {
 	return def
 }
 
+// reapedInstanceStates are terminal states a live target (e.g. "running")
+// can never reach; observing one means the launch was reaped.
+var reapedInstanceStates = map[string]struct{}{
+	ec2.InstanceStateNameShuttingDown: {},
+	ec2.InstanceStateNameTerminated:   {},
+}
+
 // WaitForInstanceState polls DescribeInstances until State.Name == target.
 // Returns the latest instance on success; t.Fatal on timeout.
 func WaitForInstanceState(t *testing.T, c *AWSClient, id, target string, opts ...PollOpt) *ec2.Instance {
@@ -66,6 +73,17 @@ func WaitForInstanceState(t *testing.T, c *AWSClient, id, target string, opts ..
 		}
 		last = out.Reservations[0].Instances[0]
 		lastState = aws.StringValue(last.State.Name)
+		// A reaped instance can never reach a live target: fail fast with the
+		// recorded reason instead of burning the full timeout.
+		if _, reaped := reapedInstanceStates[lastState]; reaped {
+			if _, targetReaped := reapedInstanceStates[target]; !targetReaped {
+				reason := "no state reason recorded"
+				if last.StateReason != nil {
+					reason = aws.StringValue(last.StateReason.Message)
+				}
+				t.Fatalf("instance %s reaped to %s (want %s): %s", id, lastState, target, reason)
+			}
+		}
 		if lastState == target {
 			return nil
 		}


### PR DESCRIPTION
## Summary

From RCA of E2E run [29258398516](https://github.com/mulgadc/spinifex/actions/runs/29258398516) (`TestAccountScoping/Step2_InstanceScoping`). An instance was launched (RunInstances returned an ID) but its async launch failed on the node; `vmMgr.MarkFailed` reaped it to `terminated`. Two gaps surfaced:

1. The harness burned a full 5-minute opaque timeout waiting for `running` on an instance that could never reach it.
2. The failure reason never landed in the ES APM error stream — `slog` lands in app-logs (`logs-apm.app.*`), not `processor.event=error`, so the reaped launch was not queryable / correlatable by trace id.

## Changes

### Fail fast on reaped instances — `tests/e2e/harness/poll.go`
`WaitForInstanceState` now aborts immediately with the recorded `StateReason.Message` when it observes a reaped state (`shutting-down`/`terminated`) while waiting for a live target, instead of retrying to the timeout. Guarded so waiting *for* a reaped state still works. `WaitForVolume/Snapshot/Image` untouched.

### Emit APM error on MarkFailed — `spinifex/vm/{shutdown,lifecycle}.go` + callers
- New `recordInstanceFailure(ctx, id, reason)` helper: records the failure on the active span via `span.RecordError` (`instance.id` / `failure.reason` attrs). No-op when ctx carries no recording span. Deliberately no `SetStatus` — a batched RunInstances span must not be marked failed for one reaped instance.
- `MarkFailed` takes a `ctx`; log escalated `Info` -> `ErrorContext`.
- Only the `LaunchRunInstances` path passes a live span-bearing ctx (the RCA path); watchdog + system-instance callers pass `context.Background()` (record is a safe no-op).

## Test

- `GOWORK=off go build ./...` + `go build -tags e2e ./tests/e2e/...` pass
- `go vet` clean; golangci-lint 0 issues; govulncheck clean
- `go test ./spinifex/vm/... ./spinifex/daemon/... ./spinifex/handlers/ec2/instance/...` pass
- Invariant tests (`gc_invariants_test.go`, `lifecycle_invariants_test.go`) unaffected