### PR TITLE
fix: gate ovn-controller on SB RAFT readiness and force recompute

### DIFF
--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -379,6 +379,28 @@ EOF
         sleep 1
     done
 
+    # Wait for the Southbound DB to be serving before ovn-controller (Step 5)
+    # dials it. On a single node ovn-controller races a fresh SB RAFT election
+    # with no join step to absorb the window — attaching before the leader is
+    # elected (and before northd writes the gateway logical flows) leaves it with
+    # a partial datapath that never reconverges. Gate on SB reachable and, when
+    # clustered, an elected leader.
+    for i in $(seq 1 30); do
+        if sudo ovn-sbctl --timeout=2 show >/dev/null 2>&1; then
+            if [ -z "$DB_CLUSTER_LOCAL_ADDR" ]; then
+                break
+            fi
+            SB_LEADER=$(sudo ovs-appctl -t /var/run/ovn/ovnsb_db.ctl \
+                cluster/status OVN_Southbound 2>/dev/null \
+                | awk '/^Leader:/{print $2; exit}')
+            if [ -n "$SB_LEADER" ] && [ "$SB_LEADER" != "unknown" ]; then
+                break
+            fi
+        fi
+        echo "  Waiting for OVN SB DB leader... ($i/30)"
+        sleep 1
+    done
+
     # Set the NB/SB client listen addresses. set-connection writes through RAFT
     # (replicated cluster-wide), so it only runs on the create node — a joining
     # node would redirect to the leader, which the init node already configured.
@@ -853,6 +875,25 @@ echo "  ovn-controller log level: file:warn (via systemd drop-in)"
 
 sudo systemctl restart ovn-controller
 echo "  ovn-controller: started"
+
+# Force a full datapath recompute once ovn-controller has connected to the SB.
+# On a fresh single-node RAFT the controller can attach mid-election and program
+# a partial datapath (SNAT ct-commit without output/delivery), then never
+# reconverge. Recomputing after the SB connection is up rebuilds all OpenFlow
+# from the converged Southbound. Compute nodes race a remote SB too, so this
+# runs on every node.
+for i in $(seq 1 30); do
+    CTRL_STATUS=$(sudo OVS_RUNDIR=/var/run/ovn ovs-appctl -t ovn-controller \
+        connection-status 2>/dev/null)
+    if [ "$CTRL_STATUS" = "connected" ]; then
+        break
+    fi
+    echo "  Waiting for ovn-controller SB connection... ($i/30)"
+    sleep 1
+done
+sudo OVS_RUNDIR=/var/run/ovn ovs-appctl -t ovn-controller inc-engine/recompute \
+    2>/dev/null || true
+echo "  ovn-controller: forced datapath recompute"
 
 # --- Step 6: Sysctl tuning ---
 echo ""


### PR DESCRIPTION
## Problem

`setup-ovn.sh` gates bring-up only on the Northbound DB socket, then restarts `ovn-controller` without waiting for the Southbound DB to elect a RAFT leader or for northd to write the gateway logical flows.

On a single node there is no join step to absorb the boot window, so `ovn-controller` attaches mid-election and programs a partial datapath — SNAT ct-commit without output/delivery — and then never reconverges. NAT-GW egress and EIP ingress intermittently black-hole on the single-node baremetal host.

## Changes

`scripts/setup-ovn.sh` only, 41 lines added:

1. Before Step 5 starts `ovn-controller`, wait for the SB DB to answer `ovn-sbctl show`. When clustered (`DB_CLUSTER_LOCAL_ADDR` set), additionally poll `cluster/status OVN_Southbound` until a leader is elected. 30s bounded.
2. After `systemctl restart ovn-controller`, wait for its `connection-status` to reach `connected`, then force `inc-engine/recompute` so OpenFlow is rebuilt from the converged Southbound.

The recompute runs on every node — compute nodes race a remote SB too. Both loops are bounded and non-fatal, so behaviour on an already-healthy cluster is unchanged.

## Testing

`make preflight` passes (golangci-lint 0 issues, govulncheck clean). No Go source touched.

Needs a live single-node bring-up to confirm NAT-GW egress and EIP ingress are stable across repeated runs.