### PR TITLE
feat: deliver backend ENOSPC to the guest and enable chunk GC in production

### DIFF
--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -297,6 +297,14 @@ var viperblockStartCmd = &cobra.Command{
 			shardWAL = *nodeConfig.Viperblock.ShardWAL
 		}
 
+		// Resolve chunk GC setting: default false unless explicitly set to true.
+		// GC is not a per-volume toggle — flipping it on applies to every VB this
+		// node constructs (nbdkit plugin + volume service).
+		gcEnabled := false
+		if nodeConfig.Viperblock.GCEnabled != nil {
+			gcEnabled = *nodeConfig.Viperblock.GCEnabled
+		}
+
 		encryptionKeyFile := nodeConfig.Viperblock.EncryptionKeyFile
 		if envKey := viper.GetString("viperblock-encryption-key-file"); envKey != "" {
 			encryptionKeyFile = envKey
@@ -317,6 +325,7 @@ var viperblockStartCmd = &cobra.Command{
 			BaseDir:           nodeConfig.Predastore.BaseDir,
 			NodeName:          clusterConfig.Node,
 			ShardWAL:          shardWAL,
+			GCEnabled:         gcEnabled,
 			EncryptionKeyFile: encryptionKeyFile,
 		})
 

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/klauspost/cpuid/v2 v2.4.0
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910
-	github.com/mulgadc/predastore v1.12.1
-	github.com/mulgadc/viperblock v1.12.2-0.20260718030705-d5e2bb38ab28
+	github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152
+	github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910
 	github.com/mulgadc/predastore v1.12.1
-	github.com/mulgadc/viperblock v1.12.1
+	github.com/mulgadc/viperblock v1.12.2-0.20260718030705-d5e2bb38ab28
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910
 	github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152
-	github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744
+	github.com/mulgadc/viperblock v1.12.2-0.20260720054349-054a44a3f0f5
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/klauspost/cpuid/v2 v2.4.0
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910
-	github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152
-	github.com/mulgadc/viperblock v1.12.2-0.20260720054349-054a44a3f0f5
+	github.com/mulgadc/predastore v1.12.2-0.20260721042232-56993298a996
+	github.com/mulgadc/viperblock v1.12.2-0.20260721051906-35dd9f2c1b9e
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1323,6 +1323,8 @@ github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152 h1:8bdDhzH2I
 github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152/go.mod h1:kgTncuCaB11e3eCQeZF0ydEFG0biuOlrZ4DlHNzwvZY=
 github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744 h1:4zYKxg1tqp3GuBhkywTAOYlK3HB1knYIPUEDaOS4Ul4=
 github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
+github.com/mulgadc/viperblock v1.12.2-0.20260720054349-054a44a3f0f5 h1:8cMSZHYh5RPfPIrjM8QYxRjwDFbUpRTUBHGlp2ITdOA=
+github.com/mulgadc/viperblock v1.12.2-0.20260720054349-054a44a3f0f5/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -1319,12 +1319,10 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910 h1:em4NMKrCbjCFI+nuQ06Vcy+OK8JDimCf1tV2lCnX31k=
 github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910/go.mod h1:wSbEv6trLTyLJM4jdyS9JQabx52FQOfQ9CtHMBo/A64=
-github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152 h1:8bdDhzH2ImmKFKV8ZdfjV1js1f6fJ8bS1clUgh+/PUo=
-github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152/go.mod h1:kgTncuCaB11e3eCQeZF0ydEFG0biuOlrZ4DlHNzwvZY=
-github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744 h1:4zYKxg1tqp3GuBhkywTAOYlK3HB1knYIPUEDaOS4Ul4=
-github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
-github.com/mulgadc/viperblock v1.12.2-0.20260720054349-054a44a3f0f5 h1:8cMSZHYh5RPfPIrjM8QYxRjwDFbUpRTUBHGlp2ITdOA=
-github.com/mulgadc/viperblock v1.12.2-0.20260720054349-054a44a3f0f5/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
+github.com/mulgadc/predastore v1.12.2-0.20260721042232-56993298a996 h1:trj4crGlgNiAGTn0dWOscXibPd1ldCMTmw7P2OnF734=
+github.com/mulgadc/predastore v1.12.2-0.20260721042232-56993298a996/go.mod h1:kgTncuCaB11e3eCQeZF0ydEFG0biuOlrZ4DlHNzwvZY=
+github.com/mulgadc/viperblock v1.12.2-0.20260721051906-35dd9f2c1b9e h1:mY6m8KwRqd4rK/gHx12rh9AOd/zKLOQuUCJaJsw0r5A=
+github.com/mulgadc/viperblock v1.12.2-0.20260721051906-35dd9f2c1b9e/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -1319,10 +1319,10 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910 h1:em4NMKrCbjCFI+nuQ06Vcy+OK8JDimCf1tV2lCnX31k=
 github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910/go.mod h1:wSbEv6trLTyLJM4jdyS9JQabx52FQOfQ9CtHMBo/A64=
-github.com/mulgadc/predastore v1.12.1 h1:mkJqmUbxfI3kBRmtBecjvBsRLFpnKARGWtmx4b9XKKg=
-github.com/mulgadc/predastore v1.12.1/go.mod h1:kgTncuCaB11e3eCQeZF0ydEFG0biuOlrZ4DlHNzwvZY=
-github.com/mulgadc/viperblock v1.12.2-0.20260718030705-d5e2bb38ab28 h1:XQpDJmXqa++ulnzFhT8lyJJpSNoYvTNF1l0NcHedQIg=
-github.com/mulgadc/viperblock v1.12.2-0.20260718030705-d5e2bb38ab28/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
+github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152 h1:8bdDhzH2ImmKFKV8ZdfjV1js1f6fJ8bS1clUgh+/PUo=
+github.com/mulgadc/predastore v1.12.2-0.20260718235316-831a8dbb8152/go.mod h1:kgTncuCaB11e3eCQeZF0ydEFG0biuOlrZ4DlHNzwvZY=
+github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744 h1:4zYKxg1tqp3GuBhkywTAOYlK3HB1knYIPUEDaOS4Ul4=
+github.com/mulgadc/viperblock v1.12.2-0.20260719001705-014b7bb76744/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.sum
+++ b/go.sum
@@ -1321,8 +1321,8 @@ github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910 h1:em4NMKrCbj
 github.com/mulgadc/northstar v1.12.1-0.20260716014846-f85933fe2910/go.mod h1:wSbEv6trLTyLJM4jdyS9JQabx52FQOfQ9CtHMBo/A64=
 github.com/mulgadc/predastore v1.12.1 h1:mkJqmUbxfI3kBRmtBecjvBsRLFpnKARGWtmx4b9XKKg=
 github.com/mulgadc/predastore v1.12.1/go.mod h1:kgTncuCaB11e3eCQeZF0ydEFG0biuOlrZ4DlHNzwvZY=
-github.com/mulgadc/viperblock v1.12.1 h1:DWMbzPhIkYzdhOy4sn/D0/BJWJ5uhBoKWbVMfS7DMl4=
-github.com/mulgadc/viperblock v1.12.1/go.mod h1:5MGciKEvqpwLv2pdjk9j7PR8NHtXPs4pJzJi4UJojeU=
+github.com/mulgadc/viperblock v1.12.2-0.20260718030705-d5e2bb38ab28 h1:XQpDJmXqa++ulnzFhT8lyJJpSNoYvTNF1l0NcHedQIg=
+github.com/mulgadc/viperblock v1.12.2-0.20260718030705-d5e2bb38ab28/go.mod h1:UGIWumMNLiV++B5HJ1VFnlbEuJBm/b0pyC/Sfi4Oslo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -124,6 +124,13 @@ type ViperblockConfig struct {
 	// EncryptionKeyFile is the path to the shared 32-byte AES-256 master key for viperblock at-rest encryption.
 	// Empty means cleartext. When set, all VB instances must load it via masterkey.LoadShared.
 	EncryptionKeyFile string `json:"EncryptionKeyFile" mapstructure:"encryption_key_file"`
+
+	// GCEnabled turns on viperblock chunk garbage collection (mark-and-sweep,
+	// snapshot-ancestry gated) on every VB this node constructs: the nbdkit
+	// plugin backing a mounted volume, and the short-lived VBs used by the
+	// volume service. Default false when nil so existing deployments keep
+	// today's behavior until explicitly opted in.
+	GCEnabled *bool `json:"GCEnabled" mapstructure:"gc_enabled"`
 }
 
 // VPCDConfig holds the VPC daemon (vpcd) configuration.

--- a/spinifex/config/config_test.go
+++ b/spinifex/config/config_test.go
@@ -785,6 +785,50 @@ shardwal = true
 	assert.True(t, *n.Viperblock.ShardWAL)
 }
 
+func TestLoadConfig_ViperblockGCEnabled_DefaultNil(t *testing.T) {
+	resetViper(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+
+	toml := `
+node = "n1"
+
+[nodes.n1]
+region = "us-east-1"
+`
+	require.NoError(t, os.WriteFile(path, []byte(toml), 0600))
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+
+	n := cfg.Nodes["n1"]
+	assert.Nil(t, n.Viperblock.GCEnabled, "GCEnabled should be nil when not configured (defaults to false in service)")
+}
+
+func TestLoadConfig_ViperblockGCEnabled_True(t *testing.T) {
+	resetViper(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spinifex.toml")
+
+	toml := `
+node = "n1"
+
+[nodes.n1]
+region = "us-east-1"
+
+[nodes.n1.viperblock]
+gc_enabled = true
+`
+	require.NoError(t, os.WriteFile(path, []byte(toml), 0600))
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+
+	n := cfg.Nodes["n1"]
+	require.NotNil(t, n.Viperblock.GCEnabled, "GCEnabled should be set when explicitly configured")
+	assert.True(t, *n.Viperblock.GCEnabled)
+}
+
 func TestParseEndpoints(t *testing.T) {
 	cases := []struct {
 		name string

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -202,6 +202,10 @@ func (s *VolumeServiceImpl) CreateVolume(ctx context.Context, input *ec2.CreateV
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
+	// GCEnabled: default false unless explicitly set to true, matching the
+	// nbdkit plugin and viperblockd resolution of the same config field.
+	gcEnabled := s.config.Viperblock.GCEnabled != nil && *s.config.Viperblock.GCEnabled
+
 	vbconfig := viperblock.VB{
 		VolumeName:        volumeID,
 		VolumeSize:        volumeSizeBytes,
@@ -210,6 +214,7 @@ func (s *VolumeServiceImpl) CreateVolume(ctx context.Context, input *ec2.CreateV
 		VolumeConfig:      volumeConfig,
 		MasterKey:         mkey,
 		EncryptionEnabled: mkey != nil,
+		GCEnabled:         gcEnabled,
 	}
 
 	// If created from a snapshot, set the snapshot fields so viperblock's

--- a/spinifex/nbd/nbd.go
+++ b/spinifex/nbd/nbd.go
@@ -30,6 +30,11 @@ type NBDKitConfig struct {
 	// it is forwarded to the viperblock plugin so encrypted volumes open with
 	// matching encryption state. Empty → plugin opens in cleartext mode.
 	EncryptionKeyFile string `json:"encryption_key_file"`
+
+	// GCEnabled forwards spinifex's [viperblock] gc_enabled toggle to the
+	// plugin's gc_enabled param, gating chunk garbage collection on the VB
+	// this nbdkit process constructs. Default false, matching ShardWAL.
+	GCEnabled bool `json:"gc_enabled"`
 }
 
 // buildArgs constructs the nbdkit command-line arguments from the config.
@@ -69,6 +74,7 @@ func (cfg *NBDKitConfig) buildArgs() ([]string, error) {
 		fmt.Sprintf("host=%s", cfg.Host),
 		fmt.Sprintf("cache_size=%d", cfg.CacheSize),
 		fmt.Sprintf("shardwal=%t", cfg.ShardWAL),
+		fmt.Sprintf("gc_enabled=%t", cfg.GCEnabled),
 	}
 	// Only forward the key when configured; an empty value would explicitly
 	// set the plugin to cleartext and override its ENCRYPTION_KEY_FILE fallback.

--- a/spinifex/nbd/nbd_test.go
+++ b/spinifex/nbd/nbd_test.go
@@ -44,6 +44,7 @@ func TestBuildArgs_TCPTransport(t *testing.T) {
 		"host=localhost:9000",
 		"cache_size=256",
 		"shardwal=true",
+		"gc_enabled=false",
 	}
 
 	assertArgs(t, expected, args)
@@ -65,6 +66,7 @@ func TestBuildArgs_UnixSocketTransport(t *testing.T) {
 		Host:       "10.0.0.1:9000",
 		CacheSize:  128,
 		ShardWAL:   false,
+		GCEnabled:  true,
 	}
 
 	args, err := cfg.buildArgs()
@@ -87,6 +89,7 @@ func TestBuildArgs_UnixSocketTransport(t *testing.T) {
 		"host=10.0.0.1:9000",
 		"cache_size=128",
 		"shardwal=false",
+		"gc_enabled=true",
 	}
 
 	assertArgs(t, expected, args)
@@ -269,6 +272,41 @@ func TestBuildArgs_EncryptionKeyFileOmittedWhenEmpty(t *testing.T) {
 		if len(arg) >= 19 && arg[:19] == "encryption_key_file" {
 			t.Errorf("encryption_key_file must be absent when unset, got: %q", arg)
 		}
+	}
+}
+
+func TestBuildArgs_GCEnabledForwarded(t *testing.T) {
+	cfg := &NBDKitConfig{
+		Socket:     "/tmp/nbd.sock",
+		PidFile:    "/tmp/nbd.pid",
+		PluginPath: "/plugin.so",
+		GCEnabled:  true,
+	}
+
+	args, err := cfg.buildArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if slices.Index(args, "gc_enabled=true") < 0 {
+		t.Errorf("expected gc_enabled=true in args, got: %v", args)
+	}
+}
+
+func TestBuildArgs_GCEnabledDefaultFalse(t *testing.T) {
+	cfg := &NBDKitConfig{
+		Socket:     "/tmp/nbd.sock",
+		PidFile:    "/tmp/nbd.pid",
+		PluginPath: "/plugin.so",
+	}
+
+	args, err := cfg.buildArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if slices.Index(args, "gc_enabled=false") < 0 {
+		t.Errorf("expected gc_enabled=false (default off) in args, got: %v", args)
 	}
 }
 

--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -120,6 +120,12 @@ type Config struct {
 	// ShardWAL enables sharded WAL for mounted volumes (default false)
 	ShardWAL bool
 
+	// GCEnabled turns on viperblock chunk garbage collection for every VB this
+	// service constructs: the nbdkit plugin backing each mounted volume, and
+	// the short-lived detached VBs opened for config updates and sealing.
+	// Default false, matching ShardWAL.
+	GCEnabled bool
+
 	// EncryptionKeyFile is the path to the shared AES-256 master key for at-rest
 	// encryption. Empty → cleartext mode (legacy).
 	EncryptionKeyFile string
@@ -208,6 +214,7 @@ func openVolumeVB(cfg *Config, volumeName string) (*viperblock.VB, error) {
 		VolumeConfig:      viperblock.VolumeConfig{},
 		MasterKey:         cfg.masterKey,
 		EncryptionEnabled: cfg.masterKey != nil,
+		GCEnabled:         cfg.GCEnabled,
 	}
 	vb, err := viperblock.New(&vbconfig, "s3", s3cfg)
 	if err != nil {
@@ -365,7 +372,7 @@ func launchService(cfg *Config) (err error) {
 		slog.Warn("Viperblock at-rest encryption disabled (no EncryptionKeyFile configured)")
 	}
 
-	slog.Info("Viperblock config", "shardwal", cfg.ShardWAL)
+	slog.Info("Viperblock config", "shardwal", cfg.ShardWAL, "gc_enabled", cfg.GCEnabled)
 
 	if cfg.NodeName != "" {
 		slog.Info("Waiting for EBS events", "node", cfg.NodeName)
@@ -854,6 +861,7 @@ func launchService(cfg *Config) (err error) {
 			SecretKey:         cfg.SecretKey,
 			CacheSize:         nbdCacheSize,
 			ShardWAL:          cfg.ShardWAL,
+			GCEnabled:         cfg.GCEnabled,
 			EncryptionKeyFile: cfg.EncryptionKeyFile,
 		}
 

--- a/spinifex/vm/lifecycle.go
+++ b/spinifex/vm/lifecycle.go
@@ -1124,6 +1124,13 @@ func buildDrives(requests []types.EBSRequest, cpuCount int, machineType string) 
 			drive.ID = "os"
 			drive.Cache = "none"
 
+			// Report backend write errors to the guest rather than letting
+			// QEMU's default werror=enospc pause the VM: when the storage pool
+			// exhausts, the guest fs then returns a clean ENOSPC to userspace
+			// and the VM stays reachable instead of freezing.
+			drive.Werror = "report"
+			drive.Rerror = "report"
+
 			iothreadID := "ioth-os"
 			iothreads = append(iothreads, IOThread{ID: iothreadID})
 			devices = append(devices, BlkDevice(machineType, drive.ID, iothreadID, cpuCount, 1))

--- a/spinifex/vm/lifecycle_test.go
+++ b/spinifex/vm/lifecycle_test.go
@@ -122,7 +122,7 @@ func TestBuildDrives(t *testing.T) {
 			},
 			cpuCount: 4,
 			wantDrives: []Drive{
-				{File: "nbd:unix:/tmp/boot.sock", Format: "raw", If: "none", Media: "disk", ID: "os", Cache: "none"},
+				{File: "nbd:unix:/tmp/boot.sock", Format: "raw", If: "none", Media: "disk", ID: "os", Cache: "none", Werror: "report", Rerror: "report"},
 			},
 			wantIOThreads: []IOThread{{ID: "ioth-os"}},
 			wantDevices: []Device{
@@ -163,7 +163,7 @@ func TestBuildDrives(t *testing.T) {
 			},
 			cpuCount: 4,
 			wantDrives: []Drive{
-				{File: "nbd:unix:/tmp/boot.sock", Format: "raw", If: "none", Media: "disk", ID: "os", Cache: "none"},
+				{File: "nbd:unix:/tmp/boot.sock", Format: "raw", If: "none", Media: "disk", ID: "os", Cache: "none", Werror: "report", Rerror: "report"},
 				{File: "nbd:unix:/tmp/efi.sock", Format: "raw", If: "pflash", Unit: 1},
 			},
 			wantIOThreads: []IOThread{{ID: "ioth-os"}},

--- a/spinifex/vm/vm.go
+++ b/spinifex/vm/vm.go
@@ -204,6 +204,15 @@ type Drive struct {
 	Media  string `json:"media"`
 	ID     string `json:"id"`
 	Cache  string `json:"cache,omitempty"`
+	// Werror and Rerror set QEMU's block on-error policy. Left empty, QEMU
+	// applies its default werror=enospc, which pauses the whole VM on an
+	// out-of-space write rather than reporting it — so a guest never sees the
+	// backend's ENOSPC. Setting "report" delivers the error to the guest,
+	// letting its filesystem surface a clean out-of-space to userspace and stay
+	// alive. Set on the drive: with if=none the virtio-blk device inherits the
+	// BlockBackend's on-error policy.
+	Werror string `json:"werror,omitempty"`
+	Rerror string `json:"rerror,omitempty"`
 	// Unit selects the pflash slot when If=="pflash": 0 is the CODE blob,
 	// 1 is the per-VM VARS volume. Ignored for non-pflash drives.
 	Unit int `json:"unit,omitempty"`
@@ -395,6 +404,14 @@ func (cfg *Config) Execute() (*exec.Cmd, error) {
 
 		if drive.Cache != "" {
 			opts = append(opts, fmt.Sprintf("cache=%s", drive.Cache))
+		}
+
+		if drive.Werror != "" {
+			opts = append(opts, fmt.Sprintf("werror=%s", drive.Werror))
+		}
+
+		if drive.Rerror != "" {
+			opts = append(opts, fmt.Sprintf("rerror=%s", drive.Rerror))
 		}
 
 		args = append(args, "-drive", strings.Join(opts, ","))

--- a/tests/e2e/storagegrowth/image_pull_test.go
+++ b/tests/e2e/storagegrowth/image_pull_test.go
@@ -568,7 +568,7 @@ func TestImagePullGrowth(t *testing.T) {
 // fix.AWS.EC2.RunInstances directly instead (launchImagePullRootInstance).
 func ensureImagePullInstance(t *testing.T, fix *Fixture, launch func(ami, instType, keyName, subnetID, sgID string) string) (instanceID string, tgt harness.SSHTarget, inst *ec2.Instance) {
 	t.Helper()
-	instType, arch := harness.DiscoverNanoInstanceType(t, fix.Harness)
+	instType, arch := imagePullInstanceType(t, fix)
 	ami := harness.DiscoverUbuntuAMI(t, fix.Harness, arch)
 	keyName, keyPath := harness.EnsureKeyPair(t, fix.Harness, fix.ArtifactDir(t))
 
@@ -633,6 +633,68 @@ func imagePullDefaultSG(t *testing.T, c *harness.AWSClient, vpcID string) string
 	require.NoErrorf(t, err, "describe default SG for %s", vpcID)
 	require.Lenf(t, out.SecurityGroups, 1, "vpc %s default SG", vpcID)
 	return aws.StringValue(out.SecurityGroups[0].GroupId)
+}
+
+// imagePullInstanceType selects the guest for the image-pull repro. The
+// synthetic npass suite uses a nano (512MB) to pack many suites onto one node,
+// but a real multi-GB image pull onto 512MB OOM-thrashes containerd long before
+// any disk-driven ENOSPC, and 512MB against a concurrent-write pull is exactly
+// the guest-memory-pressure regime that produces the separate siv-482 lost-write
+// corruption — conflating two faults in one measurement. This mode instead picks
+// an instance with headroom well above the pull's working set, so the run
+// measures the storage leak and not memory pressure.
+//
+// SPINIFEX_STORAGEGROWTH_INSTANCE_TYPE overrides the choice outright.
+// Otherwise the smallest advertised type at or above SPINIFEX_STORAGEGROWTH_MIN_MEM_MIB
+// (default 16384, matching the ~16GB EKS GPU worker the incident was reported on)
+// is used — smallest-above-floor so it gets headroom without grabbing a type the
+// node cannot seat.
+func imagePullInstanceType(t *testing.T, fix *Fixture) (instanceType, arch string) {
+	t.Helper()
+	out, err := fix.AWS.EC2.DescribeInstanceTypes(&ec2.DescribeInstanceTypesInput{})
+	require.NoError(t, err, "DescribeInstanceTypes")
+
+	archOf := func(it *ec2.InstanceTypeInfo) string {
+		if it.ProcessorInfo == nil || len(it.ProcessorInfo.SupportedArchitectures) == 0 {
+			return ""
+		}
+		return aws.StringValue(it.ProcessorInfo.SupportedArchitectures[0])
+	}
+
+	if override := os.Getenv("SPINIFEX_STORAGEGROWTH_INSTANCE_TYPE"); override != "" {
+		for _, it := range out.InstanceTypes {
+			if aws.StringValue(it.InstanceType) == override {
+				a := archOf(it)
+				require.NotEmptyf(t, a, "instance type %s advertises no architecture", override)
+				return override, a
+			}
+		}
+		t.Fatalf("SPINIFEX_STORAGEGROWTH_INSTANCE_TYPE=%s not advertised by this cluster", override)
+	}
+
+	minMemMiB := int64(16384)
+	if v := os.Getenv("SPINIFEX_STORAGEGROWTH_MIN_MEM_MIB"); v != "" {
+		parsed, perr := strconv.ParseInt(v, 10, 64)
+		require.NoErrorf(t, perr, "parse SPINIFEX_STORAGEGROWTH_MIN_MEM_MIB=%q", v)
+		minMemMiB = parsed
+	}
+
+	var best *ec2.InstanceTypeInfo
+	var bestMem int64
+	for _, it := range out.InstanceTypes {
+		if it.MemoryInfo == nil || it.MemoryInfo.SizeInMiB == nil || archOf(it) == "" {
+			continue
+		}
+		mem := aws.Int64Value(it.MemoryInfo.SizeInMiB)
+		if mem < minMemMiB {
+			continue
+		}
+		if best == nil || mem < bestMem {
+			best, bestMem = it, mem
+		}
+	}
+	require.NotNilf(t, best, "no advertised instance type has >= %d MiB memory", minMemMiB)
+	return aws.StringValue(best.InstanceType), archOf(best)
 }
 
 // createImagePullVolume creates the volume the pull runs against, sized by


### PR DESCRIPTION
## TL;DR

An EKS GPU worker with a 16 GiB root volume pulled a ~13 GB vLLM image inside a containerd retry loop and grew the predastore backend to ~156 GB (~11x). This PR lands spinifex's two contributions to the fix: it sets `werror=report,rerror=report` on the guest boot drive so a full backend surfaces as a guest-visible I/O error instead of freezing the VM, and it plumbs a `GCEnabled` config toggle through every place spinifex constructs a `viperblock.VB`, which is what makes viperblock's chunk garbage collection reachable in production for the first time. It also fixes the e2e image-pull harness, which had never driven a volume to real exhaustion, and repins predastore/viperblock to the commits carrying the rest of this fix.

## Background

viperblock is a log-structured, append-only block store over an immutable predastore backend: every overwrite mints a new chunk and orphans the old one. That design needs a reclamation half (GC + compaction), and until this line of work `GCEnabled` defaulted off at every construction site, so nothing was ever reclaimed — every containerd retry re-wrote the whole image and the backend grew without bound. Fixing that exposed a second problem: even with GC bounding backend growth, a pool that does hit exhaustion needs to fail cleanly rather than wedge the node or freeze the guest. That's a four-hop delivery chain — predastore's nearfull header, viperblock's `ErrNoSpace` write gate, nbdkit's ENOSPC errno, and QEMU's block-error policy — ending at the guest kernel. spinifex owns the last hop (QEMU) and, separately, owns the config surface that makes GC reachable at all. Full design and evidence: `docs/development/improvements/storage-capacity-safety-architecture.md`.

## What this PR changes

### 1. QEMU `werror=report` on the guest boot drive — the core fix

`spinifex/vm/vm.go:207-215` adds `Werror`/`Rerror` fields to the `Drive` struct, and `vm.go:409-415` emits them as `werror=...`/`rerror=...` drive options (alongside `cache=`) when set. `spinifex/vm/lifecycle.go:1127-1133` sets both to `"report"` on the OS boot drive in `buildDrives`.

QEMU's default is `werror=enospc`: on an out-of-space backend write it issues a QMP `STOP` with no `RESUME`, pausing the entire VM. This is not theoretical — on the first env12 validation cycle the whole software chain fired correctly and early (store plateaued at 85%, clean nbdkit ENOSPC, no spin, node healthy) and the guest still froze solid, confirmed via serial console to be a hypervisor pause rather than a guest-side hang. `werror=report` instead delivers the error to the guest kernel so the VM stays reachable.

**Honest limitation, not swept under the rug:** virtio-blk's status field is a single generic I/O-error bit — it cannot carry a typed ENOSPC. So the guest sees a generic I/O error, its ext4 (mounted `errors=remount-ro`) aborts its journal and remounts root read-only, and containerd sees `EROFS`, not "no space left on device". This is accepted, not deferred: it matches how real AWS behaves (a guest only ever sees ENOSPC from its *own* filesystem filling within its provisioned size; a shared-pool exhaustion like this incident is a misprovisioned backstop, not a normal path), and because the block layer's actual job under exhaustion is node survival, not guest UX polish.

### 2. `GCEnabled` config plumbed to every VB construction site

A single `[nodes.<node>.viperblock] gc_enabled` config key threads through spinifex to every place it builds a `viperblock.VB`:

- `spinifex/config/config.go:127-133` — `ViperblockConfig.GCEnabled *bool`, `mapstructure:"gc_enabled"`, same shape as `ShardWAL`. Nil defaults to off so existing deployments don't change behavior silently.
- `cmd/spinifex/cmd/service.go:300-306,328` — `viperblockStartCmd` resolves the pointer to a bool (default `false`) and passes it into `viperblockd.Config`.
- `spinifex/services/viperblockd/viperblockd.go:123-125,217,864` — `Config.GCEnabled bool` field; forwarded into the direct `openVolumeVB` construction and into the spawned nbdkit's `NBDKitConfig`.
- `spinifex/nbd/nbd.go:33-36,77` — `NBDKitConfig.GCEnabled bool`; `buildArgs()` appends `gc_enabled=%t` to the nbdkit plugin argv.
- `spinifex/handlers/ec2/volume/service_impl.go:205-208,217` — the direct volume-service `CreateVolume` path resolves the same pointer-to-bool default and sets it on the `viperblock.VB` it constructs.

Before this PR, `GCEnabled` was effectively unreachable — every VB spinifex constructed used the zero value, so chunk GC never ran in production regardless of what viperblock itself supported. The env12 four-arm image-pull ladder measured the difference directly: GC off grew the backend linearly to 136 GB and kept climbing; the same workload with GC reachable (this plumbing) plus predastore's dev line settled into a bounded, self-reclaiming band (~45 GB, draining further as compaction caught up). Chunk GC is the load-bearing fix for the incident; this PR is what makes it possible to turn on.

### 3. storagegrowth e2e harness fix

`tests/e2e/storagegrowth/image_pull_test.go:638` (new `imagePullInstanceType`) replaces the nano instance the image-pull repro used to launch. A synthetic nano (512 MB) OOM-thrashes containerd long before a multi-GB image pull produces any disk-driven ENOSPC signal, conflating memory pressure with the storage fault under test (and with a separate known lost-write corruption issue under concurrent writes at low memory). The new selector picks the smallest advertised instance type at or above a memory floor (default 16384 MiB, matching the incident's ~16 GB EKS GPU worker), overridable via `SPINIFEX_STORAGEGROWTH_INSTANCE_TYPE` / `SPINIFEX_STORAGEGROWTH_MIN_MEM_MIB`. Before this fix, the exhaustion path had never been exercised end-to-end by any test — this harness is what drove all three env12 validation cycles referenced above.

### 4. Dependency repins

`go.mod`/`go.sum` repin:
- `github.com/mulgadc/predastore` `v1.12.1` → `v1.12.2-0.20260718235316-831a8dbb8152`
- `github.com/mulgadc/viperblock` `v1.12.1` → `v1.12.2-0.20260719001705-014b7bb76744`

These point at the consolidated `feat/storage-capacity-safety` commits in each submodule (predastore: free-space watermark, nearfull header, byte-counted statfs refresh; viperblock: GC lineage plus `ErrNoSpace`/nearfull-gate/bounded-retry). See "Cross-repo dependency" below — these pseudo-versions need to move before this PR merges.

## Design rationale / trade-offs

**Why `werror=report` over the default `werror=enospc`.** The default trades guest availability for guest safety against thin-provisioning surprises (pause-and-wait rather than silently corrupt). That trade is wrong for us: our failure mode is a shared multi-tenant pool where one guest's exhaustion should not require operator intervention to un-freeze it. `report` accepts a worse guest-visible failure (generic I/O error, not a typed ENOSPC) in exchange for the guest staying alive and reachable, which is strictly better for both node operators and the guest's own recovery (it can reboot, retry from a clean state, or be terminated normally instead of needing a QMP `cont`).

**Why the EROFS end state is accepted rather than chased further.** virtio-blk structurally cannot carry a typed ENOSPC — there is no "report-only-ENOSPC" QEMU mode, and the generic I/O-error bit is all the protocol has. Chasing a clean guest-visible ENOSPC through this path is not achievable without a different guest-facing block protocol. This is acceptable because it mirrors real AWS behavior: a guest only sees ENOSPC from its own filesystem filling within its provisioned capacity, never from the shared backend pool running out — pool exhaustion overrunning a guest is already an edge case outside normal operation, and the job of this layer is to keep the node and the rest of the fleet alive when it happens, not to give the affected guest a pretty error message.

**Why `GCEnabled` is one global config key, not per-volume.** GC correctness is not a property of an individual volume's workload — if the reclaim algorithm is safe, it is safe for every volume on the node, and if it isn't, no volume should have it. A per-volume toggle would only add surface area for a node to end up in the exact unreachable-GC state this PR fixes for some volumes and not others. The plumbing defaults to off (nil/false) so upgrading spinifex does not silently change behavior; operators opt in once by setting `gc_enabled = true` per node.

## What this PR does NOT do

- **No provisioning-time admission control.** This does not stop a volume from being created smaller than its expected workload, or reject placement based on available disk. That's a separate scheduler-level epic (disk-aware admission control), out of scope here.
- **No filesystem isolation of the store from the OS root.** predastore's store and spinifex's own data can still land on the node's OS root filesystem; a full store can still fill root and take journald/systemd/OVN down with it. This is a real open gap, tracked separately as an install/image-build change (dedicated data-dir provisioning + OS reserve), not addressed by this PR.
- **Does not make the guest see a typed ENOSPC.** As covered above, this is a structural virtio-blk limitation, not something left undone — it's not achievable through this transport.

## Testing

- `spinifex/vm/lifecycle_test.go` — golden `TestBuildDrives` cases updated to expect `Werror: "report", Rerror: "report"` on the OS boot drive.
- `spinifex/config/config_test.go` — new `TestLoadConfig_ViperblockGCEnabled_DefaultNil` and `TestLoadConfig_ViperblockGCEnabled_True` cover the nil-default and explicit-opt-in config paths.
- `spinifex/nbd/nbd_test.go` — `TestBuildArgs_TCPTransport`/`TestBuildArgs_UnixSocketTransport` updated for `gc_enabled=...`; new `TestBuildArgs_GCEnabledForwarded` and `TestBuildArgs_GCEnabledDefaultFalse`.
- `make preflight` passes (tests, race tests, vet, lint).
- Live validation on env12 across three cycles: cycle 1 found the QEMU freeze (software chain correct, hypervisor paused the VM); cycle 2 (this `werror` fix) confirmed the guest stays reachable and surfaced the virtio-blk EROFS finding plus a predastore watermark-overshoot bug (fixed on the predastore side); cycle 3 passed on both headline checks — store held the line (25%→85%→63% after compaction, never near 100%), control plane survived (83/83 health polls ok, zero raft/badger/panic entries), guest stayed reachable with no QMP freeze, and the pull failed cleanly.

## Cross-repo dependency & merge order

This PR's `go.mod`/`go.sum` repin points at `feat/storage-capacity-safety` commits in `predastore` (`v1.12.2-0.20260718235316-831a8dbb8152`) and `viperblock` (`v1.12.2-0.20260719001705-014b7bb76744`) that are not yet merged to their `dev` branches. **Those two PRs need to merge first**, and this repin should then be updated to point at the merged SHAs/tags (or the next tagged release) before this PR merges — do not merge this PR against the unmerged feature-branch pseudo-versions.

## Risk & rollback

`werror`/`rerror` are set per-drive and only on the boot drive; every other drive keeps QEMU's default policy. `GCEnabled` defaults to off (nil in config, `false` resolved) so existing deployments see no behavior change until a node operator explicitly sets `gc_enabled = true`. Both changes are single-flag reverts: drop the two `drive.Werror`/`drive.Rerror` assignments in `lifecycle.go`, or unset `gc_enabled` in config.
