### PR TITLE
fix(ec2,eks,ecs,images): root volume sizing + revive the rotted Ubuntu catalog entries

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -385,6 +385,27 @@ func init() {
 	}
 }
 
+// amiVolumeSizeGiB returns the smallest whole GiB that still holds sizeBytes.
+//
+// Rounding up is load-bearing. The image is copied into a root volume of
+// exactly this size, so a volume smaller than the image truncates it and the
+// guest comes up with no root partition — it stalls on the root device until
+// systemd drops it to an emergency shell, and nothing on the way there reports
+// an undersized volume. Flooring (plain integer division) undersizes every
+// image that is not an exact multiple of a GiB, which is why this went unseen
+// while every system image happened to be a round 16 GiB.
+//
+// The downstream guard cannot cover for a wrong answer here: floorVolumeSizeToAMI
+// raises a caller's requested size to this value, so it inherits the mistake
+// rather than catching it.
+func amiVolumeSizeGiB(sizeBytes int64) uint64 {
+	const bytesPerGiB = 1024 * 1024 * 1024
+	if sizeBytes <= 0 {
+		return 0
+	}
+	return utils.SafeInt64ToUint64((sizeBytes + bytesPerGiB - 1) / bytesPerGiB)
+}
+
 func runimagesImportCmd(cmd *cobra.Command, args []string) {
 	var image utils.Images
 
@@ -591,7 +612,7 @@ func runimagesImportCmd(cmd *cobra.Command, args []string) {
 	manifest.AMIMetadata.RootDeviceType = "ebs"
 	manifest.AMIMetadata.Virtualization = "hvm"
 	manifest.AMIMetadata.ImageOwnerAlias = "system"
-	manifest.AMIMetadata.VolumeSizeGiB = utils.SafeInt64ToUint64(imageStat.Size() / 1024 / 1024 / 1024)
+	manifest.AMIMetadata.VolumeSizeGiB = amiVolumeSizeGiB(imageStat.Size())
 	manifest.AMIMetadata.BootMode = image.BootMode
 	manifest.AMIMetadata.Distro = image.Distro
 	manifest.AMIMetadata.DistroFamily = utils.DistroFamily(image.Distro)

--- a/cmd/spinifex/cmd/admin_test.go
+++ b/cmd/spinifex/cmd/admin_test.go
@@ -702,3 +702,40 @@ func TestAdminInitFlag_CompactionIntervalReachesRenderedConfig(t *testing.T) {
 	})
 	assert.Contains(t, out, "interval_seconds = 45")
 }
+
+// The image is written into a root volume of exactly the size this returns, so
+// anything less than the image size truncates the image and the guest never
+// finds its root. The old flooring conversion undersized every non-round image.
+func TestAMIVolumeSizeGiB(t *testing.T) {
+	const giB int64 = 1024 * 1024 * 1024
+
+	tests := []struct {
+		name  string
+		bytes int64
+		want  uint64
+	}{
+		// The regression: a real 4.94 GiB mkosi image floored to 4 GiB and the
+		// guest hung with no root partition.
+		{name: "non-round image rounds up", bytes: 5306470400, want: 5},
+		// Exact multiples must not gain a spare GiB — the round sizes are the
+		// common case and were the only ones the old code got right.
+		{name: "exact multiple is unchanged", bytes: 16 * giB, want: 16},
+		{name: "one byte over a multiple rounds up", bytes: 16*giB + 1, want: 17},
+		{name: "one byte under a multiple rounds up", bytes: 16*giB - 1, want: 16},
+		// Sub-GiB images still need a whole GiB to live in.
+		{name: "sub-GiB image gets a full GiB", bytes: 1, want: 1},
+		{name: "empty image", bytes: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := amiVolumeSizeGiB(tt.bytes)
+			assert.Equal(t, tt.want, got)
+			// The invariant the guest depends on, stated directly.
+			if tt.bytes > 0 {
+				assert.GreaterOrEqual(t, int64(got)*giB, tt.bytes,
+					"volume must be large enough to hold the image")
+			}
+		})
+	}
+}

--- a/spinifex/handlers/ecs/capacity.go
+++ b/spinifex/handlers/ecs/capacity.go
@@ -17,6 +17,14 @@ const (
 	// defaultCapacityInstanceType is the EC2 type used when the caller omits one.
 	defaultCapacityInstanceType = "t3.small"
 
+	// defaultCapacityDiskSizeGiB is the container instance's root volume when the
+	// caller omits one, mirroring the 30 GiB the AWS ECS-optimized AMI declares.
+	// The size has to be decided here because EC2 itself has no default: omitting
+	// the block device mapping leaves the node on whatever volume the AMI declares,
+	// which is sized to hold the image and leaves the agent no room for the
+	// container images it exists to pull.
+	defaultCapacityDiskSizeGiB = 30
+
 	// maxCapacityCount caps the instances a single ProvisionCapacity launches.
 	maxCapacityCount = 10
 
@@ -36,6 +44,8 @@ var ErrECSNodeAMINotFound = errors.New("ecs: spinifex-ecs-node AMI not found")
 var ErrECSGPUNodeAMINotFound = errors.New("ecs: ecs GPU node AMI not found")
 
 // ProvisionCapacityInput requests N container instances into a cluster.
+// DiskSize is the root volume in GiB; omitted or non-positive takes
+// defaultCapacityDiskSizeGiB.
 type ProvisionCapacityInput struct {
 	Cluster         string
 	InstanceType    string
@@ -43,6 +53,7 @@ type ProvisionCapacityInput struct {
 	SubnetID        string
 	SecurityGroupID string
 	KeyName         string
+	DiskSize        int64
 }
 
 // ProvisionCapacityOutput returns the launched instance IDs.
@@ -68,6 +79,10 @@ func (s *Service) ProvisionCapacity(ctx context.Context, input *ProvisionCapacit
 	count := input.Count
 	if count <= 0 {
 		count = 1
+	}
+	diskSize := input.DiskSize
+	if diskSize <= 0 {
+		diskSize = defaultCapacityDiskSizeGiB
 	}
 	if count > maxCapacityCount {
 		count = maxCapacityCount
@@ -115,6 +130,10 @@ func (s *Service) ProvisionCapacity(ctx context.Context, input *ProvisionCapacit
 		SecurityGroupIds:   aws.StringSlice([]string{input.SecurityGroupID}),
 		UserData:           aws.String(userData),
 		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{Arn: aws.String(profileARN)},
+		BlockDeviceMappings: []*ec2.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/vda"),
+			Ebs:        &ec2.EbsBlockDevice{VolumeSize: aws.Int64(diskSize)},
+		}},
 		TagSpecifications: []*ec2.TagSpecification{{
 			ResourceType: aws.String("instance"),
 			Tags: []*ec2.Tag{

--- a/spinifex/handlers/ecs/capacity_test.go
+++ b/spinifex/handlers/ecs/capacity_test.go
@@ -177,6 +177,37 @@ func TestProvisionCapacity_DefaultsAndCount(t *testing.T) {
 	assert.Equal(t, defaultCapacityInstanceType, aws.StringValue(captured.InstanceType))
 	assert.Equal(t, int64(1), aws.Int64Value(captured.MinCount))
 	assert.Nil(t, captured.KeyName)
+
+	// An omitted DiskSize must still size the root volume: falling through to the
+	// AMI's own size leaves the agent no room for container images.
+	require.Len(t, captured.BlockDeviceMappings, 1)
+	require.NotNil(t, captured.BlockDeviceMappings[0].Ebs)
+	assert.Equal(t, int64(defaultCapacityDiskSizeGiB),
+		aws.Int64Value(captured.BlockDeviceMappings[0].Ebs.VolumeSize))
+}
+
+// An explicit DiskSize must win over the default.
+func TestProvisionCapacity_ExplicitDiskSize(t *testing.T) {
+	var captured *ec2.RunInstancesInput
+	svc := NewService(nil, testRegion, "internal").WithDeps(Deps{
+		IAM:    stubIAM{},
+		Images: &stubImages{images: ecsNodeImage()},
+		RunInstances: func(_ context.Context, in *ec2.RunInstancesInput, _ string) (*ec2.Reservation, error) {
+			captured = in
+			return &ec2.Reservation{Instances: []*ec2.Instance{{InstanceId: aws.String("i-1")}}}, nil
+		},
+	})
+
+	_, err := svc.ProvisionCapacity(context.Background(), &ProvisionCapacityInput{
+		Cluster:         "web",
+		SubnetID:        "subnet-1",
+		SecurityGroupID: "sg-1",
+		DiskSize:        75,
+	}, testAccountID)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Len(t, captured.BlockDeviceMappings, 1)
+	assert.Equal(t, int64(75), aws.Int64Value(captured.BlockDeviceMappings[0].Ebs.VolumeSize))
 }
 
 func TestProvisionCapacity_MissingRequired(t *testing.T) {

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -30,6 +30,13 @@ import (
 // when the caller omits instanceTypes.
 const defaultNodegroupInstanceType = "t3.medium"
 
+// defaultNodegroupDiskSizeGiB mirrors the AWS EKS managed-nodegroup default when
+// the caller omits diskSize. Without it the record stores 0, the launch skips
+// its block device mapping entirely, and the node silently inherits the AMI's
+// own volume size — which is sized to hold the image and nothing more, leaving
+// a worker no room for the container images it exists to run.
+const defaultNodegroupDiskSizeGiB = 20
+
 // defaultNodegroupReadyTimeout / defaultNodegroupReadyPoll bound how long
 // launchNodegroupInfra waits for its workers to register Ready (observed via the
 // CP state report's Ready-node count, refreshed at the reconcile cadence) before
@@ -262,6 +269,13 @@ func (s *EKSServiceImpl) createNodegroup(ctx context.Context, acctKV nats.KeyVal
 		version = meta.Version
 	}
 
+	// Resolved once here rather than at launch so DescribeNodegroup reports the
+	// size the node actually gets, as AWS does.
+	diskSize := aws.Int64Value(input.DiskSize)
+	if diskSize <= 0 {
+		diskSize = defaultNodegroupDiskSizeGiB
+	}
+
 	now := time.Now().UTC()
 	rec := &NodegroupRecord{
 		ClusterName:    cluster,
@@ -271,7 +285,7 @@ func (s *EKSServiceImpl) createNodegroup(ctx context.Context, acctKV nats.KeyVal
 		Subnets:        subnets,
 		InstanceTypes:  instanceTypes,
 		AMIType:        amiType,
-		DiskSize:       aws.Int64Value(input.DiskSize),
+		DiskSize:       diskSize,
 		ScalingMin:     minSize,
 		ScalingMax:     maxSize,
 		ScalingDesired: desired,

--- a/spinifex/handlers/eks/nodegroup_test.go
+++ b/spinifex/handlers/eks/nodegroup_test.go
@@ -373,6 +373,31 @@ func TestCreateNodegroup_HappyPath(t *testing.T) {
 	require.EqualError(t, err, awserrors.ErrorEKSResourceInUse)
 }
 
+// Omitting diskSize must fall back to the AWS default rather than 0. A 0 skips
+// the block device mapping entirely, which drops the worker onto the AMI's own
+// volume — sized to hold the image and nothing else.
+func TestCreateNodegroup_OmittedDiskSizeUsesAWSDefault(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	seedActiveClusterWithToken(t, f, "c1")
+
+	// createNGInput leaves DiskSize nil, which is the case being covered.
+	_, err := f.svc.CreateNodegroup(context.Background(), createNGInput("c1", "ng1", 1), testAccountID)
+	require.NoError(t, err)
+
+	rec, err := GetNodegroupRecord(f.kv, "c1", "ng1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(defaultNodegroupDiskSizeGiB), rec.DiskSize)
+
+	markWorkersReady(t, f, "c1", "ng1", 1)
+	f.svc.WaitLaunches()
+
+	// The default has to reach the launch, not just the record.
+	require.Len(t, f.worker.runCalls, 1)
+	bdms := f.worker.runCalls[0].BlockDeviceMappings
+	require.Len(t, bdms, 1, "a defaulted diskSize must still produce a block device mapping")
+	assert.Equal(t, int64(defaultNodegroupDiskSizeGiB), aws.Int64Value(bdms[0].Ebs.VolumeSize))
+}
+
 // A GPU instance type must mark the record GPUEnabled with the matching
 // vendor, so the worker-launch path resolves the GPU node AMI instead of the
 // default eks-node AMI.
@@ -666,21 +691,6 @@ func TestCreateNodegroup_DiskSizePropagatesToBlockDeviceMapping(t *testing.T) {
 	require.Len(t, bdm, 1)
 	require.NotNil(t, bdm[0].Ebs)
 	assert.Equal(t, int64(30), aws.Int64Value(bdm[0].Ebs.VolumeSize))
-}
-
-func TestCreateNodegroup_NoDiskSizeOmitsBlockDeviceMapping(t *testing.T) {
-	f := newEKSServiceFixture(t)
-	seedActiveClusterWithToken(t, f, "c1")
-
-	_, err := f.svc.CreateNodegroup(context.Background(), createNGInput("c1", "ng1", 1), testAccountID)
-	require.NoError(t, err)
-
-	markWorkersReady(t, f, "c1", "ng1", 1)
-	f.svc.WaitLaunches()
-
-	require.Len(t, f.worker.runCalls, 1)
-	// No DiskSize requested → leave the launch path on its default sizing.
-	assert.Empty(t, f.worker.runCalls[0].BlockDeviceMappings)
 }
 
 func TestCreateNodegroup_ClusterNotActive(t *testing.T) {

--- a/spinifex/utils/images.go
+++ b/spinifex/utils/images.go
@@ -306,6 +306,11 @@ var AvailableImages = map[string]Images{
 		BootMode:     "uefi",
 	},
 
+	// Ubuntu is pulled from releases/, not the codename dailies tree: Canonical
+	// prunes old daily builds, so a pinned daily URL 404s once it ages out and
+	// takes the catalog entry with it. Release builds are kept, so the pin stays
+	// resolvable. Note the filename carries the version rather than the codename
+	// under releases/ — the sums entry is matched on that basename.
 	"ubuntu-26.04-x86_64": {
 		Name:         "ubuntu-26.04-x86_64",
 		Description:  "Ubuntu 26.04 LTS (Resolute Reindeer) x86_64 cloud image",
@@ -313,9 +318,9 @@ var AvailableImages = map[string]Images{
 		Version:      "26.04",
 		Arch:         "x86_64",
 		Platform:     "Linux/UNIX",
-		CreatedAt:    time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
-		URL:          "https://cloud-images.ubuntu.com/resolute/20260421/resolute-server-cloudimg-amd64.img",
-		Checksum:     "https://cloud-images.ubuntu.com/resolute/20260421/SHA256SUMS",
+		CreatedAt:    time.Date(2026, 7, 13, 0, 0, 0, 0, time.UTC),
+		URL:          "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/ubuntu-26.04-server-cloudimg-amd64.img",
+		Checksum:     "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/SHA256SUMS",
 		ChecksumType: "sha256",
 		BootMode:     "uefi",
 	},
@@ -327,9 +332,9 @@ var AvailableImages = map[string]Images{
 		Version:      "26.04",
 		Arch:         "arm64",
 		Platform:     "Linux/UNIX",
-		CreatedAt:    time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
-		URL:          "https://cloud-images.ubuntu.com/resolute/20260421/resolute-server-cloudimg-arm64.img",
-		Checksum:     "https://cloud-images.ubuntu.com/resolute/20260421/SHA256SUMS",
+		CreatedAt:    time.Date(2026, 7, 13, 0, 0, 0, 0, time.UTC),
+		URL:          "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/ubuntu-26.04-server-cloudimg-arm64.img",
+		Checksum:     "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/SHA256SUMS",
 		ChecksumType: "sha256",
 		BootMode:     "uefi",
 	},


### PR DESCRIPTION
Four fixes. The first three are root-volume sizing, all surfaced while moving the system images to mkosi, which sizes a disk to its content and so removes the accidental headroom today's images carry. The fourth is unrelated rot found while auditing the catalog.

## 1. Round the AMI root volume up so the image fits

`admin images import` computed the registered volume size with integer division:

```go
VolumeSizeGiB = SafeInt64ToUint64(imageStat.Size() / 1024 / 1024 / 1024)
```

A 4.94 GiB image therefore registered as **4 GiB** — a volume smaller than the image it holds. The guest hangs in dracut on `dev-gpt-auto-root.device`, given a root device that cannot contain its own filesystem. `floorVolumeSizeToAMI` existed to prevent exactly this ("Under-sizing hangs the guest in dracut; we round up silently") but inherited the same truncated value.

This is worse than one bad image. **Alpine's cloud image has a 214 MiB virtual disk**, which truncates to `VolumeSizeGiB = 0` — and `floorVolumeSizeToAMI` bails at `if amiMeta.VolumeSizeGiB == 0 { return requested }`, so the dracut guard silently disables itself for that AMI entirely. The ceiling makes it 1 GiB and re-arms the guard.

`TestAMIVolumeSizeGiB` covers it, including the production value that triggered the bug (5306470400 → 5, not 4).

## 2. Default an EKS nodegroup's root volume to 20 GiB

`CreateNodegroup` stored `diskSize` verbatim, so omitting it persisted `0`, `if rec.DiskSize > 0` skipped the block device mapping, and the worker inherited whatever volume the AMI declares.

Not only a future problem: `spinifex-eks-node` is registered at **4 GiB**, so a CPU nodegroup created without an explicit diskSize gets a 4 GiB root today. The GPU path escapes it only because that AMI happens to declare 16 GiB for ~2 GiB of content.

20 GiB matches the AWS EKS managed-nodegroup default, resolved at create so `DescribeNodegroup` reports the size the node actually gets.

`TestCreateNodegroup_NoDiskSizeOmitsBlockDeviceMapping` asserted the old fall-through and is replaced by its inverse. The explicit-size case was already covered by `TestCreateNodegroup_DiskSizePropagatesToBlockDeviceMapping`.

## 3. Default an ECS container instance's root volume to 30 GiB

`ProvisionCapacity` built its `RunInstancesInput` with no block device mapping at all, with the same consequence. 30 GiB mirrors what the AWS ECS-optimized AMI declares. `ProvisionCapacity` is spinifex's own API rather than an AWS one, so `DiskSize` is added to its input for callers that want to size a cluster explicitly, defaulting when omitted exactly as `InstanceType` and `Count` already do.

## 4. Revive the Ubuntu catalog entries

Both Ubuntu entries pointed at a dated build under the codename dailies tree, which Canonical prunes. That path now **404s**, so `spx admin images import --name ubuntu-26.04-x86_64` fails outright, for x86_64 and arm64 alike. Repointed at `releases/`, whose builds are retained, keeping a specific reproducible pin. Filenames there carry the version rather than the codename, which matters because the sums entry is matched on the URL basename.

CI could not have caught this: it fetches `resolute/current/`, a symlink that never rots, so nothing exercised the pinned path. Debian pins a dated directory too but is fine — those builds are retained and its entries still resolve.

## Why EC2 itself is deliberately unchanged

AWS has no service-wide default root volume; the size comes from the AMI's block device mapping, which is why Canonical's AWS AMI declares 8 GiB. Spinifex's own `parseVolumeParams` already applies a hardcoded 4 GiB default and `floorVolumeSizeToAMI` raises it to the AMI size, so its effective behaviour is `max(4 GiB, AMI size)`. Whether that 4 GiB default should be larger is a real question, but it is a separate decision from these fixes and is left alone here.

## Testing

- `make preflight` passes.
- Every new test was confirmed to fail against the unfixed code with the real symptom (`expected: 5, actual: 4`; `expected: 20, actual: 0` with the mapping absent; `expected: 30, actual: 0`).
- Catalog URLs verified live: every entry returns 200, including both new Ubuntu release URLs and their SHA256SUMS entries.
- Verified live on wattle: an image registering 5 GiB launched with a 20G root and reported 20G on `df -h /`.