### PR TITLE
fix(network): scrub stale dnat_and_snat by logical IP on EIP bind

### DIFF
--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -290,12 +290,8 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 	}
 
 	// Scrub any predecessor row sharing this private IP under a different external
-	// IP. A recycled private IP that lands on a new EIP leaves the terminated
-	// owner's dnat_and_snat (old EIP -> this private IP) intact; its SNAT half is
-	// keyed on logical_ip and wins the guest's return path, rewriting replies to
-	// the old EIP and blackholing the new one. dnat_and_snat is 1:1 per private IP,
-	// so any row on this router for this logical IP is stale here. Router-scoped:
-	// private IPs repeat across VPCs.
+	// IP: dnat_and_snat is 1:1 per private IP, and a stale row's SNAT half (keyed on
+	// logical_ip) blackholes the new EIP. Router-scoped — private IPs repeat per VPC.
 	if err := m.ovn.DeleteNAT(ctx, router, "dnat_and_snat", eip.LogicalIP); err != nil &&
 		!errors.Is(err, ovn.ErrNATNotFound) {
 		slog.Warn("policy: stale logical-IP NAT cleanup failed before AddEIP",

--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -289,6 +289,19 @@ func (m *natManager) AddEIP(ctx context.Context, eip EIPSpec) error {
 		slog.Info("policy: cleaned stale dnat_and_snat rules before AddEIP", "external_ip", eip.ExternalIP, "removed", removed)
 	}
 
+	// Scrub any predecessor row sharing this private IP under a different external
+	// IP. A recycled private IP that lands on a new EIP leaves the terminated
+	// owner's dnat_and_snat (old EIP -> this private IP) intact; its SNAT half is
+	// keyed on logical_ip and wins the guest's return path, rewriting replies to
+	// the old EIP and blackholing the new one. dnat_and_snat is 1:1 per private IP,
+	// so any row on this router for this logical IP is stale here. Router-scoped:
+	// private IPs repeat across VPCs.
+	if err := m.ovn.DeleteNAT(ctx, router, "dnat_and_snat", eip.LogicalIP); err != nil &&
+		!errors.Is(err, ovn.ErrNATNotFound) {
+		slog.Warn("policy: stale logical-IP NAT cleanup failed before AddEIP",
+			"logical_ip", eip.LogicalIP, "err", err)
+	}
+
 	if err := m.ovn.AddNAT(ctx, router, natRule); err != nil {
 		return fmt.Errorf("add dnat_and_snat %s -> %s on %s: %w", eip.LogicalIP, eip.ExternalIP, router, err)
 	}

--- a/spinifex/network/policy/nat_test.go
+++ b/spinifex/network/policy/nat_test.go
@@ -380,6 +380,85 @@ func TestNATManager_AddEIP_IdempotentSkip_SameOwner_Centralized(t *testing.T) {
 	assert.Equal(t, 1, barrierCalls, "same-ENI re-add must not fire the barrier")
 }
 
+// A successor reusing a recycled private IP with a NEW external IP must leave
+// exactly one dnat_and_snat for that private IP, pointing at the new EIP. The
+// predecessor's old-EIP row survives its (lost) DeleteEIP and shares the private
+// IP; its SNAT half (keyed on logical_ip) would blackhole the successor's new EIP.
+// Sibling of the same-external-IP re-point (RePointsOnOwnerChange) and the
+// same-external/different-private scrub (RemovesStaleRuleOnOtherRouter).
+func TestNATManager_AddEIP_ScrubsPredecessorSharingPrivateIP(t *testing.T) {
+	const privateIP = "172.31.0.5"
+	for _, tc := range []struct {
+		name string
+		mode NATMode
+		mac  string
+	}{
+		{"centralized", NATModeCentralized, ""},
+		{"distributed", NATModeDistributed, "bb:bb:bb:bb:bb:bb"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			m := mock.New()
+			seedRouter(t, m, "vpc-1")
+			seedGatewayPort(t, m, "vpc-1", "aa:bb:cc:00:00:01")
+			nm, err := NewNATManager(m, tc.mode)
+			require.NoError(t, err)
+
+			// Predecessor terminated but its dnat_and_snat (old EIP -> private IP) survives.
+			require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+				VPCID: "vpc-1", ExternalIP: "192.168.0.213", LogicalIP: privateIP,
+				PortName: "port-eni-old", MAC: tc.mac,
+			}))
+			// Successor recycles the private IP but binds a NEW EIP.
+			require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+				VPCID: "vpc-1", ExternalIP: "192.168.0.214", LogicalIP: privateIP,
+				PortName: "port-eni-new", MAC: tc.mac,
+			}))
+
+			require.Equal(t, 1, countNAT(m, "dnat_and_snat", privateIP),
+				"exactly one dnat_and_snat may exist for a recycled private IP")
+			got := findNAT(m, "dnat_and_snat", privateIP)
+			require.NotNil(t, got)
+			assert.Equal(t, "192.168.0.214", got.ExternalIP,
+				"row must point at the successor's new EIP, not the predecessor's stale one")
+			assert.Equal(t, "port-eni-new", got.ExternalIDs["spinifex:logical_port"])
+		})
+	}
+}
+
+// The logical-IP scrub is router-scoped: private IPs repeat across VPCs, so a
+// same-private-IP row on another VPC's router is a legitimate separate EIP and
+// must not be touched.
+func TestNATManager_AddEIP_LeavesSamePrivateIPOnOtherRouterIntact(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedRouter(t, m, "vpc-a")
+	seedRouter(t, m, "vpc-b")
+	nm, err := NewNATManager(m, NATModeDistributed)
+	require.NoError(t, err)
+
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-a", ExternalIP: "192.168.0.10", LogicalIP: "172.31.0.5",
+		PortName: "port-a", MAC: "aa:aa:aa:aa:aa:aa",
+	}))
+	// A different instance in vpc-b that happens to reuse the same private IP.
+	require.NoError(t, nm.AddEIP(ctx, EIPSpec{
+		VPCID: "vpc-b", ExternalIP: "192.168.0.11", LogicalIP: "172.31.0.5",
+		PortName: "port-b", MAC: "bb:bb:bb:bb:bb:bb",
+	}))
+
+	byExt := map[string]*nbdb.NAT{}
+	for _, n := range m.NATs {
+		if n.Type == "dnat_and_snat" && n.LogicalIP == "172.31.0.5" {
+			byExt[n.ExternalIP] = n
+		}
+	}
+	assert.Len(t, byExt, 2,
+		"same private IP on a different VPC router is a separate EIP and must survive")
+	assert.Contains(t, byExt, "192.168.0.10", "vpc-a's row must survive")
+	assert.Contains(t, byExt, "192.168.0.11", "vpc-b's row must survive")
+}
+
 func TestNATManager_PruneOrphanEIPs(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()


### PR DESCRIPTION
## Summary

When a terminated instance's private IP is recycled onto a fresh instance that receives a **different** Elastic IP, the successor was unreachable on its new EIP: external SSH/TCP timed out even though the guest booted healthy and the new `dnat_and_snat` ingress row was correct.

The predecessor's `dnat_and_snat` (old EIP -> reused private IP) survived — its `DeleteEIP` is fire-and-forget and the orphan-prune sweep is too slow — so two rows shared the private IP. OVN's SNAT direction is keyed on `logical_ip`, so the guest's replies were rewritten to the **old** EIP while the client dialed the **new** one: asymmetric NAT dropped every inbound flow.

`AddEIP` previously scrubbed stale rows only by the **new external IP** (`DeleteAllNATsByExternalIP`), which never matched the predecessor's *different* external IP.

## Change

In `AddEIP`, after the external-IP scrub and before `AddNAT`, also delete any `dnat_and_snat` on the VPC router carrying the new `LogicalIP` (router-scoped `DeleteNAT`). `dnat_and_snat` is strictly 1:1 per private IP, so any such row is stale here. Router scoping is required and correct: private IPs repeat across VPCs, so a same-private row on another VPC's router is a legitimate separate EIP.

The idempotent same-owner re-publish returns before the scrub, so a steady reconcile keeps its no-flow-gap guarantee — only a genuine re-point reaches the delete-then-add.