### PR TITLE
fix(eks): don't baseline a nodegroup's Ready-gate on its prior incarnation

### DIFF
--- a/spinifex/handlers/eks/nodegroup.go
+++ b/spinifex/handlers/eks/nodegroup.go
@@ -434,9 +434,23 @@ func (s *EKSServiceImpl) launchNodegroupInfra(ctx context.Context, lc nodegroupL
 	// merely on RunInstances success — a worker that boots but never joins must
 	// surface CREATE_FAILED, not falsely ACTIVE. Scoped to THIS nodegroup so
 	// another nodegroup's Ready workers can never mask this one's shortfall.
-	// Baseline is the create-time count for this nodegroup; the workers add
-	// lc.desired Ready nodes.
-	if err := s.waitWorkersReady(acctKV, cluster, ng, meta.NodegroupNodeCounts[ng], lc.desired); err != nil {
+	// Baseline is 0, NOT the create-time count for this nodegroup name.
+	//
+	// A create means every worker under this name is new, so the gate is simply
+	// "lc.desired Ready nodes carrying this nodegroup label". Baselining on the
+	// live count breaks re-creating a nodegroup of the same name — which is what
+	// a terraform replace does after a CREATE_FAILED. There the previous
+	// incarnation's workers are still Ready when the create starts, so the
+	// baseline captures them and the target becomes old+new; the old ones are
+	// then terminated, the count falls, and the target can never be reached. The
+	// gate fails a cluster whose new workers all joined perfectly, and the retry
+	// fails the same way with a larger baseline each round.
+	//
+	// Trade-off, stated plainly: a stale incarnation's Ready nodes can briefly
+	// inflate the count and satisfy the gate early. They go NotReady within
+	// about a minute of termination, whereas baselining on them fails every
+	// replacement permanently.
+	if err := s.waitWorkersReady(acctKV, cluster, ng, 0, lc.desired); err != nil {
 		rec.Status = eks.NodegroupStatusCreateFailed
 		rec.StatusReason = "workers did not become Ready: " + err.Error()
 		rec.ModifiedAt = time.Now().UTC()

--- a/spinifex/handlers/eks/nodegroup_recreate_test.go
+++ b/spinifex/handlers/eks/nodegroup_recreate_test.go
@@ -1,0 +1,57 @@
+package handlers_eks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Re-creating a nodegroup of the same name must not baseline its Ready-gate on
+// the previous incarnation's workers.
+//
+// A terraform replace after CREATE_FAILED destroys and re-creates the same
+// nodegroup name. The old workers are still Ready when the create begins, so a
+// gate that baselines on the live count demands old+new Ready nodes — then the
+// old ones are terminated, the count falls, and the target becomes unreachable.
+// The observed effect was a cluster whose three new workers all joined being
+// failed with "reports 3 Ready nodes, want >= 5 (baseline 2 + 3 workers)", and
+// each retry raising the bar again.
+func TestCreateNodegroup_RecreateDoesNotBaselineOnPriorWorkers(t *testing.T) {
+	f := newEKSServiceFixture(t)
+	seedActiveClusterWithToken(t, f, "c1")
+
+	// First incarnation: two workers register Ready and the nodegroup activates.
+	_, err := f.svc.CreateNodegroup(context.Background(), createNGInput("c1", "ng", 2), testAccountID)
+	require.NoError(t, err)
+	markWorkersReady(t, f, "c1", "ng", 2)
+	f.svc.WaitLaunches()
+
+	rec, err := GetNodegroupRecord(f.kv, "c1", "ng")
+	require.NoError(t, err)
+	require.Equal(t, eks.NodegroupStatusActive, rec.Status)
+
+	// A terraform replace deletes the nodegroup, then re-creates the same name.
+	// The CP's Ready report lags the delete, so the previous incarnation's two
+	// workers are still counted Ready when the create begins — exactly the state
+	// that produced "want >= 4 (baseline 2 + 2 workers)" in the field.
+	require.NoError(t, DeleteNodegroupRecord(f.kv, "c1", "ng"))
+	markWorkersReady(t, f, "c1", "ng", 2)
+
+	_, err = f.svc.CreateNodegroup(context.Background(), createNGInput("c1", "ng", 2), testAccountID)
+	require.NoError(t, err)
+
+	// The new incarnation's own two workers register Ready. With a zero
+	// baseline this satisfies the gate; baselining on the prior count would
+	// demand four and never resolve.
+	markWorkersReady(t, f, "c1", "ng", 2)
+	f.svc.WaitLaunches()
+
+	rec, err = GetNodegroupRecord(f.kv, "c1", "ng")
+	require.NoError(t, err)
+	assert.Equal(t, eks.NodegroupStatusActive, rec.Status,
+		"a re-created nodegroup whose own workers are Ready must reach ACTIVE, not CREATE_FAILED")
+	assert.NotContains(t, rec.StatusReason, "did not become Ready")
+}


### PR DESCRIPTION
Re-creating a nodegroup of the same name could never reach ACTIVE.

The Ready-gate baselined on the live Ready count for that nodegroup name. A terraform replace after `CREATE_FAILED` deletes and re-creates the same name, so the baseline captured the **previous** incarnation's workers, demanded old+new Ready nodes, and then watched the count fall as those old workers were terminated. Unreachable by construction.

Seen on env19 with a healthy cluster — all three new workers joined and were Ready:

```
NodeCreationFailure: workers did not become Ready: timed out after 20m0s:
  nodegroup toc-ng reports 3 Ready nodes, want >= 5 (baseline 2 + 3 workers)
```

Each retry raised the bar (baseline 3 ⇒ want 6), so the deploy could only be unblocked by untainting the resource by hand — which is exactly the kind of manual step a one-shot `make apply` should never need.

## Fix

Baseline 0 on create. A create means every worker under that name is new, so the gate is simply "desired Ready nodes carrying this nodegroup label".

The trade-off is stated in the code rather than hidden: a stale incarnation's Ready nodes can briefly inflate the count and satisfy the gate early. They go NotReady within about a minute of termination, whereas baselining on them fails **every** replacement permanently. The precise alternative — counting only nodes whose instance IDs belong to this incarnation — needs per-node identity that the CP state report doesn't currently carry (`NodegroupNodeCounts` is a count per nodegroup name).

The existing per-nodegroup scoping is untouched: one nodegroup's Ready workers still cannot satisfy another's gate.

## Test

`TestCreateNodegroup_RecreateDoesNotBaselineOnPriorWorkers` models the real sequence — activate, delete the record, leave the stale Ready count reported (the CP report lags the delete), re-create. Without the fix it fails with the field's error shape:

```
"workers did not become Ready: timed out after 1s: nodegroup ng reports 2 Ready nodes,
 want >= 4 (baseline 2 + 2 workers)" should not contain "did not become Ready"
```