### PR TITLE
fix: prevent live volume tag clobbering

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -679,6 +679,12 @@ func runimagesImportCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// Import is an interactive command whose output is a progress bar, so the
+	// volume's routine mount chatter is noise here: a fresh import has no prior
+	// state, making the "no state found" / 404 lines expected rather than
+	// notable. Scoping the logger to this VB (New copies it onto the backend
+	// too) keeps it off the process-wide default. Errors still surface, both
+	// through this logger and as the returned error the caller prints.
 	vbConfig := viperblock.VB{
 		VolumeName: volumeId,
 		VolumeSize: utils.SafeInt64ToUint64(imageStat.Size()),
@@ -691,6 +697,7 @@ func runimagesImportCmd(cmd *cobra.Command, args []string) {
 		VolumeConfig:      manifest,
 		MasterKey:         mkey,
 		EncryptionEnabled: mkey != nil,
+		Logger:            slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
 	}
 
 	// Bake the deployment CA into the image trust store so a stock cloud image

--- a/spinifex/handlers/ec2/volume/config_route_test.go
+++ b/spinifex/handlers/ec2/volume/config_route_test.go
@@ -52,7 +52,12 @@ func seedEncryptedConfig(t *testing.T, store *objectstore.MemoryObjectStore, vol
 		BlockSize:         4096,
 		EncryptionEnabled: true,
 		VolumeConfig: viperblock.VolumeConfig{
-			VolumeMetadata: viperblock.VolumeMetadata{VolumeID: volumeID, SizeGiB: 10, State: "available"},
+			VolumeMetadata: viperblock.VolumeMetadata{
+				VolumeID: volumeID,
+				TenantID: testVolAccountID,
+				SizeGiB:  10,
+				State:    "available",
+			},
 		},
 	}
 	data, err := json.Marshal(state)

--- a/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
+++ b/spinifex/handlers/ec2/volume/lifecycle_invariants_test.go
@@ -2,18 +2,44 @@ package handlers_ec2_volume
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/objectstore"
+	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/viperblock/viperblock"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const testVolAccountID = "123456789012"
+
+// recordingObjectStore records and optionally rejects object writes in tests.
+type recordingObjectStore struct {
+	objectstore.ObjectStore
+
+	putKeys  []string
+	putError map[string]error
+}
+
+var _ objectstore.ObjectStore = (*recordingObjectStore)(nil)
+
+// PutObject records the destination before delegating the write.
+func (s *recordingObjectStore) PutObject(ctx context.Context, input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	key := aws.StringValue(input.Key)
+	s.putKeys = append(s.putKeys, key)
+	if err := s.putError[key]; err != nil {
+		return nil, err
+	}
+	return s.ObjectStore.PutObject(ctx, input)
+}
 
 // seedVolume writes a volume config.json into the store so listAllVolumeIDs /
 // GetVolumeConfig see it. CreateVolume cannot be used in unit tests — it needs a
@@ -64,6 +90,74 @@ func TestRLC3_VolumeDeleteRequiresDetach(t *testing.T) {
 		"ADR-0005 §2: deleting an attached volume must return VolumeInUse (detach-before-delete, rule #3)")
 }
 
+// TestVolumeTagMirror_WritesOnlyControlPlaneTagsObject locks the single-writer
+// invariant: tag mutations must never rewrite config.json or route an encrypted
+// volume through the ebs.config keyholder queue.
+func TestVolumeTagMirror_WritesOnlyControlPlaneTagsObject(t *testing.T) {
+	memoryStore := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", memoryStore)
+	svc.natsConn = startTestNATS(t)
+	volumeID := "vol-enc-tag-writer"
+	seedEncryptedConfig(t, memoryStore, volumeID)
+	require.NoError(t, svc.putVolumeState(context.Background(), volumeID, volumeStateRecord{
+		State:            "in-use",
+		AttachedInstance: "i-live0000000000",
+		DeviceName:       "/dev/nbd0",
+	}))
+	before := getStoredConfig(t, memoryStore, volumeID)
+	store := &recordingObjectStore{ObjectStore: memoryStore}
+	svc.store = store
+
+	var configRequests atomic.Int32
+	sub, err := svc.natsConn.Subscribe("ebs.config", func(msg *nats.Msg) {
+		configRequests.Add(1)
+		data, marshalErr := json.Marshal(types.EBSConfigUpdateResponse{Volume: volumeID, Success: true})
+		if marshalErr == nil {
+			_ = msg.Respond(data)
+		}
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.natsConn.Flush())
+	defer sub.Unsubscribe()
+
+	require.NoError(t, svc.ApplyRecordTags(&ec2.CreateTagsInput{
+		Resources: []*string{aws.String(volumeID)},
+		Tags:      []*ec2.Tag{{Key: aws.String("owner"), Value: aws.String("control-plane")}},
+	}, testVolAccountID))
+	require.NoError(t, svc.RemoveRecordTags(&ec2.DeleteTagsInput{
+		Resources: []*string{aws.String(volumeID)},
+		Tags:      []*ec2.Tag{{Key: aws.String("owner"), Value: aws.String("control-plane")}},
+	}, testVolAccountID))
+
+	assert.Equal(t, []string{volumeTagsKey(volumeID), volumeTagsKey(volumeID)}, store.putKeys,
+		"tag mutations must write only tags.json")
+	assert.Equal(t, int32(0), configRequests.Load(),
+		"tag mutations must never issue an ebs.config request")
+	assert.Equal(t, before, getStoredConfig(t, memoryStore, volumeID),
+		"tag mutations must leave the sealed config.json untouched")
+}
+
+// TestVolumeTagMirror_ReturnsTagsObjectWriteFailure prevents tag persistence
+// errors from becoming false-successful CreateTags responses.
+func TestVolumeTagMirror_ReturnsTagsObjectWriteFailure(t *testing.T) {
+	memoryStore := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", memoryStore)
+	volumeID := "vol-tag-write-error"
+	seedVolume(t, svc, volumeID, "in-use", "i-live0000000000")
+	svc.store = &recordingObjectStore{
+		ObjectStore: memoryStore,
+		putError: map[string]error{
+			volumeTagsKey(volumeID): errors.New("tags store unavailable"),
+		},
+	}
+
+	err := svc.ApplyRecordTags(&ec2.CreateTagsInput{
+		Resources: []*string{aws.String(volumeID)},
+		Tags:      []*ec2.Tag{{Key: aws.String("owner"), Value: aws.String("control-plane")}},
+	}, testVolAccountID)
+	require.ErrorContains(t, err, "tags store unavailable")
+}
+
 // TestRLC5_VolumeGCMarksLeakedVolumeNeverDeletes enforces ADR-0005 §3 — the one
 // principled exception to the GC backstop's reap-actual−desired default. A
 // volume left attached to a definitively-gone instance is data: the GC must
@@ -74,6 +168,10 @@ func TestRLC5_VolumeGCMarksLeakedVolumeNeverDeletes(t *testing.T) {
 	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
 	seedVolume(t, svc, "vol-leaked0000000", "in-use", "i-gone0000000000")
 	seedVolume(t, svc, "vol-live000000000", "in-use", "i-running00000000")
+	require.NoError(t, svc.ApplyRecordTags(&ec2.CreateTagsInput{
+		Resources: []*string{aws.String("vol-leaked0000000")},
+		Tags:      []*ec2.Tag{{Key: aws.String("customer"), Value: aws.String("preserved")}},
+	}, testVolAccountID))
 
 	reaper := svc.NewVolumeLeakReaper(func() (map[string]bool, error) {
 		return map[string]bool{"i-gone0000000000": true}, nil
@@ -87,6 +185,8 @@ func TestRLC5_VolumeGCMarksLeakedVolumeNeverDeletes(t *testing.T) {
 	require.NoErrorf(t, err, "ADR-0005 §3: the GC must NOT delete the leaked volume — it carries data; it may only mark + alarm")
 	assert.NotEmpty(t, leaked.VolumeMetadata.Tags[orphanTagKey],
 		"ADR-0005 §3: a leaked volume must be marked orphaned")
+	assert.Equal(t, "preserved", leaked.VolumeMetadata.Tags["customer"],
+		"orphan marking must preserve tags from the authoritative tags.json")
 
 	// A volume attached to an instance NOT in the leaked set must be untouched —
 	// node-local detection never false-marks another node's live-instance volume.

--- a/spinifex/handlers/ec2/volume/record_tags_test.go
+++ b/spinifex/handlers/ec2/volume/record_tags_test.go
@@ -1,10 +1,13 @@
 package handlers_ec2_volume
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mulgadc/spinifex/spinifex/objectstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +45,114 @@ func TestVolumeRecordTagsMirror(t *testing.T) {
 	assert.Equal(t, "yes", cfg.VolumeMetadata.Tags["keep"])
 	_, ok := cfg.VolumeMetadata.Tags["drop"]
 	assert.False(t, ok)
+}
+
+func TestApplyRecordTags_AttachedVolumePersistsForTagFilterDiscovery(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	volumeID := "vol-taggedattached"
+	seedVolume(t, svc, volumeID, "in-use", "i-live0000000000")
+
+	require.NoError(t, svc.ApplyRecordTags(&ec2.CreateTagsInput{
+		Resources: []*string{aws.String(volumeID)},
+		Tags:      []*ec2.Tag{{Key: aws.String("e2e:run"), Value: aws.String("run-123")}},
+	}, testVolAccountID))
+
+	out, err := svc.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{{
+			Name:   aws.String("tag:e2e:run"),
+			Values: []*string{aws.String("run-123")},
+		}},
+	}, testVolAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.Volumes, 1)
+	assert.Equal(t, volumeID, aws.StringValue(out.Volumes[0].VolumeId))
+}
+
+func TestApplyRecordTags_SurvivesStaleConfigRewrite(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	volumeID := "vol-staleconfigtag"
+	seedVolume(t, svc, volumeID, "in-use", "i-live0000000000")
+	staleConfig := getStoredConfig(t, store, volumeID)
+
+	require.NoError(t, svc.ApplyRecordTags(&ec2.CreateTagsInput{
+		Resources: []*string{aws.String(volumeID)},
+		Tags:      []*ec2.Tag{{Key: aws.String("sweep"), Value: aws.String("retain")}},
+	}, testVolAccountID))
+
+	// Simulate the live nbdkit VB saving its mount-time config after the tag write.
+	_, err := store.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String(volumeID + "/config.json"),
+		Body:   bytes.NewReader(staleConfig),
+	})
+	require.NoError(t, err)
+
+	cfg, err := svc.GetVolumeConfig(volumeID)
+	require.NoError(t, err)
+	assert.Equal(t, "retain", cfg.VolumeMetadata.Tags["sweep"])
+
+	out, err := svc.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{{
+			Name:   aws.String("tag:sweep"),
+			Values: []*string{aws.String("retain")},
+		}},
+	}, testVolAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.Volumes, 1)
+	assert.Equal(t, volumeID, aws.StringValue(out.Volumes[0].VolumeId))
+}
+
+func TestApplyRecordTags_FirstWriteSeedsEmbeddedTags(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	volumeID := "vol-seedembedded"
+	seedVolumeWithEmbeddedTags(t, svc, volumeID, map[string]string{"created-with": "volume"})
+
+	require.NoError(t, svc.ApplyRecordTags(&ec2.CreateTagsInput{
+		Resources: []*string{aws.String(volumeID)},
+		Tags:      []*ec2.Tag{{Key: aws.String("added-later"), Value: aws.String("yes")}},
+	}, testVolAccountID))
+
+	cfg, err := svc.GetVolumeConfig(volumeID)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"created-with": "volume",
+		"added-later":  "yes",
+	}, cfg.VolumeMetadata.Tags)
+}
+
+func TestRemoveRecordTags_EmptyTagsJSONOverridesEmbeddedTags(t *testing.T) {
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	volumeID := "vol-emptytagsjson"
+	seedVolumeWithEmbeddedTags(t, svc, volumeID, map[string]string{"legacy": "tag"})
+
+	require.NoError(t, svc.RemoveRecordTags(&ec2.DeleteTagsInput{
+		Resources: []*string{aws.String(volumeID)},
+		Tags:      []*ec2.Tag{{Key: aws.String("legacy"), Value: aws.String("tag")}},
+	}, testVolAccountID))
+
+	tags, found, err := svc.getVolumeTags(context.Background(), volumeID)
+	require.NoError(t, err)
+	assert.True(t, found, "removing the final tag must leave an authoritative tags.json")
+	assert.Empty(t, tags)
+
+	cfg, err := svc.GetVolumeConfig(volumeID)
+	require.NoError(t, err)
+	assert.Empty(t, cfg.VolumeMetadata.Tags, "present empty tags.json must not fall back to embedded tags")
+}
+
+// seedVolumeWithEmbeddedTags creates a legacy or create-time tagged volume with
+// no tags.json so tests exercise the migration fallback.
+func seedVolumeWithEmbeddedTags(t *testing.T, svc *VolumeServiceImpl, volumeID string, tags map[string]string) {
+	t.Helper()
+	seedVolume(t, svc, volumeID, "available", "")
+	cfg, err := svc.GetVolumeConfig(volumeID)
+	require.NoError(t, err)
+	cfg.VolumeMetadata.Tags = tags
+	require.NoError(t, svc.putVolumeConfig(context.Background(), volumeID, cfg))
 }
 
 func TestVolumeRecordTagsMirror_CrossTenantNoMutation(t *testing.T) {

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -1023,6 +1023,9 @@ type volumeStateRecord struct {
 // volumeStateKey is the S3 key for a volume's control-plane state object.
 func volumeStateKey(volumeID string) string { return volumeID + "/state.json" }
 
+// volumeTagsKey is the S3 key for a volume's control-plane tags object.
+func volumeTagsKey(volumeID string) string { return volumeID + "/tags.json" }
+
 // putVolumeState writes the control-plane attachment state to state.json.
 func (s *VolumeServiceImpl) putVolumeState(ctx context.Context, volumeID string, rec volumeStateRecord) error {
 	data, err := json.Marshal(rec)
@@ -1067,7 +1070,56 @@ func (s *VolumeServiceImpl) getVolumeState(ctx context.Context, volumeID string)
 	return rec, true, nil
 }
 
-// GetVolumeConfig reads the raw VolumeConfig from S3 for a given volume ID.
+// putVolumeTags writes the control-plane-owned tag set to tags.json.
+func (s *VolumeServiceImpl) putVolumeTags(ctx context.Context, volumeID string, tags map[string]string) error {
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	data, err := json.Marshal(tags)
+	if err != nil {
+		return fmt.Errorf("marshal volume tags: %w", err)
+	}
+	_, err = s.store.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(s.bucketName),
+		Key:    aws.String(volumeTagsKey(volumeID)),
+		Body:   bytes.NewReader(data),
+	})
+	if err != nil {
+		return fmt.Errorf("write volume tags to S3: %w", err)
+	}
+	return nil
+}
+
+// getVolumeTags reads tags.json. found=false means the object is absent, while
+// a present empty map is an authoritative empty tag set.
+func (s *VolumeServiceImpl) getVolumeTags(ctx context.Context, volumeID string) (map[string]string, bool, error) {
+	getResult, err := s.store.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucketName),
+		Key:    aws.String(volumeTagsKey(volumeID)),
+	})
+	if err != nil {
+		if objectstore.IsNoSuchKeyError(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("get volume tags: %w", err)
+	}
+	defer getResult.Body.Close()
+
+	body, err := io.ReadAll(getResult.Body)
+	if err != nil {
+		return nil, false, fmt.Errorf("read volume tags body: %w", err)
+	}
+	var tags map[string]string
+	if err := json.Unmarshal(body, &tags); err != nil {
+		return nil, false, fmt.Errorf("unmarshal volume tags: %w", err)
+	}
+	if tags == nil {
+		return nil, false, errors.New("unmarshal volume tags: expected JSON object")
+	}
+	return tags, true, nil
+}
+
+// GetVolumeConfig reads the effective VolumeConfig for a given volume ID.
 func (s *VolumeServiceImpl) GetVolumeConfig(volumeID string) (*viperblock.VolumeConfig, error) {
 	return s.getVolumeConfig(context.Background(), volumeID)
 }
@@ -1078,9 +1130,42 @@ func (s *VolumeServiceImpl) getVolumeConfig(ctx context.Context, volumeID string
 	return cfg, err
 }
 
-// getVolumeConfigAndEncryption reads config.json and returns the VolumeConfig plus the
-// VBState.EncryptionEnabled flag. Pre-VBState blobs report encryptionEnabled=false.
+// getVolumeConfigAndEncryption reads config.json and overlays control-plane-owned
+// state and tags. Pre-VBState blobs report encryptionEnabled=false.
 func (s *VolumeServiceImpl) getVolumeConfigAndEncryption(ctx context.Context, volumeID string) (*viperblock.VolumeConfig, bool, error) {
+	vc, encryptionEnabled, err := s.getBaseVolumeConfigAndEncryption(ctx, volumeID)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Overlay the control-plane-owned attachment state from state.json. The State
+	// embedded in config.json is rewritten by the live nbdkit VB (stale
+	// "available") and is not authoritative; state.json is. Absent state.json
+	// keeps the embedded value (volumes predating the split).
+	if rec, found, stateErr := s.getVolumeState(ctx, volumeID); stateErr != nil {
+		return nil, false, stateErr
+	} else if found {
+		vc.VolumeMetadata.State = rec.State
+		vc.VolumeMetadata.AttachedInstance = rec.AttachedInstance
+		vc.VolumeMetadata.DeviceName = rec.DeviceName
+		vc.VolumeMetadata.AttachedAt = rec.AttachedAt
+	}
+
+	// tags.json is authoritative when present, including when it contains an
+	// empty map. Falling back to config.json preserves tags on older volumes and
+	// tags supplied at volume creation until their first tag mutation.
+	if tags, found, tagsErr := s.getVolumeTags(ctx, volumeID); tagsErr != nil {
+		return nil, false, tagsErr
+	} else if found {
+		vc.VolumeMetadata.Tags = tags
+	}
+
+	return vc, encryptionEnabled, nil
+}
+
+// getBaseVolumeConfigAndEncryption reads config.json without overlaying the
+// control-plane-owned state and tags objects.
+func (s *VolumeServiceImpl) getBaseVolumeConfigAndEncryption(ctx context.Context, volumeID string) (*viperblock.VolumeConfig, bool, error) {
 	configKey := volumeID + "/config.json"
 
 	getResult, err := s.store.GetObject(ctx, &s3.GetObjectInput{
@@ -1121,29 +1206,15 @@ func (s *VolumeServiceImpl) getVolumeConfigAndEncryption(ctx context.Context, vo
 		vc = &wrapper.VolumeConfig
 	}
 
-	// Overlay the control-plane-owned attachment state from state.json. The State
-	// embedded in config.json is rewritten by the live nbdkit VB (stale
-	// "available") and is not authoritative; state.json is. Absent state.json
-	// keeps the embedded value (volumes predating the split).
-	if rec, found, stateErr := s.getVolumeState(ctx, volumeID); stateErr != nil {
-		return nil, false, stateErr
-	} else if found {
-		vc.VolumeMetadata.State = rec.State
-		vc.VolumeMetadata.AttachedInstance = rec.AttachedInstance
-		vc.VolumeMetadata.DeviceName = rec.DeviceName
-		vc.VolumeMetadata.AttachedAt = rec.AttachedAt
-	}
-
 	return vc, encryptionEnabled, nil
 }
 
 // putVolumeConfig writes a VolumeConfig back to S3 as config.json.
 // It performs a read-modify-write to preserve full VBState if viperblock
 // has already written state (BlockSize, SeqNum, WALNum, etc.) to config.json.
-// Callers are the safe non-live writers only (CreateVolume pre-mount,
-// markVolumeOrphaned detached, ModifyVolume stopped-instance); the
-// control-plane attachment state of a live-mounted volume goes to state.json via
-// UpdateVolumeState, never here.
+// Callers are the safe non-live writers only (CreateVolume pre-mount and
+// ModifyVolume stopped-instance); control-plane-owned state and tags go to
+// state.json and tags.json, never here.
 func (s *VolumeServiceImpl) putVolumeConfig(ctx context.Context, volumeID string, cfg *viperblock.VolumeConfig) error {
 	configKey := volumeID + "/config.json"
 
@@ -1589,9 +1660,9 @@ func (s *VolumeServiceImpl) volumeHasSnapshotsKV(volumeID string) (bool, error) 
 	return len(snapshots) > 0, nil
 }
 
-// ApplyRecordTags mirrors CreateTags into the owning volume config so
-// DescribeVolumes observes tags added after create. Non-vol ids, volumes
-// absent from this store, and volumes the caller does not own are skipped.
+// ApplyRecordTags mirrors CreateTags into the owning volume's tags.json so
+// DescribeVolumes observes tags added after create. Non-vol ids, volumes absent
+// from this store, and volumes the caller does not own are skipped.
 func (s *VolumeServiceImpl) ApplyRecordTags(input *ec2.CreateTagsInput, accountID string) error {
 	if input == nil {
 		return nil
@@ -1599,7 +1670,7 @@ func (s *VolumeServiceImpl) ApplyRecordTags(input *ec2.CreateTagsInput, accountI
 	return s.mirrorVolumeTags(context.Background(), input.Resources, accountID, utils.MergeTagsMut(input))
 }
 
-// RemoveRecordTags mirrors DeleteTags into the owning volume config with
+// RemoveRecordTags mirrors DeleteTags into the owning volume's tags.json with
 // AWS-faithful delete semantics.
 func (s *VolumeServiceImpl) RemoveRecordTags(input *ec2.DeleteTagsInput, accountID string) error {
 	if input == nil {
@@ -1608,15 +1679,15 @@ func (s *VolumeServiceImpl) RemoveRecordTags(input *ec2.DeleteTagsInput, account
 	return s.mirrorVolumeTags(context.Background(), input.Resources, accountID, utils.RemoveTagsMut(input))
 }
 
-// mirrorVolumeTags read-modify-writes VolumeMetadata.Tags for each vol- id.
-// config.json lives at a global ID-keyed path, so the mutation is gated on the
-// caller owning the volume (TenantID match); mismatch or absence is a no-op.
+// mirrorVolumeTags read-modify-writes tags.json for each vol- id. The base
+// config supplies the ownership gate and create-time tag fallback. Mismatch or
+// absence is a no-op.
 func (s *VolumeServiceImpl) mirrorVolumeTags(ctx context.Context, resources []*string, accountID string, mut func(map[string]string)) error {
 	for _, res := range resources {
 		if res == nil || !strings.HasPrefix(*res, "vol-") {
 			continue
 		}
-		cfg, err := s.GetVolumeConfig(*res)
+		cfg, _, err := s.getBaseVolumeConfigAndEncryption(ctx, *res)
 		if err != nil {
 			if err.Error() == awserrors.ErrorInvalidVolumeNotFound {
 				continue
@@ -1627,11 +1698,19 @@ func (s *VolumeServiceImpl) mirrorVolumeTags(ctx context.Context, resources []*s
 			slog.Debug("mirrorVolumeTags: skipping volume not owned by caller", "volumeId", *res)
 			continue
 		}
-		if cfg.VolumeMetadata.Tags == nil {
-			cfg.VolumeMetadata.Tags = map[string]string{}
+
+		tags, found, err := s.getVolumeTags(ctx, *res)
+		if err != nil {
+			return err
 		}
-		mut(cfg.VolumeMetadata.Tags)
-		if err := s.putVolumeConfig(ctx, *res, cfg); err != nil {
+		if !found {
+			tags = cfg.VolumeMetadata.Tags
+		}
+		if tags == nil {
+			tags = map[string]string{}
+		}
+		mut(tags)
+		if err := s.putVolumeTags(ctx, *res, tags); err != nil {
 			return err
 		}
 	}

--- a/spinifex/handlers/ec2/volume/volume_leak_reaper.go
+++ b/spinifex/handlers/ec2/volume/volume_leak_reaper.go
@@ -100,13 +100,13 @@ func (r *VolumeLeakReaper) Sweep(ctx context.Context) (int, error) {
 	return marked, nil
 }
 
-// markVolumeOrphaned tags the volume as orphaned and persists it. Tag-only: the
-// volume's data and state are untouched so reclamation stays an explicit choice.
+// markVolumeOrphaned tags the volume as orphaned in the control-plane-owned
+// tags.json. The volume's data and state remain untouched.
 func (s *VolumeServiceImpl) markVolumeOrphaned(ctx context.Context, volumeID string, cfg *viperblock.VolumeConfig) error {
 	if cfg.VolumeMetadata.Tags == nil {
 		cfg.VolumeMetadata.Tags = make(map[string]string)
 	}
 	cfg.VolumeMetadata.Tags[orphanTagKey] = time.Now().UTC().Format(time.RFC3339)
 	cfg.VolumeMetadata.Tags[orphanInstanceTagKey] = cfg.VolumeMetadata.AttachedInstance
-	return s.putVolumeConfig(ctx, volumeID, cfg)
+	return s.putVolumeTags(ctx, volumeID, cfg.VolumeMetadata.Tags)
 }


### PR DESCRIPTION
## Summary
- persist mutable EBS volume tags in control-plane-owned `tags.json` and overlay them on reads
- keep create-time and legacy embedded tags as the first-write fallback while preserving authoritative empty tag sets
- route orphan marking through `tags.json` and prevent encrypted tag updates from touching `config.json` or `ebs.config`
- add attached-volume, stale-config, migration, empty-tag, encrypted, and write-failure regression coverage

## Testing
- `make preflight`