### PR TITLE
ci: build sibling repos from a co-named branch, falling back to dev

### DIFF
--- a/.github/resolve-sibling-refs.sh
+++ b/.github/resolve-sibling-refs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Resolve which branch of each sibling repo (viperblock, predastore) the CI
+# workspace should build against. A cross-repo change is developed on a branch
+# of the SAME name in each repo; build against that branch when it exists so the
+# set can be tested together, and fall back to dev otherwise. This mirrors the
+# resolution the e2e path already does in
+# mulga/scripts/tofu-cluster/build-install-artifacts.sh, so unit CI and e2e CI
+# agree on how sibling branches are selected.
+#
+# Reads $BRANCH (the triggering head/ref name) and writes viperblock=<ref> and
+# predastore=<ref> to $GITHUB_OUTPUT for the checkout steps to consume.
+set -euo pipefail
+
+: "${BRANCH:?BRANCH must be set to the triggering branch name}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+for repo in viperblock predastore; do
+  if git ls-remote --exit-code --heads \
+      "https://github.com/mulgadc/${repo}.git" "$BRANCH" >/dev/null 2>&1; then
+    ref="$BRANCH"
+  else
+    ref="dev"
+  fi
+  echo "${repo}: building against ${ref}"
+  echo "${repo}=${ref}" >>"$GITHUB_OUTPUT"
+done

--- a/.github/workflows/spinifex.yml
+++ b/.github/workflows/spinifex.yml
@@ -32,18 +32,25 @@ jobs:
           path: spinifex
           fetch-depth: 2
 
+      - name: Resolve sibling refs
+        id: siblings
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: bash .github/resolve-sibling-refs.sh
+        working-directory: spinifex
+
       - name: Checkout Viperblock
         uses: actions/checkout@v7
         with:
           repository: mulgadc/viperblock
-          ref: dev
+          ref: ${{ steps.siblings.outputs.viperblock }}
           path: viperblock
 
       - name: Checkout Predastore
         uses: actions/checkout@v7
         with:
           repository: mulgadc/predastore
-          ref: dev
+          ref: ${{ steps.siblings.outputs.predastore }}
           path: predastore
 
       - name: Setup Go
@@ -80,18 +87,25 @@ jobs:
         with:
           path: spinifex
 
+      - name: Resolve sibling refs
+        id: siblings
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: bash .github/resolve-sibling-refs.sh
+        working-directory: spinifex
+
       - name: Checkout Viperblock
         uses: actions/checkout@v7
         with:
           repository: mulgadc/viperblock
-          ref: dev
+          ref: ${{ steps.siblings.outputs.viperblock }}
           path: viperblock
 
       - name: Checkout Predastore
         uses: actions/checkout@v7
         with:
           repository: mulgadc/predastore
-          ref: dev
+          ref: ${{ steps.siblings.outputs.predastore }}
           path: predastore
 
       - name: Setup Go
@@ -116,18 +130,25 @@ jobs:
         with:
           path: spinifex
 
+      - name: Resolve sibling refs
+        id: siblings
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: bash .github/resolve-sibling-refs.sh
+        working-directory: spinifex
+
       - name: Checkout Viperblock
         uses: actions/checkout@v7
         with:
           repository: mulgadc/viperblock
-          ref: dev
+          ref: ${{ steps.siblings.outputs.viperblock }}
           path: viperblock
 
       - name: Checkout Predastore
         uses: actions/checkout@v7
         with:
           repository: mulgadc/predastore
-          ref: dev
+          ref: ${{ steps.siblings.outputs.predastore }}
           path: predastore
 
       - name: Setup Go


### PR DESCRIPTION
## Problem

The Build/Test, Race, and Lint jobs in `.github/workflows/spinifex.yml` check out
`viperblock` and `predastore` at a **hardcoded `ref: dev`** and then overlay them
with `go work init`. The workspace overlay overrides the `go.mod` pins entirely, so
a spinifex change that depends on an **unmerged sibling change can never compile in
CI** — CI always builds against sibling `dev`, no matter what the branch needs.

This is exactly why PR #549 (storage-capacity-safety) fails with
`unknown field GCEnabled in struct literal of type viperblock.VB`: the field exists
on the sibling feature branch but not yet on sibling `dev`.

## Fix

Add a `Resolve sibling refs` step to each job that runs
`.github/resolve-sibling-refs.sh`. For each sibling it does a
`git ls-remote --heads`: if a branch of the **same name** as the triggering branch
exists on that repo, build against it; otherwise fall back to `dev`. The checkout
steps consume `steps.siblings.outputs.{viperblock,predastore}`.

This mirrors the resolution the **e2e path already performs** in
`mulga/scripts/tofu-cluster/build-install-artifacts.sh`, so unit CI and e2e CI now
agree on how sibling branches are selected. A cross-repo change developed on a
co-named branch in each repo can be built and tested together **before** the
siblings merge to `dev`.

## Effect

- `feat/storage-capacity-safety` in spinifex now builds against the same-named
  branch in viperblock/predastore, unblocking #549's CI.
- Single-repo branches (no sibling match) fall back to `dev` exactly as today — no
  behaviour change for the common case.