### PR TITLE
fix(daemon): fail the system-instance launch when the VM never reaches running

### DIFF
--- a/spinifex/daemon/daemon_system_instance.go
+++ b/spinifex/daemon/daemon_system_instance.go
@@ -418,6 +418,11 @@ func (d *Daemon) LaunchSystemInstance(input *handlers_elbv2.SystemInstanceInput)
 // right NIC for the Ec2 datasource on its own. The instance is owned by
 // input.AccountID (the account its pre-created ENI lives in) and tagged
 // input.ManagedBy so customer listings hide it.
+//
+// Sharing the Prepare/Launch pair with RunInstances means a GPU instance type
+// gets the same admission, GPU claim and teardown-time release as a customer
+// VM: PrepareRunInstances gates on a free GPU slot, LaunchRunInstances claims
+// the device, and vm.Manager's cleanup chain releases it.
 func (d *Daemon) launchAMISystemInstance(input *sysinstance.SystemInstanceInput) (*sysinstance.SystemInstanceOutput, error) {
 	if d.instanceService == nil {
 		return nil, errors.New("sysinstance: instance service not initialized")
@@ -499,6 +504,10 @@ func (d *Daemon) launchAMISystemInstance(input *sysinstance.SystemInstanceInput)
 
 	d.instanceService.LaunchRunInstances(context.Background(), instances, runInput, instanceType)
 
+	if err := d.verifySystemInstanceLaunched(inst); err != nil {
+		return nil, err
+	}
+
 	privateIP := input.ENIIP
 	if privateIP == "" && inst.Instance != nil {
 		privateIP = aws.StringValue(inst.Instance.PrivateIpAddress)
@@ -515,6 +524,21 @@ func (d *Daemon) launchAMISystemInstance(input *sysinstance.SystemInstanceInput)
 		PrivateIP:  privateIP,
 		MgmtIP:     inst.MgmtIP,
 	}, nil
+}
+
+// verifySystemInstanceLaunched checks that inst actually reached running state
+// after LaunchRunInstances. That call is a best-effort batch launcher: volume
+// preparation, GPU claim and vmMgr.Run failures each mark the instance failed
+// and return nothing, so the outcome is only visible in the VM's state. Without
+// this check a system-instance caller (EKS control plane, ELB, Bedrock serving
+// VM) receives an instance ID for a VM already being torn down and waits on an
+// endpoint that will never answer. Cleanup is left to the MarkFailed chain
+// LaunchRunInstances already ran.
+func (d *Daemon) verifySystemInstanceLaunched(inst *vm.VM) error {
+	if status := d.vmMgr.Status(inst); status != vm.StateRunning {
+		return fmt.Errorf("sysinstance: instance %s did not reach running state (status %q)", inst.ID, status)
+	}
+	return nil
 }
 
 // attachSystemMgmtNIC allocates a management-bridge IP + MAC for a system VM and

--- a/spinifex/daemon/daemon_system_instance_test.go
+++ b/spinifex/daemon/daemon_system_instance_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -82,6 +83,50 @@ func TestWaitForSystemInstance_Timeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// verifySystemInstanceLaunched
+// ---------------------------------------------------------------------------
+
+func TestVerifySystemInstanceLaunched_Running(t *testing.T) {
+	inst := &vm.VM{ID: "i-up", Status: vm.StateRunning}
+	d := newDaemonWithVMs(inst)
+
+	require.NoError(t, d.verifySystemInstanceLaunched(inst))
+}
+
+// LaunchRunInstances swallows launch errors and leaves the instance in a
+// cleanup state, so every non-running state must surface as a launch failure —
+// a GPU claim failure marks the VM shutting-down via MarkFailed.
+func TestVerifySystemInstanceLaunched_NonRunningStatesFail(t *testing.T) {
+	for _, status := range []vm.InstanceState{
+		vm.StateShuttingDown,
+		vm.StateError,
+		vm.StateTerminated,
+		vm.StatePending,
+		vm.StateProvisioning,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			inst := &vm.VM{ID: "i-down", Status: status}
+			d := newDaemonWithVMs(inst)
+
+			err := d.verifySystemInstanceLaunched(inst)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "i-down")
+			assert.Contains(t, err.Error(), string(status))
+		})
+	}
+}
+
+// MarkFailed transitions synchronously before running its cleanup goroutine, so
+// the check sees the failure without racing the teardown.
+func TestVerifySystemInstanceLaunched_AfterMarkFailedIsAnError(t *testing.T) {
+	inst := &vm.VM{ID: "i-gpu-claim-failed", Status: vm.StateProvisioning}
+	d := newDaemonWithVMs(inst)
+	d.vmMgr.MarkFailed(context.Background(), inst, "gpu_claim_failed")
+
+	require.Error(t, d.verifySystemInstanceLaunched(inst))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`launchAMISystemInstance` calls `d.instanceService.LaunchRunInstances` and then unconditionally returns a `SystemInstanceOutput`.

`LaunchRunInstances` is a best-effort batch launcher that returns nothing. Volume preparation, GPU claim and `vmMgr.Run` failures each call `MarkFailed` and continue, so the outcome is only observable in the VM's state. An EKS control-plane server, ELB load balancer or Bedrock serving VM whose launch failed therefore received a nil error and an instance ID for a VM that was already being torn down, and then waited on an endpoint that would never answer.

## Change

Check the instance reached running state before returning, and turn anything else into an error. Cleanup stays with the `MarkFailed` chain `LaunchRunInstances` has already run, so there is no double teardown.

The doc comment on `launchAMISystemInstance` now also records that GPU handling is inherited from the shared Prepare/Launch pair — GPU slot admission in `PrepareRunInstances` via `canAllocateLocked`, the claim in `LaunchRunInstances`, and release through `vm.Manager`'s cleanup chain. That was previously believed to be missing on this path, and the note is there so it is not re-added and made to double-claim.

## Testing

- `TestVerifySystemInstanceLaunched_Running` — running state passes.
- `TestVerifySystemInstanceLaunched_NonRunningStatesFail` — every non-running state errors, and the message names the instance and the state.
- `TestVerifySystemInstanceLaunched_AfterMarkFailedIsAnError` — `MarkFailed` transitions synchronously before its cleanup goroutine, so the check sees the failure without racing teardown.
- `make preflight` passes: 0 lint issues, 0 vulnerabilities, race/e2e-harness/integration suites green.

Closes mulga-vmfng.7.2.