### PR TITLE
feat(config): enable viperblock chunk GC in rendered node configs

### DIFF
--- a/cmd/spinifex/cmd/admin_test.go
+++ b/cmd/spinifex/cmd/admin_test.go
@@ -545,6 +545,32 @@ func TestSpinifexTomlTemplate_EncryptionKeyFile(t *testing.T) {
 	assert.NotContains(t, string(data2), "encryption_key_file", "blank key must omit the field")
 }
 
+// A rendered node config must turn chunk GC on. Asserting the template text
+// alone is not enough: the value has to survive parsing into a non-nil true
+// pointer, because every consumer treats nil as off. Rendering and loading
+// together is the only check that covers the whole path.
+func TestSpinifexTomlTemplate_GCEnabled(t *testing.T) {
+	dir := t.TempDir()
+	settings := admin.ConfigSettings{
+		Node: "node1", Az: "ap-southeast-2a", Port: "4432", Region: "ap-southeast-2",
+		BindIP: "0.0.0.0", AccessKey: "AKIATEST", SecretKey: "SECRET",
+		AccountID: "123456789012", NatsToken: "token",
+		OVNNBAddr: "tcp:127.0.0.1:6641", OVNSBAddr: "tcp:127.0.0.1:6642",
+		ConfigDir: dir,
+	}
+
+	path := filepath.Join(dir, "spinifex.toml")
+	require.NoError(t, admin.GenerateConfigFile(path, spinifexTomlTemplate, settings))
+
+	cfg, err := config.LoadConfig(path)
+	require.NoError(t, err)
+
+	node, ok := cfg.Nodes["node1"]
+	require.True(t, ok, "rendered config must define the node")
+	require.NotNil(t, node.Viperblock.GCEnabled, "gc_enabled must be rendered; nil leaves chunk GC off on every deployed node")
+	assert.True(t, *node.Viperblock.GCEnabled, "chunk GC must be enabled in a freshly rendered node config")
+}
+
 // Joiners run `spx admin join` against a configDir that doesn't yet contain
 // a predastore/ subdir. The helper must create it (predastore subdir is
 // owned by spinifex-storage in prod, but the helper just needs the dir to

--- a/cmd/spinifex/cmd/templates/spinifex.toml
+++ b/cmd/spinifex/cmd/templates/spinifex.toml
@@ -106,6 +106,7 @@ token = "{{.NatsToken}}"
 
 [nodes.{{.Node}}.viperblock]
 shardwal = false
+gc_enabled = true
 {{- if .EncryptionKeyFile}}
 encryption_key_file = "{{.EncryptionKeyFile}}"
 {{- end}}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.13.0
 	github.com/mulgadc/predastore v1.13.1-0.20260722023246-c0a90d23b3a0
-	github.com/mulgadc/viperblock v1.13.1-0.20260722023228-f8cfd7740bf4
+	github.com/mulgadc/viperblock v1.13.1-0.20260722115304-3b56d613e4fa
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1319,14 +1319,10 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/mulgadc/northstar v1.13.0 h1:L9PyYZ9Klg7dv2kE5+DHOcgPHelaZRDIvnwBsbHsdGI=
 github.com/mulgadc/northstar v1.13.0/go.mod h1:erQE/PzK9UMtgH8Y+uI5RdiboO/nqe1CUJbIpkae/FM=
-github.com/mulgadc/predastore v1.13.0 h1:jDPpLJP/GA4WK2t+9lksTSFDuQiV8vgDl6ISnPJRUuo=
-github.com/mulgadc/predastore v1.13.0/go.mod h1:38YSuk9zvYmbmgyM13WTkIQPJtvo2KmGJBYJul6NeAE=
 github.com/mulgadc/predastore v1.13.1-0.20260722023246-c0a90d23b3a0 h1:29g+uPZ0LAANVA1IPnE/ogxJzJBJnBZvnTl51icp378=
 github.com/mulgadc/predastore v1.13.1-0.20260722023246-c0a90d23b3a0/go.mod h1:38YSuk9zvYmbmgyM13WTkIQPJtvo2KmGJBYJul6NeAE=
-github.com/mulgadc/viperblock v1.13.0 h1:NuqmPRm26/j58GKbzcyshm0uZwdobzdjKK1qEsb2pCY=
-github.com/mulgadc/viperblock v1.13.0/go.mod h1:sW0hxZjN7WDQQZ39L5mE58fVLbSv3mBP3/ifFPdwJtU=
-github.com/mulgadc/viperblock v1.13.1-0.20260722023228-f8cfd7740bf4 h1:FpNYQoqP3jF5XOu/gxsaasVDCSueg74mznlUkpiuEyo=
-github.com/mulgadc/viperblock v1.13.1-0.20260722023228-f8cfd7740bf4/go.mod h1:sW0hxZjN7WDQQZ39L5mE58fVLbSv3mBP3/ifFPdwJtU=
+github.com/mulgadc/viperblock v1.13.1-0.20260722115304-3b56d613e4fa h1:Oyl8jRcE7M/4aUAJHZjOKyuwcbrR51onHF+5EfYJ3aw=
+github.com/mulgadc/viperblock v1.13.1-0.20260722115304-3b56d613e4fa/go.mod h1:sW0hxZjN7WDQQZ39L5mE58fVLbSv3mBP3/ifFPdwJtU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
## Summary

Chunk GC has been off on every deployed node since it was plumbed through. This renders `gc_enabled = true` in the node config template so it is actually on.

## The gap

`GCEnabled` was threaded to every `viperblock.VB` construction site, but nothing ever set it. It is a `*bool` that every consumer treats as off when nil:

| Site | Default when unset |
| --- | --- |
| `spinifex/config/config.go:133` | `GCEnabled *bool` — nil |
| `cmd/spinifex/cmd/service.go:303` | `gcEnabled := false` |
| `handlers/ec2/volume/service_impl.go:207` | nil-guarded false |
| `viperblock/nbd/viperblock.go:79` | `var gc_enabled bool = false` |

The config template renders `shardwal` but omitted `gc_enabled`, despite the two being introduced as siblings. No `.toml` template in the repo contained the key, and there is no occurrence anywhere in `ansible/`. Confirmed on a live node — nbdkit's own command line carried `gc_enabled=false`, and the rendered `[nodes.<host>.viperblock]` block had no such key.

So superseded chunks were never reclaimed under overwrite churn on any deployed node.

## Test

`TestSpinifexTomlTemplate_GCEnabled` renders the template and loads it through `config.LoadConfig`, asserting a non-nil `true`. Matching the template text would not be enough: the value only matters if it parses into a non-nil pointer, since nil is indistinguishable from off at every consumer. Mutation-checked — removing the template line fails the test on the nil assertion.

## Deployment note

The template governs install and bootstrap, so **existing deployments keep GC off until their config is regenerated**. This is not a hot toggle.

**Order matters:** do not deploy GC-on to a node whose viperblock predates the read-modify-write atomicity fix (viperblock #42). GC increases chunk churn and that bug corrupts on the RMW path.

## Known limitation, not addressed here

`ensureGCSnapshotSafe` caches its snapshot-ancestry answer for the life of the VB, and the latch that disables GC when a snapshot appears is in-process only. Spinifex creates snapshots of running volumes from a *different* process (`handlers/ec2/image/service_impl.go`, `snapshotRunningVolume`), so a snapshot taken during a mount does not reach the sweeping engine. Closing that needs a cheap per-volume generation marker checked before each sweep; tracked separately.