### PR TITLE
test: assert the gateway->vpcd->OVN crossing in the integration tier

### DIFF
--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -57,6 +57,10 @@ func (c *LiveClient) ensureNamedRowOps(table, name string, createObj model.Model
 	return append([]ovsdb.Operation{waitOp}, createOps...), nil
 }
 
+// waitTimedOutError is the result ovsdb reports for a wait-op whose condition
+// was not met within its timeout.
+const waitTimedOutError = "timed out"
+
 // transactOps runs ops as one transaction and checks per-op results.
 func (c *LiveClient) transactOps(ctx context.Context, ops []ovsdb.Operation) error {
 	results, err := c.client.Transact(ctx, ops...)
@@ -66,16 +70,31 @@ func (c *LiveClient) transactOps(ctx context.Context, ops []ovsdb.Operation) err
 	_, err = ovsdb.CheckOperationResults(results, ops)
 	if err != nil {
 		for i, r := range results {
-			if r.Error != "" {
-				opTable := ""
-				if i < len(ops) {
-					opTable = fmt.Sprintf("%s on %s", ops[i].Op, ops[i].Table)
-				}
-				slog.Error("OVSDB operation failed", "index", i, "op", opTable, "error", r.Error, "details", r.Details)
+			if r.Error == "" {
+				continue
 			}
+			opTable := ""
+			if i < len(ops) {
+				opTable = fmt.Sprintf("%s on %s", ops[i].Op, ops[i].Table)
+			}
+			// ensureNamedRowOps' probe times out precisely when the row it
+			// guards already exists, which is the common idempotent path — the
+			// caller handles it by reusing the existing row. Logging that at
+			// ERROR made every re-ensure look like a fault.
+			if isEnsureProbeTimeout(ops, i, r.Error) {
+				slog.Debug("OVSDB ensure probe found existing row", "index", i, "op", opTable)
+				continue
+			}
+			slog.Error("OVSDB operation failed", "index", i, "op", opTable, "error", r.Error, "details", r.Details)
 		}
 	}
 	return err
+}
+
+// isEnsureProbeTimeout reports whether results[i] is ensureNamedRowOps' wait-op
+// failing because the named row is already present.
+func isEnsureProbeTimeout(ops []ovsdb.Operation, i int, resultErr string) bool {
+	return i < len(ops) && ops[i].Op == ovsdb.OperationWait && resultErr == waitTimedOutError
 }
 
 // namedUUID builds a valid OVSDB named-uuid by replacing non-[_a-zA-Z0-9]

--- a/spinifex/network/ovn/live.go
+++ b/spinifex/network/ovn/live.go
@@ -78,9 +78,11 @@ func (c *LiveClient) transactOps(ctx context.Context, ops []ovsdb.Operation) err
 				opTable = fmt.Sprintf("%s on %s", ops[i].Op, ops[i].Table)
 			}
 			// ensureNamedRowOps' probe times out precisely when the row it
-			// guards already exists, which is the common idempotent path — the
-			// caller handles it by reusing the existing row. Logging that at
-			// ERROR made every re-ensure look like a fault.
+			// guards already exists — a re-ensure that got past the cache
+			// lookup because another writer, or this client moments earlier,
+			// created the row before the monitor caught up. The caller handles
+			// it by reusing the existing row, so reporting it as a failure
+			// made an ordinary idempotent write look like a fault.
 			if isEnsureProbeTimeout(ops, i, r.Error) {
 				slog.Debug("OVSDB ensure probe found existing row", "index", i, "op", opTable)
 				continue

--- a/spinifex/network/ovn/live_test.go
+++ b/spinifex/network/ovn/live_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
 
 func ptr(s string) *string { return &s }
@@ -61,6 +62,36 @@ func TestNamedUUID(t *testing.T) {
 			got := namedUUID(tt.prefix, tt.input)
 			if got != tt.expected {
 				t.Errorf("namedUUID(%q, %q) = %q, want %q", tt.prefix, tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsEnsureProbeTimeout pins which failed transaction results are the
+// idempotent ensure path rather than a fault, since only the former is
+// downgraded out of the ERROR log.
+func TestIsEnsureProbeTimeout(t *testing.T) {
+	ops := []ovsdb.Operation{
+		{Op: ovsdb.OperationWait, Table: "Logical_Router"},
+		{Op: ovsdb.OperationInsert, Table: "Logical_Router"},
+	}
+
+	tests := []struct {
+		name      string
+		index     int
+		resultErr string
+		want      bool
+	}{
+		{"ensure probe found existing row", 0, "timed out", true},
+		{"wait op failed for another reason", 0, "constraint violation", false},
+		{"insert op timed out", 1, "timed out", false},
+		{"index past the op list", 5, "timed out", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEnsureProbeTimeout(ops, tt.index, tt.resultErr); got != tt.want {
+				t.Errorf("isEnsureProbeTimeout(ops, %d, %q) = %v, want %v", tt.index, tt.resultErr, got, tt.want)
 			}
 		})
 	}

--- a/spinifex/network/ovn/live_test.go
+++ b/spinifex/network/ovn/live_test.go
@@ -1,9 +1,12 @@
 package ovn
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/ovntest"
 	"github.com/ovn-kubernetes/libovsdb/ovsdb"
 )
 
@@ -95,4 +98,55 @@ func TestIsEnsureProbeTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTransactOps_FailedResults drives transactOps over a real NB DB for both
+// kinds of failed result, since the two are logged at different levels and
+// only one of them is a genuine fault.
+func TestTransactOps_FailedResults(t *testing.T) {
+	nb := ovntest.StartNB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	cli := NewLiveClient(nb.Endpoint)
+	if err := cli.Connect(ctx); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(cli.Close)
+
+	if _, _, err := cli.EnsureLogicalRouter(ctx, &nbdb.LogicalRouter{Name: "lr-dup"}); err != nil {
+		t.Fatalf("seed EnsureLogicalRouter: %v", err)
+	}
+
+	// Re-ensuring an existing row is what the caller's cache lookup normally
+	// absorbs; going straight to transactOps reproduces the case where it did
+	// not, and the guard probe fires instead.
+	t.Run("ensure probe on existing row", func(t *testing.T) {
+		ops, err := cli.ensureNamedRowOps("Logical_Router", "lr-dup", &nbdb.LogicalRouter{
+			UUID: namedUUID("lr_", "lr-dup"),
+			Name: "lr-dup",
+		})
+		if err != nil {
+			t.Fatalf("ensureNamedRowOps: %v", err)
+		}
+		if err := cli.transactOps(ctx, ops); err == nil {
+			t.Fatal("transactOps succeeded, want the probe to report the row already exists")
+		}
+	})
+
+	// Two same-named inserts in one transaction violate the schema's name
+	// index — a real fault, and the path that must stay at ERROR.
+	t.Run("genuine constraint violation", func(t *testing.T) {
+		var ops []ovsdb.Operation
+		for _, uuid := range []string{"ls_a", "ls_b"} {
+			createOps, err := cli.client.Create(&nbdb.LogicalSwitch{UUID: uuid, Name: "ls-clash"})
+			if err != nil {
+				t.Fatalf("build create ops: %v", err)
+			}
+			ops = append(ops, createOps...)
+		}
+		if err := cli.transactOps(ctx, ops); err == nil {
+			t.Fatal("transactOps succeeded, want a constraint violation")
+		}
+	})
 }

--- a/tests/fixtures/vpcd/vpcd.go
+++ b/tests/fixtures/vpcd/vpcd.go
@@ -1,0 +1,99 @@
+// Package vpcd builds the network managers a live vpcd runs, wired against a
+// real in-process OVN Northbound DB (network/ovn/ovntest). It exists so tests
+// outside the network/ tree can assert against genuine NB rows instead of the
+// hand-rolled ovn/mock.
+//
+// network/reconcile's scenario tests construct the same set of managers, but
+// they do it inside a _test.go and so cannot be imported. This package
+// deliberately repeats that wiring rather than exporting a helper out of
+// network/: dependencies run tests/ -> spinifex/, and inverting that to save a
+// block of construction is the worse trade.
+package vpcd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/ovntest"
+	"github.com/mulgadc/spinifex/spinifex/network/policy"
+	"github.com/mulgadc/spinifex/spinifex/network/subscribers"
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+)
+
+// connectTimeout bounds the initial OVSDB handshake. The server is in-process
+// on a unix socket, so this only ever fires on a genuine failure.
+const connectTimeout = 5 * time.Second
+
+// Fixture is a connected OVN NB DB plus the managers that drive it. OVN is
+// exposed so tests can read rows back; Subscribers is the config a
+// subscribers.Subscriber is built from.
+type Fixture struct {
+	// OVN is the connected client, for asserting NB state directly.
+	OVN ovn.Client
+	// Subscribers carries every manager subscribers.New requires. MAC is left
+	// nil: flushing SB MAC_Binding rows needs a real SB DB, which this fixture
+	// does not run, and a nil flusher makes the flush a no-op.
+	Subscribers subscribers.Config
+}
+
+// Start boots an in-process OVN NB server and returns the managers wired to
+// it. The server and client are torn down via t.Cleanup.
+//
+// The managers are the production types a live vpcd constructs
+// (spinifex/vpcd/vpcd.go), minus the host-dependent options: NAT runs in
+// distributed mode with no chassis list, IGW allocates link-local addresses
+// rather than drawing from a configured pool, and nothing seeds a nexthop MAC
+// or waits on an OpenFlow barrier. Those all reach for the host datapath,
+// which belongs to the live e2e tier.
+func Start(t testing.TB) *Fixture {
+	t.Helper()
+
+	nb := ovntest.StartNB(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), connectTimeout)
+	defer cancel()
+	cli := ovn.NewLiveClient(nb.Endpoint)
+	if err := cli.Connect(ctx); err != nil {
+		t.Fatalf("vpcd fixture: LiveClient.Connect: %v", err)
+	}
+	t.Cleanup(cli.Close)
+
+	sg := policy.NewSecurityGroupManager(cli)
+	nat, err := policy.NewNATManager(cli, policy.NATModeDistributed)
+	if err != nil {
+		t.Fatalf("vpcd fixture: NewNATManager: %v", err)
+	}
+	routes := policy.NewRouteManager(cli)
+	igw, err := external.NewIGWManager(external.IGWManagerConfig{
+		OVN:       cli,
+		Routes:    routes,
+		NAT:       nat,
+		Allocator: external.LinkLocalAllocator{},
+		NATMode:   policy.NATModeDistributed,
+	})
+	if err != nil {
+		t.Fatalf("vpcd fixture: NewIGWManager: %v", err)
+	}
+	eip, err := external.NewEIPManager(nat, nil)
+	if err != nil {
+		t.Fatalf("vpcd fixture: NewEIPManager: %v", err)
+	}
+	natgw, err := external.NewNATGWManager(nat)
+	if err != nil {
+		t.Fatalf("vpcd fixture: NewNATGWManager: %v", err)
+	}
+
+	return &Fixture{
+		OVN: cli,
+		Subscribers: subscribers.Config{
+			Topology: topology.NewLiveManager(cli),
+			SG:       sg,
+			EIP:      eip,
+			NATGW:    natgw,
+			IGW:      igw,
+		},
+	}
+}

--- a/tests/integration/daemon_lite.go
+++ b/tests/integration/daemon_lite.go
@@ -57,6 +57,29 @@ type DaemonLite struct {
 	MemStore *objectstore.MemoryObjectStore
 }
 
+// daemonLiteOpts records which of StartDaemonLite's defaults a caller has
+// turned off.
+type daemonLiteOpts struct {
+	// stubVPCD installs the canned vpc.create-sg/vpc.delete-sg acks. On by
+	// default; StartVPCDLite is the only reason to turn it off.
+	stubVPCD bool
+}
+
+// DaemonLiteOption customises what StartDaemonLite wires.
+type DaemonLiteOption func(*daemonLiteOpts)
+
+// WithRealVPCD suppresses the canned vpc.create-sg/vpc.delete-sg acks so a
+// real subscriber wired by StartVPCDLite answers them instead. Without it the
+// stub and the subscriber both reply to the same request and whichever lands
+// first wins, so a test would be racing its own fake.
+//
+// StartVPCDLite must run BEFORE the StartDaemonLite it is paired with:
+// StartDaemonLite calls EnsureDefaultVPC, which requests vpc.create-sg
+// synchronously and would time out with nothing subscribed.
+func WithRealVPCD() DaemonLiteOption {
+	return func(o *daemonLiteOpts) { o.stubVPCD = false }
+}
+
 // StartDaemonLite constructs the in-scope service impls against gw.NATSConn
 // (memory-backed for key/tags, embedded-JetStream-backed for VPC/route
 // table/IGW — the same wiring pattern as
@@ -69,8 +92,13 @@ type DaemonLite struct {
 // StubSubject and StartDaemonLite must never cover the same subject in one
 // test, since NATS would deliver the request to both plain subscribers and
 // whichever responds first wins the race.
-func StartDaemonLite(t *testing.T, gw *Gateway) *DaemonLite {
+func StartDaemonLite(t *testing.T, gw *Gateway, opts ...DaemonLiteOption) *DaemonLite {
 	t.Helper()
+
+	o := daemonLiteOpts{stubVPCD: true}
+	for _, apply := range opts {
+		apply(&o)
+	}
 
 	nc := gw.NATSConn
 	memStore := objectstore.NewMemoryObjectStore()
@@ -122,8 +150,13 @@ func StartDaemonLite(t *testing.T, gw *Gateway) *DaemonLite {
 	// stubbing the vpcd ack never substitutes for in-scope logic under test —
 	// it only unblocks the synchronous call so CreateVpc/DeleteVpc can
 	// complete instead of failing with ServerInternal on every VPC creation.
-	gw.StubSubject(t, "vpc.create-sg", []byte(`{"success":true}`))
-	gw.StubSubject(t, "vpc.delete-sg", []byte(`{"success":true}`))
+	//
+	// WithRealVPCD skips both, for the tests that wire a genuine subscriber
+	// over a real OVN NB DB (StartVPCDLite) and assert on the rows it writes.
+	if o.stubVPCD {
+		gw.StubSubject(t, "vpc.create-sg", []byte(`{"success":true}`))
+		gw.StubSubject(t, "vpc.delete-sg", []byte(`{"success":true}`))
+	}
 
 	// A live daemon creates the account's default VPC by reacting to the
 	// "iam.account.created" event SeedBootstrap publishes at gateway startup

--- a/tests/integration/run_instances_clienttoken_test.go
+++ b/tests/integration/run_instances_clienttoken_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// clientTokenRun numbers each invocation of the test below so its ClientToken
+// values are fresh on every pass; see the test's doc comment.
+var clientTokenRun atomic.Int64
+
 // TestRunInstances_ClientTokenIdempotency proves ClientToken dedup
 // (gateway/ec2/instance/RunInstances.go's ClientTokenStore wrapping) runs for
 // real through the full gateway: a replayed token must not reach the daemon a
@@ -22,12 +26,16 @@ import (
 // getClientTokenStore (clienttoken.go) binds its JetStream KV bucket via a
 // process-wide sync.Once, so the very first test in this package's binary
 // that supplies a ClientToken permanently decides which test's NATS account
-// backs the store for the rest of the run. That is harmless here because
-// every key is namespaced by accountID+token and this test uses ClientToken
-// values that appear nowhere else in the suite, so no other test's launch can
-// collide with this one's regardless of run order (including -shuffle).
+// backs the store for the rest of the run. No other test can collide with
+// this one — every key is namespaced by accountID+token, and these token
+// values appear nowhere else in the suite — but THIS test collides with
+// itself under -count=N: the store outlives each pass, so a fixed token would
+// make the second pass's opening launch look like a replay of the first
+// pass's. Hence the per-invocation suffix.
 func TestRunInstances_ClientTokenIdempotency(t *testing.T) {
 	gw := StartGateway(t)
+
+	run := clientTokenRun.Add(1)
 
 	const (
 		instanceType = "t3.micro"
@@ -69,7 +77,7 @@ func TestRunInstances_ClientTokenIdempotency(t *testing.T) {
 		}
 	}
 
-	const tokenA = "integration-test-clienttoken-a"
+	tokenA := fmt.Sprintf("integration-test-clienttoken-a-%d", run)
 	res1, err := gw.EC2Client(t).RunInstances(baseInput(tokenA))
 	require.NoError(t, err, "first launch with token A")
 	require.Len(t, res1.Instances, 1)
@@ -87,7 +95,7 @@ func TestRunInstances_ClientTokenIdempotency(t *testing.T) {
 	require.Equal(t, firstInstanceID, aws.StringValue(res2.Instances[0].InstanceId), "replay must return the original instance")
 
 	// A different token for the same account must launch again, independently.
-	const tokenB = "integration-test-clienttoken-b"
+	tokenB := fmt.Sprintf("integration-test-clienttoken-b-%d", run)
 	res3, err := gw.EC2Client(t).RunInstances(baseInput(tokenB))
 	require.NoError(t, err, "launch with token B")
 	require.Equal(t, int64(2), dispatchCount.Load(), "a different token must dispatch a fresh launch")

--- a/tests/integration/shared_nats.go
+++ b/tests/integration/shared_nats.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -155,10 +156,17 @@ func (a *accountAuthenticator) accountFor(name string) (*server.Account, error) 
 // path with "/", and some test names contain spaces).
 var accountNameReplacer = strings.NewReplacer("/", "_", " ", "_")
 
-// accountNameFor derives a unique NATS account name for t. Go guarantees
-// t.Name() is unique among tests running in the same binary (subtests that
-// share a literal name get a "#NN" suffix), so it doubles as the account
-// key without needing a separate counter.
+// accountSeq disambiguates repeat runs of one test. t.Name() is unique among
+// tests in a binary but NOT across passes: -count=N replays identical names
+// inside the same TestMain, so a name-only account key hands the second pass
+// the first pass's JetStream namespace. That namespace still holds an ECR
+// signing key sealed with the first pass's master key, which StartGateway
+// regenerates per call — so the reused key failed to decrypt and took down
+// every gateway-starting test on the second pass.
+var accountSeq atomic.Uint64
+
+// accountNameFor derives a fresh NATS account name for t, so each gateway gets
+// an empty JetStream namespace no matter how often the test is replayed.
 func accountNameFor(t *testing.T) string {
-	return accountNameReplacer.Replace(t.Name())
+	return fmt.Sprintf("%s_%d", accountNameReplacer.Replace(t.Name()), accountSeq.Add(1))
 }

--- a/tests/integration/vpc_ordering_test.go
+++ b/tests/integration/vpc_ordering_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/network/subscribers"
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+)
+
+// startVPCDEvents wires a real vpcd consumer over a real OVN NB DB with no
+// daemon behind it. These tests publish the vpc.* events directly because the
+// property under test is delivery order, which the SDK path cannot produce on
+// demand: through it, CreateVpc necessarily precedes CreateSubnet.
+func startVPCDEvents(t *testing.T) (*VPCDLite, *nats.Conn) {
+	t.Helper()
+	gw := StartGateway(t)
+	return StartVPCDLite(t, gw), gw.NATSConn
+}
+
+// publishEvent marshals and fires a fire-and-forget vpc.* topology event, the
+// way handlers/ec2/vpc's publishVPCEvent/publishSubnetEvent do.
+func publishEvent(t *testing.T, nc *nats.Conn, topic string, evt any) {
+	t.Helper()
+	payload, err := json.Marshal(evt)
+	require.NoError(t, err, "marshal %s event", topic)
+	require.NoError(t, nc.Publish(topic, payload), "publish %s", topic)
+	require.NoError(t, nc.Flush(), "flush %s", topic)
+}
+
+// countRouters returns how many logical routers carry name.
+func countRouters(ctx context.Context, vpcd *VPCDLite, name string) (int, error) {
+	routers, err := vpcd.OVN.ListLogicalRouters(ctx)
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, r := range routers {
+		if r.Name == name {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// TestVPCD_SubnetBeforeVPCConverges covers the case where vpc.create-subnet
+// is delivered with no preceding vpc.create. The two topics have no ordering
+// guarantee, so on new-tenant bootstrap the subnet can genuinely land first;
+// the subnet handler's defensive pre-ensure is what stops that from being a
+// dropped subnet.
+//
+// The convergence claim is the point: the pre-ensure creates the router
+// without a CIDR, and the real vpc.create arriving afterwards must fill it in
+// rather than being discarded as a duplicate or forking a second router.
+func TestVPCD_SubnetBeforeVPCConverges(t *testing.T) {
+	vpcd, nc := startVPCDEvents(t)
+	ctx := context.Background()
+
+	const vpcID, subnetID = "vpc-order-a", "subnet-order-a"
+	router := topology.VPCRouter(vpcID)
+
+	publishEvent(t, nc, subscribers.TopicSubnetCreate, subscribers.SubnetEvent{
+		SubnetId:  subnetID,
+		VpcId:     vpcID,
+		CidrBlock: "10.50.1.0/24",
+	})
+
+	awaitNB(t, "logical switch for subnet-first delivery", func(ctx context.Context) error {
+		_, err := vpcd.OVN.GetLogicalSwitch(ctx, topology.SubnetSwitch(subnetID))
+		return err
+	})
+
+	publishEvent(t, nc, subscribers.TopicVPCCreate, subscribers.VPCEvent{
+		VpcId:     vpcID,
+		CidrBlock: "10.50.0.0/16",
+	})
+
+	awaitNB(t, "VPC CIDR backfilled onto pre-ensured router", func(ctx context.Context) error {
+		lr, err := vpcd.OVN.GetLogicalRouter(ctx, router)
+		if err != nil {
+			return err
+		}
+		if got := lr.ExternalIDs["spinifex:cidr"]; got != "10.50.0.0/16" {
+			return fmt.Errorf("spinifex:cidr = %q, want 10.50.0.0/16", got)
+		}
+		return nil
+	})
+
+	n, err := countRouters(ctx, vpcd, router)
+	require.NoError(t, err, "list logical routers")
+	require.Equal(t, 1, n, "out-of-order delivery forked %s into %d routers", router, n)
+}

--- a/tests/integration/vpc_sg_test.go
+++ b/tests/integration/vpc_sg_test.go
@@ -1,0 +1,66 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVPCD_SecurityGroupReachesOVN asserts the synchronous half of the
+// handler-to-vpcd contract against a real responder. The SG topics use
+// utils.RequestEvent, so unlike the topology events these need no polling: by
+// the time the SDK call returns, vpcd has already committed to OVN.
+//
+// This is the case the tier previously faked outright with a canned
+// {"success":true} — the API call succeeded whether or not any OVN work was
+// possible, let alone correct.
+func TestVPCD_SecurityGroupReachesOVN(t *testing.T) {
+	vpcd, c := startVPCDStack(t)
+	ctx := context.Background()
+
+	vpcID := createScratchVPC(t, c, "10.44.0.0/16")
+	sgOut, err := c.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
+		VpcId:       aws.String(vpcID),
+		GroupName:   aws.String("integration-sg"),
+		Description: aws.String("vpcd integration tier"),
+	})
+	require.NoError(t, err, "create-security-group in %s", vpcID)
+	sgID := aws.StringValue(sgOut.GroupId)
+	require.NotEmpty(t, sgID, "GroupId empty")
+
+	pgName := topology.SecurityGroupPortGroup(sgID)
+	pg, err := vpcd.OVN.GetPortGroup(ctx, pgName)
+	require.NoError(t, err, "SG port group %s absent after create-security-group", pgName)
+	baseACLs := len(pg.ACLs)
+
+	_, err = c.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(sgID),
+		IpPermissions: []*ec2.IpPermission{{
+			IpProtocol: aws.String("tcp"),
+			FromPort:   aws.Int64(22),
+			ToPort:     aws.Int64(22),
+			IpRanges:   []*ec2.IpRange{{CidrIp: aws.String("10.44.0.0/16")}},
+		}},
+	})
+	require.NoError(t, err, "authorize-security-group-ingress on %s", sgID)
+
+	// The rule count is the assertion, not the ACL match text: that the rule
+	// crossed the wire at all is this tier's claim, while the match expression
+	// it compiles to belongs to policy's own tests.
+	pg, err = vpcd.OVN.GetPortGroup(ctx, pgName)
+	require.NoError(t, err, "SG port group %s after authorize", pgName)
+	require.Greater(t, len(pg.ACLs), baseACLs,
+		"authorize-security-group-ingress added no ACL to port group %s", pgName)
+
+	_, err = c.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: aws.String(sgID)})
+	require.NoError(t, err, "delete-security-group %s", sgID)
+
+	_, err = vpcd.OVN.GetPortGroup(ctx, pgName)
+	require.Error(t, err, "SG port group %s still present after delete-security-group", pgName)
+}

--- a/tests/integration/vpc_topology_test.go
+++ b/tests/integration/vpc_topology_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/stretchr/testify/require"
+)
+
+// startVPCDStack wires the full API-to-OVN chain: the real gateway router, a
+// real vpcd event consumer over a real OVN NB DB, and the real VPC service
+// impl answering the ec2.* subjects.
+//
+// Order matters. StartVPCDLite runs first because StartDaemonLite's
+// EnsureDefaultVPC synchronously requests vpc.create-sg, which now has a real
+// responder rather than a canned ack.
+func startVPCDStack(t *testing.T) (*VPCDLite, *ec2.EC2) {
+	t.Helper()
+
+	gw := StartGateway(t)
+	vpcd := StartVPCDLite(t, gw)
+	StartDaemonLite(t, gw, WithRealVPCD())
+
+	return vpcd, gw.EC2Client(t)
+}
+
+// TestVPCD_VPCLifecycleReachesOVN asserts CreateVpc/DeleteVpc travel the whole
+// chain — SigV4 request, gateway, ec2.CreateVpc, VPCServiceImpl, vpc.create,
+// subscriber, topology manager, OVSDB transaction — and land as a logical
+// router carrying the VPC's identity.
+//
+// Row contents beyond identity are network/reconcile's scenario tests to
+// assert; what is unique here is that the wire between the two services
+// carries the event at all.
+func TestVPCD_VPCLifecycleReachesOVN(t *testing.T) {
+	vpcd, c := startVPCDStack(t)
+
+	vpcID := createScratchVPC(t, c, "10.42.0.0/16")
+	router := topology.VPCRouter(vpcID)
+
+	awaitNB(t, "logical router "+router, func(ctx context.Context) error {
+		lr, err := vpcd.OVN.GetLogicalRouter(ctx, router)
+		if err != nil {
+			return err
+		}
+		if got := lr.ExternalIDs["spinifex:vpc_id"]; got != vpcID {
+			return fmt.Errorf("spinifex:vpc_id = %q, want %q", got, vpcID)
+		}
+		if got := lr.ExternalIDs["spinifex:cidr"]; got != "10.42.0.0/16" {
+			return fmt.Errorf("spinifex:cidr = %q, want 10.42.0.0/16", got)
+		}
+		return nil
+	})
+
+	_, err := c.DeleteVpc(&ec2.DeleteVpcInput{VpcId: aws.String(vpcID)})
+	require.NoError(t, err, "delete-vpc %s", vpcID)
+
+	awaitNB(t, "logical router "+router+" removed", func(ctx context.Context) error {
+		if _, err := vpcd.OVN.GetLogicalRouter(ctx, router); err == nil {
+			return fmt.Errorf("logical router %s still present", router)
+		}
+		return nil
+	})
+}
+
+// TestVPCD_SubnetLifecycleReachesOVN asserts CreateSubnet/DeleteSubnet reach
+// OVN as a logical switch attached to the owning VPC's router.
+func TestVPCD_SubnetLifecycleReachesOVN(t *testing.T) {
+	vpcd, c := startVPCDStack(t)
+
+	vpcID := createScratchVPC(t, c, "10.43.0.0/16")
+	out, err := c.CreateSubnet(&ec2.CreateSubnetInput{
+		VpcId:     aws.String(vpcID),
+		CidrBlock: aws.String("10.43.1.0/24"),
+	})
+	require.NoError(t, err, "create-subnet in %s", vpcID)
+	require.NotNil(t, out.Subnet, "create-subnet returned nil Subnet")
+	subnetID := aws.StringValue(out.Subnet.SubnetId)
+	require.NotEmpty(t, subnetID, "SubnetId empty")
+
+	sw := topology.SubnetSwitch(subnetID)
+	awaitNB(t, "logical switch "+sw, func(ctx context.Context) error {
+		ls, err := vpcd.OVN.GetLogicalSwitch(ctx, sw)
+		if err != nil {
+			return err
+		}
+		if got := ls.ExternalIDs["spinifex:subnet_id"]; got != subnetID {
+			return fmt.Errorf("spinifex:subnet_id = %q, want %q", got, subnetID)
+		}
+		return nil
+	})
+
+	// The subnet's default gateway terminates on an LRP of the VPC router, so
+	// its presence is what proves the switch was joined to the right VPC
+	// rather than merely created.
+	lrp := topology.SubnetRouterPort(subnetID)
+	awaitNB(t, "logical router port "+lrp, func(ctx context.Context) error {
+		_, err := vpcd.OVN.GetLogicalRouterPort(ctx, lrp)
+		return err
+	})
+
+	_, err = c.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: aws.String(subnetID)})
+	require.NoError(t, err, "delete-subnet %s", subnetID)
+
+	awaitNB(t, "logical switch "+sw+" removed", func(ctx context.Context) error {
+		if _, err := vpcd.OVN.GetLogicalSwitch(ctx, sw); err == nil {
+			return fmt.Errorf("logical switch %s still present", sw)
+		}
+		return nil
+	})
+}

--- a/tests/integration/vpcd_lite.go
+++ b/tests/integration/vpcd_lite.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/ovn"
+	"github.com/mulgadc/spinifex/spinifex/network/subscribers"
+	vpcdfixture "github.com/mulgadc/spinifex/tests/fixtures/vpcd"
+	"github.com/stretchr/testify/require"
+)
+
+// VPCDLite is a real vpcd event consumer over a real in-process OVN
+// Northbound DB. OVN is the connected client, for reading NB rows back.
+type VPCDLite struct {
+	OVN ovn.Client
+}
+
+// StartVPCDLite subscribes a real network/subscribers.Subscriber — the same
+// production type a live vpcd runs — to every vpc.* lifecycle topic, backed by
+// managers driving a genuine in-process OVN NB DB.
+//
+// This closes the one seam the tier otherwise leaves open. StartDaemonLite
+// already runs the real VPCServiceImpl for the AWS-facing half, so an API call
+// is authenticated, validated and persisted for real; but the vpc.* events it
+// publishes had no consumer, so the SG topics were answered by a canned ack
+// and the fire-and-forget topology topics were dropped. With this wired, an
+// SDK call is asserted all the way through to OVN NB rows.
+//
+// Call BEFORE StartDaemonLite, and pass WithRealVPCD to it — see the ordering
+// and double-responder notes on that option.
+//
+// What is deliberately absent: ovn-controller, so nothing translates NB to SB
+// to OpenFlow, and no OVS bridge, tap, netns or nftables rule exists. Correct
+// NB rows do not imply correct flows; that remains the live tier's claim.
+func StartVPCDLite(t *testing.T, gw *Gateway) *VPCDLite {
+	t.Helper()
+
+	fixture := vpcdfixture.Start(t)
+
+	subscriber, err := subscribers.New(fixture.Subscribers)
+	require.NoError(t, err, "construct vpcd subscriber")
+
+	subs, err := subscriber.Subscribe(gw.NATSConn)
+	require.NoError(t, err, "subscribe vpcd topics")
+	t.Cleanup(func() {
+		for _, s := range subs {
+			_ = s.Unsubscribe()
+		}
+	})
+
+	return &VPCDLite{OVN: fixture.OVN}
+}
+
+// nbPollInterval/nbPollTimeout bound the wait in awaitNB. Topology events are
+// fire-and-forget (utils.PublishEvent), so there is no reply to synchronise
+// on: the only honest assertion is to poll until the row appears. The timeout
+// is generous relative to an in-process OVSDB round-trip, since it is only
+// ever paid in full by a genuine failure.
+const (
+	nbPollInterval = 10 * time.Millisecond
+	nbPollTimeout  = 5 * time.Second
+)
+
+// awaitNB polls check until it returns nil, failing the test with the last
+// error once nbPollTimeout elapses. Use it for anything driven by a
+// fire-and-forget vpc.* event; the synchronous SG topics need no polling.
+func awaitNB(t *testing.T, what string, check func(ctx context.Context) error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), nbPollTimeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		if lastErr = check(ctx); lastErr == nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for %s: %v", what, lastErr)
+		case <-time.After(nbPollInterval):
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The integration tier already ran the real `VPCServiceImpl` for the AWS-facing half of VPC, but nothing consumed the `vpc.*` events it published: the SG topics were answered by a canned `{"success":true}` and the twenty fire-and-forget topology topics were dropped. Both sides of that wire were tested only against stubs, so the join was asserted nowhere below the live e2e tier.

This wires a real `subscribers.Subscriber` over a real in-process OVN Northbound DB (`ovntest.StartNB`), so an SDK call is now asserted all the way through to OVN NB rows before CI provisions anything.

Plan: `docs/development/improvements/vpcd-ovn-integration-tier.md` (mulga). Beads: `mulga-fwesh`, `mulga-c7psw`, `mulga-99k5t`.

## What landed

- `tests/fixtures/vpcd` — NB server plus the manager set a live vpcd builds.
- `tests/integration/vpcd_lite.go` — `StartVPCDLite`, opt-in per test so only tests asserting OVN state pay the startup cost, plus `awaitNB` for the fire-and-forget topics.
- `StartDaemonLite(..., WithRealVPCD())` — suppresses the canned SG acks. Load-bearing: a stub and the real subscriber both answering one request-reply means the test races its own fake.
- Four tests: VPC lifecycle, subnet lifecycle, security group + authorize-ingress, and subnet-event-before-VPC-event convergence.

Whole package runs in ~0.5s.

## Scope

Assertions sit at the crossing, not on NB row shapes — `network/reconcile`'s scenario tests own those, and duplicating them behind a slower gate buys nothing. Everything host-dependent stays with the live tier: ovn-controller (NB to SB to OpenFlow), OVS bridges, taps, netns, nftables, DHCP on the wire, packet paths, multi-node OVN raft. Correct NB rows do not imply correct flows.

## Fail-first evidence

All four tests go red when the subscriber is unsubscribed. `TestVPCD_SubnetBeforeVPCConverges` was independently mutation-checked: deleting the defensive pre-ensure at `subscribers/topology.go:75` makes it time out with the subnet's logical switch never created.

**A concurrent-ensure test was written and then cut**, rather than deferred. It passed, then failed its mutation check twice, so it was asserting nothing:

1. `Logical_Router.name` is a schema index, so ovsdb cannot accept a duplicate row. "Exactly one router" is the server's guarantee, not the code's — removing the wait-op TOCTOU guard left it green.
2. Reframed around the observable damage (a subnet dropped when its handler bails at the pre-ensure after losing the insert race) it also stayed green with `EnsureLogicalRouter`'s lost-race fallback removed. The losing interleaving never occurs: the first handler commits within microseconds and the second short-circuits on the cache.

Forcing that window open needs a barrier injected into production code, and a test that only fails on a lucky interleaving is a flake. The concurrency half of `ovn-ensurevpc-toctou-duplicate-routers` therefore remains uncovered below the live tier — recorded rather than papered over.

## Second commit: two defects this work surfaced

- **The tier was not re-runnable** (`mulga-c7psw`). Green at `-count=1`, red package-wide at `-count=2`, and reproduced on a clean tree so it predates this branch. Test accounts were keyed by `t.Name()`, which is unique among tests but repeats across passes in one `TestMain`, so pass 2 inherited pass 1's JetStream namespace — including an ECR signing key sealed with a master key `StartGateway` regenerates per call. Accounts now carry a counter suffix. `TestRunInstances_ClientTokenIdempotency` collided with itself for the same reason (its dedup store outlives a pass, so a fixed `ClientToken` made pass 2's opening launch read as a replay); its tokens are now suffixed per invocation.
- **Idempotent ensure logged at ERROR on its expected path** (`mulga-99k5t`). `ensureWaitTimeoutMS = 0` makes the wait-op fail fast by design when the row already exists, but `transactOps` reported the fall-through as `OVSDB operation failed`, once per re-ensure, drowning real faults in the sink live RCA reads first. That one result is now classified and logged at Debug; every other failed result still logs at ERROR, so a genuine constraint violation on the same op stays loud.

## Testing

- `make preflight` green.
- `make test-integration` green at `-count=2 -race` and at `-count=2 -shuffle=on`.
- `TestIsEnsureProbeTimeout` pins the new log classification.