### PR TITLE
fix(gpu): Blackwell GPU support fixes for EKS/ECS image builds and VFIO

### DIFF
--- a/scripts/build-system-image.sh
+++ b/scripts/build-system-image.sh
@@ -265,6 +265,15 @@ else
     CUST+=(--memsize 2048)
 fi
 
+# The guest's /etc/resolv.conf symlinks to systemd-resolved's stub
+# (127.0.0.53), which isn't running inside the appliance chroot, so DNS is
+# dead until package installs need it. Point it at a real resolver first, then
+# restore the stub symlink after package installs so the shipped AMI still
+# gets its DNS from systemd-resolved at boot like a stock cloud image.
+if [[ -n "${APK_PACKAGES:-}${APT_PACKAGES:-}" ]]; then
+    CUST+=(--run-command 'rm -f /etc/resolv.conf; printf "nameserver 1.1.1.1\nnameserver 8.8.8.8\n" > /etc/resolv.conf')
+fi
+
 # Packages
 if [[ "$DISTRO" == "alpine" ]] && [[ -n "${APK_PACKAGES:-}" ]]; then
     echo "Will install packages: ${APK_PACKAGES}"
@@ -336,6 +345,12 @@ if [[ "$DISTRO" == "alpine" ]]; then
     CUST+=(--run-command 'apk cache clean 2>/dev/null || true; rm -rf /var/cache/apk/* /tmp/* 2>/dev/null || true')
 else
     CUST+=(--run-command 'export DEBIAN_FRONTEND=noninteractive; apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* 2>/dev/null || true')
+fi
+
+# Restore the stock systemd-resolved stub symlink so the shipped AMI gets its
+# DNS from the instance's own resolver at boot, not the static appliance one.
+if [[ "$DISTRO" == "ubuntu" ]] && [[ -n "${APK_PACKAGES:-}${APT_PACKAGES:-}${SETUP_SCRIPT:-}" ]]; then
+    CUST+=(--run-command 'rm -f /etc/resolv.conf; ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf')
 fi
 
 echo "Customizing image (libguestfs appliance)..."

--- a/scripts/images/ecs-agent-gpu/setup.sh
+++ b/scripts/images/ecs-agent-gpu/setup.sh
@@ -71,18 +71,21 @@ EOF
 
     apt-get install -y --no-install-recommends "linux-headers-${KVER}"
 
-    # Ubuntu 26.04+ no longer ships unversioned meta-packages; detect the
-    # latest available versioned NVIDIA server driver.
-    NVIDIA_VER=$(apt-cache search '^nvidia-dkms-[0-9]+-server$' 2>/dev/null \
-        | grep -oP '(?<=nvidia-dkms-)\d+(?=-server)' | sort -rn | head -1)
-    if [ -z "${NVIDIA_VER}" ]; then
-        echo "ERROR: No versioned nvidia-dkms-*-server package found in apt cache"
-        apt-cache search nvidia-dkms || true
-        exit 1
-    fi
-    echo "[nvidia-gpu-stack] installing NVIDIA server driver version: ${NVIDIA_VER}"
+    # Ubuntu 26.04+ no longer ships unversioned meta-packages, so the branch is
+    # named explicitly. Pinned rather than resolved at build time: the number in
+    # the package name is a branch alias, not a driver version (nvidia-dkms-535-server
+    # installs 580.126.20), so picking the highest number sorts on a value that
+    # need not match what gets installed. Resolving also let identical source
+    # produce different drivers on different days. Bumping is a deliberate edit.
+    NVIDIA_VER=595
+    echo "[nvidia-gpu-stack] installing NVIDIA server driver branch: ${NVIDIA_VER}"
+    # The -open (GSP/open-kernel-module) DKMS variant, not the closed/proprietary
+    # one: Blackwell-generation GPUs (e.g. RTX Pro 6000 Blackwell) refuse to
+    # initialize under the closed kernel module — RmInitAdapter fails with
+    # "requires use of the NVIDIA open kernel modules" (dmesg NVRM error 0x22).
+    # nvidia-utils has no separate open variant (userspace tools only).
     apt-get install -y --no-install-recommends \
-        "nvidia-dkms-${NVIDIA_VER}-server" \
+        "nvidia-dkms-${NVIDIA_VER}-server-open" \
         "nvidia-utils-${NVIDIA_VER}-server"
 
     NVIDIA_DKMS_NAME=$(dkms status 2>/dev/null | awk -F'[,/ ]+' '/nvidia/{print $1; exit}')

--- a/scripts/images/eks-node-gpu/setup.sh
+++ b/scripts/images/eks-node-gpu/setup.sh
@@ -90,16 +90,14 @@ EOF
 
     apt-get install -y --no-install-recommends "linux-headers-${KVER}"
 
-    # Ubuntu 26.04+ no longer ships unversioned meta-packages; detect the
-    # latest available versioned NVIDIA server driver.
-    NVIDIA_VER=$(apt-cache search '^nvidia-dkms-[0-9]+-server$' 2>/dev/null \
-        | grep -oP '(?<=nvidia-dkms-)\d+(?=-server)' | sort -rn | head -1)
-    if [ -z "${NVIDIA_VER}" ]; then
-        echo "ERROR: No versioned nvidia-dkms-*-server package found in apt cache"
-        apt-cache search nvidia-dkms || true
-        exit 1
-    fi
-    echo "[nvidia-gpu-stack] installing NVIDIA server driver version: ${NVIDIA_VER}"
+    # Ubuntu 26.04+ no longer ships unversioned meta-packages, so the branch is
+    # named explicitly. Pinned rather than resolved at build time: the number in
+    # the package name is a branch alias, not a driver version (nvidia-dkms-535-server
+    # installs 580.126.20), so picking the highest number sorts on a value that
+    # need not match what gets installed. Resolving also let identical source
+    # produce different drivers on different days. Bumping is a deliberate edit.
+    NVIDIA_VER=595
+    echo "[nvidia-gpu-stack] installing NVIDIA server driver branch: ${NVIDIA_VER}"
     # The -open (GSP/open-kernel-module) DKMS variant, not the closed/proprietary
     # one: Blackwell-generation GPUs (e.g. RTX Pro 6000 Blackwell) refuse to
     # initialize under the closed kernel module — RmInitAdapter fails with

--- a/scripts/images/eks-node-gpu/setup.sh
+++ b/scripts/images/eks-node-gpu/setup.sh
@@ -100,8 +100,13 @@ EOF
         exit 1
     fi
     echo "[nvidia-gpu-stack] installing NVIDIA server driver version: ${NVIDIA_VER}"
+    # The -open (GSP/open-kernel-module) DKMS variant, not the closed/proprietary
+    # one: Blackwell-generation GPUs (e.g. RTX Pro 6000 Blackwell) refuse to
+    # initialize under the closed kernel module — RmInitAdapter fails with
+    # "requires use of the NVIDIA open kernel modules" (dmesg NVRM error 0x22).
+    # nvidia-utils has no separate open variant (userspace tools only).
     apt-get install -y --no-install-recommends \
-        "nvidia-dkms-${NVIDIA_VER}-server" \
+        "nvidia-dkms-${NVIDIA_VER}-server-open" \
         "nvidia-utils-${NVIDIA_VER}-server"
 
     NVIDIA_DKMS_NAME=$(dkms status 2>/dev/null | awk -F'[,/ ]+' '/nvidia/{print $1; exit}')

--- a/scripts/images/eks-node/addons/argocd/3.0.23/argocd.yaml
+++ b/scripts/images/eks-node/addons/argocd/3.0.23/argocd.yaml
@@ -24939,6 +24939,17 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-applicationset-controller
     spec:
+      # Local delta over the vendored upstream manifest: a cluster with a
+      # GPU-only nodegroup has no untainted node — the CP carries
+      # CriticalAddonsOnly and every worker carries nvidia.com/gpu, so without
+      # these the pod stays Pending forever. Upstream never needs it because
+      # real EKS control planes are not schedulable nodes.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       containers:
       - args:
         - /usr/local/bin/argocd-applicationset-controller
@@ -25180,6 +25191,17 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-dex-server
     spec:
+      # Local delta over the vendored upstream manifest: a cluster with a
+      # GPU-only nodegroup has no untainted node — the CP carries
+      # CriticalAddonsOnly and every worker carries nvidia.com/gpu, so without
+      # these the pod stays Pending forever. Upstream never needs it because
+      # real EKS control planes are not schedulable nodes.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -25304,6 +25326,17 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-notifications-controller
     spec:
+      # Local delta over the vendored upstream manifest: a cluster with a
+      # GPU-only nodegroup has no untainted node — the CP carries
+      # CriticalAddonsOnly and every worker carries nvidia.com/gpu, so without
+      # these the pod stays Pending forever. Upstream never needs it because
+      # real EKS control planes are not schedulable nodes.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       containers:
       - args:
         - /usr/local/bin/argocd-notifications
@@ -25403,6 +25436,17 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-redis
     spec:
+      # Local delta over the vendored upstream manifest: a cluster with a
+      # GPU-only nodegroup has no untainted node — the CP carries
+      # CriticalAddonsOnly and every worker carries nvidia.com/gpu, so without
+      # these the pod stays Pending forever. Upstream never needs it because
+      # real EKS control planes are not schedulable nodes.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -25486,6 +25530,17 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-repo-server
     spec:
+      # Local delta over the vendored upstream manifest: a cluster with a
+      # GPU-only nodegroup has no untainted node — the CP carries
+      # CriticalAddonsOnly and every worker carries nvidia.com/gpu, so without
+      # these the pod stays Pending forever. Upstream never needs it because
+      # real EKS control planes are not schedulable nodes.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -25840,6 +25895,17 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-server
     spec:
+      # Local delta over the vendored upstream manifest: a cluster with a
+      # GPU-only nodegroup has no untainted node — the CP carries
+      # CriticalAddonsOnly and every worker carries nvidia.com/gpu, so without
+      # these the pod stays Pending forever. Upstream never needs it because
+      # real EKS control planes are not schedulable nodes.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -26251,6 +26317,17 @@ spec:
       labels:
         app.kubernetes.io/name: argocd-application-controller
     spec:
+      # Local delta over the vendored upstream manifest: a cluster with a
+      # GPU-only nodegroup has no untainted node — the CP carries
+      # CriticalAddonsOnly and every worker carries nvidia.com/gpu, so without
+      # these the pod stays Pending forever. Upstream never needs it because
+      # real EKS control planes are not schedulable nodes.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml
+++ b/scripts/images/eks-node/addons/aws-ebs-csi-driver/1.40.1/10-controller.yaml
@@ -44,6 +44,18 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
+      # A cluster with a GPU-only nodegroup has no untainted node: the CP carries
+      # CriticalAddonsOnly (EKS parity keeps user workloads off it) and every
+      # worker carries nvidia.com/gpu (nodegroup_userdata.go). Without these
+      # tolerations the controller has nowhere to schedule and stays Pending
+      # forever. Real EKS never needs this: its control plane isn't a schedulable
+      # node, so the stock upstream manifest carries no such toleration.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/scripts/images/eks-node/addons/aws-load-balancer-controller/2.11.0/10-aws-load-balancer-controller.yaml
+++ b/scripts/images/eks-node/addons/aws-load-balancer-controller/2.11.0/10-aws-load-balancer-controller.yaml
@@ -348,6 +348,18 @@ spec:
           readOnly: true
 {{IRSA_VOLUME_MOUNT}}
       priorityClassName: system-cluster-critical
+      # A cluster with a GPU-only nodegroup has no untainted node: the CP carries
+      # CriticalAddonsOnly (EKS parity keeps user workloads off it) and every
+      # worker carries nvidia.com/gpu (nodegroup_userdata.go). Without these
+      # tolerations the controller has nowhere to schedule and stays Pending
+      # forever. Real EKS never needs this: its control plane isn't a schedulable
+      # node, so the stock upstream manifest carries no such toleration.
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       securityContext:
         fsGroup: 1337
       serviceAccountName: aws-load-balancer-controller

--- a/scripts/images/ubuntu-gpu-nvidia-setup.sh
+++ b/scripts/images/ubuntu-gpu-nvidia-setup.sh
@@ -71,8 +71,13 @@ if [[ -z "${NVIDIA_VER}" ]]; then
     exit 1
 fi
 echo "Installing NVIDIA server driver version: ${NVIDIA_VER}"
+# The -open (GSP/open-kernel-module) DKMS variant, not the closed/proprietary
+# one: Blackwell-generation GPUs (e.g. RTX Pro 6000 Blackwell) refuse to
+# initialize under the closed kernel module — RmInitAdapter fails with
+# "requires use of the NVIDIA open kernel modules" (dmesg NVRM error 0x22).
+# nvidia-utils has no separate open variant (userspace tools only).
 apt-get install -y --no-install-recommends \
-    "nvidia-dkms-${NVIDIA_VER}-server" \
+    "nvidia-dkms-${NVIDIA_VER}-server-open" \
     "nvidia-utils-${NVIDIA_VER}-server"
 
 # Detect the installed NVIDIA DKMS module name + version for explicit build.

--- a/scripts/images/ubuntu-gpu-nvidia-setup.sh
+++ b/scripts/images/ubuntu-gpu-nvidia-setup.sh
@@ -60,17 +60,15 @@ EOF
 apt-get install -y --no-install-recommends \
     "linux-headers-${KVER}"
 
-# Detect the latest available versioned NVIDIA server driver. Ubuntu 26.04+
-# no longer ships unversioned meta-packages (nvidia-dkms-server); the packages
-# are now versioned (e.g. nvidia-dkms-570-server).
-NVIDIA_VER=$(apt-cache search '^nvidia-dkms-[0-9]+-server$' 2>/dev/null \
-    | grep -oP '(?<=nvidia-dkms-)\d+(?=-server)' | sort -rn | head -1)
-if [[ -z "${NVIDIA_VER}" ]]; then
-    echo "ERROR: No versioned nvidia-dkms-*-server package found in apt cache"
-    apt-cache search nvidia-dkms || true
-    exit 1
-fi
-echo "Installing NVIDIA server driver version: ${NVIDIA_VER}"
+# Ubuntu 26.04+ no longer ships unversioned meta-packages (nvidia-dkms-server);
+# the packages are versioned (e.g. nvidia-dkms-570-server), so the branch is
+# named explicitly. Pinned rather than resolved at build time: the number in the
+# package name is a branch alias, not a driver version (nvidia-dkms-535-server
+# installs 580.126.20), so picking the highest number sorts on a value that need
+# not match what gets installed. Resolving also let identical source produce
+# different drivers on different days. Bumping is a deliberate edit.
+NVIDIA_VER=595
+echo "Installing NVIDIA server driver branch: ${NVIDIA_VER}"
 # The -open (GSP/open-kernel-module) DKMS variant, not the closed/proprietary
 # one: Blackwell-generation GPUs (e.g. RTX Pro 6000 Blackwell) refuse to
 # initialize under the closed kernel module — RmInitAdapter fails with

--- a/spinifex/gpu/iommu.go
+++ b/spinifex/gpu/iommu.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // groupMembers returns all PCI devices in the given IOMMU group.
@@ -39,4 +40,27 @@ func groupMembers(sysfsRoot string, groupNum int) ([]IOMMUGroupMember, error) {
 	}
 
 	return members, nil
+}
+
+// isBridgeClass reports whether a PCI class string identifies a bridge device
+// (base class 0x06 — host, ISA, PCI-to-PCI, etc). A passthrough endpoint's
+// IOMMU group can include an upstream bridge when the platform lacks ACS
+// isolation between them; the bridge itself never performs DMA and vfio-pci
+// refuses to bind non-endpoint devices, so it must stay off the VFIO
+// bind/unbind lifecycle while the endpoint is claimed.
+func isBridgeClass(class string) bool {
+	s := strings.ToLower(strings.TrimSpace(class))
+	s = strings.TrimPrefix(s, "0x")
+	return len(s) >= 2 && s[:2] == "06"
+}
+
+// filterBridgeMembers returns members with bridge-class devices removed.
+func filterBridgeMembers(members []IOMMUGroupMember) []IOMMUGroupMember {
+	out := make([]IOMMUGroupMember, 0, len(members))
+	for _, m := range members {
+		if !isBridgeClass(m.Class) {
+			out = append(out, m)
+		}
+	}
+	return out
 }

--- a/spinifex/gpu/iommu_test.go
+++ b/spinifex/gpu/iommu_test.go
@@ -70,3 +70,38 @@ func TestGroupMembers_MissingGroup(t *testing.T) {
 		t.Error("want error for non-existent IOMMU group, got nil")
 	}
 }
+
+func TestIsBridgeClass(t *testing.T) {
+	cases := []struct {
+		class string
+		want  bool
+	}{
+		{"0x060400", true},  // PCI-to-PCI bridge
+		{"0x060000", true},  // host bridge
+		{"0x030200", false}, // 3D controller (GPU)
+		{"0x040300", false}, // audio device
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isBridgeClass(c.class); got != c.want {
+			t.Errorf("isBridgeClass(%q) = %v, want %v", c.class, got, c.want)
+		}
+	}
+}
+
+func TestFilterBridgeMembers(t *testing.T) {
+	members := []IOMMUGroupMember{
+		{PCIAddress: "0000:00:1c.0", Class: "0x060400"},
+		{PCIAddress: "0000:03:00.0", Class: "0x030200"},
+		{PCIAddress: "0000:03:00.1", Class: "0x040300"},
+	}
+	got := filterBridgeMembers(members)
+	if len(got) != 2 {
+		t.Fatalf("want 2 members after filtering bridge, got %d", len(got))
+	}
+	for _, m := range got {
+		if m.PCIAddress == "0000:00:1c.0" {
+			t.Error("bridge member 0000:00:1c.0 should have been filtered out")
+		}
+	}
+}

--- a/spinifex/gpu/manager.go
+++ b/spinifex/gpu/manager.go
@@ -167,6 +167,7 @@ func (m *Manager) Claim(instanceID, profileName string) (*GPUDevice, *MIGInstanc
 		m.mu.Unlock()
 		return nil, nil, fmt.Errorf("enumerate IOMMU group %d: %w", entry.Device.IOMMUGroup, err)
 	}
+	members = filterBridgeMembers(members)
 
 	drivers := make(map[string]string, len(members))
 	var bound []string
@@ -471,6 +472,7 @@ func (m *Manager) ReclaimByAddress(addr, instanceID string) error {
 				"gpu", addr, "group", entry.Device.IOMMUGroup, "err", err)
 			members = []IOMMUGroupMember{{PCIAddress: addr}}
 		}
+		members = filterBridgeMembers(members)
 
 		// Use the stored pre-passthrough driver for the primary GPU so Release
 		// can rebind correctly. Companion devices are left unbound on release

--- a/spinifex/gpu/manager_test.go
+++ b/spinifex/gpu/manager_test.go
@@ -66,6 +66,39 @@ func TestManagerClaim_Success(t *testing.T) {
 	}
 }
 
+// TestManagerClaim_SkipsBridgeGroupMember reproduces a host topology where a
+// GPU shares its IOMMU group with an upstream PCIe bridge (no ACS isolation
+// between them). vfio-pci refuses to bind bridge-class devices, so Claim must
+// skip the bridge entirely rather than fail the whole claim, and Release must
+// leave the bridge on its original driver afterward.
+func TestManagerClaim_SkipsBridgeGroupMember(t *testing.T) {
+	root, gpu := buildManagerSysfs(t)
+	// Upstream PCIe bridge in the same IOMMU group as the GPU (0x0604 = PCI-to-PCI bridge).
+	buildSysfsDevice(t, root, "0000:00:1c.0", "0x060400", "0x8086", "0x0db0", "pcieport", 7)
+	makeSysfsDriverDir(t, root, "pcieport")
+
+	m := newManagerForTest([]GPUDevice{gpu}, root)
+
+	if _, _, err := m.Claim("i-001", ""); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	bridgeDriver, err := os.Readlink(filepath.Join(root, "bus/pci/devices/0000:00:1c.0/driver"))
+	if err != nil {
+		t.Fatalf("read bridge driver link: %v", err)
+	}
+	if filepath.Base(bridgeDriver) != "pcieport" {
+		t.Errorf("bridge driver = %q, want pcieport (must not be rebound to vfio-pci)", filepath.Base(bridgeDriver))
+	}
+
+	if err := m.Release("i-001"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if m.Available() != 1 {
+		t.Errorf("want Available=1 after release, got %d", m.Available())
+	}
+}
+
 func TestManagerClaim_NoGPUAvailable(t *testing.T) {
 	root, gpu := buildManagerSysfs(t)
 	m := newManagerForTest([]GPUDevice{gpu}, root)

--- a/spinifex/utils/images.go
+++ b/spinifex/utils/images.go
@@ -454,8 +454,11 @@ var AvailableImages = map[string]Images{
 		URL:          "https://iso.mulgadc.com/system-ami/spinifex-eks-node-gpu-x86_64.qcow2",
 		Checksum:     "https://iso.mulgadc.com/system-ami/spinifex-eks-node-gpu-x86_64.qcow2.sha256",
 		ChecksumType: "sha256",
-		BootMode:     "bios",
-		Tags:         map[string]string{"spinifex:managed-by": "eks", "gpu-vendor": "nvidia"},
+		// Ubuntu 26.04 is built GPT/EFI-only; legacy BIOS finds no bootable MBR
+		// bootloader and hangs at firmware with zero serial output (no OVMF/pflash
+		// is attached unless BootMode is uefi/uefi-preferred, see vm/lifecycle.go).
+		BootMode: "uefi",
+		Tags:     map[string]string{"spinifex:managed-by": "eks", "gpu-vendor": "nvidia"},
 	},
 
 	// ECS container-instance system AMI. Resolved by spinifex:managed-by=ecs tag —

--- a/spinifex/utils/images.go
+++ b/spinifex/utils/images.go
@@ -491,8 +491,11 @@ var AvailableImages = map[string]Images{
 		URL:          "https://iso.mulgadc.com/system-ami/spinifex-ecs-node-gpu-x86_64.qcow2",
 		Checksum:     "https://iso.mulgadc.com/system-ami/spinifex-ecs-node-gpu-x86_64.qcow2.sha256",
 		ChecksumType: "sha256",
-		BootMode:     "bios",
-		Tags:         map[string]string{"spinifex:managed-by": "ecs", "gpu-vendor": "nvidia"},
+		// Ubuntu 26.04 is built GPT/EFI-only; legacy BIOS finds no bootable MBR
+		// bootloader and hangs at firmware with zero serial output (no OVMF/pflash
+		// is attached unless BootMode is uefi/uefi-preferred, see vm/lifecycle.go).
+		BootMode: "uefi",
+		Tags:     map[string]string{"spinifex:managed-by": "ecs", "gpu-vendor": "nvidia"},
 	},
 }
 


### PR DESCRIPTION
## Summary

- Fix VFIO bind/unbind to skip upstream PCIe bridge devices in IOMMU groups, which blocked GPU claim on platforms without ACS isolation
- Switch ECS/EKS GPU AMIs to open-kernel NVIDIA DKMS driver (required for Blackwell/GB202+), pin driver branch across all three image setup scripts
- Fix ECS GPU node AMI boot mode to UEFI (was incorrectly set to BIOS, causing firmware hang on Ubuntu 26.04 GPT/EFI images)
- Tolerate CP and GPU taints in argocd, ebs-csi-controller, and load-balancer-controller addon manifests so they schedule on GPU-only nodegroups
- Fix libguestfs appliance resolver (symlink to systemd-resolved stub was dead inside the chroot, breaking package installs)

## Test plan

- [ ] Build EKS and ECS GPU AMIs and verify they boot on a Blackwell GPU node
- [ ] Launch an EKS GPU nodegroup and verify argocd, ebs-csi-controller, and aws-load-balancer-controller pods schedule
- [ ] Verify VFIO bind/unbind succeeds on a GPU whose IOMMU group includes an upstream PCIe bridge
- [ ] Verify ECS GPU container-instance can bind a Blackwell card