### PR TITLE
test: add Northstar multi-node DNS coverage

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -2652,7 +2652,7 @@ func createConfigSubdirs(configDir string) (configDirs, error) {
 // zero pair and an empty path, so the node renders no northstar config at all
 // rather than a resolver holding a key its own predastore would reject.
 func northstarFromFormation(creds *formation.SharedCredentials, dirs configDirs) (admin.NorthstarCredentials, string) {
-	if creds.NorthstarAccessKey == "" {
+	if creds.NorthstarAccessKey == "" || creds.NorthstarSecretKey == "" {
 		return admin.NorthstarCredentials{}, ""
 	}
 	return admin.NorthstarCredentials{
@@ -2665,6 +2665,16 @@ func northstarFromFormation(creds *formation.SharedCredentials, dirs configDirs)
 // generateAndWriteConfigs renders the standard config files (spinifex.toml,
 // awsgw.toml, nats.conf, and optionally predastore.toml) from templates.
 func generateAndWriteConfigs(dirs configDirs, spinifexTomlPath string, settings admin.ConfigSettings, skipPredastore bool) error {
+	// A one-sided pair must disable Northstar wholesale. Rendering only the
+	// public stanza or only the secret file advertises a resolver that cannot run.
+	northstarEnabled := settings.NorthstarAccessKey != "" && settings.NorthstarSecretKey != ""
+	if !northstarEnabled {
+		settings.NorthstarAccessKey = ""
+		settings.NorthstarSecretKey = ""
+		settings.NorthstarBucket = ""
+		settings.NorthstarConfigPath = ""
+	}
+
 	configs := []admin.ConfigFile{
 		{Name: "spinifex.toml", Path: spinifexTomlPath, Template: spinifexTomlTemplate},
 		{Name: filepath.Join(dirs.AWSGW, "awsgw.toml"), Path: filepath.Join(dirs.AWSGW, "awsgw.toml"), Template: awsgwTomlTemplate},
@@ -2674,7 +2684,7 @@ func generateAndWriteConfigs(dirs configDirs, spinifexTomlPath string, settings 
 	// provisioned. A cluster formed by a leader that predates their distribution
 	// leaves the keys empty, yielding no northstar config rather than a partial
 	// one pointing at a bucket the local predastore does not serve.
-	if settings.NorthstarAccessKey != "" {
+	if northstarEnabled {
 		configs = append(configs, admin.ConfigFile{
 			Name: filepath.Join(dirs.Northstar, "northstar.toml"), Path: filepath.Join(dirs.Northstar, "northstar.toml"), Template: northstarTomlTemplate,
 		})

--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -385,6 +385,27 @@ func init() {
 	}
 }
 
+// amiVolumeSizeGiB returns the smallest whole GiB that still holds sizeBytes.
+//
+// Rounding up is load-bearing. The image is copied into a root volume of
+// exactly this size, so a volume smaller than the image truncates it and the
+// guest comes up with no root partition — it stalls on the root device until
+// systemd drops it to an emergency shell, and nothing on the way there reports
+// an undersized volume. Flooring (plain integer division) undersizes every
+// image that is not an exact multiple of a GiB, which is why this went unseen
+// while every system image happened to be a round 16 GiB.
+//
+// The downstream guard cannot cover for a wrong answer here: floorVolumeSizeToAMI
+// raises a caller's requested size to this value, so it inherits the mistake
+// rather than catching it.
+func amiVolumeSizeGiB(sizeBytes int64) uint64 {
+	const bytesPerGiB = 1024 * 1024 * 1024
+	if sizeBytes <= 0 {
+		return 0
+	}
+	return utils.SafeInt64ToUint64((sizeBytes + bytesPerGiB - 1) / bytesPerGiB)
+}
+
 func runimagesImportCmd(cmd *cobra.Command, args []string) {
 	var image utils.Images
 
@@ -591,7 +612,7 @@ func runimagesImportCmd(cmd *cobra.Command, args []string) {
 	manifest.AMIMetadata.RootDeviceType = "ebs"
 	manifest.AMIMetadata.Virtualization = "hvm"
 	manifest.AMIMetadata.ImageOwnerAlias = "system"
-	manifest.AMIMetadata.VolumeSizeGiB = utils.SafeInt64ToUint64(imageStat.Size() / 1024 / 1024 / 1024)
+	manifest.AMIMetadata.VolumeSizeGiB = amiVolumeSizeGiB(imageStat.Size())
 	manifest.AMIMetadata.BootMode = image.BootMode
 	manifest.AMIMetadata.Distro = image.Distro
 	manifest.AMIMetadata.DistroFamily = utils.DistroFamily(image.Distro)

--- a/cmd/spinifex/cmd/admin_test.go
+++ b/cmd/spinifex/cmd/admin_test.go
@@ -702,8 +702,9 @@ type predastoreBucketAuth struct {
 		Type string `toml:"type"`
 	} `toml:"buckets"`
 	Auth []struct {
-		AccessKeyID string `toml:"access_key_id"`
-		Policy      []struct {
+		AccessKeyID     string `toml:"access_key_id"`
+		SecretAccessKey string `toml:"secret_access_key"`
+		Policy          []struct {
 			Bucket  string   `toml:"bucket"`
 			Actions []string `toml:"actions"`
 		} `toml:"policy"`
@@ -765,12 +766,18 @@ func TestPredastoreMultinodeTemplate_NorthstarProvisioned(t *testing.T) {
 	// resolver's. Without this grant, seeding fails on every node.
 	systemActions, ok := cfg.policyFor("AK", admin.NorthstarBucketName)
 	require.True(t, ok, "system key has no policy for the northstar bucket")
-	assert.Contains(t, systemActions, "s3:PutObject")
+	assert.Contains(t, systemActions, "s3:GetObject", "bootstrap must check whether the zone already exists")
+	assert.Contains(t, systemActions, "s3:PutObject", "bootstrap must create a missing zone")
 
 	// The resolver's key stays read-only and scoped to the zone bucket alone.
 	nsActions, ok := cfg.policyFor("NSAK", admin.NorthstarBucketName)
 	require.True(t, ok, "northstar key has no policy for the northstar bucket")
 	assert.ElementsMatch(t, []string{"s3:ListBucket", "s3:GetObject"}, nsActions)
+	for _, auth := range cfg.Auth {
+		if auth.AccessKeyID == "NSAK" {
+			assert.Equal(t, "NSSK", auth.SecretAccessKey)
+		}
+	}
 
 	_, ok = cfg.policyFor("NSAK", "predastore")
 	assert.False(t, ok, "northstar key must not reach the predastore bucket")
@@ -810,14 +817,31 @@ func TestNorthstarFromFormation_UsesDistributedPair(t *testing.T) {
 	assert.Equal(t, "/etc/spinifex/northstar/northstar.toml", path)
 }
 
-// A leader predating credential distribution sends no keys. The joiner must
-// then render no northstar config at all: a config path without honoured keys
-// would advertise 169.254.169.253 to guests while the resolver serves nothing.
-func TestNorthstarFromFormation_LegacyLeaderYieldsNoConfig(t *testing.T) {
-	got, path := northstarFromFormation(&formation.SharedCredentials{}, configDirs{Northstar: "/etc/spinifex/northstar"})
+// A leader predating credential distribution, or returning only half a pair,
+// must yield no Northstar config. Advertising a resolver without usable keys
+// would send guests to a service that cannot read its zones.
+func TestNorthstarFromFormation_IncompletePairYieldsNoConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		access string
+		secret string
+	}{
+		{name: "legacy leader"},
+		{name: "access key only", access: "NSAK"},
+		{name: "secret key only", secret: "NSSK"},
+	}
 
-	assert.Equal(t, admin.NorthstarCredentials{}, got)
-	assert.Empty(t, path, "config path without credentials advertises a resolver that cannot read its zones")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, path := northstarFromFormation(&formation.SharedCredentials{
+				NorthstarAccessKey: tt.access,
+				NorthstarSecretKey: tt.secret,
+			}, configDirs{Northstar: "/etc/spinifex/northstar"})
+
+			assert.Equal(t, admin.NorthstarCredentials{}, got)
+			assert.Empty(t, path, "config path without credentials advertises a resolver that cannot read its zones")
+		})
+	}
 }
 
 // multinodeNorthstarSettings mirrors what both formation paths hand
@@ -857,25 +881,45 @@ func TestGenerateAndWriteConfigs_MultinodeRendersNorthstar(t *testing.T) {
 	assert.Equal(t, nsPath, cfg.Nodes["node1"].Northstar.ConfigPath)
 }
 
-// The inverse: no credentials must yield neither file nor stanza. A stanza
-// without a rendered northstar.toml would point guests at a resolver that never
-// starts.
-func TestGenerateAndWriteConfigs_NoNorthstarWithoutCredentials(t *testing.T) {
-	dirs, err := createConfigSubdirs(t.TempDir())
-	require.NoError(t, err)
-	spinifexTomlPath := filepath.Join(t.TempDir(), "spinifex.toml")
+// Incomplete credentials must yield neither file nor stanza. A stanza without
+// a usable northstar.toml would point guests at a resolver that never starts.
+func TestGenerateAndWriteConfigs_NoNorthstarWithoutCompleteCredentials(t *testing.T) {
+	tests := []struct {
+		name   string
+		access string
+		secret string
+	}{
+		{name: "no credentials"},
+		{name: "access key only", access: "AKIANORTHSTAR"},
+		{name: "secret key only", secret: "northstar-secret"},
+	}
 
-	settings := multinodeNorthstarSettings("")
-	settings.NorthstarAccessKey = ""
-	settings.NorthstarSecretKey = ""
-	require.NoError(t, generateAndWriteConfigs(dirs, spinifexTomlPath, settings, true))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirs, err := createConfigSubdirs(t.TempDir())
+			require.NoError(t, err)
+			spinifexTomlPath := filepath.Join(t.TempDir(), "spinifex.toml")
 
-	_, err = os.Stat(filepath.Join(dirs.Northstar, "northstar.toml"))
-	assert.True(t, os.IsNotExist(err), "northstar.toml rendered without credentials")
+			settings := multinodeNorthstarSettings(filepath.Join(dirs.Northstar, "northstar.toml"))
+			settings.NorthstarAccessKey = tt.access
+			settings.NorthstarSecretKey = tt.secret
+			require.NoError(t, generateAndWriteConfigs(dirs, spinifexTomlPath, settings, false))
 
-	cfg, err := config.LoadConfig(spinifexTomlPath)
-	require.NoError(t, err)
-	assert.Empty(t, cfg.Nodes["node1"].Northstar.ConfigPath)
+			_, err = os.Stat(filepath.Join(dirs.Northstar, "northstar.toml"))
+			assert.True(t, os.IsNotExist(err), "northstar.toml rendered without complete credentials")
+
+			cfg, err := config.LoadConfig(spinifexTomlPath)
+			require.NoError(t, err)
+			assert.Empty(t, cfg.Nodes["node1"].Northstar.ConfigPath)
+
+			predastoreContent, err := os.ReadFile(filepath.Join(dirs.Predastore, "predastore.toml"))
+			require.NoError(t, err)
+			var predastoreCfg predastoreBucketAuth
+			require.NoError(t, toml.Unmarshal(predastoreContent, &predastoreCfg))
+			assert.False(t, predastoreCfg.hasBucket(admin.NorthstarBucketName))
+			assert.Len(t, predastoreCfg.Auth, 1, "incomplete pair rendered a Northstar auth entry")
+		})
+	}
 }
 
 // renderClusterNode renders one node's spinifex.toml as its own formation path
@@ -886,6 +930,7 @@ func renderClusterNode(t *testing.T, node string, allNodes map[string]formation.
 
 	settings := multinodeNorthstarSettings(nsPath)
 	settings.Node = node
+	settings.BindIP = allNodes[node].BindIP
 	settings.AdvertiseIP = allNodes[node].AdvertiseIP
 	settings.RemoteNodes = buildRemoteNodes(allNodes, node, nsPath)
 
@@ -909,10 +954,17 @@ func TestSpinifexTomlTemplate_PeerNorthstarSeedsAreUniform(t *testing.T) {
 		"node3": {Name: "node3", BindIP: "10.0.0.3", AdvertiseIP: "192.168.1.33"},
 	}
 
-	want := []string{"192.168.1.31", "192.168.1.32", "192.168.1.33"}
+	wantIPs := []string{"192.168.1.31", "192.168.1.32", "192.168.1.33"}
+	wantHosts := []string{"ns1", "ns2", "ns3"}
 	for _, node := range []string{"node1", "node2", "node3"} {
 		cfg := renderClusterNode(t, node, allNodes)
-		assert.Equal(t, want, handlers_dns.ResolverNameserverIPs(cfg),
+		seeds := handlers_dns.NameserverSeeds(cfg)
+		require.Len(t, seeds, 3)
+		for i, seed := range seeds {
+			assert.Equal(t, wantHosts[i], seed.Host)
+			assert.Equal(t, wantIPs[i], seed.IP)
+		}
+		assert.Equal(t, wantIPs, handlers_dns.ResolverNameserverIPs(cfg),
 			"%s derived a different nameserver set from its own config", node)
 	}
 }

--- a/cmd/spinifex/cmd/admin_test.go
+++ b/cmd/spinifex/cmd/admin_test.go
@@ -702,3 +702,40 @@ func TestAdminInitFlag_CompactionIntervalReachesRenderedConfig(t *testing.T) {
 	})
 	assert.Contains(t, out, "interval_seconds = 45")
 }
+
+// The image is written into a root volume of exactly the size this returns, so
+// anything less than the image size truncates the image and the guest never
+// finds its root. The old flooring conversion undersized every non-round image.
+func TestAMIVolumeSizeGiB(t *testing.T) {
+	const giB int64 = 1024 * 1024 * 1024
+
+	tests := []struct {
+		name  string
+		bytes int64
+		want  uint64
+	}{
+		// The regression: a real 4.94 GiB mkosi image floored to 4 GiB and the
+		// guest hung with no root partition.
+		{name: "non-round image rounds up", bytes: 5306470400, want: 5},
+		// Exact multiples must not gain a spare GiB — the round sizes are the
+		// common case and were the only ones the old code got right.
+		{name: "exact multiple is unchanged", bytes: 16 * giB, want: 16},
+		{name: "one byte over a multiple rounds up", bytes: 16*giB + 1, want: 17},
+		{name: "one byte under a multiple rounds up", bytes: 16*giB - 1, want: 16},
+		// Sub-GiB images still need a whole GiB to live in.
+		{name: "sub-GiB image gets a full GiB", bytes: 1, want: 1},
+		{name: "empty image", bytes: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := amiVolumeSizeGiB(tt.bytes)
+			assert.Equal(t, tt.want, got)
+			// The invariant the guest depends on, stated directly.
+			if tt.bytes > 0 {
+				assert.GreaterOrEqual(t, int64(got)*giB, tt.bytes,
+					"volume must be large enough to hold the image")
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/insomniacslk/dhcp v0.0.0-20260407060928-11b94ed970f2
 	github.com/klauspost/cpuid/v2 v2.4.0
+	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910
 	github.com/mulgadc/predastore v1.12.1
 	github.com/mulgadc/viperblock v1.12.1
@@ -145,7 +146,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.21 // indirect
 	github.com/mdlayher/packet v1.1.2 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
-	github.com/miekg/dns v1.1.72 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/highwayhash v1.0.4 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/spinifex/handlers/ecs/capacity.go
+++ b/spinifex/handlers/ecs/capacity.go
@@ -17,6 +17,14 @@ const (
 	// defaultCapacityInstanceType is the EC2 type used when the caller omits one.
 	defaultCapacityInstanceType = "t3.small"
 
+	// defaultCapacityDiskSizeGiB is the container instance's root volume when the
+	// caller omits one, mirroring the 30 GiB the AWS ECS-optimized AMI declares.
+	// The size has to be decided here because EC2 itself has no default: omitting
+	// the block device mapping leaves the node on whatever volume the AMI declares,
+	// which is sized to hold the image and leaves the agent no room for the
+	// container images it exists to pull.
+	defaultCapacityDiskSizeGiB = 30
+
 	// maxCapacityCount caps the instances a single ProvisionCapacity launches.
 	maxCapacityCount = 10
 
@@ -36,6 +44,8 @@ var ErrECSNodeAMINotFound = errors.New("ecs: spinifex-ecs-node AMI not found")
 var ErrECSGPUNodeAMINotFound = errors.New("ecs: ecs GPU node AMI not found")
 
 // ProvisionCapacityInput requests N container instances into a cluster.
+// DiskSize is the root volume in GiB; omitted or non-positive takes
+// defaultCapacityDiskSizeGiB.
 type ProvisionCapacityInput struct {
 	Cluster         string
 	InstanceType    string
@@ -43,6 +53,7 @@ type ProvisionCapacityInput struct {
 	SubnetID        string
 	SecurityGroupID string
 	KeyName         string
+	DiskSize        int64
 }
 
 // ProvisionCapacityOutput returns the launched instance IDs.
@@ -68,6 +79,10 @@ func (s *Service) ProvisionCapacity(ctx context.Context, input *ProvisionCapacit
 	count := input.Count
 	if count <= 0 {
 		count = 1
+	}
+	diskSize := input.DiskSize
+	if diskSize <= 0 {
+		diskSize = defaultCapacityDiskSizeGiB
 	}
 	if count > maxCapacityCount {
 		count = maxCapacityCount
@@ -115,6 +130,10 @@ func (s *Service) ProvisionCapacity(ctx context.Context, input *ProvisionCapacit
 		SecurityGroupIds:   aws.StringSlice([]string{input.SecurityGroupID}),
 		UserData:           aws.String(userData),
 		IamInstanceProfile: &ec2.IamInstanceProfileSpecification{Arn: aws.String(profileARN)},
+		BlockDeviceMappings: []*ec2.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/vda"),
+			Ebs:        &ec2.EbsBlockDevice{VolumeSize: aws.Int64(diskSize)},
+		}},
 		TagSpecifications: []*ec2.TagSpecification{{
 			ResourceType: aws.String("instance"),
 			Tags: []*ec2.Tag{

--- a/spinifex/handlers/ecs/capacity_test.go
+++ b/spinifex/handlers/ecs/capacity_test.go
@@ -177,6 +177,37 @@ func TestProvisionCapacity_DefaultsAndCount(t *testing.T) {
 	assert.Equal(t, defaultCapacityInstanceType, aws.StringValue(captured.InstanceType))
 	assert.Equal(t, int64(1), aws.Int64Value(captured.MinCount))
 	assert.Nil(t, captured.KeyName)
+
+	// An omitted DiskSize must still size the root volume: falling through to the
+	// AMI's own size leaves the agent no room for container images.
+	require.Len(t, captured.BlockDeviceMappings, 1)
+	require.NotNil(t, captured.BlockDeviceMappings[0].Ebs)
+	assert.Equal(t, int64(defaultCapacityDiskSizeGiB),
+		aws.Int64Value(captured.BlockDeviceMappings[0].Ebs.VolumeSize))
+}
+
+// An explicit DiskSize must win over the default.
+func TestProvisionCapacity_ExplicitDiskSize(t *testing.T) {
+	var captured *ec2.RunInstancesInput
+	svc := NewService(nil, testRegion, "internal").WithDeps(Deps{
+		IAM:    stubIAM{},
+		Images: &stubImages{images: ecsNodeImage()},
+		RunInstances: func(_ context.Context, in *ec2.RunInstancesInput, _ string) (*ec2.Reservation, error) {
+			captured = in
+			return &ec2.Reservation{Instances: []*ec2.Instance{{InstanceId: aws.String("i-1")}}}, nil
+		},
+	})
+
+	_, err := svc.ProvisionCapacity(context.Background(), &ProvisionCapacityInput{
+		Cluster:         "web",
+		SubnetID:        "subnet-1",
+		SecurityGroupID: "sg-1",
+		DiskSize:        75,
+	}, testAccountID)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.Len(t, captured.BlockDeviceMappings, 1)
+	assert.Equal(t, int64(75), aws.Int64Value(captured.BlockDeviceMappings[0].Ebs.VolumeSize))
 }
 
 func TestProvisionCapacity_MissingRequired(t *testing.T) {

--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -30,6 +30,13 @@ import (
 // when the caller omits instanceTypes.
 const defaultNodegroupInstanceType = "t3.medium"
 
+// defaultNodegroupDiskSizeGiB mirrors the AWS EKS managed-nodegroup default when
+// the caller omits diskSize. Without it the record stores 0, the launch skips
+// its block device mapping entirely, and the node silently inherits the AMI's
+// own volume size — which is sized to hold the image and nothing more, leaving
+// a worker no room for the container images it exists to run.
+const defaultNodegroupDiskSizeGiB = 20
+
 // defaultNodegroupReadyTimeout / defaultNodegroupReadyPoll bound how long
 // launchNodegroupInfra waits for its workers to register Ready (observed via the
 // CP state report's Ready-node count, refreshed at the reconcile cadence) before
@@ -262,6 +269,13 @@ func (s *EKSServiceImpl) createNodegroup(ctx context.Context, acctKV nats.KeyVal
 		version = meta.Version
 	}
 
+	// Resolved once here rather than at launch so DescribeNodegroup reports the
+	// size the node actually gets, as AWS does.
+	diskSize := aws.Int64Value(input.DiskSize)
+	if diskSize <= 0 {
+		diskSize = defaultNodegroupDiskSizeGiB
+	}
+
 	now := time.Now().UTC()
 	rec := &NodegroupRecord{
 		ClusterName:    cluster,
@@ -271,7 +285,7 @@ func (s *EKSServiceImpl) createNodegroup(ctx context.Context, acctKV nats.KeyVal
 		Subnets:        subnets,
 		InstanceTypes:  instanceTypes,
 		AMIType:        amiType,
-		DiskSize:       aws.Int64Value(input.DiskSize),
+		DiskSize:       diskSize,
 		ScalingMin:     minSize,
 		ScalingMax:     maxSize,
 		ScalingDesired: desired,

--- a/spinifex/handlers/eks/nodegroup_test.go
+++ b/spinifex/handlers/eks/nodegroup_test.go
@@ -373,6 +373,31 @@ func TestCreateNodegroup_HappyPath(t *testing.T) {
 	require.EqualError(t, err, awserrors.ErrorEKSResourceInUse)
 }
 
+// Omitting diskSize must fall back to the AWS default rather than 0. A 0 skips
+// the block device mapping entirely, which drops the worker onto the AMI's own
+// volume — sized to hold the image and nothing else.
+func TestCreateNodegroup_OmittedDiskSizeUsesAWSDefault(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	seedActiveClusterWithToken(t, f, "c1")
+
+	// createNGInput leaves DiskSize nil, which is the case being covered.
+	_, err := f.svc.CreateNodegroup(context.Background(), createNGInput("c1", "ng1", 1), testAccountID)
+	require.NoError(t, err)
+
+	rec, err := GetNodegroupRecord(f.kv, "c1", "ng1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(defaultNodegroupDiskSizeGiB), rec.DiskSize)
+
+	markWorkersReady(t, f, "c1", "ng1", 1)
+	f.svc.WaitLaunches()
+
+	// The default has to reach the launch, not just the record.
+	require.Len(t, f.worker.runCalls, 1)
+	bdms := f.worker.runCalls[0].BlockDeviceMappings
+	require.Len(t, bdms, 1, "a defaulted diskSize must still produce a block device mapping")
+	assert.Equal(t, int64(defaultNodegroupDiskSizeGiB), aws.Int64Value(bdms[0].Ebs.VolumeSize))
+}
+
 // A GPU instance type must mark the record GPUEnabled with the matching
 // vendor, so the worker-launch path resolves the GPU node AMI instead of the
 // default eks-node AMI.
@@ -666,21 +691,6 @@ func TestCreateNodegroup_DiskSizePropagatesToBlockDeviceMapping(t *testing.T) {
 	require.Len(t, bdm, 1)
 	require.NotNil(t, bdm[0].Ebs)
 	assert.Equal(t, int64(30), aws.Int64Value(bdm[0].Ebs.VolumeSize))
-}
-
-func TestCreateNodegroup_NoDiskSizeOmitsBlockDeviceMapping(t *testing.T) {
-	f := newEKSServiceFixture(t)
-	seedActiveClusterWithToken(t, f, "c1")
-
-	_, err := f.svc.CreateNodegroup(context.Background(), createNGInput("c1", "ng1", 1), testAccountID)
-	require.NoError(t, err)
-
-	markWorkersReady(t, f, "c1", "ng1", 1)
-	f.svc.WaitLaunches()
-
-	require.Len(t, f.worker.runCalls, 1)
-	// No DiskSize requested → leave the launch path on its default sizing.
-	assert.Empty(t, f.worker.runCalls[0].BlockDeviceMappings)
 }
 
 func TestCreateNodegroup_ClusterNotActive(t *testing.T) {

--- a/spinifex/services/northstar/bootstrap_test.go
+++ b/spinifex/services/northstar/bootstrap_test.go
@@ -13,7 +13,9 @@ import (
 	"testing"
 	"time"
 
+	nsconfig "github.com/mulgadc/northstar/pkg/config"
 	"github.com/mulgadc/spinifex/spinifex/config"
+	toml "github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -138,6 +140,79 @@ func flakyS3(t *testing.T, bucket string, failUntil int) (endpoint string, objec
 	}))
 	t.Cleanup(srv.Close)
 	return srv.URL, objects
+}
+
+// assertZoneNameservers verifies the exact apex NS and glue topology rendered
+// into a bootstrapped zone.
+func assertZoneNameservers(t *testing.T, body, domain string, wantIPs []string) {
+	t.Helper()
+	var zone nsconfig.ConfigArr
+	require.NoError(t, toml.Unmarshal([]byte(body), &zone))
+	assert.Equal(t, domain, zone.Domain.Domain)
+	assert.Equal(t, "ns1."+domain+".", zone.Domain.SOA)
+
+	var nameservers, glue []string
+	for _, record := range zone.Records {
+		switch record.Type {
+		case nsconfig.TypeNS:
+			nameservers = append(nameservers, record.Address)
+		case nsconfig.TypeA:
+			glue = append(glue, record.Domain+"="+record.Address)
+		}
+	}
+
+	wantNameservers := make([]string, len(wantIPs))
+	wantGlue := make([]string, len(wantIPs))
+	for i, ip := range wantIPs {
+		host := fmt.Sprintf("ns%d", i+1)
+		wantNameservers[i] = host + "." + domain + "."
+		wantGlue[i] = host + ".=" + ip
+	}
+	assert.Equal(t, wantNameservers, nameservers)
+	assert.Equal(t, wantGlue, glue)
+}
+
+// TestBootstrapBaseZoneMultiNode ensures the bootstrap path passes the complete
+// cluster topology into both zones rather than seeding only the writing node.
+func TestBootstrapBaseZoneMultiNode(t *testing.T) {
+	endpoint, objects := fakeS3(t, "northstar")
+	tomlBody := fmt.Sprintf(`listen = "0.0.0.0:5300"
+default_domain = "spx3.net"
+[s3]
+endpoint = %q
+bucket = "northstar"
+region = "us-east-1"
+access_key = "READONLY"
+secret_key = "READONLY"
+`, endpoint)
+	configPath := filepath.Join(t.TempDir(), "northstar.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(tomlBody), 0o600))
+
+	cluster := &config.ClusterConfig{
+		Node: "node1",
+		Nodes: map[string]config.Config{
+			"node3": {
+				Host: "10.0.0.3", AdvertiseIP: "192.168.1.33",
+				Northstar: config.NorthstarConfig{ConfigPath: configPath},
+			},
+			"node1": {
+				Host: "10.0.0.1", AdvertiseIP: "192.168.1.31",
+				Predastore: config.PredastoreConfig{AccessKey: "SYSTEM", SecretKey: "SYSTEMSECRET"},
+				Northstar:  config.NorthstarConfig{ConfigPath: configPath},
+			},
+			"node2": {
+				Host: "10.0.0.2", AdvertiseIP: "192.168.1.32",
+				Northstar: config.NorthstarConfig{ConfigPath: configPath},
+			},
+		},
+	}
+
+	require.NoError(t, BootstrapBaseZone(configPath, cluster))
+	require.Contains(t, objects, "spx3.net.toml")
+	require.Contains(t, objects, "compute.internal.toml")
+	wantIPs := []string{"192.168.1.31", "192.168.1.32", "192.168.1.33"}
+	assertZoneNameservers(t, objects["spx3.net.toml"], "spx3.net", wantIPs)
+	assertZoneNameservers(t, objects["compute.internal.toml"], "compute.internal", wantIPs)
 }
 
 func TestBootstrapBaseZoneRetries(t *testing.T) {

--- a/spinifex/utils/images.go
+++ b/spinifex/utils/images.go
@@ -306,6 +306,11 @@ var AvailableImages = map[string]Images{
 		BootMode:     "uefi",
 	},
 
+	// Ubuntu is pulled from releases/, not the codename dailies tree: Canonical
+	// prunes old daily builds, so a pinned daily URL 404s once it ages out and
+	// takes the catalog entry with it. Release builds are kept, so the pin stays
+	// resolvable. Note the filename carries the version rather than the codename
+	// under releases/ — the sums entry is matched on that basename.
 	"ubuntu-26.04-x86_64": {
 		Name:         "ubuntu-26.04-x86_64",
 		Description:  "Ubuntu 26.04 LTS (Resolute Reindeer) x86_64 cloud image",
@@ -313,9 +318,9 @@ var AvailableImages = map[string]Images{
 		Version:      "26.04",
 		Arch:         "x86_64",
 		Platform:     "Linux/UNIX",
-		CreatedAt:    time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
-		URL:          "https://cloud-images.ubuntu.com/resolute/20260421/resolute-server-cloudimg-amd64.img",
-		Checksum:     "https://cloud-images.ubuntu.com/resolute/20260421/SHA256SUMS",
+		CreatedAt:    time.Date(2026, 7, 13, 0, 0, 0, 0, time.UTC),
+		URL:          "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/ubuntu-26.04-server-cloudimg-amd64.img",
+		Checksum:     "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/SHA256SUMS",
 		ChecksumType: "sha256",
 		BootMode:     "uefi",
 	},
@@ -327,9 +332,9 @@ var AvailableImages = map[string]Images{
 		Version:      "26.04",
 		Arch:         "arm64",
 		Platform:     "Linux/UNIX",
-		CreatedAt:    time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
-		URL:          "https://cloud-images.ubuntu.com/resolute/20260421/resolute-server-cloudimg-arm64.img",
-		Checksum:     "https://cloud-images.ubuntu.com/resolute/20260421/SHA256SUMS",
+		CreatedAt:    time.Date(2026, 7, 13, 0, 0, 0, 0, time.UTC),
+		URL:          "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/ubuntu-26.04-server-cloudimg-arm64.img",
+		Checksum:     "https://cloud-images.ubuntu.com/releases/resolute/release-20260713/SHA256SUMS",
 		ChecksumType: "sha256",
 		BootMode:     "uefi",
 	},

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -11,7 +11,7 @@ SUITE_TAG   ?= $(notdir $(patsubst %/...,%,$(firstword $(PKG))))
 # named suite into BIN_DIR/<suite>.test so CI can ship binaries (not source +
 # go toolchain) to the remote VM.
 BIN_DIR      ?= $(CURDIR)/_bin
-SUITES_BUILD ?= cert lb eks ecs single iam ecr bedrock gpu natuplink
+SUITES_BUILD ?= cert lb eks ecs single iam ecr bedrock gpu natuplink multinode
 
 .PHONY: e2e e2e-cert e2e-lb e2e-eks e2e-ecs e2e-single e2e-iam e2e-ecr e2e-bedrock e2e-multinode e2e-bm e2e-reboot e2e-tofu e2e-gpu e2e-natuplink e2e-all clean e2e-build
 

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -46,6 +46,7 @@ const (
 // would blow the suite timeout on dev nodes.
 func TestEKS(t *testing.T) {
 	env := harness.LoadEnv(t)
+	harness.RequireDNSEnabled(t, env)
 	artifacts := harness.ArtifactDir(t, env)
 	c := harness.NewAWSClient(t, env)
 
@@ -970,19 +971,16 @@ func deleteClusterBestEffort(t *testing.T, c *harness.AWSClient, fx *clusterFixt
 
 // assertEKSEndpointResolves confirms the DescribeCluster endpoint is an
 // AWS-shaped DNS name that resolves through the host resolver (the path a
-// kubectl/AWS SDK client uses), matching real EKS. Skipped when northstar is not
-// configured and the endpoint is still a bare IP. Retries because the endpoint A
-// record is published asynchronously by the control-plane writer.
+// kubectl/AWS SDK client uses), matching real EKS. The suite requires Northstar,
+// so a bare-IP endpoint is a failure. Retries because the endpoint A record is
+// published asynchronously by the control-plane writer.
 func assertEKSEndpointResolves(t *testing.T, endpoint string) {
 	t.Helper()
 	require.NotEmpty(t, endpoint, "cluster endpoint must be set")
 	u, err := url.Parse(endpoint)
 	require.NoErrorf(t, err, "parse cluster endpoint %q", endpoint)
 	host := u.Hostname()
-	if net.ParseIP(host) != nil {
-		t.Logf("endpoint %q is a bare IP — DNS registration off, skipping resolution check", endpoint)
-		return
-	}
+	require.Nilf(t, net.ParseIP(host), "EKS endpoint %q is a bare IP despite required Northstar DNS", endpoint)
 	deadline := time.Now().Add(90 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {

--- a/tests/e2e/harness/dns.go
+++ b/tests/e2e/harness/dns.go
@@ -44,6 +44,40 @@ func NorthstarBaseDomain(env *Env) string {
 	return ""
 }
 
+// NorthstarInternalDomain returns the cluster's authoritative internal DNS
+// domain, or "" when DNS registration is not configured.
+func NorthstarInternalDomain(env *Env) string {
+	if env == nil || env.ConfigDir == "" {
+		return ""
+	}
+	cc, err := loadClusterConfig(filepath.Join(env.ConfigDir, "spinifex.toml"))
+	if err != nil {
+		return ""
+	}
+	if n, ok := cc.Nodes[cc.Node]; ok {
+		if d := handlers_dns.ResolveInternalDomain(&n); d != "" {
+			return d
+		}
+	}
+	for _, n := range cc.Nodes {
+		if d := handlers_dns.ResolveInternalDomain(&n); d != "" {
+			return d
+		}
+	}
+	return ""
+}
+
+// RequireDNSEnabled fails when a fixture expected to provide Northstar DNS has
+// no authoritative base domain configured. It returns the configured domain.
+func RequireDNSEnabled(t *testing.T, env *Env) string {
+	t.Helper()
+	domain := NorthstarBaseDomain(env)
+	if domain == "" {
+		t.Fatalf("fixture requires Northstar DNS, but no authoritative base domain is configured")
+	}
+	return domain
+}
+
 // PeerClusterConfig reads and decodes a node's cluster configuration without
 // allowing the harness's SPINIFEX_* environment variables to shadow it.
 func PeerClusterConfig(t *testing.T, node Node) *config.ClusterConfig {

--- a/tests/e2e/harness/dns.go
+++ b/tests/e2e/harness/dns.go
@@ -4,6 +4,10 @@ package harness
 
 import (
 	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/config"
 
 	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 )
@@ -38,4 +42,33 @@ func NorthstarBaseDomain(env *Env) string {
 		}
 	}
 	return ""
+}
+
+// PeerClusterConfig reads and decodes a node's cluster configuration without
+// allowing the harness's SPINIFEX_* environment variables to shadow it.
+func PeerClusterConfig(t *testing.T, node Node) *config.ClusterConfig {
+	t.Helper()
+	const path = "/etc/spinifex/spinifex.toml"
+	cc, err := loadClusterConfigBytes(PeerFileContents(t, node, path))
+	if err != nil {
+		t.Fatalf("decode %s on %s: %v", path, node.Name, err)
+	}
+	return cc
+}
+
+// PeerNorthstarDomains returns the public and internal authoritative domains
+// mirrored into a peer's local node configuration.
+func PeerNorthstarDomains(t *testing.T, node Node) (string, string) {
+	t.Helper()
+	cc := PeerClusterConfig(t, node)
+	local, ok := cc.Nodes[cc.Node]
+	if !ok {
+		t.Fatalf("cluster config on %s has no local node stanza %q", node.Name, cc.Node)
+	}
+	base := strings.TrimSpace(local.Northstar.DefaultDomain)
+	internal := strings.TrimSpace(local.Northstar.InternalDomain)
+	if base == "" || internal == "" {
+		t.Fatalf("northstar domains are not fully configured on %s: base=%q internal=%q", node.Name, base, internal)
+	}
+	return base, internal
 }

--- a/tests/e2e/harness/dns_test.go
+++ b/tests/e2e/harness/dns_test.go
@@ -72,14 +72,49 @@ host = "192.168.1.20"
 	}
 }
 
-func TestNorthstarBaseDomainMissing(t *testing.T) {
-	if got := NorthstarBaseDomain(nil); got != "" {
-		t.Fatalf("NorthstarBaseDomain(nil) = %q, want empty", got)
+func TestNorthstarInternalDomain(t *testing.T) {
+	dir := t.TempDir()
+	config := `node = "dev1"
+[nodes.dev1.northstar]
+internal_domain = "compute.internal"
+`
+	if err := os.WriteFile(filepath.Join(dir, "spinifex.toml"), []byte(config), 0o600); err != nil {
+		t.Fatalf("write toml: %v", err)
 	}
-	if got := NorthstarBaseDomain(&Env{}); got != "" {
-		t.Fatalf("NorthstarBaseDomain(no ConfigDir) = %q, want empty", got)
+	if got := NorthstarInternalDomain(&Env{ConfigDir: dir}); got != "compute.internal" {
+		t.Fatalf("NorthstarInternalDomain = %q, want %q", got, "compute.internal")
 	}
-	if got := NorthstarBaseDomain(&Env{ConfigDir: t.TempDir()}); got != "" {
-		t.Fatalf("NorthstarBaseDomain(missing file) = %q, want empty", got)
+}
+
+func TestRequireDNSEnabled(t *testing.T) {
+	dir := t.TempDir()
+	config := `[nodes.dev1.northstar]
+default_domain = "spx3.net"
+`
+	if err := os.WriteFile(filepath.Join(dir, "spinifex.toml"), []byte(config), 0o600); err != nil {
+		t.Fatalf("write toml: %v", err)
+	}
+	if got := RequireDNSEnabled(t, &Env{ConfigDir: dir}); got != "spx3.net" {
+		t.Fatalf("RequireDNSEnabled = %q, want %q", got, "spx3.net")
+	}
+}
+
+func TestNorthstarDomainsMissing(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  *Env
+	}{
+		{name: "nil environment"},
+		{name: "no config directory", env: &Env{}},
+		{name: "missing config file", env: &Env{ConfigDir: t.TempDir()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NorthstarBaseDomain(tc.env); got != "" {
+				t.Fatalf("NorthstarBaseDomain = %q, want empty", got)
+			}
+			if got := NorthstarInternalDomain(tc.env); got != "" {
+				t.Fatalf("NorthstarInternalDomain = %q, want empty", got)
+			}
+		})
 	}
 }

--- a/tests/e2e/harness/eks_mgmt.go
+++ b/tests/e2e/harness/eks_mgmt.go
@@ -3,6 +3,7 @@
 package harness
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,6 +79,19 @@ func loadClusterConfig(path string) (*config.ClusterConfig, error) {
 	if err := v.ReadInConfig(); err != nil {
 		return nil, err
 	}
+	return unmarshalClusterConfig(v)
+}
+
+func loadClusterConfigBytes(data []byte) (*config.ClusterConfig, error) {
+	v := viper.New()
+	v.SetConfigType("toml")
+	if err := v.ReadConfig(bytes.NewReader(data)); err != nil {
+		return nil, err
+	}
+	return unmarshalClusterConfig(v)
+}
+
+func unmarshalClusterConfig(v *viper.Viper) (*config.ClusterConfig, error) {
 	var cc config.ClusterConfig
 	if err := v.Unmarshal(&cc); err != nil {
 		return nil, err

--- a/tests/e2e/harness/multinode_distribution.go
+++ b/tests/e2e/harness/multinode_distribution.go
@@ -21,7 +21,10 @@ func InstanceHostingNode(t *testing.T, c *Cluster, instanceID string) *Node {
 	for i := range c.Nodes {
 		n := c.Nodes[i]
 		out, err := runPSGrep(ctx, ssh, n, instanceID)
-		if err == nil && strings.Contains(out, instanceID) {
+		if err != nil {
+			t.Fatalf("discover instance %s on %s: %v", instanceID, n.Name, err)
+		}
+		if strings.Contains(out, instanceID) {
 			return &c.Nodes[i]
 		}
 	}

--- a/tests/e2e/harness/multinode_node_lifecycle.go
+++ b/tests/e2e/harness/multinode_node_lifecycle.go
@@ -23,6 +23,44 @@ var nodeServiceUnits = []string{
 	"spinifex-nats.service",
 }
 
+// NodeUnitState returns systemd's current state for unit on node.
+func NodeUnitState(node Node, unit string) (string, error) {
+	ssh := NewPeerSSH()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := ssh.Run(ctx, node.Addr, "systemctl is-active -- "+shellQuote(unit))
+	return strings.TrimSpace(string(out)), err
+}
+
+// AssertUnitActive fails the test unless unit is active on node.
+func AssertUnitActive(t *testing.T, node Node, unit string) {
+	t.Helper()
+	state, err := NodeUnitState(node, unit)
+	if err != nil {
+		t.Fatalf("unit %s on %s: %v", unit, node.Name, err)
+	}
+	if state != "active" {
+		t.Fatalf("unit %s on %s: state %q, want active", unit, node.Name, state)
+	}
+}
+
+// PeerFileContents reads a root-owned file from node over peer SSH.
+func PeerFileContents(t *testing.T, node Node, path string) []byte {
+	t.Helper()
+	ssh := NewPeerSSH()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := ssh.Run(ctx, node.Addr, "sudo cat -- "+shellQuote(path))
+	if err != nil {
+		t.Fatalf("read %s on %s: %v", path, node.Name, err)
+	}
+	return out
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
 // StopNode simulates a hard node outage by stopping the spinifex service units
 // directly (not spinifex.target), so guests keep running (daemon
 // KillMode=process) and the target's drain ExecStop never fires. Non-fatal:

--- a/tests/e2e/harness/ssh.go
+++ b/tests/e2e/harness/ssh.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
+	"strconv"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -21,6 +23,27 @@ import (
 type SSH interface {
 	Run(ctx context.Context, node Node, cmd string) ([]byte, error)
 	Close() error
+}
+
+// RunGuestSSH executes cmd in a guest addressed by an SSHTarget. It returns
+// combined output so callers can retry assertions without terminating a test.
+func RunGuestSSH(ctx context.Context, target SSHTarget, cmd string) ([]byte, error) {
+	args := []string{
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "LogLevel=ERROR",
+		"-o", "ConnectTimeout=5",
+		"-o", "BatchMode=yes",
+		"-p", strconv.Itoa(target.Port),
+		"-i", target.KeyPath,
+		target.User + "@" + target.Host,
+		cmd,
+	}
+	out, err := exec.CommandContext(ctx, "ssh", args...).CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("guest ssh %s@%s:%d: %w: %s", target.User, target.Host, target.Port, err, out)
+	}
+	return out, nil
 }
 
 // sshClient is the production SSH transport, backed by

--- a/tests/e2e/iam/imds_test.go
+++ b/tests/e2e/iam/imds_test.go
@@ -220,18 +220,17 @@ func runIMDS(t *testing.T, fix *Fixture) {
 		require.NotEmpty(t, pubIP, "pool-mode VM must have a public IP")
 		gotHost := imdsGet(t, tgtX, tokenX, "/latest/meta-data/public-hostname")
 
-		// With a base domain configured the responder serves the AWS-shaped EC2
-		// name built from the ENI's public IP and its AZ's region; with none it
-		// falls back to mirroring public-ipv4. The domain is fixture-specific, so
-		// resolve it from config the same way the live responder does.
-		if base := harness.NorthstarBaseDomain(fix.Env); base != "" {
-			want := handlers_dns.EC2PublicName(pubIP, imdsRegionFromAZ(azX), base)
-			require.Equal(t, want, gotHost,
-				"public-hostname must be the AWS-shaped EC2 name for public-ipv4")
-		} else {
-			require.Equal(t, pubIP, gotHost,
-				"no base domain configured → public-hostname mirrors public-ipv4")
-		}
+		// A pool-mode fixture provides Northstar, so the responder must serve the
+		// AWS-shaped EC2 name built from the ENI's public IP and its AZ's region.
+		base := harness.RequireDNSEnabled(t, fix.Env)
+		want := handlers_dns.EC2PublicName(pubIP, imdsRegionFromAZ(azX), base)
+		require.Equal(t, want, gotHost,
+			"public-hostname must be the AWS-shaped EC2 name for public-ipv4")
+
+		harness.Step(t, "resolve IMDS public-hostname %s from the guest", gotHost)
+		resolved := runSSH(t, tgtX, "getent ahostsv4 "+gotHost)
+		require.Containsf(t, strings.Fields(resolved), pubIP,
+			"public-hostname %s did not resolve to public-ipv4 %s: %s", gotHost, pubIP, resolved)
 	} else {
 		require.Equal(t, "404",
 			imdsCode(tgtX, fmt.Sprintf(`-H "X-aws-ec2-metadata-token: %s"`, tokenX),

--- a/tests/e2e/lb/lb_test.go
+++ b/tests/e2e/lb/lb_test.go
@@ -56,6 +56,7 @@ const (
 func TestLoadBalancer(t *testing.T) {
 	env := harness.LoadEnv(t)
 	skipIfDevNetworking(t, env)
+	harness.RequireDNSEnabled(t, env)
 
 	// Resolve peer availability before building the shared fixture so the "skip" message
 	// appears immediately rather than after minutes of VPC/VM setup.
@@ -1488,15 +1489,14 @@ func assertInternalDNS(t *testing.T, c *harness.AWSClient, lbArn, label string) 
 
 // assertLBDNSResolves confirms the SDK-returned DNSName resolves to the LB's
 // frontend IP through the host resolver (the same path an AWS SDK/CLI client
-// uses). Skipped when northstar is not configured (legacy .spinifex.local
-// naming, which northstar does not serve). Retries because the control-plane
-// writer publishes the record asynchronously (best-effort + reconcile).
+// uses). The suite requires Northstar, so an empty or legacy name is a failure.
+// Retries because the control-plane writer publishes the record asynchronously
+// (best-effort + reconcile).
 func assertLBDNSResolves(t *testing.T, dnsName, wantIP, label string) {
 	t.Helper()
-	if dnsName == "" || strings.HasSuffix(dnsName, ".spinifex.local") {
-		t.Logf("%s: DNS registration off (dns=%q) — skipping resolution check", label, dnsName)
-		return
-	}
+	require.NotEmptyf(t, dnsName, "%s: load balancer returned no DNS name despite required Northstar DNS", label)
+	require.Falsef(t, strings.HasSuffix(dnsName, ".spinifex.local"),
+		"%s: load balancer returned legacy DNS name %q despite required Northstar DNS", label, dnsName)
 	harness.Step(t, "resolve LB DNS %s → %s (northstar path)", dnsName, wantIP)
 	deadline := time.Now().Add(90 * time.Second)
 	var last []string

--- a/tests/e2e/multinode/baseline_test.go
+++ b/tests/e2e/multinode/baseline_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os/exec"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -61,9 +59,12 @@ func baselineLaunch(t *testing.T, fix *Fixture, amiID, instType, keyName, subnet
 	}
 	require.NotEmpty(t, id, "RunInstances never succeeded")
 	t.Cleanup(func() {
-		_, _ = fix.AWS.EC2.TerminateInstances(&ec2.TerminateInstancesInput{
+		if _, err := fix.AWS.EC2.TerminateInstances(&ec2.TerminateInstancesInput{
 			InstanceIds: []*string{aws.String(id)},
-		})
+		}); err != nil {
+			t.Errorf("terminate instance %s: %v", id, err)
+			return
+		}
 		harness.WaitForInstanceState(t, fix.AWS, id, "terminated")
 	})
 	harness.WaitForInstanceState(t, fix.AWS, id, "running")
@@ -88,18 +89,9 @@ func instancePrivateIP(t *testing.T, fix *Fixture, id string) string {
 func sshCapture(pem, user, host string, port int, cmd string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	args := []string{
-		"-i", pem,
-		"-p", strconv.Itoa(port),
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "ConnectTimeout=5",
-		"-o", "BatchMode=yes",
-		"-o", "LogLevel=ERROR",
-		fmt.Sprintf("%s@%s", user, host),
-		cmd,
-	}
-	out, err := exec.CommandContext(ctx, "ssh", args...).CombinedOutput()
+	out, err := harness.RunGuestSSH(ctx, harness.SSHTarget{
+		User: user, Host: host, Port: port, KeyPath: pem,
+	}, cmd)
 	return string(out), err
 }
 

--- a/tests/e2e/multinode/dns_test.go
+++ b/tests/e2e/multinode/dns_test.go
@@ -1,0 +1,388 @@
+//go:build e2e
+
+package multinode
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	nsconfig "github.com/mulgadc/northstar/pkg/config"
+	spinconfig "github.com/mulgadc/spinifex/spinifex/config"
+	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	northstarUnit       = "spinifex-northstar.service"
+	northstarConfigPath = "/etc/spinifex/northstar/northstar.toml"
+	vpcResolverIP       = "169.254.169.253"
+)
+
+type dnsGuest struct {
+	ID        string
+	PrivateIP string
+	PublicIP  string
+	Node      harness.Node
+	SSH       harness.SSHTarget
+}
+
+// runMultinodeDNS proves every node serves one converged Northstar topology and
+// guests retain DNS when the first resolver backend is unavailable.
+func runMultinodeDNS(t *testing.T, fix *Fixture) {
+	harness.Phase(t, "Multinode — Northstar DNS")
+	require.Len(t, fix.Cluster.Nodes, 3, "DNS cross-node coverage requires the three-node fixture")
+
+	harness.Step(t, "D1: assert Northstar is active on every node")
+	for _, node := range fix.Cluster.Nodes {
+		harness.AssertUnitActive(t, node, northstarUnit)
+	}
+
+	harness.Step(t, "D2: assert every node carries the cluster-wide Northstar configuration")
+	configs := make(map[string]*spinconfig.ClusterConfig, len(fix.Cluster.Nodes))
+	for _, node := range fix.Cluster.Nodes {
+		cc := harness.PeerClusterConfig(t, node)
+		configs[node.Name] = cc
+		require.Equalf(t, node.Name, cc.Node, "local node identity in %s config", node.Name)
+		for name, cfg := range cc.Nodes {
+			require.Equalf(t, northstarConfigPath, cfg.Northstar.ConfigPath,
+				"Northstar config path for %s as viewed from %s", name, node.Name)
+		}
+		stat := runPeerCommand(t, node, "sudo stat -c '%a %U' -- "+northstarConfigPath)
+		require.Equalf(t, "600 spinifex-northstar", strings.TrimSpace(stat),
+			"Northstar credential file metadata on %s", node.Name)
+	}
+
+	firstNode := fix.Cluster.Nodes[0]
+	baseDomain, internalDomain := harness.PeerNorthstarDomains(t, firstNode)
+	firstConfig := configs[firstNode.Name]
+	expectedSeeds := make([]nsconfig.NameserverSeed, 0, len(fix.Cluster.Nodes))
+	expectedResolvers := make([]string, 0, len(fix.Cluster.Nodes))
+	for i, node := range fix.Cluster.Nodes {
+		ip := net.ParseIP(addressHost(node.Addr))
+		require.NotNilf(t, ip, "cluster node %s address %q is not an IP", node.Name, node.Addr)
+		require.Falsef(t, ip.IsLoopback() || ip.IsUnspecified(), "cluster node %s has unusable DNS address %s", node.Name, ip)
+		expectedResolvers = append(expectedResolvers, ip.String())
+		expectedSeeds = append(expectedSeeds, nsconfig.NameserverSeed{Host: fmt.Sprintf("ns%d", i+1), IP: ip.String()})
+	}
+	expectedTopology := seedTopology(baseDomain, expectedSeeds)
+
+	harness.Step(t, "D3: query identical base-zone NS topology from every node")
+	for _, node := range fix.Cluster.Nodes {
+		peerBase, peerInternal := harness.PeerNorthstarDomains(t, node)
+		require.Equalf(t, baseDomain, peerBase, "base domain differs on %s", node.Name)
+		require.Equalf(t, internalDomain, peerInternal, "internal domain differs on %s", node.Name)
+		require.Equalf(t, expectedSeeds, handlers_dns.NameserverSeeds(configs[node.Name]),
+			"nameserver seeds differ on %s", node.Name)
+		require.Equalf(t, expectedResolvers, handlers_dns.ResolverNameserverIPs(configs[node.Name]),
+			"resolver backends differ on %s", node.Name)
+
+		for _, port := range []string{"53", "5300"} {
+			var topology []string
+			harness.EventuallyErr(t, func() error {
+				var err error
+				topology, err = queryNSTopology(node.Addr, port, baseDomain)
+				if err != nil {
+					return err
+				}
+				if !slices.Equal(topology, expectedTopology) {
+					return fmt.Errorf("%s:%s topology %v, want %v", node.Name, port, topology, expectedTopology)
+				}
+				return nil
+			}, 90*time.Second, 3*time.Second)
+			harness.Detail(t, "node", node.Name, "port", port, "topology", topology)
+		}
+	}
+
+	harness.Step(t, "launch one DNS test guest on each of node1, node2, and node3")
+	guests := launchDNSGuests(t, fix)
+	source := guests[fix.Cluster.Nodes[1].Name]
+	target := guests[fix.Cluster.Nodes[2].Name]
+	failoverRecord := guests[fix.Cluster.Nodes[0].Name]
+
+	region := strings.TrimSpace(firstConfig.AWS.Region)
+	require.NotEmpty(t, region, "cluster AWS region is required to build internal DNS names")
+
+	harness.Step(t, "D4: resolve internal and recursive names from a non-init-node guest")
+	assertGuestResolver(t, source.SSH)
+	sourceName := handlers_dns.EC2PrivateName(source.PrivateIP, region, internalDomain)
+	assertGuestIPv4(t, source.SSH, sourceName, source.PrivateIP)
+	assertGuestIPv4(t, source.SSH, "google.com", "")
+
+	harness.Step(t, "D5: resolve a node3 guest record from the node2 guest and every backend")
+	targetName := handlers_dns.EC2PrivateName(target.PrivateIP, region, internalDomain)
+	assertGuestIPv4(t, source.SSH, targetName, target.PrivateIP)
+	for _, node := range fix.Cluster.Nodes {
+		assertNodeIPv4(t, node, targetName, target.PrivateIP)
+	}
+
+	harness.Step(t, "D6: stop the first resolver backend and retain guest DNS")
+	firstBackend := &fix.Cluster.Nodes[0]
+	restored := false
+	t.Cleanup(func() {
+		if restored {
+			return
+		}
+		if _, err := peerCommand(*firstBackend, "sudo systemctl start "+northstarUnit); err != nil {
+			t.Errorf("restore %s on %s: %v", northstarUnit, firstBackend.Name, err)
+			return
+		}
+		state, err := harness.NodeUnitState(*firstBackend, northstarUnit)
+		if err != nil || state != "active" {
+			t.Errorf("restore %s on %s: state=%q err=%v", northstarUnit, firstBackend.Name, state, err)
+		}
+	})
+
+	// Converge a fresh record on every backend before stopping one. The guest has
+	// not queried this name, so its first lookup cannot be satisfied from cache.
+	failoverName := handlers_dns.EC2PrivateName(failoverRecord.PrivateIP, region, internalDomain)
+	for _, node := range fix.Cluster.Nodes {
+		assertNodeIPv4(t, node, failoverName, failoverRecord.PrivateIP)
+	}
+	publicFailoverName := handlers_dns.EC2PublicName(source.PublicIP, region, baseDomain)
+	for _, node := range fix.Cluster.Nodes {
+		assertNodeIPv4(t, node, publicFailoverName, source.PublicIP)
+	}
+
+	runPeerCommand(t, *firstBackend, "sudo systemctl stop "+northstarUnit)
+	state, _ := harness.NodeUnitState(*firstBackend, northstarUnit)
+	require.Equalf(t, "inactive", state, "%s did not stop on %s", northstarUnit, firstBackend.Name)
+	require.Error(t, queryDNS(*firstBackend, "5300", failoverName, dns.TypeA),
+		"stopped backend still answered on the guest-forwarder port")
+
+	out, err := guestIPv4(source.SSH, failoverName, failoverRecord.PrivateIP)
+	require.NoErrorf(t, err, "first guest lookup did not fail over after stopping %s: %s", firstBackend.Name, out)
+	elapsed, out, err := timedGuestIPv4(source.SSH, publicFailoverName, source.PublicIP)
+	require.NoErrorf(t, err, "second guest lookup failed during backend cooldown: %s", out)
+	require.Lessf(t, elapsed, 1500*time.Millisecond,
+		"down backend was not deprioritised; second lookup took %s: %s", elapsed, out)
+
+	runPeerCommand(t, *firstBackend, "sudo systemctl start "+northstarUnit)
+	harness.AssertUnitActive(t, *firstBackend, northstarUnit)
+	restored = true
+}
+
+func seedTopology(domain string, seeds []nsconfig.NameserverSeed) []string {
+	fqdn := dns.Fqdn(domain)
+	topology := make([]string, 0, len(seeds)*2)
+	for _, seed := range seeds {
+		host := dns.Fqdn(seed.Host + "." + fqdn)
+		topology = append(topology, "NS "+host, "A "+host+"="+seed.IP)
+	}
+	sort.Strings(topology)
+	return topology
+}
+
+func queryNSTopology(host, port, domain string) ([]string, error) {
+	query := new(dns.Msg)
+	query.SetQuestion(dns.Fqdn(domain), dns.TypeNS)
+	response, _, err := (&dns.Client{Timeout: 3 * time.Second}).Exchange(query, net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, fmt.Errorf("query NS %s via %s: %w", domain, host, err)
+	}
+	if response.Rcode != dns.RcodeSuccess {
+		return nil, fmt.Errorf("query NS %s via %s: rcode %s", domain, host, dns.RcodeToString[response.Rcode])
+	}
+	if !response.Authoritative {
+		return nil, fmt.Errorf("query NS %s via %s: response is not authoritative", domain, host)
+	}
+
+	topology := make([]string, 0, len(response.Answer)+len(response.Extra))
+	for _, record := range response.Answer {
+		if ns, ok := record.(*dns.NS); ok {
+			topology = append(topology, "NS "+dns.Fqdn(ns.Ns))
+		}
+	}
+	for _, record := range response.Extra {
+		if a, ok := record.(*dns.A); ok {
+			topology = append(topology, "A "+dns.Fqdn(a.Hdr.Name)+"="+a.A.String())
+		}
+	}
+	sort.Strings(topology)
+	return topology, nil
+}
+
+func launchDNSGuests(t *testing.T, fix *Fixture) map[string]dnsGuest {
+	t.Helper()
+	_, defaultSG, subnetID := harness.DiscoverDefaultVPC(t, fix.AWS)
+	harness.AuthorizeSSHIngress(t, fix.AWS, defaultSG)
+	instanceType, arch := needInstanceTypeArch(t, fix)
+	amiID := needAMI(t, fix, arch)
+	keyName, keyPath := needKeyPair(t, fix)
+
+	wanted := make(map[string]harness.Node, 3)
+	for _, node := range fix.Cluster.Nodes[:3] {
+		wanted[node.Name] = node
+	}
+	guests := make(map[string]dnsGuest, len(wanted))
+	for attempt := 1; attempt <= 9 && len(guests) < len(wanted); attempt++ {
+		id := baselineLaunch(t, fix, amiID, instanceType, keyName, subnetID, []string{defaultSG})
+		host := harness.InstanceHostingNode(t, fix.Cluster, id)
+		if host == nil {
+			t.Logf("DNS guest %s hosting node was not discoverable", id)
+			continue
+		}
+		if _, needed := wanted[host.Name]; !needed {
+			continue
+		}
+		if _, exists := guests[host.Name]; exists {
+			t.Logf("DNS guest %s colocated on already-covered %s", id, host.Name)
+			continue
+		}
+		guests[host.Name] = dnsGuest{
+			ID:        id,
+			PrivateIP: instancePrivateIP(t, fix, id),
+			Node:      *host,
+		}
+	}
+	for name := range wanted {
+		require.Containsf(t, guests, name, "could not place a DNS guest on %s after bounded rescans", name)
+	}
+
+	source := guests[fix.Cluster.Nodes[1].Name]
+	host, port := harness.GuestSSHEndpoint(t, fix.AWS, fix.Cluster, source.ID)
+	harness.GuestSSHReady(t, host, port, "ubuntu", keyPath,
+		harness.WithTimeout(3*time.Minute), harness.WithPoll(3*time.Second))
+	source.PublicIP = host
+	source.SSH = harness.SSHTarget{User: "ubuntu", Host: host, Port: port, KeyPath: keyPath}
+	guests[source.Node.Name] = source
+	return guests
+}
+
+func assertGuestResolver(t *testing.T, target harness.SSHTarget) {
+	t.Helper()
+	harness.EventuallyErr(t, func() error {
+		out, err := runGuestCommand(target, "cat /etc/resolv.conf")
+		if err != nil {
+			return err
+		}
+		for _, line := range strings.Split(string(out), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[0] == "nameserver" && fields[1] == vpcResolverIP {
+				return nil
+			}
+		}
+		return fmt.Errorf("/etc/resolv.conf does not advertise %s: %s", vpcResolverIP, out)
+	}, time.Minute, 3*time.Second)
+}
+
+func assertGuestIPv4(t *testing.T, target harness.SSHTarget, name, expectedIP string) {
+	t.Helper()
+	harness.EventuallyErr(t, func() error {
+		_, err := guestIPv4(target, name, expectedIP)
+		return err
+	}, 2*time.Minute, 3*time.Second)
+}
+
+func guestIPv4(target harness.SSHTarget, name, expectedIP string) ([]byte, error) {
+	out, err := runGuestCommand(target, "getent ahostsv4 "+shellQuoteDNS(name))
+	if err != nil {
+		return out, err
+	}
+	if outputContainsIPv4(out, expectedIP) {
+		return out, nil
+	}
+	return out, fmt.Errorf("getent ahostsv4 %s did not return %q: %s", name, expectedIP, out)
+}
+
+func timedGuestIPv4(target harness.SSHTarget, name, expectedIP string) (time.Duration, []byte, error) {
+	command := "start=$(date +%s%N); getent ahostsv4 " + shellQuoteDNS(name) +
+		"; status=$?; end=$(date +%s%N); echo __elapsed_ms=$(((end-start)/1000000)); exit $status"
+	out, err := runGuestCommand(target, command)
+	if err != nil {
+		return 0, out, err
+	}
+	if !outputContainsIPv4(out, expectedIP) {
+		return 0, out, fmt.Errorf("getent ahostsv4 %s did not return %q: %s", name, expectedIP, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.HasPrefix(line, "__elapsed_ms=") {
+			continue
+		}
+		var milliseconds int64
+		if _, err := fmt.Sscanf(line, "__elapsed_ms=%d", &milliseconds); err != nil {
+			return 0, out, fmt.Errorf("parse DNS lookup duration %q: %w", line, err)
+		}
+		return time.Duration(milliseconds) * time.Millisecond, out, nil
+	}
+	return 0, out, fmt.Errorf("DNS lookup output omitted elapsed time: %s", out)
+}
+
+func outputContainsIPv4(out []byte, expectedIP string) bool {
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		ip := net.ParseIP(fields[0])
+		if ip != nil && ip.To4() != nil && (expectedIP == "" || fields[0] == expectedIP) {
+			return true
+		}
+	}
+	return false
+}
+
+func assertNodeIPv4(t *testing.T, node harness.Node, name, expectedIP string) {
+	t.Helper()
+	harness.EventuallyErr(t, func() error {
+		query := new(dns.Msg)
+		query.SetQuestion(dns.Fqdn(name), dns.TypeA)
+		response, _, err := (&dns.Client{Timeout: 3 * time.Second}).Exchange(query, net.JoinHostPort(node.Addr, "5300"))
+		if err != nil {
+			return fmt.Errorf("query A %s via %s: %w", name, node.Name, err)
+		}
+		if response.Rcode != dns.RcodeSuccess {
+			return fmt.Errorf("query A %s via %s: rcode %s", name, node.Name, dns.RcodeToString[response.Rcode])
+		}
+		for _, record := range response.Answer {
+			if a, ok := record.(*dns.A); ok && a.A.String() == expectedIP {
+				return nil
+			}
+		}
+		return fmt.Errorf("query A %s via %s did not return %s: %v", name, node.Name, expectedIP, response.Answer)
+	}, 2*time.Minute, 3*time.Second)
+}
+
+func runGuestCommand(target harness.SSHTarget, command string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return harness.RunGuestSSH(ctx, target, command)
+}
+
+func runPeerCommand(t *testing.T, node harness.Node, command string) string {
+	t.Helper()
+	out, err := peerCommand(node, command)
+	require.NoErrorf(t, err, "%s on %s: %s", command, node.Name, out)
+	return string(out)
+}
+
+func peerCommand(node harness.Node, command string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	return harness.NewPeerSSH().Run(ctx, node.Addr, command)
+}
+
+func queryDNS(node harness.Node, port, name string, queryType uint16) error {
+	query := new(dns.Msg)
+	query.SetQuestion(dns.Fqdn(name), queryType)
+	_, _, err := (&dns.Client{Timeout: 3 * time.Second}).Exchange(query, net.JoinHostPort(node.Addr, port))
+	return err
+}
+
+func addressHost(address string) string {
+	if host, _, err := net.SplitHostPort(address); err == nil {
+		return host
+	}
+	return strings.Trim(address, "[]")
+}
+
+func shellQuoteDNS(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/tests/e2e/multinode/tests_test.go
+++ b/tests/e2e/multinode/tests_test.go
@@ -36,6 +36,12 @@ func TestMultinodeInstanceDistribution(t *testing.T) {
 	runInstanceDistribution(t, requireMultiNodeFixture(t))
 }
 
+// TestMultinodeDNS is sequential because it launches guests and briefly stops
+// one Northstar unit while exercising resolver failover.
+func TestMultinodeDNS(t *testing.T) {
+	runMultinodeDNS(t, requireMultiNodeFixture(t))
+}
+
 // TestMultinodeJetStreamReplicas is read-only over NATS; parallel so it resumes
 // after the sequential node-failure/recovery tests have restabilised the cluster.
 func TestMultinodeJetStreamReplicas(t *testing.T) {

--- a/tests/e2e/single/baseline_test.go
+++ b/tests/e2e/single/baseline_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -112,18 +111,7 @@ func pingConverged(tgt harness.SSHTarget, dst string, timeout time.Duration) (st
 func sshCapture(tgt harness.SSHTarget, cmd string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	args := []string{
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
-		"-o", "LogLevel=ERROR",
-		"-o", "ConnectTimeout=5",
-		"-o", "BatchMode=yes",
-		"-p", strconv.Itoa(tgt.Port),
-		"-i", tgt.KeyPath,
-		tgt.User + "@" + tgt.Host,
-		cmd,
-	}
-	out, err := exec.CommandContext(ctx, "ssh", args...).CombinedOutput()
+	out, err := harness.RunGuestSSH(ctx, tgt, cmd)
 	return string(out), err
 }
 

--- a/tests/e2e/single/dns_test.go
+++ b/tests/e2e/single/dns_test.go
@@ -3,10 +3,12 @@
 package single
 
 import (
+	"strings"
+	"testing"
 	"time"
 
-	"testing"
-
+	"github.com/aws/aws-sdk-go/aws"
+	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 	"github.com/mulgadc/spinifex/tests/e2e/harness"
 	"github.com/stretchr/testify/require"
 )
@@ -15,9 +17,11 @@ import (
 // inside a running instance. It launches one instance, SSHes in over its public
 // IP, and over that session:
 //
-//  1. pings the instance's own private IP (from DescribeInstances) to prove the
-//     local ICMP datapath before DNS is exercised, and
-//  2. resolves public hostnames (google.com, cloudflare.com) through the guest
+//  1. asserts DHCP installed the VPC resolver in /etc/resolv.conf,
+//  2. pings the instance's own private IP (from DescribeInstances) to prove the
+//     local ICMP datapath before DNS is exercised,
+//  3. resolves the instance's internal EC2 name to its private IP, and
+//  4. resolves public hostnames (google.com, cloudflare.com) through the guest
 //     resolver, then pings them.
 //
 // Resolution is asserted separately from the ping via `getent ahostsv4` (AF_INET
@@ -34,6 +38,11 @@ import (
 // behaves the same), so no own-public-IP ping is attempted.
 func runGuestDNSResolution(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Single — Guest DNS end-to-end: resolver + ICMP egress")
+	harness.RequireDNSEnabled(t, fix.Env)
+	internalDomain := harness.NorthstarInternalDomain(fix.Env)
+	require.NotEmpty(t, internalDomain, "fixture requires Northstar's internal DNS domain")
+	region := aws.StringValue(fix.AWS.EC2Conf.Config.Region)
+	require.NotEmpty(t, region, "AWS region is required to build the internal EC2 name")
 
 	vpcID, _, subnetID := harness.DiscoverDefaultVPC(t, fix.AWS)
 	instType, _ := needInstanceTypeArch(t, fix)
@@ -57,6 +66,12 @@ func runGuestDNSResolution(t *testing.T, fix *Fixture) {
 
 	tgt := harness.SSHTarget{User: "ubuntu", Host: pubIP, Port: 22, KeyPath: keyPath}
 
+	harness.Step(t, "assert guest uses the VPC resolver 169.254.169.253")
+	resolvConf, err := sshCapture(tgt, "cat /etc/resolv.conf")
+	require.NoErrorf(t, err, "read guest /etc/resolv.conf\n%s", resolvConf)
+	require.Regexp(t, `(?m)^nameserver[[:space:]]+169\.254\.169\.253[[:space:]]*$`, resolvConf,
+		"guest /etc/resolv.conf must advertise the VPC resolver")
+
 	// Step 1: ping the instance's own private IP — local datapath sanity, no DNS
 	// involved. (Own public IP is unreachable from inside via gateway NAT, and the
 	// public inbound path is already proven by the SSH above.)
@@ -65,6 +80,13 @@ func runGuestDNSResolution(t *testing.T, fix *Fixture) {
 	require.Truef(t, ok,
 		"guest ping to own private IP %s never reached 0%% loss within 30s\n%s",
 		privIP, out)
+
+	privateName := handlers_dns.EC2PrivateName(privIP, region, internalDomain)
+	harness.Step(t, "resolve internal EC2 name %s via guest resolver", privateName)
+	internalResult, err := sshCapture(tgt, "getent ahostsv4 "+privateName)
+	require.NoErrorf(t, err, "guest failed to resolve internal name %s\n%s", privateName, internalResult)
+	require.Containsf(t, strings.Fields(internalResult), privIP,
+		"internal name %s did not resolve to private IP %s\n%s", privateName, privIP, internalResult)
 
 	// Step 2: resolve each public hostname through the guest resolver (the
 	// northstar path), then ping it. getent hosts is the DNS assertion; the ping


### PR DESCRIPTION
## Summary

- add multi-node unit coverage for Northstar credential rendering, formation propagation, seed convergence, and base-zone bootstrap
- add multi-node e2e coverage for per-node service configuration, nameserver topology, guest internal DNS, cross-node consistency, and resolver failover
- make single-node DNS coverage assert the VPC resolver, internal EC2 names, and resolvable IMDS public hostnames
- add shared e2e harness helpers and include the multinode suite in prebuilt test binaries

## Testing

- `make preflight`
