### PR TITLE
fix(dhcp): retransmit within a DORA transaction, resolve the chaddr on every path, stop masking IPAM errors

### DIFF
--- a/cmd/dhcptest/main.go
+++ b/cmd/dhcptest/main.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
 	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
 )
@@ -36,6 +37,7 @@ func main() {
 	timeout := flag.Duration("timeout", 10*time.Second, "Per-attempt DHCP timeout")
 	retries := flag.Int("retries", 3, "Number of DORA attempts before giving up")
 	verbose := flag.Bool("verbose", false, "Print full DHCP packet contents")
+	broadcast := flag.Bool("broadcast", false, "Set the BOOTP broadcast flag, as vpcd's Acquire path does, so replies come back to ff:ff:ff:ff:ff:ff rather than unicast to the bridge MAC")
 	flag.Parse()
 
 	// Resolve the hardware address to use.
@@ -114,6 +116,9 @@ func main() {
 	// Identity modifiers — client-id / hostname / vendor-class for upstream lease
 	// tagging. Built by the vpcd code path so the probe cannot drift from it.
 	mods := dhcp.IdentityModifiers(cid, *hostname, *vendorClass, hwAddr)
+	if *broadcast {
+		mods = append(mods, dhcpv4.WithBroadcast(true))
+	}
 
 	fmt.Println("Sending DHCP Discover...")
 	start := time.Now()

--- a/spinifex/handlers/ec2/eip/service_impl.go
+++ b/spinifex/handlers/ec2/eip/service_impl.go
@@ -80,7 +80,13 @@ func (s *EIPServiceImpl) AllocateAddress(ctx context.Context, input *ec2.Allocat
 		publicIP, err = s.externalIPAM.AllocateFromPool(ctx, poolName, handlers_ec2_vpc.PurposeEIP, allocID, "", "")
 		if err != nil {
 			slog.ErrorContext(ctx, "AllocateAddress: IPAM pool allocation failed", "pool", poolName, "err", err)
-			return nil, errors.New(awserrors.ErrorInsufficientAddressCapacity)
+			// Carry the allocator's own error rather than a flat capacity code:
+			// the gateway resolves the AWS code out of the wrap chain, so a
+			// genuinely exhausted pool still surfaces
+			// InsufficientAddressCapacity while an upstream DHCP or IPAM fault
+			// reports as itself instead of wearing a capacity code it did not
+			// earn.
+			return nil, fmt.Errorf("allocate from pool %s: %w", poolName, err)
 		}
 	} else {
 		// Allocate from the best pool matching region/AZ (empty strings = global fallback).
@@ -89,7 +95,7 @@ func (s *EIPServiceImpl) AllocateAddress(ctx context.Context, input *ec2.Allocat
 		publicIP, poolName, err = s.externalIPAM.AllocateIP(ctx, region, az, handlers_ec2_vpc.PurposeEIP, allocID, "", "")
 		if err != nil {
 			slog.ErrorContext(ctx, "AllocateAddress: IPAM allocation failed", "err", err)
-			return nil, errors.New(awserrors.ErrorInsufficientAddressCapacity)
+			return nil, fmt.Errorf("allocate external IP: %w", err)
 		}
 	}
 

--- a/spinifex/handlers/ec2/eip/service_impl_test.go
+++ b/spinifex/handlers/ec2/eip/service_impl_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/network/external"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
@@ -68,6 +69,34 @@ func TestEIP_AllocateFromSpecificPool(t *testing.T) {
 	assert.NotEmpty(t, *out.AllocationId)
 	assert.Equal(t, "vpc", *out.Domain)
 	assert.NotEmpty(t, *out.PublicIp)
+}
+
+// A named pool that does not exist must surface the allocator's own error
+// rather than a flat capacity code, so an upstream fault is not misreported
+// as a genuinely exhausted pool.
+func TestEIP_AllocateFromNamedPoolThatDoesNotExist(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	_, err := svc.AllocateAddress(context.Background(), &ec2.AllocateAddressInput{
+		PublicIpv4Pool: aws.String("no-such-pool"),
+	}, testAccountID)
+	require.Error(t, err)
+}
+
+// Once the default pool's ten allocable addresses are exhausted, the eleventh
+// allocation must still resolve to InsufficientAddressCapacity — the wrap
+// added around the allocator's error must not swallow the AWS error code.
+func TestEIP_AllocateFromExhaustedDefaultPool(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	for range 10 {
+		_, err := svc.AllocateAddress(context.Background(), &ec2.AllocateAddressInput{}, testAccountID)
+		require.NoError(t, err)
+	}
+
+	_, err := svc.AllocateAddress(context.Background(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInsufficientAddressCapacity, awserrors.ValidErrorCodeFromError(err))
 }
 
 func TestEIP_Release(t *testing.T) {

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -696,7 +696,13 @@ func (s *InstanceServiceImpl) PrepareRunInstances(ctx context.Context, input *ec
 							slog.WarnContext(ctx, "PrepareRunInstances: failed to delete ENI after public-IP allocation failure",
 								"eniId", *eni.NetworkInterfaceId, "err", delErr)
 						}
-						lastRunErr = errors.New(awserrors.ErrorInsufficientAddressCapacity)
+						// Carry the allocator's own error rather than a flat
+						// capacity code: the gateway resolves the AWS code out
+						// of the wrap chain, so a genuinely exhausted pool still
+						// surfaces InsufficientAddressCapacity while an upstream
+						// DHCP or IPAM fault reports as itself instead of
+						// wearing a capacity code it did not earn.
+						lastRunErr = fmt.Errorf("allocate public IP for %s: %w", instance.ID, allocErr)
 						if reservationID == "" {
 							s.resourceMgr.Deallocate(instanceType)
 						} else {
@@ -750,7 +756,11 @@ func (s *InstanceServiceImpl) PrepareRunInstances(ctx context.Context, input *ec
 			}
 		}
 		errCode := awserrors.ValidErrorCodeFromError(lastRunErr)
-		slog.ErrorContext(ctx, "PrepareRunInstances: failed to create minimum instances", "created", len(instances), "minCount", minCount, "err", errCode)
+		// Log the cause next to the code: collapsing to the code alone is how
+		// an upstream DHCP fault came to be recorded fleet-wide as an exhausted
+		// address pool, with nothing left in the record to contradict it.
+		slog.ErrorContext(ctx, "PrepareRunInstances: failed to create minimum instances",
+			"created", len(instances), "minCount", minCount, "code", errCode, "err", lastRunErr)
 		return nil, nil, nil, errors.New(errCode)
 	}
 

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -3257,45 +3257,69 @@ func TestPrepareRunInstances_NATFailureRollsBackPublicIP(t *testing.T) {
 }
 
 // TestPrepareRunInstances_PublicIPAllocFailureAbortsLaunch verifies that a
-// failed public-IP allocation aborts the launch: detaches and deletes the ENI,
-// deallocates capacity, and returns InsufficientAddressCapacity.
+// failed public-IP allocation aborts the launch — detaches and deletes the ENI,
+// deallocates capacity — and reports the allocator's real cause. Reporting every
+// cause as InsufficientAddressCapacity is what made an upstream DHCP fault look
+// like an exhausted pool on every environment that hit it.
 func TestPrepareRunInstances_PublicIPAllocFailureAbortsLaunch(t *testing.T) {
-	eni := &fakeENICreator{
-		subnet: &SubnetInfo{SubnetID: "subnet-1", VpcID: "vpc-1", MapPublicIpOnLaunch: true},
-		createOut: &ec2.CreateNetworkInterfaceOutput{
-			NetworkInterface: &ec2.NetworkInterface{
-				NetworkInterfaceId: aws.String("eni-pubip-fail"),
-				MacAddress:         aws.String("aa:bb:cc:dd:ee:02"),
-				PrivateIpAddress:   aws.String("10.0.0.50"),
-				VpcId:              aws.String("vpc-1"),
-			},
+	tests := []struct {
+		name     string
+		allocErr error
+		wantCode string
+	}{
+		{
+			// Shape mirrors StaticPoolAllocator's own exhaustion error.
+			name:     "an exhausted pool still surfaces the capacity code",
+			allocErr: fmt.Errorf("pool wan exhausted: %w", errors.New(awserrors.ErrorInsufficientAddressCapacity)),
+			wantCode: awserrors.ErrorInsufficientAddressCapacity,
+		},
+		{
+			name:     "a DHCP timeout is not dressed up as exhausted capacity",
+			allocErr: errors.New("dhcp pool allocate: acquire after 4 attempts: unable to receive an offer"),
+			wantCode: awserrors.ErrorServerInternal,
 		},
 	}
-	ipam := &fakeIPAllocator{err: errors.New("InsufficientAddressCapacity: pool wan exhausted")}
-	deleter := &fakeENIDeleter{}
-	svc, prov := prepareSvcWithENI(t, eni, ipam)
-	svc.eniDeleter = deleter
 
-	_, instances, _, err := svc.PrepareRunInstances(context.Background(), &ec2.RunInstancesInput{
-		InstanceType: aws.String("t3.micro"),
-		ImageId:      aws.String("ami-1"),
-		SubnetId:     aws.String("subnet-1"),
-		MinCount:     aws.Int64(1),
-		MaxCount:     aws.Int64(1),
-	}, "acc", "")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eni := &fakeENICreator{
+				subnet: &SubnetInfo{SubnetID: "subnet-1", VpcID: "vpc-1", MapPublicIpOnLaunch: true},
+				createOut: &ec2.CreateNetworkInterfaceOutput{
+					NetworkInterface: &ec2.NetworkInterface{
+						NetworkInterfaceId: aws.String("eni-pubip-fail"),
+						MacAddress:         aws.String("aa:bb:cc:dd:ee:02"),
+						PrivateIpAddress:   aws.String("10.0.0.50"),
+						VpcId:              aws.String("vpc-1"),
+					},
+				},
+			}
+			ipam := &fakeIPAllocator{err: tt.allocErr}
+			deleter := &fakeENIDeleter{}
+			svc, prov := prepareSvcWithENI(t, eni, ipam)
+			svc.eniDeleter = deleter
 
-	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorInsufficientAddressCapacity, err.Error(),
-		"pool exhaustion must surface as InsufficientAddressCapacity, not a silent IP-less boot")
-	assert.Empty(t, instances, "instance with no public IP must not be returned")
+			_, instances, _, err := svc.PrepareRunInstances(context.Background(), &ec2.RunInstancesInput{
+				InstanceType: aws.String("t3.micro"),
+				ImageId:      aws.String("ami-1"),
+				SubnetId:     aws.String("subnet-1"),
+				MinCount:     aws.Int64(1),
+				MaxCount:     aws.Int64(1),
+			}, "acc", "")
 
-	// The ENI is attached with a primary IP; rollback must detach before
-	// delete (in-use ENIs reject deletion) so no eniKV record leaks.
-	assert.Equal(t, 1, eni.detachCalls, "rollback must detach the ENI before delete")
-	assert.Equal(t, []string{"eni-pubip-fail"}, deleter.calls, "rollback must delete the auto-created ENI")
-	assert.Equal(t, 0, eni.updateCalls, "no public IP was allocated, so the ENI must never be updated with one")
+			require.Error(t, err)
+			assert.Equal(t, tt.wantCode, err.Error(),
+				"the code must be resolved from the allocator's cause, not asserted by the caller")
+			assert.Empty(t, instances, "instance with no public IP must not be returned")
 
-	require.Len(t, prov.deallocated, 1, "public-IP allocation failure must trigger Deallocate")
+			// The ENI is attached with a primary IP; rollback must detach before
+			// delete (in-use ENIs reject deletion) so no eniKV record leaks.
+			assert.Equal(t, 1, eni.detachCalls, "rollback must detach the ENI before delete")
+			assert.Equal(t, []string{"eni-pubip-fail"}, deleter.calls, "rollback must delete the auto-created ENI")
+			assert.Equal(t, 0, eni.updateCalls, "no public IP was allocated, so the ENI must never be updated with one")
+
+			require.Len(t, prov.deallocated, 1, "public-IP allocation failure must trigger Deallocate")
+		})
+	}
 }
 
 // natWirePayload mirrors utils.natEvent for test-side decoding.

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -82,32 +82,62 @@ func (c *NClient4Client) socketTimeout(ctx context.Context) time.Duration {
 	return min(remaining, nclient4InitialRead)
 }
 
+// resolveHWAddr picks the chaddr for an exchange: the interface's own MAC when
+// the pool leases under it, otherwise the deterministic per-client-id MAC.
+//
+// A stored address that is empty or the wrong width is repaired rather than
+// passed through. nclient4 would put all zeros in chaddr and clientIDOption
+// would fall back to its untyped form, so the lease lands upstream with no
+// hardware address against it at all — the exact outcome option 61 was fixed to
+// stop, reached by a different route.
+func resolveHWAddr(bridge, clientID string, hwAddr net.HardwareAddr, useIfaceMAC bool) (net.HardwareAddr, error) {
+	if useIfaceMAC {
+		// The uplink drops foreign source MACs (WiFi/WWAN), so lease with the
+		// interface's own MAC; option 61 keeps leases apart on sane servers.
+		iface, err := net.InterfaceByName(bridge)
+		if err != nil {
+			return nil, fmt.Errorf("interface MAC for %s: %w", bridge, err)
+		}
+		if len(iface.HardwareAddr) == 0 {
+			return nil, fmt.Errorf("interface %s has no MAC", bridge)
+		}
+		return iface.HardwareAddr, nil
+	}
+	// All-zero is six bytes wide, so a width check alone lets it through — and it
+	// is the value that produces the unattributable lease in the first place.
+	if len(hwAddr) == 6 && !isZeroMAC(hwAddr) {
+		return hwAddr, nil
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("client_id or hw_addr is required")
+	}
+	hw, err := DeriveMAC(clientID)
+	if err != nil {
+		return nil, fmt.Errorf("derive hw_addr: %w", err)
+	}
+	return hw, nil
+}
+
+// isZeroMAC reports whether hw is all zeros, the placeholder a lease carries
+// when no hardware address was ever recorded for it.
+func isZeroMAC(hw net.HardwareAddr) bool {
+	for _, b := range hw {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *NClient4Client) Acquire(ctx context.Context, req AcquireRequest) (*Lease, error) {
 	if req.Bridge == "" {
 		return nil, fmt.Errorf("dhcp acquire: bridge is required")
 	}
-	switch {
-	case req.UseIfaceMAC:
-		// The uplink drops foreign source MACs (WiFi/WWAN), so lease with the
-		// interface's own MAC; option 61 keeps leases apart on sane servers.
-		iface, err := net.InterfaceByName(req.Bridge)
-		if err != nil {
-			return nil, fmt.Errorf("dhcp acquire: interface MAC for %s: %w", req.Bridge, err)
-		}
-		if len(iface.HardwareAddr) == 0 {
-			return nil, fmt.Errorf("dhcp acquire: interface %s has no MAC", req.Bridge)
-		}
-		req.HWAddr = iface.HardwareAddr
-	case len(req.HWAddr) == 0:
-		if req.ClientID == "" {
-			return nil, fmt.Errorf("dhcp acquire: client_id or hw_addr is required")
-		}
-		hw, err := DeriveMAC(req.ClientID)
-		if err != nil {
-			return nil, fmt.Errorf("dhcp acquire: derive hw_addr: %w", err)
-		}
-		req.HWAddr = hw
+	hw, err := resolveHWAddr(req.Bridge, req.ClientID, req.HWAddr, req.UseIfaceMAC)
+	if err != nil {
+		return nil, fmt.Errorf("dhcp acquire: %w", err)
 	}
+	req.HWAddr = hw
 
 	releasePromisc, err := enableBridgePromisc(req.Bridge)
 	if err != nil {
@@ -148,6 +178,11 @@ func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error
 	if err != nil {
 		return nil, fmt.Errorf("dhcp renew: %w", err)
 	}
+	// A lease persisted before the chaddr was carried has none to renew under.
+	hwAddr, err := resolveHWAddr(lease.Bridge, lease.ClientID, lease.HWAddr, lease.UseIfaceMAC)
+	if err != nil {
+		return nil, fmt.Errorf("dhcp renew: %w", err)
+	}
 
 	releasePromisc, err := enableBridgePromisc(lease.Bridge)
 	if err != nil {
@@ -161,7 +196,7 @@ func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error
 	}
 
 	client, err := nclient4.New(lease.Bridge,
-		nclient4.WithHWAddr(lease.HWAddr),
+		nclient4.WithHWAddr(hwAddr),
 		nclient4.WithTimeout(c.socketTimeout(ctx)),
 		nclient4.WithRetry(nclient4Tries),
 	)
@@ -171,7 +206,7 @@ func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error
 	defer func() { _ = client.Close() }()
 
 	renewed, err := client.Renew(ctx, nclient4Lease,
-		IdentityModifiers(lease.ClientID, lease.Hostname, lease.VendorClass, lease.HWAddr)...)
+		IdentityModifiers(lease.ClientID, lease.Hostname, lease.VendorClass, hwAddr)...)
 	if err != nil {
 		return nil, fmt.Errorf("dhcp renew on %s (client=%s): %w", lease.Bridge, lease.ClientID, err)
 	}
@@ -181,7 +216,7 @@ func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error
 		ClientID:    lease.ClientID,
 		Hostname:    lease.Hostname,
 		VendorClass: lease.VendorClass,
-		HWAddr:      lease.HWAddr,
+		HWAddr:      hwAddr,
 		UseIfaceMAC: lease.UseIfaceMAC,
 	}, renewed), nil
 }
@@ -191,6 +226,11 @@ func (c *NClient4Client) Release(_ context.Context, lease *Lease) error {
 		return nil
 	}
 	nclient4Lease, err := reconstructNClient4Lease(lease)
+	if err != nil {
+		return fmt.Errorf("dhcp release: %w", err)
+	}
+	// Must match what took the lease out, so it resolves the same way Acquire did.
+	hwAddr, err := resolveHWAddr(lease.Bridge, lease.ClientID, lease.HWAddr, lease.UseIfaceMAC)
 	if err != nil {
 		return fmt.Errorf("dhcp release: %w", err)
 	}
@@ -207,7 +247,7 @@ func (c *NClient4Client) Release(_ context.Context, lease *Lease) error {
 	}
 
 	client, err := nclient4.New(lease.Bridge,
-		nclient4.WithHWAddr(lease.HWAddr),
+		nclient4.WithHWAddr(hwAddr),
 		nclient4.WithTimeout(c.timeout),
 	)
 	if err != nil {
@@ -218,7 +258,7 @@ func (c *NClient4Client) Release(_ context.Context, lease *Lease) error {
 	// The server matches a RELEASE to a lease by client-id, so this must encode
 	// identically to the DISCOVER/REQUEST that took the lease out.
 	if err := client.Release(nclient4Lease,
-		dhcpv4.WithOption(clientIDOption(lease.ClientID, lease.HWAddr))); err != nil {
+		dhcpv4.WithOption(clientIDOption(lease.ClientID, hwAddr))); err != nil {
 		return fmt.Errorf("dhcp release on %s (client=%s): %w", lease.Bridge, lease.ClientID, err)
 	}
 	return nil

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -13,13 +13,30 @@ import (
 )
 
 // NClient4Client is the production DHCP client (AF_PACKET per call, no
-// long-lived socket). Single-shot: Manager.acquireWithBackoff owns retries
-// so budget arithmetic stays in one place.
+// long-lived socket). Manager.acquireWithBackoff owns the outer schedule of
+// whole DORA exchanges; this type owns the retransmissions inside one exchange.
 type NClient4Client struct {
 	timeout time.Duration
 }
 
-const nclient4Retries = 1
+// nclient4InitialRead is the read deadline for the FIRST transmission of an
+// exchange. nclient4's retryFn doubles it per retransmission, so the ladder is
+// 1s, 2s, 4s, … — RFC 2131 §4.1 behaviour.
+//
+// Retransmitting inside the exchange is the whole point, and it is not the same
+// as Manager retrying: Manager builds a new client and therefore a new xid each
+// attempt, so a server that answers late, or that ignores a first-contact
+// DISCOVER while it probes the candidate address, has its OFFER dropped as
+// belonging to an unknown transaction. Observed upstream behaviour is exactly
+// that — the first DISCOVER from an unseen MAC goes unanswered and a
+// retransmission is answered within ~500ms — so a client that sends one packet
+// and waits out the window never completes DORA at all.
+const nclient4InitialRead = time.Second
+
+// nclient4Tries is the number of transmissions per exchange. Six spans a 63s
+// ladder, longer than the widest window Manager schedules, so an attempt always
+// ends on the caller's context rather than on an exhausted ladder.
+const nclient4Tries = 6
 
 var _ Client = (*NClient4Client)(nil)
 
@@ -33,28 +50,36 @@ func NewNClient4(timeout time.Duration) *NClient4Client {
 	return &NClient4Client{timeout: timeout}
 }
 
-// socketTimeoutGrace keeps the socket deadline strictly behind the caller's, so
-// ctx.Done() is what ends a timed-out attempt. Matching the two exactly makes
-// them expire together and the reported error becomes a coin toss between
-// context.DeadlineExceeded and nclient4's ErrNoResponse, which reads as a
-// packet-matching fault rather than the plain timeout it is.
-const socketTimeoutGrace = time.Second
+// retransmitLadder is the wall-clock span of tries transmissions that start at
+// initial and double each time. The caller's budget must sit inside this span,
+// otherwise the ladder runs out first and the exchange ends early with time
+// still on the clock.
+func retransmitLadder(initial time.Duration, tries int) time.Duration {
+	var total, step time.Duration = 0, initial
+	for range tries {
+		total += step
+		step *= 2
+	}
+	return total
+}
 
-// socketTimeout is the read deadline handed to nclient4 for one DORA. It must
-// track the caller's deadline: nclient4 races its own deadline against ctx and
-// the shorter one ends the attempt, so a fixed value below the caller's budget
-// silently truncates every window in Manager's retransmission schedule.
+// socketTimeout is the read deadline for the first transmission of an exchange.
+// It is deliberately short so the retransmissions above actually happen: the
+// budget is spent on repeated DISCOVERs under one xid, not on a single silent
+// wait. nclient4 races this against ctx and the shorter wins, so it is clamped
+// to whatever the caller has left.
 func (c *NClient4Client) socketTimeout(ctx context.Context) time.Duration {
 	deadline, ok := ctx.Deadline()
 	if !ok {
-		return c.timeout
+		return nclient4InitialRead
 	}
 	// A deadline already in the past is left to ctx.Done(); nclient4 rejects a
 	// non-positive timeout, so keep the fallback rather than pass it through.
-	if remaining := time.Until(deadline); remaining > 0 {
-		return remaining + socketTimeoutGrace
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return nclient4InitialRead
 	}
-	return c.timeout
+	return min(remaining, nclient4InitialRead)
 }
 
 func (c *NClient4Client) Acquire(ctx context.Context, req AcquireRequest) (*Lease, error) {
@@ -98,7 +123,7 @@ func (c *NClient4Client) Acquire(ctx context.Context, req AcquireRequest) (*Leas
 	client, err := nclient4.New(req.Bridge,
 		nclient4.WithHWAddr(req.HWAddr),
 		nclient4.WithTimeout(c.socketTimeout(ctx)),
-		nclient4.WithRetry(nclient4Retries),
+		nclient4.WithRetry(nclient4Tries),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open nclient4 on %s: %w", req.Bridge, err)
@@ -138,7 +163,7 @@ func (c *NClient4Client) Renew(ctx context.Context, lease *Lease) (*Lease, error
 	client, err := nclient4.New(lease.Bridge,
 		nclient4.WithHWAddr(lease.HWAddr),
 		nclient4.WithTimeout(c.socketTimeout(ctx)),
-		nclient4.WithRetry(nclient4Retries),
+		nclient4.WithRetry(nclient4Tries),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("open nclient4 on %s for renew: %w", lease.Bridge, err)

--- a/spinifex/network/external/dhcp/nclient4_internal_test.go
+++ b/spinifex/network/external/dhcp/nclient4_internal_test.go
@@ -10,46 +10,54 @@ import (
 	"github.com/insomniacslk/dhcp/dhcpv4"
 )
 
-// socketTimeout must never cap the caller's budget, because nclient4 ends an
-// attempt on whichever of the two deadlines fires first.
-func TestSocketTimeoutTracksContextDeadline(t *testing.T) {
+// The caller's budget must be spent retransmitting under one xid, not waiting
+// out a single silent read, so the first read is short and the ladder — not the
+// read deadline — is what has to cover the window Manager gives an attempt.
+func TestRetransmitLadderCoversTheWidestAcquireWindow(t *testing.T) {
+	widest := defaultAcquireSchedule[len(defaultAcquireSchedule)-1] + acquireAttemptJitter
+	if got := retransmitLadder(nclient4InitialRead, nclient4Tries); got <= widest {
+		t.Fatalf("ladder spans %v, want more than the widest attempt window %v — "+
+			"the exchange would end on an exhausted ladder with budget left", got, widest)
+	}
+}
+
+// nclient4 ends a read on whichever of the socket deadline and ctx fires first,
+// so a read longer than what the caller has left is dead time: the transmission
+// it belongs to can never be retried inside the exchange.
+func TestSocketTimeoutNeverOutlivesTheCaller(t *testing.T) {
 	c := NewNClient4(5 * time.Second)
 
-	t.Run("no deadline falls back to the configured timeout", func(t *testing.T) {
-		if got := c.socketTimeout(context.Background()); got != 5*time.Second {
-			t.Fatalf("socketTimeout = %v, want 5s", got)
-		}
-	})
-
-	t.Run("longer deadline is honoured rather than capped", func(t *testing.T) {
+	t.Run("ample deadline yields the short initial read", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 32*time.Second)
 		defer cancel()
-		got := c.socketTimeout(ctx)
-		if got <= 5*time.Second {
-			t.Fatalf("socketTimeout = %v, want the remaining ~32s, not the 5s fallback", got)
-		}
-		// Strictly beyond the caller's deadline so ctx.Done() reports the timeout.
-		if got <= 32*time.Second {
-			t.Fatalf("socketTimeout = %v, want more than the remaining 32s", got)
+		if got := c.socketTimeout(ctx); got != nclient4InitialRead {
+			t.Fatalf("socketTimeout = %v, want the %v initial read", got, nclient4InitialRead)
 		}
 	})
 
-	t.Run("shorter deadline shortens the read", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Run("no deadline yields the same initial read", func(t *testing.T) {
+		if got := c.socketTimeout(context.Background()); got != nclient4InitialRead {
+			t.Fatalf("socketTimeout = %v, want the %v initial read", got, nclient4InitialRead)
+		}
+	})
+
+	t.Run("deadline inside the initial read shortens it", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), nclient4InitialRead/4)
 		defer cancel()
 		got := c.socketTimeout(ctx)
-		if got <= time.Second || got > 2*time.Second {
-			t.Fatalf("socketTimeout = %v, want just beyond the remaining 1s", got)
+		if got <= 0 || got > nclient4InitialRead/4 {
+			t.Fatalf("socketTimeout = %v, want a positive value within the remaining %v",
+				got, nclient4InitialRead/4)
 		}
 	})
 
-	t.Run("expired deadline yields a positive timeout", func(t *testing.T) {
+	t.Run("expired deadline still yields a positive timeout", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
 		// nclient4 rejects a non-positive read deadline; ctx.Done() ends the
 		// attempt immediately regardless of what is passed here.
-		if got := c.socketTimeout(ctx); got != 5*time.Second {
-			t.Fatalf("socketTimeout = %v, want the 5s fallback", got)
+		if got := c.socketTimeout(ctx); got != nclient4InitialRead {
+			t.Fatalf("socketTimeout = %v, want the %v fallback", got, nclient4InitialRead)
 		}
 	})
 }

--- a/spinifex/network/external/dhcp/nclient4_internal_test.go
+++ b/spinifex/network/external/dhcp/nclient4_internal_test.go
@@ -62,6 +62,50 @@ func TestSocketTimeoutNeverOutlivesTheCaller(t *testing.T) {
 	})
 }
 
+// Renew and Release read the chaddr back out of the lease store, so a lease
+// written before the chaddr was carried has none. Passing that through puts all
+// zeros in chaddr and drops option 61 to its untyped form, and the lease lands
+// upstream with no hardware address against it.
+func TestResolveHWAddrRepairsAMissingChaddr(t *testing.T) {
+	derived, err := DeriveMAC("eipalloc-1234")
+	if err != nil {
+		t.Fatalf("derive mac: %v", err)
+	}
+
+	t.Run("a usable address is kept", func(t *testing.T) {
+		got, err := resolveHWAddr("br-wan", "eipalloc-1234", derived, false)
+		if err != nil {
+			t.Fatalf("resolveHWAddr: %v", err)
+		}
+		if !bytes.Equal(got, derived) {
+			t.Fatalf("hw addr = %s, want the stored %s", got, derived)
+		}
+	})
+
+	for _, stored := range []net.HardwareAddr{nil, {}, make(net.HardwareAddr, 6)} {
+		t.Run("an unusable address is re-derived from the client-id", func(t *testing.T) {
+			got, err := resolveHWAddr("br-wan", "eipalloc-1234", stored, false)
+			if err != nil {
+				t.Fatalf("resolveHWAddr: %v", err)
+			}
+			// All-zero is six bytes wide and so passes a length check, yet it is
+			// the very value that produces an unattributable upstream lease.
+			if isZeroMAC(got) {
+				t.Fatalf("hw addr = %s, want a real address rather than zeros", got)
+			}
+			if !bytes.Equal(got, derived) {
+				t.Fatalf("hw addr = %s, want the derived %s", got, derived)
+			}
+		})
+	}
+
+	t.Run("no client-id leaves nothing to derive from", func(t *testing.T) {
+		if _, err := resolveHWAddr("br-wan", "", nil, false); err == nil {
+			t.Fatal("want an error rather than an exchange with a zero chaddr")
+		}
+	})
+}
+
 // Option 61 carries a leading hardware-type byte. Omitting it makes the server
 // consume the identifier's first character as the type, which is how leases end
 // up in the upstream table with no hardware address at all.

--- a/spinifex/network/external/dhcp/nclient4_internal_test.go
+++ b/spinifex/network/external/dhcp/nclient4_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +103,139 @@ func TestResolveHWAddrRepairsAMissingChaddr(t *testing.T) {
 	t.Run("no client-id leaves nothing to derive from", func(t *testing.T) {
 		if _, err := resolveHWAddr("br-wan", "", nil, false); err == nil {
 			t.Fatal("want an error rather than an exchange with a zero chaddr")
+		}
+	})
+}
+
+// resolveHWAddr's useIfaceMAC branch leases with the bind interface's own MAC
+// instead of a derived one, for uplinks that drop foreign source MACs. It must
+// fail closed on a bad interface rather than fall through to a derived or zero
+// chaddr, and must ignore the client-id entirely once an interface MAC exists.
+func TestResolveHWAddrUsesTheInterfaceMACWhenConfigured(t *testing.T) {
+	t.Run("an unknown interface name errors", func(t *testing.T) {
+		if _, err := resolveHWAddr("mulga-no-such-iface0", "eipalloc-1234", nil, true); err == nil {
+			t.Fatal("want an error rather than a nil MAC for a nonexistent interface")
+		}
+	})
+
+	t.Run("an interface with no hardware address errors", func(t *testing.T) {
+		iface, err := net.InterfaceByName("lo")
+		if err != nil {
+			t.Skip("no loopback interface available on this host")
+		}
+		if len(iface.HardwareAddr) != 0 {
+			t.Skip("lo unexpectedly carries a hardware address on this host")
+		}
+		if _, err := resolveHWAddr("lo", "eipalloc-1234", nil, true); err == nil {
+			t.Fatal("want an error rather than an empty MAC")
+		}
+	})
+
+	t.Run("an interface with a MAC is returned verbatim, ignoring the client-id", func(t *testing.T) {
+		ifaces, err := net.Interfaces()
+		if err != nil {
+			t.Fatalf("list interfaces: %v", err)
+		}
+		var target *net.Interface
+		for i := range ifaces {
+			if len(ifaces[i].HardwareAddr) > 0 {
+				target = &ifaces[i]
+				break
+			}
+		}
+		if target == nil {
+			t.Skip("no interface with a hardware address available on this host")
+		}
+		got, err := resolveHWAddr(target.Name, "eipalloc-1234", nil, true)
+		if err != nil {
+			t.Fatalf("resolveHWAddr: %v", err)
+		}
+		if !bytes.Equal(got, target.HardwareAddr) {
+			t.Fatalf("hw addr = %s, want the interface's own %s", got, target.HardwareAddr)
+		}
+	})
+}
+
+// rawDHCPv4Message returns a syntactically valid, arbitrary DHCPv4 wire
+// message for use as a Lease's RawOffer/RawACK. Renew and Release only need
+// something reconstructNClient4Lease can parse before chaddr resolution runs.
+func rawDHCPv4Message(t *testing.T) []byte {
+	t.Helper()
+	msg, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("build dhcpv4 message: %v", err)
+	}
+	return msg.ToBytes()
+}
+
+// Acquire, Renew and Release each resolve a chaddr before opening a socket, so
+// all three fail the same way against a bridge that cannot exist — proof they
+// share one resolution path rather than three independently maintained ones.
+// nclient4.New rejects an unknown interface name itself, so this needs no
+// privileges and no live DHCP server.
+func TestAcquireRenewReleaseFailToOpenAnUnknownBridge(t *testing.T) {
+	const noSuchBridge = "mulga-no-such-br0"
+	c := NewNClient4(time.Second)
+
+	derived, err := DeriveMAC("eipalloc-1234")
+	if err != nil {
+		t.Fatalf("derive mac: %v", err)
+	}
+	lease := &Lease{
+		Bridge:   noSuchBridge,
+		ClientID: "eipalloc-1234",
+		HWAddr:   derived,
+		RawOffer: rawDHCPv4Message(t),
+		RawACK:   rawDHCPv4Message(t),
+	}
+
+	t.Run("Acquire", func(t *testing.T) {
+		_, err := c.Acquire(context.Background(), AcquireRequest{
+			Bridge:   noSuchBridge,
+			ClientID: "eipalloc-1234",
+		})
+		if err == nil || !strings.Contains(err.Error(), noSuchBridge) {
+			t.Fatalf("Acquire err = %v, want an error mentioning %s", err, noSuchBridge)
+		}
+	})
+
+	t.Run("Renew", func(t *testing.T) {
+		_, err := c.Renew(context.Background(), lease)
+		if err == nil || !strings.Contains(err.Error(), noSuchBridge) {
+			t.Fatalf("Renew err = %v, want an error mentioning %s", err, noSuchBridge)
+		}
+	})
+
+	t.Run("Release", func(t *testing.T) {
+		if err := c.Release(context.Background(), lease); err == nil || !strings.Contains(err.Error(), noSuchBridge) {
+			t.Fatalf("Release err = %v, want an error mentioning %s", err, noSuchBridge)
+		}
+	})
+}
+
+// A lease persisted before the chaddr was carried has neither a hardware
+// address nor a client-id to derive one from. Renew and Release must refuse
+// it before opening a socket rather than exchange with a zero chaddr — the
+// same class of bug option 61 was fixed to stop, reached by a different route.
+func TestRenewReleaseRefuseALeaseWithNoResolvableChaddr(t *testing.T) {
+	c := NewNClient4(time.Second)
+	lease := &Lease{
+		Bridge:   "br-wan",
+		ClientID: "",
+		HWAddr:   nil,
+		RawOffer: rawDHCPv4Message(t),
+		RawACK:   rawDHCPv4Message(t),
+	}
+
+	t.Run("Renew", func(t *testing.T) {
+		if _, err := c.Renew(context.Background(), lease); err == nil {
+			t.Fatal("want an error rather than a renew with a zero chaddr")
+		}
+	})
+
+	t.Run("Release", func(t *testing.T) {
+		if err := c.Release(context.Background(), lease); err == nil {
+			t.Fatal("want an error rather than a release with a zero chaddr")
 		}
 	})
 }


### PR DESCRIPTION
Three related fixes in the vpcd DHCP client, plus a diagnostic flag.

## 1. The client never retransmitted within a transaction

`nclient4`'s `retryFn` re-sends the same packet under the same xid with a doubling read deadline — RFC 2131 §4.1 retransmission. `WithRetry(1)` ran that loop exactly once, so the client sent a single DISCOVER per attempt and never retransmitted it. `socketTimeout` then handed that lone transmission the caller's entire budget, so it sat silent for 4s, then 8s, then 16s, then 32s.

`Manager.acquireWithBackoff` does retry on that schedule, but each attempt builds a fresh client and therefore a fresh xid. Every attempt is a new transaction rather than a retransmission of the previous one, so an OFFER answering an earlier exchange is discarded as belonging to an unknown transaction.

Now six transmissions per exchange starting from a 1s read, spanning a 63s ladder — longer than the widest window `Manager` schedules, so an attempt ends on the caller's context rather than on an exhausted ladder. `socketTimeout` clamps to the caller's remaining budget instead of consuming it in one silent read.

## 2. `Renew` and `Release` passed the stored chaddr through unchecked

`Acquire` derived a chaddr when the request carried none. `Renew` and `Release` read `lease.HWAddr` straight out of the KV store and handed it to nclient4, so a lease persisted before the chaddr was carried renewed with **all zeros in chaddr**, and `clientIDOption` fell back to its untyped form. The lease then lands upstream with no hardware address against it — the outcome option 61 was fixed to prevent (#565), reached by a different route. Worse, the server sees an unknown client on every renewal and hands out a new lease each time.

`resolveHWAddr` now serves all three paths and treats all-zeros as unusable rather than merely empty: six zero bytes passes a width check yet is the exact value that produces the bad entry.

## 3. Every IPAM error reported as `InsufficientAddressCapacity`

`eip.AllocateAddress` and `instance.PrepareRunInstances` both replaced the allocator's error with a bare capacity code. `ResolveErrorCode` unwraps, so wrapping instead means a genuinely exhausted static pool still surfaces `InsufficientAddressCapacity` while a DHCP fault reports as itself. `PrepareRunInstances` also logs `code` and `err` separately rather than the code alone.

This matters beyond tidiness: 229 `InsufficientAddressCapacity` hits across nine environments in Elasticsearch all came through this path, which made every failure here look like a capacity problem regardless of cause. Those hits remain unexplained, and this change is what makes them answerable rather than self-confirming.

## Scope

Deliberately **not** addressed here, and left with `mulga-mwdrn`: reconciling the deadline ladder (the ~30s awsgw NATS request timeout against the ~62s acquire ladder and botocore's 60s read timeout), and making allocation idempotent so an abandoned request is reclaimable.

No pool-exhaustion claim is made. An earlier revision of the plan doc argued for one and it did not survive scrutiny — the burst it rested on was preceded by ~23 leases taken by the diagnostic probe itself. The retraction is recorded in the plan doc.

## Testing

- `make preflight` green.
- Unit: the retransmit ladder must span more than the widest attempt window `Manager` schedules; the initial read must never outlive the caller; a missing, empty or all-zero stored chaddr is re-derived; an exhausted pool resolves to `InsufficientAddressCapacity` while a DHCP timeout does not.
- Live on env19 (3 nodes, deployed at the tip commit): `allocate-address` completes, and a `br-wan` capture shows the retransmission ladder under one xid plus correct identity on the wire — `Client-ID (61) ether 02:40:b4:70:01:0a`, `Hostname (12) "eipalloc-f2d334eb0201ecee2"`, `Vendor-Class (60) "mulga-spinifex"`.

Bead: mulga-gte4y (blocks mulga-mwdrn). Plan: `docs/development/bugs/dhcp-dora-retransmission.md`.