### PR TITLE
fix: terminate/detach volume-wedge — detach-before-delete, bounded detach, vanished-QEMU + stuck-terminate backstops

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1662,6 +1662,7 @@ func (d *Daemon) startCluster() error {
 		reapers := []vm.Reaper{
 			d.vmMgr.NewTerminatedTeardownReaper(),
 			d.vmMgr.NewOrphanQEMUReaper(),
+			d.vmMgr.NewStuckTerminateReaper(),
 		}
 		if eniRec := d.newENIReconciler(); eniRec != nil {
 			reapers = append(reapers, eniRec)

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -1598,6 +1599,119 @@ func TestInstanceCleanerAdapter_DeleteVolumes_BootVolumeDeletedAfterAttachmentCl
 	_, err = daemon.volumeService.GetVolumeConfig(volumeID)
 	require.Error(t, err, "the volume must actually be deleted")
 	assert.Contains(t, err.Error(), awserrors.ErrorInvalidVolumeNotFound)
+}
+
+// TestInstanceCleanerAdapter_DeleteVolumes_NonDoTBootVolumeDetachedNotDeleted
+// locks the running-path half of the terminate-implies-detach fix for a
+// DeleteOnTermination=false root volume: shutdownAndUnmount's Unmount
+// (daemon/vm_adapters.go) deliberately never clears a Boot volume's
+// attachment, so without this it would strand attached to the now-terminated
+// instance forever. Terminate must still detach it (AWS semantics: it
+// survives as available, it just isn't deleted).
+func TestInstanceCleanerAdapter_DeleteVolumes_NonDoTBootVolumeDetachedNotDeleted(t *testing.T) {
+	daemon, store := createFullTestDaemonWithStore(t, sharedNATSURL)
+
+	volumeID := "vol-root-nondot-attached"
+	seedVolumeConfig(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		TenantID:         testAccountID,
+		SizeGiB:          10,
+		State:            "available",
+		AttachedInstance: "i-test-boot-detach", // stale: never cleared by Unmount's Boot carve-out
+	})
+
+	instance := &vm.VM{
+		ID:        "i-test-boot-detach",
+		AccountID: testAccountID,
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{
+				{Name: volumeID, Boot: true, DeleteOnTermination: false},
+			},
+		},
+	}
+
+	cleaner := newInstanceCleanerAdapter(daemon)
+	err := cleaner.DeleteVolumes(instance)
+	require.NoError(t, err)
+
+	cfg, err := daemon.volumeService.GetVolumeConfig(volumeID)
+	require.NoError(t, err, "a DeleteOnTermination=false volume must survive terminate")
+	assert.Equal(t, "available", cfg.VolumeMetadata.State)
+	assert.Empty(t, cfg.VolumeMetadata.AttachedInstance, "terminate must still detach it")
+}
+
+// TestTerminatedTeardownReaper_SelfHealsFailedVolumeTeardown proves the
+// go-forward self-heal: a stopped-terminate that stamped
+// Teardown[volumes]=failed on a transient error (deleteInstanceVolumes,
+// handlers/ec2/instance/service_impl.go) is retried by
+// TerminatedTeardownReaper.Sweep (vm/teardown_reaper.go) through the real
+// instanceCleanerAdapter, which stage 1 rerouted through
+// DeleteVolumeOnTerminate. The retry clears the stale attachment, the delete
+// now succeeds, and the mark flips to done — without abandoning the record.
+func TestTerminatedTeardownReaper_SelfHealsFailedVolumeTeardown(t *testing.T) {
+	daemon, store := createFullTestDaemonWithStore(t, sharedJSNATSURL)
+
+	// A real terminated-instance KV, so Sweep can list/update/(not yet)purge
+	// the record exactly as production does.
+	jsManager, err := NewJetStreamManager(daemon.natsConn, 1)
+	require.NoError(t, err)
+	require.NoError(t, jsManager.InitTerminatedInstanceBucket())
+	daemon.stateStore = newStateStoreAdapter(jsManager)
+
+	// DeleteVolume's snapshot-reference guard requires a non-nil snapshotKV.
+	js, err := daemon.natsConn.JetStream()
+	require.NoError(t, err)
+	snapKV, err := js.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket: "snap-kv-" + strings.ReplaceAll(t.Name(), "/", "-"),
+	})
+	require.NoError(t, err)
+	daemon.volumeService = handlers_ec2_volume.NewVolumeServiceImplWithStore(daemon.config, store, daemon.natsConn, snapKV)
+
+	volumeID := "vol-root-self-heal"
+	instanceID := "i-self-heal"
+	seedVolumeConfig(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		TenantID:         testAccountID,
+		SizeGiB:          10,
+		State:            "available",
+		AttachedInstance: instanceID, // stale, left by the earlier failed terminate
+	})
+
+	instance := &vm.VM{
+		ID:           instanceID,
+		AccountID:    testAccountID,
+		Status:       vm.StateTerminated,
+		LastNode:     daemon.node,
+		TerminatedAt: time.Now(), // inside the visibility window: Sweep must not purge yet
+		Teardown: map[string]string{
+			vm.TeardownVolumes: string(vm.TeardownFailed),
+		},
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{
+				{Name: volumeID, Boot: true, DeleteOnTermination: true},
+			},
+		},
+	}
+	require.NoError(t, daemon.stateStore.WriteTerminatedInstance(instance.ID, instance))
+
+	reaper := vm.NewManagerWithDeps(vm.Deps{
+		NodeID:          daemon.node,
+		StateStore:      daemon.stateStore,
+		InstanceCleaner: newInstanceCleanerAdapter(daemon),
+	}).NewTerminatedTeardownReaper()
+
+	_, err = reaper.Sweep(context.Background())
+	require.NoError(t, err)
+
+	_, err = daemon.volumeService.GetVolumeConfig(volumeID)
+	require.Error(t, err, "the retried delete must actually remove the volume")
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidVolumeNotFound)
+
+	remaining, err := daemon.stateStore.ListTerminatedInstances()
+	require.NoError(t, err)
+	require.Len(t, remaining, 1, "still within the visibility window: not purged yet")
+	assert.Equal(t, string(vm.TeardownDone), remaining[0].Teardown[vm.TeardownVolumes],
+		"a retry that now succeeds must flip the mark from failed to done")
 }
 
 // TestHandleEC2Events_AttachVolume tests the attach-volume handler in handleEC2Events.

--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1545,6 +1546,58 @@ func TestInstanceCleanerAdapter_DeleteVolumes_DeleteOnTermination_False(t *testi
 
 	// Root volume with DeleteOnTermination=false should NOT receive ebs.delete
 	assert.False(t, ebsDeletedVolumes["vol-keep"], "Root volume with DeleteOnTermination=false should NOT be deleted")
+}
+
+// TestInstanceCleanerAdapter_DeleteVolumes_BootVolumeDeletedAfterAttachmentClear
+// locks the mulga-1dzx9 fix on the running-instance terminate path: a Boot,
+// DeleteOnTermination root volume left attached (terminateCleanup's
+// shutdownAndUnmount runs Unmount, which deliberately never clears a Boot
+// volume's AttachedInstance) previously hit DeleteVolume's in-use guard
+// directly. DeleteVolumes must now call DeleteVolumeOnTerminate, which clears
+// the stale attachment first, so the delete actually succeeds.
+func TestInstanceCleanerAdapter_DeleteVolumes_BootVolumeDeletedAfterAttachmentClear(t *testing.T) {
+	daemon, store := createFullTestDaemonWithStore(t, sharedNATSURL)
+
+	// DeleteVolume's snapshot-reference guard requires a non-nil snapshotKV;
+	// wire a JetStream-backed one (no snapshot refs recorded) so the delete
+	// reaches the S3 cleanup step instead of failing closed on a nil KV.
+	jsConn, err := nats.Connect(sharedJSNATSURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { jsConn.Close() })
+	js, err := jsConn.JetStream()
+	require.NoError(t, err)
+	snapKV, err := js.CreateKeyValue(&nats.KeyValueConfig{
+		Bucket: "snap-kv-" + strings.ReplaceAll(t.Name(), "/", "-"),
+	})
+	require.NoError(t, err)
+	daemon.volumeService = handlers_ec2_volume.NewVolumeServiceImplWithStore(daemon.config, store, daemon.natsConn, snapKV)
+
+	volumeID := "vol-root-attached"
+	seedVolumeConfig(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		TenantID:         testAccountID,
+		SizeGiB:          10,
+		State:            "available",
+		AttachedInstance: "i-test-boot-delete", // stale: never cleared by Stop/shutdownAndUnmount's Boot carve-out
+	})
+
+	instance := &vm.VM{
+		ID:        "i-test-boot-delete",
+		AccountID: testAccountID,
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{
+				{Name: volumeID, Boot: true, DeleteOnTermination: true},
+			},
+		},
+	}
+
+	cleaner := newInstanceCleanerAdapter(daemon)
+	err = cleaner.DeleteVolumes(instance)
+	require.NoError(t, err, "the still-attached boot volume must be deleted, not rejected as VolumeInUse")
+
+	_, err = daemon.volumeService.GetVolumeConfig(volumeID)
+	require.Error(t, err, "the volume must actually be deleted")
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidVolumeNotFound)
 }
 
 // TestHandleEC2Events_AttachVolume tests the attach-volume handler in handleEC2Events.

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -621,10 +621,34 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) error {
 			continue
 		}
 
-		// User-visible volumes: only delete when DeleteOnTermination is set.
+		// User-visible volumes: DeleteOnTermination=false survives terminate,
+		// but terminate still implies detach (AWS semantics). Only the Boot
+		// volume can still be attached here — shutdownAndUnmount's Unmount
+		// clears every non-Boot volume's attachment already, so a non-Boot
+		// DoT=false volume is genuinely a no-op skip. A DoT=false Boot volume
+		// is never touched by Unmount, so without this it would strand
+		// attached to the now-terminated instance forever.
 		if !ebsRequest.DeleteOnTermination {
-			slog.Info("Volume has DeleteOnTermination=false, skipping deletion",
+			if !ebsRequest.Boot {
+				slog.Info("Volume has DeleteOnTermination=false, skipping deletion",
+					"name", ebsRequest.Name, "id", instance.ID)
+				continue
+			}
+			slog.Info("Boot volume has DeleteOnTermination=false, detaching without deleting",
 				"name", ebsRequest.Name, "id", instance.ID)
+			if a.d.volumeService == nil {
+				slog.Warn("Volume service not configured, cannot detach volume",
+					"name", ebsRequest.Name, "id", instance.ID)
+				continue
+			}
+			if err := a.d.volumeService.DetachVolumeOnTerminate(context.Background(), ebsRequest.Name, instance.AccountID); err != nil && !awserrors.IsNotFound(err) {
+				slog.Error("Failed to detach volume on termination",
+					"name", ebsRequest.Name, "id", instance.ID, "err", err)
+				firstErr = cmp.Or(firstErr, err)
+			} else {
+				slog.Info("Detached volume on termination",
+					"name", ebsRequest.Name, "id", instance.ID)
+			}
 			continue
 		}
 

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
@@ -636,9 +635,12 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) error {
 				"name", ebsRequest.Name, "id", instance.ID)
 			continue
 		}
-		if _, err := a.d.volumeService.DeleteVolume(context.Background(), &ec2.DeleteVolumeInput{
-			VolumeId: &ebsRequest.Name,
-		}, instance.AccountID); err != nil && !awserrors.IsNotFound(err) {
+		// Terminate implies detach: DeleteVolumeOnTerminate clears the stale
+		// AttachedInstance before deleting. shutdownAndUnmount's Unmount
+		// (above, via terminateCleanup) deliberately never clears a Boot
+		// volume's attachment, so without this the root volume still hits
+		// DeleteVolume's in-use guard here.
+		if err := a.d.volumeService.DeleteVolumeOnTerminate(context.Background(), ebsRequest.Name, instance.AccountID); err != nil && !awserrors.IsNotFound(err) {
 			slog.Error("Failed to delete volume on termination",
 				"name", ebsRequest.Name, "id", instance.ID, "err", err)
 			firstErr = cmp.Or(firstErr, err)

--- a/spinifex/handlers/ec2/instance/service.go
+++ b/spinifex/handlers/ec2/instance/service.go
@@ -116,6 +116,12 @@ type VolumeDeleter interface {
 	// implies detach) before deleting, so a still-attached boot volume left
 	// over from Stop is not rejected by DeleteVolume's in-use guard.
 	DeleteVolumeOnTerminate(ctx context.Context, volumeID, accountID string) error
+
+	// DetachVolumeOnTerminate clears a still-attached volume's attachment on
+	// terminate without deleting it, matching AWS semantics for a
+	// DeleteOnTermination=false volume: terminate still implies detach, it
+	// just leaves the volume behind as available rather than deleting it.
+	DetachVolumeOnTerminate(ctx context.Context, volumeID, accountID string) error
 }
 
 // ENIDeleter deletes ENIs. Implemented by handlers/ec2/vpc's VPCServiceImpl.

--- a/spinifex/handlers/ec2/instance/service.go
+++ b/spinifex/handlers/ec2/instance/service.go
@@ -110,6 +110,12 @@ type InstanceTagWriter interface {
 // VolumeServiceImpl (used by the daemon).
 type VolumeDeleter interface {
 	DeleteVolume(ctx context.Context, input *ec2.DeleteVolumeInput, accountID string) (*ec2.DeleteVolumeOutput, error)
+
+	// DeleteVolumeOnTerminate deletes a DeleteOnTermination volume as part of
+	// an instance terminate: it clears any stale attachment (terminate
+	// implies detach) before deleting, so a still-attached boot volume left
+	// over from Stop is not rejected by DeleteVolume's in-use guard.
+	DeleteVolumeOnTerminate(ctx context.Context, volumeID, accountID string) error
 }
 
 // ENIDeleter deletes ENIs. Implemented by handlers/ec2/vpc's VPCServiceImpl.

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -2409,6 +2409,16 @@ func (s *InstanceServiceImpl) TerminateStoppedInstance(ctx context.Context, inpu
 func (s *InstanceServiceImpl) deleteInstanceVolumes(ctx context.Context, instance *vm.VM, instanceID string) {
 	instance.EBSRequests.Mu.Lock()
 	defer instance.EBSRequests.Mu.Unlock()
+
+	// Tracks whether every DeleteOnTermination volume was actually deleted, so
+	// Teardown[vm.TeardownVolumes] below mirrors markTeardownResult's
+	// done/failed semantics (vm/teardown.go) — the same mark the
+	// running-instance path already stamps via terminateCleanup. Without this,
+	// TerminateStoppedInstance never touches Teardown at all, so
+	// daemon.leakedVolumeInstances() and VolumeLeakReaper can never see a
+	// stopped-path delete failure.
+	var lastErr error
+
 	for _, ebsRequest := range instance.EBSRequests.Requests {
 		// Internal volumes (EFI) are always cleaned up via ebs.delete.
 		if ebsRequest.EFI {
@@ -2435,14 +2445,28 @@ func (s *InstanceServiceImpl) deleteInstanceVolumes(ctx context.Context, instanc
 		slog.InfoContext(ctx, "TerminateStoppedInstance: deleting volume with DeleteOnTermination=true", "name", ebsRequest.Name)
 		if s.volumeDeleter == nil {
 			slog.WarnContext(ctx, "TerminateStoppedInstance: volume deleter not configured, skipping", "name", ebsRequest.Name)
+			lastErr = errors.New("volume deleter not configured")
 			continue
 		}
-		if _, err := s.volumeDeleter.DeleteVolume(ctx, &ec2.DeleteVolumeInput{
-			VolumeId: &ebsRequest.Name,
-		}, instance.AccountID); err != nil {
+		// Terminate implies detach: DeleteVolumeOnTerminate clears the stale
+		// AttachedInstance left over from Stop (Unmount deliberately never
+		// clears a Boot volume, daemon/vm_adapters.go) before deleting, so
+		// DeleteVolume's in-use guard does not reject an otherwise-legitimate
+		// delete. The resulting error is surfaced into lastErr, not swallowed.
+		if err := s.volumeDeleter.DeleteVolumeOnTerminate(ctx, ebsRequest.Name, instance.AccountID); err != nil {
 			slog.ErrorContext(ctx, "TerminateStoppedInstance: failed to delete volume", "name", ebsRequest.Name, "err", err)
+			lastErr = err
 		}
 	}
+
+	if instance.Teardown == nil {
+		instance.Teardown = make(map[string]string)
+	}
+	instance.Teardown[vm.TeardownVolumes] = string(vm.TeardownDone)
+	if lastErr != nil {
+		instance.Teardown[vm.TeardownVolumes] = string(vm.TeardownFailed)
+	}
+
 	_ = instanceID
 }
 

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -2436,9 +2436,28 @@ func (s *InstanceServiceImpl) deleteInstanceVolumes(ctx context.Context, instanc
 			continue
 		}
 
-		// User-visible volumes: respect DeleteOnTermination.
+		// User-visible volumes: DeleteOnTermination=false survives terminate,
+		// but terminate still implies detach (AWS semantics). Only the Boot
+		// volume can still be attached here — Stop's Unmount (daemon/vm_adapters.go)
+		// clears every non-Boot volume's attachment already, so a non-Boot
+		// DoT=false volume is genuinely a no-op skip. A DoT=false Boot volume
+		// is never touched by Unmount, so without this it would strand
+		// attached to the now-terminated instance forever.
 		if !ebsRequest.DeleteOnTermination {
-			slog.InfoContext(ctx, "TerminateStoppedInstance: volume has DeleteOnTermination=false, skipping", "name", ebsRequest.Name)
+			if !ebsRequest.Boot {
+				slog.InfoContext(ctx, "TerminateStoppedInstance: volume has DeleteOnTermination=false, skipping", "name", ebsRequest.Name)
+				continue
+			}
+			slog.InfoContext(ctx, "TerminateStoppedInstance: boot volume has DeleteOnTermination=false, detaching without deleting", "name", ebsRequest.Name)
+			if s.volumeDeleter == nil {
+				slog.WarnContext(ctx, "TerminateStoppedInstance: volume deleter not configured, skipping detach", "name", ebsRequest.Name)
+				lastErr = errors.New("volume deleter not configured")
+				continue
+			}
+			if err := s.volumeDeleter.DetachVolumeOnTerminate(ctx, ebsRequest.Name, instance.AccountID); err != nil {
+				slog.ErrorContext(ctx, "TerminateStoppedInstance: failed to detach volume", "name", ebsRequest.Name, "err", err)
+				lastErr = err
+			}
 			continue
 		}
 

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -1676,6 +1676,17 @@ func (f *fakeVolumeDeleter) DeleteVolume(_ context.Context, input *ec2.DeleteVol
 	return &ec2.DeleteVolumeOutput{}, nil
 }
 
+// DeleteVolumeOnTerminate mirrors DeleteVolume's call/error bookkeeping; the
+// stopped-instance terminate path calls this instead of DeleteVolume.
+func (f *fakeVolumeDeleter) DeleteVolumeOnTerminate(_ context.Context, volumeID, _ string) error {
+	f.calls = append(f.calls, volumeID)
+	if f.err != nil {
+		return f.err
+	}
+	f.deleted = append(f.deleted, volumeID)
+	return nil
+}
+
 type fakeENIDeleter struct {
 	calls []string
 	err   error
@@ -1913,6 +1924,55 @@ func TestTerminateStoppedInstance_UserVolumeDeleted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"vol-user-001"}, vd.calls, "only DeleteOnTermination=true volumes deleted")
 	assert.Equal(t, []string{"vol-user-001"}, vd.deleted)
+}
+
+// TestTerminateStoppedInstance_StampsTeardownVolumesDone locks the mulga-1dzx9
+// fix: TerminateStoppedInstance must stamp Teardown[vm.TeardownVolumes] on
+// success, mirroring the running-instance path's markTeardownResult
+// (vm/shutdown.go). Without this, daemon.leakedVolumeInstances() and
+// VolumeLeakReaper can never see a stopped-path leak because
+// TerminateStoppedInstance previously never touched Teardown at all.
+func TestTerminateStoppedInstance_StampsTeardownVolumesDone(t *testing.T) {
+	id := "i-teardown-done"
+	v := &vm.VM{ID: id, Status: vm.StateStopped, AccountID: "acc"}
+	v.EBSRequests.Requests = []spxtypes.EBSRequest{
+		{Name: "vol-root-001", Boot: true, DeleteOnTermination: true},
+	}
+	store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: v}}
+	vd := &fakeVolumeDeleter{}
+	svc := &InstanceServiceImpl{stoppedStore: store, volumeDeleter: vd}
+
+	_, err := svc.TerminateStoppedInstance(context.Background(), &TerminateStoppedInstanceInput{InstanceID: id}, "acc")
+	require.NoError(t, err)
+
+	require.NotNil(t, store.wroteTerminated[id])
+	assert.Equal(t, string(vm.TeardownDone), store.wroteTerminated[id].Teardown[vm.TeardownVolumes],
+		"ADR-0003 §1 semantics: a successful volume delete must stamp Teardown[volumes]=done")
+	assert.Equal(t, []string{"vol-root-001"}, vd.deleted, "the still-attached root volume must actually be deleted")
+}
+
+// TestTerminateStoppedInstance_StampsTeardownVolumesFailedOnDeleteError locks
+// the "do not swallow" half of the fix: a DeleteVolumeOnTerminate failure must
+// surface as Teardown[vm.TeardownVolumes]=failed (picked up by
+// daemon.leakedVolumeInstances() / VolumeLeakReaper) rather than being merely
+// logged and forgotten.
+func TestTerminateStoppedInstance_StampsTeardownVolumesFailedOnDeleteError(t *testing.T) {
+	id := "i-teardown-failed"
+	v := &vm.VM{ID: id, Status: vm.StateStopped, AccountID: "acc"}
+	v.EBSRequests.Requests = []spxtypes.EBSRequest{
+		{Name: "vol-root-002", Boot: true, DeleteOnTermination: true},
+	}
+	store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: v}}
+	vd := &fakeVolumeDeleter{err: errors.New("delete forced failure")}
+	svc := &InstanceServiceImpl{stoppedStore: store, volumeDeleter: vd}
+
+	_, err := svc.TerminateStoppedInstance(context.Background(), &TerminateStoppedInstanceInput{InstanceID: id}, "acc")
+	require.NoError(t, err, "terminate itself stays best-effort; the failure is tracked via Teardown, not returned")
+
+	require.NotNil(t, store.wroteTerminated[id])
+	assert.Equal(t, string(vm.TeardownFailed), store.wroteTerminated[id].Teardown[vm.TeardownVolumes],
+		"a DeleteVolumeOnTerminate failure must be surfaced via Teardown, not silently swallowed")
+	assert.Empty(t, vd.deleted, "the forced failure must mean nothing was actually deleted")
 }
 
 func TestTerminateStoppedInstance_NoVolumeDeleterSkipsGracefully(t *testing.T) {

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -1661,9 +1661,10 @@ func TestModifyInstanceAttribute_ConcurrentClaimDoesNotResurrect(t *testing.T) {
 // --- TerminateStoppedInstance tests ---
 
 type fakeVolumeDeleter struct {
-	calls   []string
-	deleted []string
-	err     error
+	calls    []string
+	deleted  []string
+	detached []string
+	err      error
 }
 
 func (f *fakeVolumeDeleter) DeleteVolume(_ context.Context, input *ec2.DeleteVolumeInput, _ string) (*ec2.DeleteVolumeOutput, error) {
@@ -1684,6 +1685,18 @@ func (f *fakeVolumeDeleter) DeleteVolumeOnTerminate(_ context.Context, volumeID,
 		return f.err
 	}
 	f.deleted = append(f.deleted, volumeID)
+	return nil
+}
+
+// DetachVolumeOnTerminate mirrors DeleteVolumeOnTerminate's call/error
+// bookkeeping but records into detached instead of deleted; the non-DoT
+// Boot-volume branch calls this instead of deleting.
+func (f *fakeVolumeDeleter) DetachVolumeOnTerminate(_ context.Context, volumeID, _ string) error {
+	f.calls = append(f.calls, volumeID)
+	if f.err != nil {
+		return f.err
+	}
+	f.detached = append(f.detached, volumeID)
 	return nil
 }
 
@@ -1973,6 +1986,31 @@ func TestTerminateStoppedInstance_StampsTeardownVolumesFailedOnDeleteError(t *te
 	assert.Equal(t, string(vm.TeardownFailed), store.wroteTerminated[id].Teardown[vm.TeardownVolumes],
 		"a DeleteVolumeOnTerminate failure must be surfaced via Teardown, not silently swallowed")
 	assert.Empty(t, vd.deleted, "the forced failure must mean nothing was actually deleted")
+}
+
+// TestTerminateStoppedInstance_NonDoTBootVolumeDetachedNotDeleted locks the
+// second half of the terminate-implies-detach fix: a DeleteOnTermination=false
+// Boot volume is never cleared by Stop's Unmount (daemon/vm_adapters.go), so
+// without this it would strand attached to the now-gone instance forever.
+// Terminate must still detach it (AWS semantics: it survives as available,
+// it just isn't deleted).
+func TestTerminateStoppedInstance_NonDoTBootVolumeDetachedNotDeleted(t *testing.T) {
+	id := "i-nondot-boot"
+	v := &vm.VM{ID: id, Status: vm.StateStopped, AccountID: "acc"}
+	v.EBSRequests.Requests = []spxtypes.EBSRequest{
+		{Name: "vol-root-nondot", Boot: true, DeleteOnTermination: false},
+	}
+	store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: v}}
+	vd := &fakeVolumeDeleter{}
+	svc := &InstanceServiceImpl{stoppedStore: store, volumeDeleter: vd}
+
+	_, err := svc.TerminateStoppedInstance(context.Background(), &TerminateStoppedInstanceInput{InstanceID: id}, "acc")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"vol-root-nondot"}, vd.detached, "the still-attached non-DoT boot volume must be detached")
+	assert.Empty(t, vd.deleted, "a DeleteOnTermination=false volume must never be deleted")
+	require.NotNil(t, store.wroteTerminated[id])
+	assert.Equal(t, string(vm.TeardownDone), store.wroteTerminated[id].Teardown[vm.TeardownVolumes])
 }
 
 func TestTerminateStoppedInstance_NoVolumeDeleterSkipsGracefully(t *testing.T) {

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/filterutil"
+	handlers_ec2_instance "github.com/mulgadc/spinifex/spinifex/handlers/ec2/instance"
 	"github.com/mulgadc/spinifex/spinifex/objectstore"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
@@ -44,6 +45,11 @@ var _ VolumeService = (*VolumeServiceImpl)(nil)
 // Ensure VolumeServiceImpl satisfies vm.VolumeStateUpdater so the manager
 // can call UpdateVolumeState directly without a daemon-side adapter.
 var _ vm.VolumeStateUpdater = (*VolumeServiceImpl)(nil)
+
+// Ensure VolumeServiceImpl satisfies handlers/ec2/instance's VolumeDeleter so
+// InstanceServiceImpl can call DeleteVolume/DeleteVolumeOnTerminate through
+// the dependency wired via SetTerminationDeps.
+var _ handlers_ec2_instance.VolumeDeleter = (*VolumeServiceImpl)(nil)
 
 // VolumeServiceImpl handles EBS volume operations with S3 storage.
 type VolumeServiceImpl struct {
@@ -1487,6 +1493,26 @@ func (s *VolumeServiceImpl) ModifyVolume(ctx context.Context, input *ec2.ModifyV
 	return &ec2.ModifyVolumeOutput{
 		VolumeModification: modification,
 	}, nil
+}
+
+// DeleteVolumeOnTerminate deletes a DeleteOnTermination volume as part of an
+// instance terminate: terminate implies detach, so this clears any stale
+// attachment via UpdateVolumeState before calling DeleteVolume. Both the
+// stopped-instance path (Stop's Unmount deliberately never clears a Boot
+// volume, vm_adapters.go's volumeMounterAdapter.Unmount) and the
+// running-instance path (terminateCleanup runs after shutdownAndUnmount,
+// which has the same Boot-volume carve-out) would otherwise still have
+// AttachedInstance set and hit DeleteVolume's in-use guard. There is no live
+// QEMU to hot-unplug on either path — a stopped instance has none, and a
+// terminating instance's QEMU has already been asked to shut down — so this
+// is always a metadata-only clear, never a QMP call. Errors from either step
+// are returned, not swallowed.
+func (s *VolumeServiceImpl) DeleteVolumeOnTerminate(ctx context.Context, volumeID, accountID string) error {
+	if err := s.UpdateVolumeState(volumeID, "available", "", ""); err != nil {
+		return fmt.Errorf("clear attachment before terminate delete: %w", err)
+	}
+	_, err := s.DeleteVolume(ctx, &ec2.DeleteVolumeInput{VolumeId: &volumeID}, accountID)
+	return err
 }
 
 // DeleteVolume deletes an EBS volume: validates state, notifies viperblockd, and removes S3 data.

--- a/spinifex/handlers/ec2/volume/service_impl.go
+++ b/spinifex/handlers/ec2/volume/service_impl.go
@@ -1515,6 +1515,16 @@ func (s *VolumeServiceImpl) DeleteVolumeOnTerminate(ctx context.Context, volumeI
 	return err
 }
 
+// DetachVolumeOnTerminate clears a volume's attachment on instance terminate
+// without deleting it, matching AWS semantics for a DeleteOnTermination=false
+// volume: terminate still implies detach, it just leaves the volume behind as
+// available rather than deleting it. Metadata-only, no QMP — same rationale
+// as DeleteVolumeOnTerminate: there is no live QEMU to hot-unplug on either
+// terminate path.
+func (s *VolumeServiceImpl) DetachVolumeOnTerminate(_ context.Context, volumeID, _ string) error {
+	return s.UpdateVolumeState(volumeID, "available", "", "")
+}
+
 // DeleteVolume deletes an EBS volume: validates state, notifies viperblockd, and removes S3 data.
 func (s *VolumeServiceImpl) DeleteVolume(ctx context.Context, input *ec2.DeleteVolumeInput, accountID string) (*ec2.DeleteVolumeOutput, error) {
 	if input == nil || input.VolumeId == nil || *input.VolumeId == "" {

--- a/spinifex/handlers/ec2/volume/service_impl_test.go
+++ b/spinifex/handlers/ec2/volume/service_impl_test.go
@@ -1427,6 +1427,70 @@ func TestDeleteVolume_EmptyStateUnattachedDeletable(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestDeleteVolumeOnTerminate_ClearsAttachmentThenDeletes locks the
+// mulga-1dzx9 fix: a DeleteOnTermination root volume left attached to a
+// stopped instance (Stop's Unmount deliberately never clears a Boot volume's
+// AttachedInstance, daemon/vm_adapters.go) hits DeleteVolume's in-use guard
+// directly — see TestDeleteVolume_VolumeAttachedButAvailable above.
+// DeleteVolumeOnTerminate must clear the stale attachment first (terminate
+// implies detach) so the terminate delete actually succeeds instead of
+// leaking the volume.
+func TestDeleteVolumeOnTerminate_ClearsAttachmentThenDeletes(t *testing.T) {
+	kv := setupTestVolumeKV(t)
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	svc.snapshotKV = kv
+
+	volumeID := "vol-stopped-root"
+	createVolumeInStoreWithMeta(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		SizeGiB:          10,
+		State:            "available",
+		AttachedInstance: "i-stopped",
+	})
+
+	err := svc.DeleteVolumeOnTerminate(context.Background(), volumeID, "")
+	require.NoError(t, err, "terminate implies detach: a stale attachment must not block the terminate delete")
+
+	_, err = svc.GetVolumeConfig(volumeID)
+	require.Error(t, err, "the volume must actually be deleted, not merely detached")
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidVolumeNotFound)
+}
+
+// TestDeleteVolumeOnTerminate_SurfacesDeleteFailure verifies a DeleteVolume
+// failure downstream of the attachment clear is returned, not swallowed — the
+// caller (deleteInstanceVolumes / instanceCleanerAdapter.DeleteVolumes) relies
+// on this to mark Teardown[TeardownVolumes] failed rather than silently
+// dropping the leak.
+func TestDeleteVolumeOnTerminate_SurfacesDeleteFailure(t *testing.T) {
+	kv := setupTestVolumeKV(t)
+	store := objectstore.NewMemoryObjectStore()
+	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)
+	svc.snapshotKV = kv
+
+	volumeID := "vol-snapshotted-root"
+	createVolumeInStoreWithMeta(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		SizeGiB:          10,
+		State:            "available",
+		AttachedInstance: "i-stopped",
+	})
+	// A dependent snapshot forces DeleteVolume to fail after the attachment
+	// clear has already succeeded.
+	snapData, err := json.Marshal([]string{"snap-001"})
+	require.NoError(t, err)
+	_, err = kv.Put(volumeID, snapData)
+	require.NoError(t, err)
+
+	err = svc.DeleteVolumeOnTerminate(context.Background(), volumeID, "")
+	require.Error(t, err, "a DeleteVolume failure must be surfaced, not swallowed")
+	assert.Contains(t, err.Error(), awserrors.ErrorVolumeInUse)
+
+	cfg, getErr := svc.GetVolumeConfig(volumeID)
+	require.NoError(t, getErr, "the volume must still exist after a failed delete")
+	assert.Empty(t, cfg.VolumeMetadata.AttachedInstance, "the attachment clear runs before delete and is not rolled back on a later delete failure")
+}
+
 func TestDescribeVolumes_EmptyStateDerivedFromAttachment(t *testing.T) {
 	store := objectstore.NewMemoryObjectStore()
 	svc := newTestVolumeServiceWithStore("ap-southeast-2a", store)

--- a/spinifex/vm/orphan_qemu_reaper.go
+++ b/spinifex/vm/orphan_qemu_reaper.go
@@ -13,18 +13,27 @@ import (
 // orphan QEMU to disappear before giving up and retrying on the next sweep.
 const orphanQEMUKillTimeout = 10 * time.Second
 
-// OrphanQEMUReaper kills QEMU processes left running for instances that are
-// already terminated. TerminateInstances marks the EC2 record terminated and
-// drives node-local teardown, but if that teardown ran on a node other than the
-// one hosting the QEMU (e.g. the per-instance subscription was lost and the
-// request fell back to the ec2.terminate broadcast), the process survives and
-// keeps holding its OVN logical port / IP, blocking rebuilds.
+// OrphanQEMUReaper reconciles instances whose QEMU liveness disagrees with their
+// recorded state, in two directions:
 //
-// This reaper is node-local and conservative: it only inspects instances in the
-// terminated KV bucket and only acts when a live process is found via the
-// instance's local PID file. Running, pending, and stopped instances are never
-// touched, so a launching or healthy VM can never be reaped. Whichever node
-// actually holds the orphan PID file is the one that reaps it.
+//   - A terminated instance whose QEMU is still alive: TerminateInstances marked
+//     the record terminated and drove node-local teardown, but if that teardown
+//     ran on a node other than the one hosting the QEMU (e.g. the per-instance
+//     subscription was lost and the request fell back to the ec2.terminate
+//     broadcast), the process survives and keeps holding its OVN logical port /
+//     IP, blocking rebuilds. The reaper force-kills it.
+//   - A shutting-down instance whose QEMU has vanished: a terminate that
+//     transitioned the instance to shutting-down but wedged downstream (a dead
+//     nbdkit stalling the unmount seal, say) never reached finalizeTerminated,
+//     stranding the instance and its volumes indefinitely. The reaper finalizes
+//     the termination and hands outstanding teardown to TerminatedTeardownReaper.
+//
+// This reaper is node-local and conservative: liveness is read from the
+// instance's local PID file, so only the node actually hosting (or having
+// hosted) the process acts; every other node's lookup misses and is a no-op. A
+// live in-progress terminate still has a live QEMU, so the shutting-down
+// reconcile never steals a healthy teardown. Running, pending, and stopped
+// instances are never touched.
 type OrphanQEMUReaper struct {
 	m *Manager
 }
@@ -73,5 +82,54 @@ func (r *OrphanQEMUReaper) Sweep(context.Context) (int, error) {
 		_ = utils.RemovePidFile(v.ID)
 		reaped++
 	}
+
+	// Second direction: finalize shutting-down instances whose QEMU vanished.
+	// These live in this node's local running map (a wedged terminate never
+	// migrated them to the terminated bucket), so scan the local snapshot. A
+	// still-alive QEMU means the terminate is progressing normally — leave it.
+	for _, v := range r.m.Snapshot() {
+		if r.m.Status(v) != StateShuttingDown {
+			continue
+		}
+		if qemuProcessAlive(v.ID) {
+			continue
+		}
+		_ = utils.RemovePidFile(v.ID) // clear any stale file for the dead process
+
+		slog.Warn("vm/gc: reconciling wedged shutting-down instance, QEMU vanished",
+			"instanceId", v.ID)
+		if err := r.m.reconcileVanishedQEMU(v); err != nil {
+			slog.Error("vm/gc: failed to finalize wedged shutting-down instance, will retry next sweep",
+				"instanceId", v.ID, "err", err)
+			continue
+		}
+		reaped++
+	}
 	return reaped, nil
+}
+
+// qemuProcessAlive reports whether the instance's QEMU process is running on
+// this node, read via its local PID file. A missing PID file (process not on
+// this node, or already reaped) or a dead PID both read as not-alive. Used by
+// the reaper, where a terminated/shutting-down instance's absent PID file
+// legitimately means the process is gone.
+func qemuProcessAlive(instanceID string) bool {
+	pid, err := utils.ReadPidFile(instanceID)
+	if err != nil {
+		return false
+	}
+	return utils.ProcessAlive(pid)
+}
+
+// qemuConfirmedDead reports whether the instance's QEMU is provably gone: its
+// PID file is present but the process is not alive. Unlike qemuProcessAlive, a
+// missing PID file reads as NOT confirmed-dead (ambiguous), so a caller on a
+// still-running instance (DetachVolume) falls through to its normal QMP path
+// rather than short-circuiting on an absent file.
+func qemuConfirmedDead(instanceID string) bool {
+	pid, err := utils.ReadPidFile(instanceID)
+	if err != nil {
+		return false
+	}
+	return !utils.ProcessAlive(pid)
 }

--- a/spinifex/vm/orphan_qemu_reaper_test.go
+++ b/spinifex/vm/orphan_qemu_reaper_test.go
@@ -83,4 +83,51 @@ func TestOrphanQEMUReaper(t *testing.T) {
 		assert.Zero(t, reaped, "only terminated instances are candidates")
 		assert.True(t, utils.ProcessAlive(pid), "a non-terminated instance's process must survive")
 	})
+
+	t.Run("reconciles a wedged shutting-down instance whose QEMU vanished", func(t *testing.T) {
+		reaper, store := newOrphanReaperManager(t)
+		m := reaper.m
+
+		const id = "i-wedged"
+		// A terminate transitioned it to shutting-down then wedged; QEMU is gone
+		// (no PID file), and it never migrated to the terminated bucket.
+		m.InsertIfAbsent(&VM{ID: id, Status: StateShuttingDown, ENIId: "eni-1"})
+
+		reaped, err := reaper.Sweep(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 1, reaped, "a wedged shutting-down instance with a dead QEMU must be finalized")
+
+		_, ok := m.Get(id)
+		assert.False(t, ok, "the reconciled instance must leave the local running map")
+
+		term, ok := store.terminated[id]
+		require.True(t, ok, "the instance must be written to the terminated bucket")
+		assert.Equal(t, StateTerminated, term.Status, "it must be finalized to terminated")
+		assert.Equal(t, string(TeardownDone), term.Teardown[TeardownQEMU],
+			"QEMU is confirmed gone, so its teardown is done")
+		assert.Equal(t, string(TeardownFailed), term.Teardown[TeardownVolumes],
+			"outstanding volume teardown must be handed to TerminatedTeardownReaper")
+		assert.Equal(t, string(TeardownFailed), term.Teardown[TeardownENI],
+			"the instance's ENI teardown must be handed off too")
+	})
+
+	t.Run("a shutting-down instance with a live QEMU is left to finish terminating", func(t *testing.T) {
+		reaper, _ := newOrphanReaperManager(t)
+		m := reaper.m
+
+		cmd := exec.Command("sleep", "60")
+		require.NoError(t, cmd.Start())
+		pid := cmd.Process.Pid
+		t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+
+		const id = "i-terminating"
+		m.InsertIfAbsent(&VM{ID: id, Status: StateShuttingDown})
+		require.NoError(t, utils.WritePidFile(id, pid))
+
+		reaped, err := reaper.Sweep(context.Background())
+		require.NoError(t, err)
+		assert.Zero(t, reaped, "a live in-progress terminate must not be reconciled")
+		_, ok := m.Get(id)
+		assert.True(t, ok, "the instance must stay in the running map for its own terminate to finish")
+	})
 }

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -295,6 +295,33 @@ func (m *Manager) reconcileVanishedQEMU(instance *VM) error {
 	return m.finalizeTerminated(instance)
 }
 
+// forceFinalizeStuckTerminate force-completes a terminate wedged in
+// shutting-down past the backstop timeout. Unlike reconcileVanishedQEMU, which
+// fires only once QEMU is already gone, the process may still be alive and
+// wedged here, so kill it first to unblock whatever the terminate is waiting on.
+// It then reclaims DeleteOnTermination volume space directly through the cleaner
+// — the delete-authorized action the backstop exists for — stamps any remaining
+// teardown failed for TerminatedTeardownReaper, and drives the record to
+// terminated. The cleaner is idempotent, so racing the wedged goroutine is safe.
+func (m *Manager) forceFinalizeStuckTerminate(instance *VM) error {
+	if pid, err := utils.ReadPidFile(instance.ID); err == nil && utils.ProcessAlive(pid) {
+		slog.Warn("Force-killing wedged QEMU for stuck terminate",
+			"instanceId", instance.ID, "pid", pid)
+		if err := utils.ForceKillProcess(pid, orphanQEMUKillTimeout); err != nil {
+			slog.Error("Failed to kill wedged QEMU, continuing finalize",
+				"instanceId", instance.ID, "pid", pid, "err", err)
+		}
+		_ = utils.RemovePidFile(instance.ID)
+	}
+	m.markTeardown(instance, TeardownQEMU, TeardownDone)
+
+	if m.deps.InstanceCleaner != nil {
+		m.markTeardownResult(instance, TeardownVolumes, m.deps.InstanceCleaner.DeleteVolumes(instance))
+	}
+	m.stampOutstandingTeardownFailed(instance)
+	return m.finalizeTerminated(instance)
+}
+
 // stampOutstandingTeardownFailed marks every teardown dependent that applies to
 // this instance and is not already done as failed, so a terminated record left
 // by reconcileVanishedQEMU carries the outstanding work for TerminatedTeardownReaper
@@ -510,7 +537,10 @@ func (m *Manager) transitionWithPrecheck(instance *VM, target InstanceState) err
 	if m.deps.TransitionState == nil {
 		// Inspect (not UpdateState): MarkFailed may run this on an instance
 		// that was never inserted into the local map.
-		m.Inspect(instance, func(v *VM) { v.Status = target })
+		m.Inspect(instance, func(v *VM) {
+			v.Status = target
+			stampShuttingDownAt(v, target)
+		})
 		return nil
 	}
 	if err := m.deps.TransitionState(instance, target); err != nil {
@@ -523,7 +553,17 @@ func (m *Manager) transitionWithPrecheck(instance *VM, target InstanceState) err
 		}
 		return err
 	}
+	m.Inspect(instance, func(v *VM) { stampShuttingDownAt(v, target) })
 	return nil
+}
+
+// stampShuttingDownAt records, once, when an instance entered shutting-down, so
+// the stuck-terminate backstop can bound how long a terminate may wedge before
+// force-completing it. Only the first entry is kept.
+func stampShuttingDownAt(v *VM, target InstanceState) {
+	if target == StateShuttingDown && v.ShuttingDownAt.IsZero() {
+		v.ShuttingDownAt = time.Now()
+	}
 }
 
 // writeRunningState persists the running-VM map. View holds the lock across

--- a/spinifex/vm/shutdown.go
+++ b/spinifex/vm/shutdown.go
@@ -279,6 +279,54 @@ func (m *Manager) finalizeTerminated(instance *VM) error {
 	return nil
 }
 
+// reconcileVanishedQEMU finalizes a shutting-down instance whose QEMU process
+// has vanished. The terminate that transitioned it to shutting-down wedged
+// downstream (a dead nbdkit stalling the unmount seal, say) and never reached
+// finalizeTerminated. QEMU is confirmed gone, so the guest holds nothing open:
+// drive the record to terminated and stamp every still-outstanding teardown
+// dependent failed, so TerminatedTeardownReaper re-drives each through the
+// idempotent cleaner (volume detach+delete, ENI, NAT, placement) on its next
+// sweep. Should the original terminate goroutine later unblock, its own
+// finalizeTerminated is a no-op — the shutting-down → terminated transition is
+// already spent and terminated is terminal.
+func (m *Manager) reconcileVanishedQEMU(instance *VM) error {
+	m.markTeardown(instance, TeardownQEMU, TeardownDone)
+	m.stampOutstandingTeardownFailed(instance)
+	return m.finalizeTerminated(instance)
+}
+
+// stampOutstandingTeardownFailed marks every teardown dependent that applies to
+// this instance and is not already done as failed, so a terminated record left
+// by reconcileVanishedQEMU carries the outstanding work for TerminatedTeardownReaper
+// to complete. Over-marking a dependent the wedged goroutine had actually
+// finished is harmless: the reaper re-drives it through the idempotent cleaner.
+func (m *Manager) stampOutstandingTeardownFailed(instance *VM) {
+	m.Inspect(instance, func(v *VM) {
+		if v.Teardown == nil {
+			v.Teardown = make(map[string]string)
+		}
+		markFailed := func(dep string) {
+			if TeardownState(v.Teardown[dep]) != TeardownDone {
+				v.Teardown[dep] = string(TeardownFailed)
+			}
+		}
+		markFailed(TeardownVolumes) // volumes always apply
+		if v.PublicIP != "" {
+			markFailed(TeardownNAT)
+		}
+		if v.ENIId != "" {
+			markFailed(TeardownENI)
+			markFailed(TeardownOVN)
+		}
+		if len(v.GPUAttachments) > 0 {
+			markFailed(TeardownGPU)
+		}
+		if v.PlacementGroupName != "" {
+			markFailed(TeardownPlacement)
+		}
+	})
+}
+
 // stopCleanup performs the per-instance teardown shared by Stop and the
 // initial section of Terminate: graceful QMP shutdown, PID-file wait,
 // volume unmount, tap teardown (main + extra ENI + mgmt), resource

--- a/spinifex/vm/stuck_terminate_reaper.go
+++ b/spinifex/vm/stuck_terminate_reaper.go
@@ -1,0 +1,70 @@
+package vm
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// stuckTerminateTimeout is how long an instance may sit in shutting-down before
+// the backstop force-completes its terminate. It is deliberately far longer than
+// a healthy terminate (graceful powerdown plus the unmount seal) and longer than
+// OrphanQEMUReaper's dead-QEMU reconcile window, so the gentler paths always get
+// first chance; only a genuinely wedged terminate ever reaches this.
+const stuckTerminateTimeout = 10 * time.Minute
+
+// StuckTerminateReaper is the delete-authorized terminate backstop. When a
+// terminate wedges with QEMU still alive — so OrphanQEMUReaper's dead-QEMU
+// reconcile never fires — and stays shutting-down past stuckTerminateTimeout,
+// this reaper force-kills the wedged process, reclaims DeleteOnTermination
+// volume space, and drives the record to terminated.
+//
+// It is the one reaper explicitly authorized to DELETE volume data, but only for
+// a DeleteOnTermination volume whose instance is already being terminated — a far
+// narrower licence than the one ADR-0005 §3 denies VolumeLeakReaper. VolumeLeakReaper
+// stays mark-and-alarm-only for every merely-orphaned volume; this actor only ever
+// finishes an already-decided terminate, never reclaims a volume on its own judgement.
+type StuckTerminateReaper struct {
+	m *Manager
+}
+
+var _ Reaper = (*StuckTerminateReaper)(nil)
+
+// NewStuckTerminateReaper builds the backstop bound to this Manager.
+func (m *Manager) NewStuckTerminateReaper() *StuckTerminateReaper {
+	return &StuckTerminateReaper{m: m}
+}
+
+func (r *StuckTerminateReaper) Class() string      { return "stuck-terminate" }
+func (r *StuckTerminateReaper) Scope() ReaperScope { return ScopeNodeLocal }
+
+// Sweep force-completes terminates that have been wedged in shutting-down past
+// stuckTerminateTimeout. Wedged instances live in this node's local running map
+// (a stuck terminate never migrated them to the terminated bucket), so scan the
+// local snapshot.
+func (r *StuckTerminateReaper) Sweep(context.Context) (int, error) {
+	reaped := 0
+	for _, v := range r.m.Snapshot() {
+		if r.m.Status(v) != StateShuttingDown {
+			continue
+		}
+		// A terminate still shutting-down only briefly is progressing normally,
+		// and a dead-QEMU wedge is OrphanQEMUReaper's job. Only one stuck long
+		// past the timeout is force-completed here. A missing timestamp (never
+		// stamped, or lost across a restart) reads as not-yet-stuck, so the
+		// backstop stays conservative and never acts on an unbounded record.
+		if v.ShuttingDownAt.IsZero() || time.Since(v.ShuttingDownAt) < stuckTerminateTimeout {
+			continue
+		}
+
+		slog.Warn("vm/gc: force-completing terminate wedged past timeout",
+			"instanceId", v.ID, "shuttingDownFor", time.Since(v.ShuttingDownAt))
+		if err := r.m.forceFinalizeStuckTerminate(v); err != nil {
+			slog.Error("vm/gc: failed to force-complete wedged terminate, will retry next sweep",
+				"instanceId", v.ID, "err", err)
+			continue
+		}
+		reaped++
+	}
+	return reaped, nil
+}

--- a/spinifex/vm/stuck_terminate_reaper_test.go
+++ b/spinifex/vm/stuck_terminate_reaper_test.go
@@ -1,0 +1,118 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newStuckTerminateReaper(t *testing.T, cleaner InstanceCleaner) (*StuckTerminateReaper, *fakeStateStore) {
+	t.Helper()
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	store := newFakeStateStore()
+	m := NewManager()
+	m.SetDeps(Deps{NodeID: "test-node", StateStore: store, InstanceCleaner: cleaner})
+	return m.NewStuckTerminateReaper(), store
+}
+
+func TestStuckTerminateReaper(t *testing.T) {
+	t.Run("force-completes a terminate wedged past the timeout, reclaiming DoT volume space", func(t *testing.T) {
+		cleaner := &recordingInstanceCleaner{}
+		reaper, store := newStuckTerminateReaper(t, cleaner)
+		m := reaper.m
+
+		// A live-but-wedged QEMU the dead-QEMU reconcile would never touch. Reap
+		// the child concurrently so the force-kill's SIGKILL'd process leaves the
+		// zombie state (and reads as not-alive) rather than lingering until Wait.
+		cmd := exec.Command("sleep", "60")
+		require.NoError(t, cmd.Start())
+		pid := cmd.Process.Pid
+		var wg sync.WaitGroup
+		wg.Go(func() { _ = cmd.Wait() })
+
+		const id = "i-wedged-live"
+		require.NoError(t, utils.WritePidFile(id, pid))
+		m.InsertIfAbsent(&VM{
+			ID:             id,
+			Status:         StateShuttingDown,
+			ENIId:          "eni-1",
+			ShuttingDownAt: time.Now().Add(-(stuckTerminateTimeout + time.Minute)),
+		})
+
+		reaped, err := reaper.Sweep(context.Background())
+		require.NoError(t, err)
+		wg.Wait()
+		assert.Equal(t, 1, reaped, "a terminate wedged past the timeout must be force-completed")
+
+		assert.False(t, utils.ProcessAlive(pid), "the wedged QEMU must be force-killed")
+		_, ok := m.Get(id)
+		assert.False(t, ok, "the finalized instance must leave the local running map")
+
+		term, ok := store.terminated[id]
+		require.True(t, ok, "the instance must be driven to the terminated bucket")
+		assert.Equal(t, StateTerminated, term.Status)
+		assert.Contains(t, cleaner.deleteVolumes, id, "DoT volume space must be reclaimed via the cleaner")
+		assert.Equal(t, string(TeardownDone), term.Teardown[TeardownVolumes], "reclaimed volumes are done")
+		assert.Equal(t, string(TeardownFailed), term.Teardown[TeardownENI], "remaining ENI teardown is handed off")
+	})
+
+	t.Run("surfaces a failed volume reclaim for reaper handoff rather than blocking finalize", func(t *testing.T) {
+		cleaner := &recordingInstanceCleaner{deleteVolumesErr: errors.New("predastore delete failed")}
+		reaper, store := newStuckTerminateReaper(t, cleaner)
+		m := reaper.m
+
+		const id = "i-wedged-delete-fail"
+		m.InsertIfAbsent(&VM{
+			ID:             id,
+			Status:         StateShuttingDown,
+			ShuttingDownAt: time.Now().Add(-(stuckTerminateTimeout + time.Minute)),
+		})
+
+		reaped, err := reaper.Sweep(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 1, reaped, "the instance is still finalized even when the volume delete fails")
+
+		term := store.terminated[id]
+		require.NotNil(t, term)
+		assert.Equal(t, string(TeardownFailed), term.Teardown[TeardownVolumes],
+			"a failed reclaim must be stamped failed so TerminatedTeardownReaper retries it")
+	})
+
+	t.Run("a recently shutting-down instance is left to finish terminating", func(t *testing.T) {
+		cleaner := &recordingInstanceCleaner{}
+		reaper, _ := newStuckTerminateReaper(t, cleaner)
+		m := reaper.m
+
+		const id = "i-terminating"
+		m.InsertIfAbsent(&VM{ID: id, Status: StateShuttingDown, ShuttingDownAt: time.Now()})
+
+		reaped, err := reaper.Sweep(context.Background())
+		require.NoError(t, err)
+		assert.Zero(t, reaped, "a terminate still within the timeout must not be force-completed")
+		assert.Empty(t, cleaner.deleteVolumes, "no volume must be reclaimed for a healthy in-progress terminate")
+		_, ok := m.Get(id)
+		assert.True(t, ok, "the instance must stay in the running map")
+	})
+
+	t.Run("a shutting-down instance with no timestamp is never force-completed", func(t *testing.T) {
+		cleaner := &recordingInstanceCleaner{}
+		reaper, _ := newStuckTerminateReaper(t, cleaner)
+		m := reaper.m
+
+		const id = "i-no-timestamp"
+		m.InsertIfAbsent(&VM{ID: id, Status: StateShuttingDown}) // ShuttingDownAt zero
+
+		reaped, err := reaper.Sweep(context.Background())
+		require.NoError(t, err)
+		assert.Zero(t, reaped, "an unbounded record (no timestamp) must be left untouched")
+		_, ok := m.Get(id)
+		assert.True(t, ok)
+	})
+}

--- a/spinifex/vm/vm.go
+++ b/spinifex/vm/vm.go
@@ -155,6 +155,11 @@ type VM struct {
 	// 1h TTL bounds visibility regardless.
 	TerminatedAt time.Time `json:"terminated_at,omitzero"`
 
+	// ShuttingDownAt is when the instance entered StateShuttingDown, stamped once
+	// on the transition. The stuck-terminate backstop uses it to bound how long a
+	// terminate may wedge before being force-completed.
+	ShuttingDownAt time.Time `json:"shutting_down_at,omitzero"`
+
 	// CapacityReservationId is the On-Demand Capacity Reservation this instance
 	// was launched into (targeted launch). Empty for instances on general
 	// capacity. Drives slot restore to the reservation on stop/terminate.

--- a/spinifex/vm/volumes.go
+++ b/spinifex/vm/volumes.go
@@ -22,6 +22,14 @@ import (
 // DetachDelay. 20 × DetachDelay (default 1s) gives a 20s budget.
 const blockdevDelMaxAttempts = 20
 
+// detachAggregateTimeout bounds the ctx-driven portion of DetachVolume's
+// hot-unplug chain (the QMP device_del / DEVICE_DELETED wait / blockdev-del /
+// object-del steps), so a wedged-but-responsive QEMU cannot stack per-step
+// timeouts into an effectively unbounded hang. It comfortably covers those
+// steps' own budgets (qmpCommandTimeout + the bounded blockdev-del retry) plus
+// margin; the ebs.unmount seal keeps its separate unmountSealTimeout.
+const detachAggregateTimeout = 3 * time.Minute
+
 // rollbackUnmount best-effort unmounts a volume while unwinding a failed
 // AttachVolume. The volume never took guest writes, so the unmount seal is a
 // no-op; a failure is logged and tolerated rather than masking the attach error.
@@ -304,6 +312,14 @@ func (m *Manager) DetachVolume(ctx context.Context, id, volumeID, device string,
 			ErrVolumeDeviceMismatch, device, ebsReq.DeviceName)
 	}
 
+	// Bound the ctx-driven portion of the hot-unplug chain so a wedged-but-
+	// responsive QEMU cannot stack per-step QMP timeouts into an unbounded hang
+	// that pins attachMu forever. The ebs.unmount seal below keeps its own
+	// unmountSealTimeout. This deadline cannot preempt a plain-mutex QMP call,
+	// which is why a fully dead QEMU is short-circuited outright below.
+	ctx, cancel := context.WithTimeout(ctx, detachAggregateTimeout)
+	defer cancel()
+
 	// Shared with buildDrives' cold-boot path: a relaunched data volume gets
 	// exactly these names, so these addresses resolve whether the volume was
 	// hot-attached or cold-booted.
@@ -311,57 +327,69 @@ func (m *Manager) DetachVolume(ctx context.Context, id, volumeID, device string,
 	nodeName := VolumeNodeName(volumeID)
 	iothreadID := VolumeIOThreadID(volumeID)
 
-	// device_del is idempotent on DeviceNotFound so a second AWS-CLI
-	// retry can drive blockdev-del to completion when a prior detach left
-	// the guest device gone but the block node intact.
-	deviceDelIssued := false
-	_, err := sendQMPCommand(ctx, instance.QMPClient, qmp.QMPCommand{
-		Execute:   "device_del",
-		Arguments: map[string]any{"id": deviceID},
-	}, instance.ID)
-	switch {
-	case err == nil:
-		deviceDelIssued = true
-	case isQMPDeviceNotFound(err):
-		slog.InfoContext(ctx, "DetachVolume: guest device already removed (resuming detach)",
-			"volumeId", volumeID, "err", err)
-	case force:
-		slog.WarnContext(ctx, "DetachVolume: QMP device_del failed (force=true, continuing)",
-			"volumeId", volumeID, "err", err)
-	default:
-		slog.ErrorContext(ctx, "DetachVolume: QMP device_del failed", "volumeId", volumeID, "err", err)
-		return "", fmt.Errorf("QMP device_del: %w", err)
-	}
-
-	// device_del only requests the unplug; QEMU frees the block node once the
-	// guest ACKs it (DEVICE_DELETED). Wait for that real completion signal
-	// instead of blindly sleeping, so blockdev-del isn't attempted while the
-	// node still has a user. A miss (timeout, event drained by a racing read,
-	// or a resumed/forced detach with no fresh unplug in flight) falls
-	// through to the bounded retry below unchanged.
-	if deviceDelIssued && m.deps.DeviceDeletedTimeout > 0 {
-		if waitErr := waitForDeviceDeletedEvent(ctx, instance.QMPClient, deviceID, m.deps.DeviceDeletedTimeout, instance.ID); waitErr != nil {
-			slog.DebugContext(ctx, "DetachVolume: DEVICE_DELETED not observed, falling back to blockdev-del retry",
-				"volumeId", volumeID, "err", waitErr)
+	// A confirmed-dead QEMU took every block node and guest device down with it,
+	// so the QMP unplug steps are moot — and worse, issuing them only risks
+	// hanging on the wedged process. Skip straight to the ebs.unmount seal and
+	// the attachment clear. This is the detach-wedges-when-QEMU-dies fix: the
+	// context deadline above cannot interrupt a plain-mutex QMP path, so a
+	// provably-gone process must bypass it rather than wait on it. A missing PID
+	// file is ambiguous (not provably dead), so the normal QMP path still runs.
+	if !qemuConfirmedDead(instance.ID) {
+		// device_del is idempotent on DeviceNotFound so a second AWS-CLI
+		// retry can drive blockdev-del to completion when a prior detach left
+		// the guest device gone but the block node intact.
+		deviceDelIssued := false
+		_, err := sendQMPCommand(ctx, instance.QMPClient, qmp.QMPCommand{
+			Execute:   "device_del",
+			Arguments: map[string]any{"id": deviceID},
+		}, instance.ID)
+		switch {
+		case err == nil:
+			deviceDelIssued = true
+		case isQMPDeviceNotFound(err):
+			slog.InfoContext(ctx, "DetachVolume: guest device already removed (resuming detach)",
+				"volumeId", volumeID, "err", err)
+		case force:
+			slog.WarnContext(ctx, "DetachVolume: QMP device_del failed (force=true, continuing)",
+				"volumeId", volumeID, "err", err)
+		default:
+			slog.ErrorContext(ctx, "DetachVolume: QMP device_del failed", "volumeId", volumeID, "err", err)
+			return "", fmt.Errorf("QMP device_del: %w", err)
 		}
-	} else if m.deps.DetachDelay > 0 {
-		time.Sleep(m.deps.DetachDelay)
-	}
 
-	// blockdev-del with bounded retry on "node is in use".
-	if blockdevErr := m.tryBlockdevDel(ctx, instance, nodeName); blockdevErr != nil {
-		slog.ErrorContext(ctx, "DetachVolume: QMP blockdev-del failed, leaving volume state intact",
-			"volumeId", volumeID, "err", blockdevErr)
-		return "", fmt.Errorf("QMP blockdev-del: %w", blockdevErr)
-	}
+		// device_del only requests the unplug; QEMU frees the block node once the
+		// guest ACKs it (DEVICE_DELETED). Wait for that real completion signal
+		// instead of blindly sleeping, so blockdev-del isn't attempted while the
+		// node still has a user. A miss (timeout, event drained by a racing read,
+		// or a resumed/forced detach with no fresh unplug in flight) falls
+		// through to the bounded retry below unchanged.
+		if deviceDelIssued && m.deps.DeviceDeletedTimeout > 0 {
+			if waitErr := waitForDeviceDeletedEvent(ctx, instance.QMPClient, deviceID, m.deps.DeviceDeletedTimeout, instance.ID); waitErr != nil {
+				slog.DebugContext(ctx, "DetachVolume: DEVICE_DELETED not observed, falling back to blockdev-del retry",
+					"volumeId", volumeID, "err", waitErr)
+			}
+		} else if m.deps.DetachDelay > 0 {
+			time.Sleep(m.deps.DetachDelay)
+		}
 
-	// object-del (best-effort).
-	if _, iothreadErr := sendQMPCommand(ctx, instance.QMPClient, qmp.QMPCommand{
-		Execute:   "object-del",
-		Arguments: map[string]any{"id": iothreadID},
-	}, instance.ID); iothreadErr != nil {
-		slog.WarnContext(ctx, "DetachVolume: QMP object-del iothread failed (non-fatal)",
-			"volumeId", volumeID, "err", iothreadErr)
+		// blockdev-del with bounded retry on "node is in use".
+		if blockdevErr := m.tryBlockdevDel(ctx, instance, nodeName); blockdevErr != nil {
+			slog.ErrorContext(ctx, "DetachVolume: QMP blockdev-del failed, leaving volume state intact",
+				"volumeId", volumeID, "err", blockdevErr)
+			return "", fmt.Errorf("QMP blockdev-del: %w", blockdevErr)
+		}
+
+		// object-del (best-effort).
+		if _, iothreadErr := sendQMPCommand(ctx, instance.QMPClient, qmp.QMPCommand{
+			Execute:   "object-del",
+			Arguments: map[string]any{"id": iothreadID},
+		}, instance.ID); iothreadErr != nil {
+			slog.WarnContext(ctx, "DetachVolume: QMP object-del iothread failed (non-fatal)",
+				"volumeId", volumeID, "err", iothreadErr)
+		}
+	} else {
+		slog.WarnContext(ctx, "DetachVolume: QEMU process gone, skipping QMP unplug and sealing directly",
+			"volumeId", volumeID, "instanceId", instance.ID)
 	}
 
 	// ebs.unmount drives the synchronous block-map seal to predastore. On

--- a/spinifex/vm/volumes_test.go
+++ b/spinifex/vm/volumes_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/qmp"
 	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1252,6 +1253,47 @@ func TestDetachVolume_DeviceDeletedTimeout_FallsBackToRetry(t *testing.T) {
 	assert.Equal(t, "/dev/sdf", device)
 	assert.Equal(t, int32(2), blockdevAttempts.Load(),
 		"a missed DEVICE_DELETED event must still resolve via the bounded blockdev-del retry")
+}
+
+// TestDetachVolume_ConfirmedDeadQEMU_SkipsQMPAndSeals proves the
+// detach-wedges-when-QEMU-dies fix: when QEMU is provably gone (PID file
+// present, process dead), DetachVolume issues no QMP command — those steps
+// would only hang on the wedged process — and proceeds straight to the
+// ebs.unmount seal and the attachment clear.
+func TestDetachVolume_ConfirmedDeadQEMU_SkipsQMPAndSeals(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	var qmpCalled atomic.Bool
+	qmpClient, cancel := newMockQMPClientWithEvents(t, func(cmd qmp.QMPCommand, srv *mockQMPServer) map[string]any {
+		qmpCalled.Store(true)
+		return nil
+	})
+	defer cancel()
+
+	const id = "i-1"
+	require.NoError(t, utils.WritePidFile(id, 999999)) // PID file present but process dead
+
+	mounter := &fakeVolumeMounter{}
+	updater := &fakeVolumeStateUpdater{}
+	m := NewManagerWithDeps(Deps{VolumeMounter: mounter, VolumeStateUpdater: updater})
+	m.Insert(&VM{
+		ID:        id,
+		Status:    StateRunning,
+		Instance:  &ec2.Instance{},
+		QMPClient: qmpClient,
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{{Name: "vol-1", DeviceName: "/dev/sdf"}},
+		},
+	})
+
+	device, err := m.DetachVolume(t.Context(), id, "vol-1", "", false)
+	require.NoError(t, err)
+	assert.Equal(t, "/dev/sdf", device)
+	assert.False(t, qmpCalled.Load(), "a confirmed-dead QEMU must receive no QMP command")
+	assert.Equal(t, []string{"vol-1"}, mounter.unmountedOne, "the ebs.unmount seal must still run")
+	calls := updater.snapshot()
+	require.Len(t, calls, 1, "the stale attachment must be cleared exactly once")
+	assert.Equal(t, "available", calls[0].State, "the volume must be returned to available")
 }
 
 // TestDetachVolume_BlockdevDelAlreadyRemoved_IdempotentSuccess covers the


### PR DESCRIPTION
## Summary

Three related bugs all end the same way: a terminate or detach that cannot complete leaves a volume permanently `in-use` and a leaked instance record, with no automatic path back to `available`/deletable. One branch, three stages, all sharing the volume-attachment state machine (`VolumeMetadata.AttachedInstance`/`State` via `UpdateVolumeState`) and the reaper/GC scaffolding.

### Stage 1 — detach before delete on both terminate paths (`mulga-1dzx9`)
`TerminateStoppedInstance` and the running-instance `terminateCleanup` both called `DeleteVolume` directly on a `DeleteOnTermination` root volume without clearing its attachment first, so the in-use guard rejected it (`VolumeInUse`) and the volume's space was never reclaimed. Shared `DeleteVolumeOnTerminate` helper clears the attachment via `UpdateVolumeState` then deletes; a non-DoT root is detached (`DetachVolumeOnTerminate`) rather than stranded. The stopped path now stamps `Teardown[volumes]`, so a transient delete failure self-heals through `TerminatedTeardownReaper`.

### Stage 2 — bounded detach + vanished-QEMU reconcile (`mulga-knybc`)
`DetachVolume` gains a bounded aggregate context deadline over the QMP chain and a confirmed-dead-QEMU short-circuit (skips the QMP steps that would only hang on the wedged process, seals directly) — a detach can no longer pin `attachMu` forever when nbdkit/QEMU die mid-flight. `OrphanQEMUReaper` now also finalizes shutting-down instances whose QEMU has vanished: drives them to `terminated`, stamps outstanding teardown `failed` for `TerminatedTeardownReaper`, no daemon restart. Gated on a dead process, so a live in-progress terminate is never stolen; a running instance with a dead QEMU stays crash-recovery's domain.

### Stage 3 — delete-authorized stuck-terminate backstop (`mulga-t4hz1`, backstop half)
`StuckTerminateReaper` force-completes a terminate wedged in shutting-down past `stuckTerminateTimeout` (10m) with QEMU still alive: force-kills the wedged process, reclaims `DeleteOnTermination` volume space through the idempotent cleaner, finalizes to terminated. It is the one reaper explicitly authorized to delete volume data — only for a DoT volume on an already-terminating instance. `VolumeLeakReaper` stays mark-and-alarm-only (ADR-0005 §3); its never-delete invariant tests remain green. A new `ShuttingDownAt` timestamp bounds the wedge; a missing timestamp reads as not-yet-stuck.

## Testing
- `make preflight` green (race-clean, diff coverage 72.3%).
- New unit tests: detach dead-QEMU short-circuit; OrphanQEMUReaper shutting-down reconcile (+ live-QEMU-left-alone); StuckTerminateReaper force-complete / failed-reclaim handoff / not-yet-stuck / no-timestamp gates; TerminatedTeardownReaper self-heal.
- Live on env13: stage-1 stop→terminate PASS (detach-before-delete ordering; root DoT deleted, non-DoT detached to available; zero leaked volumes); running-instance terminate regression PASS; stage-2 shutting-down scoping validated by crash-recovery owning a running+dead-QEMU instance.

## Notes
`mulga-t4hz1` half (a) — isolate NATS/control-state from the bulk predastore store — is out of scope here and tracked on that bead as the remaining P1 root fix.