### PR TITLE
fix(lbagent): quiet expected startup heartbeat failures below ERROR

### DIFF
--- a/spinifex/lbagent/agent.go
+++ b/spinifex/lbagent/agent.go
@@ -43,6 +43,15 @@ const (
 
 	// pollInterval is how often the agent sends a heartbeat.
 	pollInterval = 5 * time.Second
+
+	// registrationGrace bounds how long startup heartbeat failures are logged
+	// below ERROR. A freshly launched LB races its own record's replication to
+	// the gateway node that fields the first heartbeat, so early failures
+	// (LoadBalancerNotFound, IMDS credentials not yet warm) are expected and
+	// self-heal within a few ticks. Past this window with no success — the
+	// fingerprint of a genuinely network-blackholed agent — failures escalate
+	// to ERROR so the serial-console telemetry still surfaces them.
+	registrationGrace = 60 * time.Second
 )
 
 // Data-plane engine names (duplicated from handlers/elbv2 to avoid an import cycle).
@@ -68,6 +77,12 @@ type Agent struct {
 	engine          string         // data-plane engine of the last applied config
 	healthTargets   []HealthTarget // active probe targets (nginx/NLB only)
 	stopCh          chan struct{}
+
+	// startedAt anchors the registration grace window; firstHeartbeatOK
+	// records whether any heartbeat has ever succeeded. Both are touched only
+	// from the single poll goroutine (Start -> tick), so they need no lock.
+	startedAt        time.Time
+	firstHeartbeatOK bool
 
 	// For testing: override the reload functions (HAProxy / nginx).
 	reloadFn      func(configPath, pidPath string) error
@@ -127,6 +142,7 @@ func New(lbID, gatewayURL, accessKey, secretKey, region string) (*Agent, error) 
 		signer:        signer,
 		client:        client,
 		stopCh:        make(chan struct{}),
+		startedAt:     time.Now(),
 		reloadFn:      reloadHAProxy,
 		reloadNginxFn: reloadNginx,
 		statsFn:       queryHAProxyStats,
@@ -184,9 +200,21 @@ func (a *Agent) tick() {
 		// Include the dial target so the serial console disambiguates a
 		// transport failure (never reached AWSGW — "send request: dial ...")
 		// from an HTTP-level rejection ("gateway returned NNN: ...").
+		//
+		// Before the first successful heartbeat, and only within the grace
+		// window, a failure is an expected startup race (record not yet
+		// replicated, credentials not yet warm) and logs at INFO. Past the
+		// window, or once any heartbeat has succeeded, a failure is real and
+		// logs at ERROR so the console telemetry still catches a blackhole.
+		if !a.firstHeartbeatOK && time.Since(a.startedAt) < registrationGrace {
+			slog.Info("Heartbeat pending during startup", "err", err,
+				"gateway", a.gatewayURL, "elapsed", time.Since(a.startedAt).Round(time.Second))
+			return
+		}
 		slog.Error("Heartbeat failed", "err", err, "gateway", a.gatewayURL, "region", a.region)
 		return
 	}
+	a.firstHeartbeatOK = true
 
 	slog.Debug("Heartbeat OK", "status", resp.Status, "configHash", resp.ConfigHash)
 

--- a/spinifex/lbagent/agent_test.go
+++ b/spinifex/lbagent/agent_test.go
@@ -1,12 +1,15 @@
 package lbagent
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -645,5 +648,98 @@ func TestFetchConfig_WriteError(t *testing.T) {
 
 	if agent.localConfigHash != "" {
 		t.Errorf("localConfigHash should be empty after write failure, got %q", agent.localConfigHash)
+	}
+}
+
+// notFoundGateway returns 400 LoadBalancerNotFound for every heartbeat, the
+// shape a freshly launched LB sees while its record replicates to the gateway
+// node fielding the first heartbeat.
+func notFoundGateway(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `<ErrorResponse><Error><Type>Sender</Type><Code>LoadBalancerNotFound</Code><Message>One or more load balancers not found.</Message></Error></ErrorResponse>`)
+	}))
+}
+
+// captureSlog redirects the default logger to a buffer for the duration of the
+// test and returns an accessor for the accumulated output.
+func captureSlog(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf.String
+}
+
+func TestHeartbeat_StartupFailureLogsBelowError(t *testing.T) {
+	gw := notFoundGateway(t)
+	defer gw.Close()
+
+	agent := newTestAgent(t, gw.URL)
+	logs := captureSlog(t)
+
+	// Fresh agent, inside the grace window and never yet successful: a
+	// LoadBalancerNotFound is a startup race, not an error.
+	agent.tick()
+
+	out := logs()
+	if strings.Contains(out, "level=ERROR") {
+		t.Errorf("startup heartbeat failure logged at ERROR within grace window:\n%s", out)
+	}
+	if !strings.Contains(out, "Heartbeat pending during startup") {
+		t.Errorf("expected startup-pending log line, got:\n%s", out)
+	}
+}
+
+func TestHeartbeat_FailureAfterGraceLogsError(t *testing.T) {
+	gw := notFoundGateway(t)
+	defer gw.Close()
+
+	agent := newTestAgent(t, gw.URL)
+	logs := captureSlog(t)
+
+	// Past the grace window with no prior success — the blackhole fingerprint —
+	// must escalate so the console telemetry catches it.
+	agent.startedAt = time.Now().Add(-2 * registrationGrace)
+	agent.tick()
+
+	out := logs()
+	if !strings.Contains(out, "level=ERROR") || !strings.Contains(out, "Heartbeat failed") {
+		t.Errorf("post-grace heartbeat failure did not escalate to ERROR:\n%s", out)
+	}
+}
+
+func TestHeartbeat_FailureAfterFirstSuccessLogsError(t *testing.T) {
+	// A gateway that answers healthily once, then only ever 400s.
+	var beats atomic.Int32
+	gw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		if beats.Add(1) == 1 {
+			fmt.Fprint(w, `<LBAgentHeartbeatResponse><LBAgentHeartbeatResult><Status>active</Status><ConfigHash></ConfigHash></LBAgentHeartbeatResult></LBAgentHeartbeatResponse>`)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `<ErrorResponse><Error><Code>LoadBalancerNotFound</Code></Error></ErrorResponse>`)
+	}))
+	defer gw.Close()
+
+	agent := newTestAgent(t, gw.URL)
+	logs := captureSlog(t)
+
+	// First tick succeeds (still inside grace); the next failure must be ERROR
+	// regardless of the window, because the agent has proven it can reach the
+	// gateway, so any later failure is real.
+	agent.tick()
+	agent.tick()
+
+	out := logs()
+	if !agent.firstHeartbeatOK {
+		t.Fatal("firstHeartbeatOK not set after a successful heartbeat")
+	}
+	if !strings.Contains(out, "level=ERROR") || !strings.Contains(out, "Heartbeat failed") {
+		t.Errorf("post-success heartbeat failure did not log ERROR:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Problem

A freshly launched LB agent starts heartbeating the instant the VM boots. The gateway node fielding that first heartbeat may not be the node that created the LB, so the LB record has not yet replicated and the gateway returns `400 LoadBalancerNotFound` (`handlers/elbv2/service_impl.go:862`). The IMDS credential chain is likewise not always warm on the first tick. Both self-heal within a few ticks, but every early failure was logged by `tick()` as `slog.Error("Heartbeat failed", ...)`.

Surfaced by the new lbagent console telemetry in E2E run 29961054845 — 46 ERROR heartbeat lines across all 8 LB instances (29 `LoadBalancerNotFound`, 17 transport/timeout including one IMDS `failed to refresh cached credentials`), all self-healed, suite green throughout. Pure startup noise, and a 400 masks a genuine rejection if one ever lands in that window.

## Change

A `registrationGrace` window (60s). Before any heartbeat has ever succeeded, and only within the window, a failure logs at INFO (`Heartbeat pending during startup`, carrying the err and elapsed) and returns. Past the window with no success — the fingerprint of a genuinely network-blackholed agent — or once any heartbeat has succeeded, a failure logs at ERROR exactly as before.

This suppresses the whole class of startup transients without coupling the agent to the gateway's error vocabulary. Crucially it does not blunt the reason the telemetry exists: a genuinely blackholed agent (the mgmt-IP collision victim was exactly that) never succeeds, so after 60s it escalates to ERROR every tick and is caught. The only change for a persistent failure is a bounded delay before it escalates — negligible against a multi-minute suite.

`startedAt` and `firstHeartbeatOK` are touched only from the single poll goroutine (`Start` → `tick`), so no lock is needed.

## Tests

- `TestHeartbeat_StartupFailureLogsBelowError` — a fresh agent's 400 within grace logs INFO, not ERROR.
- `TestHeartbeat_FailureAfterGraceLogsError` — past the deadline with no prior success escalates to ERROR (the blackhole path).
- `TestHeartbeat_FailureAfterFirstSuccessLogsError` — a failure after the first success logs ERROR regardless of the window.

`make preflight` passes (golangci-lint 0 issues, govulncheck clean, race tests).

## Out of scope

Whether the gateway should itself return a retriable signal instead of 400 while the LB record replicates. The agent-side grace addresses the reported symptom; a gateway-side change would touch the heartbeat contract and is a separate design.

Bead: mulga-cwxoq. The paired log.level mapping fix (mulga-lc6nm) lands separately in the mulga Alloy config. Plan: `docs/development/bugs/lb-agent-startup-noise-and-log-level.md`.