### PR TITLE
fix: make the seal-failure unmount test deterministic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.13.0
 	github.com/mulgadc/predastore v1.13.1-0.20260722023246-c0a90d23b3a0
-	github.com/mulgadc/viperblock v1.13.1-0.20260722115304-3b56d613e4fa
+	github.com/mulgadc/viperblock v1.13.1-0.20260722235138-30ce53d32153
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1321,8 +1321,8 @@ github.com/mulgadc/northstar v1.13.0 h1:L9PyYZ9Klg7dv2kE5+DHOcgPHelaZRDIvnwBsbHs
 github.com/mulgadc/northstar v1.13.0/go.mod h1:erQE/PzK9UMtgH8Y+uI5RdiboO/nqe1CUJbIpkae/FM=
 github.com/mulgadc/predastore v1.13.1-0.20260722023246-c0a90d23b3a0 h1:29g+uPZ0LAANVA1IPnE/ogxJzJBJnBZvnTl51icp378=
 github.com/mulgadc/predastore v1.13.1-0.20260722023246-c0a90d23b3a0/go.mod h1:38YSuk9zvYmbmgyM13WTkIQPJtvo2KmGJBYJul6NeAE=
-github.com/mulgadc/viperblock v1.13.1-0.20260722115304-3b56d613e4fa h1:Oyl8jRcE7M/4aUAJHZjOKyuwcbrR51onHF+5EfYJ3aw=
-github.com/mulgadc/viperblock v1.13.1-0.20260722115304-3b56d613e4fa/go.mod h1:sW0hxZjN7WDQQZ39L5mE58fVLbSv3mBP3/ifFPdwJtU=
+github.com/mulgadc/viperblock v1.13.1-0.20260722235138-30ce53d32153 h1:IwF+nlszV2pupsVBakcCc9pReq2nAh4Xb8a7XtiVYtM=
+github.com/mulgadc/viperblock v1.13.1-0.20260722235138-30ce53d32153/go.mod h1:sW0hxZjN7WDQQZ39L5mE58fVLbSv3mBP3/ifFPdwJtU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -132,7 +132,24 @@ type Config struct {
 
 	masterKey *masterkey.Key
 
+	// sealVolume overrides how a detached volume is sealed to predastore.
+	// Nil means sealVolumeVB, the real seal. Tests that need a seal to FAIL
+	// inject here rather than pointing S3Host at an unreachable endpoint: the
+	// real failure only arrives once the S3 client exhausts its jittered
+	// backoff, which takes anywhere from one to five seconds and so decides the
+	// test on where the dice land relative to the caller's deadline.
+	sealVolume func(volumeName string) error
+
 	mu sync.Mutex
+}
+
+// seal persists volumeName's block map to predastore, honouring a test's
+// injected seal if there is one.
+func (cfg *Config) seal(volumeName string) error {
+	if cfg.sealVolume != nil {
+		return cfg.sealVolume(volumeName)
+	}
+	return sealVolumeVB(cfg, volumeName)
 }
 
 type Service struct {
@@ -516,7 +533,7 @@ func launchService(cfg *Config) (err error) {
 			// the block map to predastore for volumes that hold local state to
 			// flush (see volumeNeedsSeal).
 			if volumeNeedsSeal(matched.Name, cfg.BaseDir) {
-				if err := sealVolumeVB(cfg, matched.Name); err != nil {
+				if err := cfg.seal(matched.Name); err != nil {
 					slog.ErrorContext(ctx, "ebs.unmount: failed to seal volume to predastore", "volume", matched.Name, "err", err)
 					ebsResponse.Error = fmt.Sprintf("seal volume: %v", err)
 				} else {

--- a/spinifex/services/viperblockd/viperblockd_integration_test.go
+++ b/spinifex/services/viperblockd/viperblockd_integration_test.go
@@ -6,8 +6,10 @@ package viperblockd
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -361,9 +363,16 @@ func TestIntegration_EBSUnmountSealFailureKeepsVolumeMounted(t *testing.T) {
 	defer ns.Shutdown()
 
 	cfg := setupTestConfig(t, natsURL)
-	// A local WAL directory makes volumeNeedsSeal true; the configured S3 host
-	// is an unreachable mock endpoint, so sealVolumeVB's LoadState fails.
+	// A local WAL directory makes volumeNeedsSeal true, and the injected seal
+	// then fails immediately. Letting the real seal fail against the mock S3
+	// host works too, but only after seconds of jittered client backoff, which
+	// is what put this test's outcome inside the tail of the 5s deadline below.
 	createMockVolumeState(t, cfg.BaseDir, "vol-seal-fail")
+	var sealCalls atomic.Int32
+	cfg.sealVolume = func(volumeName string) error {
+		sealCalls.Add(1)
+		return fmt.Errorf("seal %s: injected backend failure", volumeName)
+	}
 	cfg.MountedVolumes = []MountedVolume{
 		{Name: "vol-seal-fail", PID: 99999},
 	}
@@ -385,6 +394,9 @@ func TestIntegration_EBSUnmountSealFailureKeepsVolumeMounted(t *testing.T) {
 	require.NoError(t, json.Unmarshal(msg.Data, &resp))
 	assert.NotEmpty(t, resp.Error, "a seal failure must surface as an error, not a silent success")
 	assert.False(t, resp.NotFound, "a failed seal must not report NotFound")
+	// Guards the injection itself: a handler that stopped sealing altogether
+	// would otherwise satisfy every assertion below.
+	assert.Equal(t, int32(1), sealCalls.Load(), "the unmount handler must have attempted the seal")
 
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()


### PR DESCRIPTION
## Summary

`TestIntegration_EBSUnmountSealFailureKeepsVolumeMounted` failed intermittently with `nats: timeout`. It cost real time on spinifex #563, where it was initially mistaken for a regression from a viperblock dependency bump — running 10x per pin showed 2/10 vs 3/10, i.e. sample size, not the dependency.

## Root cause

The test forces the seal to fail by pointing `S3Host` at an unreachable mock endpoint, so the unmount handler only replies once the S3 client gives up. That is not a bounded cost. Measured handler time on passing runs: 1.80s, 2.59s, 3.70s, 4.12s, 4.35s, 4.84s, 5.10s, 5.45s. Failures land at 5.53s — the 500ms startup sleep plus the full 5s `nc.Request` timeout. The deadline simply sits inside the tail of the client's jittered exponential backoff.

Two theories were tested and discarded on the way:
- **DNS.** Repointing `S3Host` at `https://127.0.0.1:1` (instant connection refused, no lookup) still failed 3/20.
- **The `loadStateWithRetry` ladder.** Cutting `loadStateRetryAttempts` from 5 to 1 left the spread unchanged (1.99s–5.27s, still 1/8 failing) — `LoadState`'s error is not `ErrStateBackendUnavailable`, so the ladder never runs. The whole cost is one S3 round trip failing.

## Change

`Config` gains an unexported `sealVolume` seam; nil means `sealVolumeVB`, the real seal. The test injects a failure that returns immediately, so the handler's reaction — which is what the test is actually about — is exercised without waiting on a network client to give up.

The test also now asserts the handler attempted the seal exactly once. The old form could not tell "seal failed" from "seal never ran".

## Verification

- 50 consecutive runs pass, each 0.53s (was 1.8s–5.5s).
- `make preflight` and `make test-integration` pass.

## Follow-up, not fixed here

The unmount handler takes up to ~5s to return when the backend is unreachable, and in production that latency is exposed to whatever called `ebs.<node>.unmount`. A caller with a similar timeout would see the same failure against a real S3 outage. Same underlying reason as mulga-wtvw5.