### PR TITLE
fix(network): poll second-VPC transit SNAT in natuplink + log AddSNAT install

### DIFF
--- a/spinifex/network/policy/nat.go
+++ b/spinifex/network/policy/nat.go
@@ -579,6 +579,12 @@ func (m *natManager) AddSNAT(ctx context.Context, vpcID, vpcCIDR, externalIP str
 	if err := m.ovn.AddNAT(ctx, router, snatRule); err != nil {
 		return fmt.Errorf("add IGW snat %s -> %s on %s: %w", vpcCIDR, externalIP, router, err)
 	}
+
+	// Log the first install so RCA can pin the commit timestamp; without this
+	// only later reconcile passes emit "idempotent skip", masking whether a
+	// missing snat was programmed late or never programmed at all.
+	slog.Info("policy: AddSNAT installed",
+		"router", router, "vpc_cidr", vpcCIDR, "external_ip", externalIP)
 	return nil
 }
 

--- a/tests/e2e/natuplink/natuplink_test.go
+++ b/tests/e2e/natuplink/natuplink_test.go
@@ -487,9 +487,17 @@ func phaseUniqueTransitIP(t *testing.T, fix *fixture, defaultGwIP string) {
 	assert.NotEqualf(t, defaultGwIP, gwIP,
 		"each VPC gateway LRP must get a unique transit IP (both got %s)", gwIP)
 
-	natList := harness.OvnNbctl(t, "lr-nat-list", "vpc-"+vpcID)
-	assert.Containsf(t, natList, secondVPCCIDR,
-		"second VPC router missing snat for %s\n%s", secondVPCCIDR, natList)
+	// The IGW default snat commits a beat after the gateway LRP appears, so
+	// poll lr-nat-list instead of reading it once — a single-shot check races
+	// the OVN commit and intermittently sees an empty list.
+	harness.Step(t, "second VPC transit snat programmed")
+	harness.EventuallyErr(t, func() error {
+		natList := harness.OvnNbctl(t, "lr-nat-list", "vpc-"+vpcID)
+		if !strings.Contains(natList, secondVPCCIDR) {
+			return fmt.Errorf("second VPC router missing snat for %s\n%s", secondVPCCIDR, natList)
+		}
+		return nil
+	}, 2*time.Minute, 3*time.Second)
 
 	harness.Step(t, "host ingress route for second VPC installed on attach")
 	harness.EventuallyErr(t, func() error {


### PR DESCRIPTION
## Summary

Fixes the flaky `TestNATUplink` red seen in E2E Nightly [run 29345043488](https://github.com/mulgadc/spinifex/actions/runs/29345043488) (cell-19, `single/nat/debian-13/nat-single`), and closes the observability gap that made it hard to diagnose.

The failure was a test-side race, not a control-plane defect. Phase 8 attaches an IGW to a second VPC (`10.213.0.0/16`), polls until the gateway LRP appears on the transit net, then checked the VPC router's `lr-nat-list` for the transit SNAT with a single non-polling `assert.Containsf`. The `igw-default-snat` row commits a beat after the LRP, so the one-shot read intermittently saw an empty list.

The node journal confirms the SNAT was programmed, just after the assertion had already run:

- `02:33:08.947` `AttachInternetGateway completed` (router `vpc-vpc-627aaec89d6dbc578`)
- `02:33:09.066` `VPC ingress route installed 10.213.0.0/16 via 100.127.0.18` — the LRP the test polls for appears here; the immediate `lr-nat-list` read fires in this window and returns empty
- `02:33:48.704` `policy: AddSNAT idempotent skip — rule already current` `vpc_cidr=10.213.0.0/16 external_ip=100.127.0.18` — "already current" proves the rule existed before that reconcile pass

Programmed late, not never programmed. Phases 1-7 and 9 all passed; the assertion is non-fatal (`assert`, not `require`), so it was the sole failure with no cascade.

## Changes

**`tests/e2e/natuplink/natuplink_test.go`** — wrap the Phase 8 SNAT check in `harness.EventuallyErr(2*time.Minute, 3*time.Second)`. This was the only non-polling assertion in the phase; the sibling gateway-LRP wait (`:476-482`) and host-ingress-route check (`:495-501`) were already `EventuallyErr`-guarded.

**`spinifex/network/policy/nat.go`** — `AddSNAT` logged on the idempotent-skip, patch-exempt and replace-stale paths, but the fresh-install path returned silently after `m.ovn.AddNAT` succeeded. So a first mint produced no log and only a *subsequent* reconcile pass emitted "idempotent skip" — exactly the ambiguity that made this RCA slow. Now emits `policy: AddSNAT installed` keyed by router + vpc_cidr + external_ip, so the commit timestamp is directly observable and "late" is distinguishable from "never".

## Testing

`make preflight` passes (lint 0 issues, tests + race + govulncheck green).

Note: preflight must currently be run as `GOWORK=off make preflight`. On a tree where the local `predastore` submodule predates `pkg/sigv4`, `go.work` binds spinifex to that checkout and `gateway/auth.go`'s import fails typecheck. `GOWORK=off` resolves the pinned `predastore v1.12.0` from the module cache instead. Pre-existing, unrelated to this change.

Both edited packages also vet clean in isolation (`go vet ./spinifex/network/policy/`, `go vet -tags e2e ./tests/e2e/natuplink/`).