### PR TITLE
chore: give the integration tier its own CI job and drop it from preflight

### DIFF
--- a/.github/workflows/spinifex.yml
+++ b/.github/workflows/spinifex.yml
@@ -68,15 +68,6 @@ jobs:
       - name: Manifest check + drift lint
         run: make -C spinifex manifest-check manifest-lint
 
-      # In-process integration tier (gateway.SetupRoutes over embedded NATS
-      # JetStream). Runs here, on every PR, rather than only relying on
-      # e2e.yml's "Integration (front gate)" job: that job is push-triggered
-      # against main/dev on a self-hosted runner, so it never blocks a PR
-      # before merge. This step provisions nothing and completes in seconds,
-      # so it belongs as an ordinary required PR check, not a separate job.
-      - name: Run Integration Tests
-        run: make -C spinifex test-integration
-
       - name: Run Tests with Coverage
         run: make -C spinifex test-cover
 
@@ -85,6 +76,55 @@ jobs:
 
       - name: Check Diff Coverage
         run: cd spinifex && scripts/diff-coverage.sh coverage.out --base HEAD~1
+
+  # In-process integration tier (gateway.SetupRoutes over embedded NATS
+  # JetStream). Its own job so it runs in parallel with the unit tiers rather
+  # than adding to their wall time, and it still blocks a PR — unlike e2e.yml's
+  # "Integration (front gate)" job, which is push-triggered against main/dev on
+  # a self-hosted runner and so never gates a PR before merge.
+  integration_tests:
+    name: Integration Tests
+    runs-on: ubuntu-26.04
+
+    steps:
+      - name: Checkout Spinifex
+        uses: actions/checkout@v7
+        with:
+          path: spinifex
+          fetch-depth: 2
+
+      - name: Resolve sibling refs
+        id: siblings
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: bash .github/resolve-sibling-refs.sh
+        working-directory: spinifex
+
+      - name: Checkout Viperblock
+        uses: actions/checkout@v7
+        with:
+          repository: mulgadc/viperblock
+          ref: ${{ steps.siblings.outputs.viperblock }}
+          path: viperblock
+
+      - name: Checkout Predastore
+        uses: actions/checkout@v7
+        with:
+          repository: mulgadc/predastore
+          ref: ${{ steps.siblings.outputs.predastore }}
+          path: predastore
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          cache-dependency-path: "spinifex/go.sum"
+          go-version-file: "spinifex/go.mod"
+
+      - name: Setup Go Workspace
+        run: go work init ./spinifex ./viperblock ./predastore
+
+      - name: Run Integration Tests
+        run: make -C spinifex test-integration
 
   race_detection:
     name: Race Detection

--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,15 @@ install-microvm: $(MICROVM_ARTIFACTS) ## Install microVM artifacts to /usr/share
 	sudo install -m 0644 $(MICROVM_OUT_DIR)/vmlinuz /usr/share/spinifex/microvm/vmlinuz
 	sudo install -m 0644 $(MICROVM_OUT_DIR)/initramfs.cpio.gz /usr/share/spinifex/microvm/initramfs.cpio.gz
 
-# Preflight — runs the same checks as GitHub Actions (lint + vuln + tests).
-# Use this before committing to catch CI failures locally.
+# Preflight — the pre-commit gate: manifest checks, lint, vuln, and the unit,
+# race and e2e-harness tiers.
+#
+# The integration tier is deliberately NOT here. CI runs it as its own parallel
+# job, so it is still gated before merge, and keeping it out leaves preflight
+# the fast common-path check — run `make test-integration` directly when a
+# change touches the gateway router or the NATS subjects it drives.
 preflight:
-	@$(MAKE) --no-print-directory QUIET=1 manifest-check manifest-lint lint govulncheck test-cover diff-coverage test-race test-harness test-integration
+	@$(MAKE) --no-print-directory QUIET=1 manifest-check manifest-lint lint govulncheck test-cover diff-coverage test-race test-harness
 	@echo -e "\n ✅ Preflight passed — safe to commit."
 
 # E2E harness unit tests. Build-tagged `e2e` so they're skipped by the
@@ -137,10 +142,10 @@ test-harness:
 # JetStream, with only the daemon-side NATS subjects stubbed. Build-tagged
 # `integration` so it's skipped by the default `go test ./spinifex/...` and by
 # `test-cover`/`test-race`. Nothing provisioned — no tofu, no docker, no
-# Spinifex daemons, so the whole package runs in well under a minute — part
-# of `preflight` (and its own PR-blocking CI step) rather than the
-# self-hosted, push-triggered live e2e tiers, so a regression here is caught
-# before it can be merged, not just after.
+# Spinifex daemons, so the whole package runs in well under a minute. It gets
+# its own PR-blocking CI job rather than the self-hosted, push-triggered live
+# e2e tiers, so a regression here is caught before it can be merged, not just
+# after.
 test-integration:
 	@echo -e "\n....Running in-process integration tests...."
 	$(_Q)LOG_IGNORE=1 go test -tags=integration -timeout 60s ./tests/integration/... $(_RACEQ)


### PR DESCRIPTION
## Summary

`test-integration` ran in two places it did not need to: inside the `Build and Test` CI job, serialised ahead of `test-cover`, and again in `preflight`. Neither placement bought signal that a parallel job does not — the tier provisions nothing and finishes in seconds, so the only effect was wall time on the two paths developers wait for most.

It stays PR-blocking as its own job. That is what distinguishes it from `e2e.yml`'s "Integration (front gate)" job, which is push-triggered against main/dev on a self-hosted runner and so never gates a PR before merge.

Counterpart to the same split in viperblock.

## Changes

- `Makefile`: `preflight` no longer runs `test-integration`, and the comment above the target no longer claims it is part of preflight.
- `.github/workflows/spinifex.yml`: the `Run Integration Tests` step moves out of `build_and_test` into a new `integration_tests` job with the same sibling-checkout and Go-workspace setup.

## Testing

`make test-integration` passes standalone (`ok github.com/mulgadc/spinifex/tests/integration 11.6s`). Workflow YAML parses, and the four jobs are `build_and_test`, `integration_tests`, `race_detection`, `lint_and_security`.

## Note on scope

This does not touch the `TestIntegration_*` tests in `spinifex/services/viperblockd` and `spinifex/services/predastore`. Despite the name those carry no build tag — only a `testing.Short()` skip — so they run under `test-cover` in the unit tier and are unaffected by this change. Whether they belong in this tier is a separate decision.
