### PR TITLE
fix: stop upstream DHCP leases leaking out of the external pool

### DIFF
--- a/cmd/spinifex/cmd/get_dhcp_leases.go
+++ b/cmd/spinifex/cmd/get_dhcp_leases.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var getDHCPLeasesCmd = &cobra.Command{
+	Use:     "dhcp-leases",
+	Aliases: []string{"leases"},
+	Short:   "Display upstream DHCP leases held for external pools",
+	Long: `Display the upstream DHCP leases vpcd holds for source="dhcp" external pools,
+with the resource each was taken for and whether that resource still exists.
+
+An OWNER of "gone" is a leaked address: nothing renews it on purpose and nothing
+will release it. "unknown" means the owning service could not be reached.`,
+	Run: runGetDHCPLeases,
+}
+
+func init() {
+	getCmd.AddCommand(getDHCPLeasesCmd)
+	getDHCPLeasesCmd.Flags().Bool("orphans", false, "Show only leases whose owning resource is gone")
+	getDHCPLeasesCmd.Flags().Bool("skip-owner-check", false, "Skip the owner lookup (faster; OWNER reads as unchecked)")
+}
+
+func runGetDHCPLeases(cmd *cobra.Command, args []string) {
+	_, nc, err := loadConfigAndConnect()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer nc.Close()
+
+	orphansOnly, _ := cmd.Flags().GetBool("orphans")
+	skipOwnerCheck, _ := cmd.Flags().GetBool("skip-owner-check")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	entries, err := listDHCPLeases(ctx, nc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if len(entries) == 0 {
+		pterm.Info.Println("No DHCP leases held (no source=\"dhcp\" external pool, or none taken yet)")
+		return
+	}
+
+	tableData := pterm.TableData{
+		{"CLIENT ID", "AZ", "PURPOSE", "VPC", "IP", "MAC", "NODE", "EXPIRES", "OWNER"},
+	}
+	shown := 0
+	for _, l := range entries {
+		owner := "unchecked"
+		if !skipOwnerCheck {
+			owner = dhcpLeaseOwnerStatus(ctx, nc, l.entry, timeout)
+		}
+		if orphansOnly && owner != dhcp.OwnerStatusGone {
+			continue
+		}
+		shown++
+		tableData = append(tableData, []string{
+			l.entry.Lease.ClientID,
+			l.az,
+			l.entry.Purpose,
+			l.entry.VPCID,
+			l.entry.Lease.IP.String(),
+			l.entry.Lease.HWAddr.String(),
+			leaseNodeLabel(l.entry),
+			formatLeaseExpiry(l.entry),
+			owner,
+		})
+	}
+
+	if shown == 0 {
+		pterm.Info.Printfln("No orphaned leases among %d held", len(entries))
+		return
+	}
+	if err := pterm.DefaultTable.WithHasHeader().WithData(tableData).Render(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error rendering table: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// azEntry pairs a lease with the AZ whose bucket held it, since the client-id
+// alone does not say which vpcd owns it.
+type azEntry struct {
+	az    string
+	entry dhcp.Entry
+}
+
+// listDHCPLeases reads every per-AZ lease bucket. Buckets are enumerated rather
+// than derived from config so an AZ that no longer appears in the local config
+// still shows the addresses it is holding.
+func listDHCPLeases(ctx context.Context, nc *nats.Conn) ([]azEntry, error) {
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return nil, fmt.Errorf("jetstream: %w", err)
+	}
+	buckets, err := kvutil.BucketNames(ctx, js)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate KV buckets: %w", err)
+	}
+
+	var out []azEntry
+	for _, bucket := range buckets {
+		if !strings.HasPrefix(bucket, dhcp.KVBucketPrefix) {
+			continue
+		}
+		az := strings.TrimPrefix(strings.TrimPrefix(bucket, dhcp.KVBucketPrefix), "-")
+		kv, err := js.KeyValue(ctx, bucket)
+		if err != nil {
+			return nil, fmt.Errorf("open %s: %w", bucket, err)
+		}
+		entries, err := dhcp.NewStoreWithKV(kv, az).List(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list %s: %w", bucket, err)
+		}
+		for _, e := range entries {
+			if e.Lease == nil {
+				continue
+			}
+			out = append(out, azEntry{az: az, entry: e})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].az != out[j].az {
+			return out[i].az < out[j].az
+		}
+		return out[i].entry.Lease.ClientID < out[j].entry.Lease.ClientID
+	})
+	return out, nil
+}
+
+// dhcpLeaseOwnerStatus asks the daemon whether the lease's resource survives.
+// Reported as unknown on any failure, matching what the reaper acts on.
+func dhcpLeaseOwnerStatus(ctx context.Context, nc *nats.Conn, e dhcp.Entry, timeout time.Duration) string {
+	payload, err := json.Marshal(dhcp.OwnerCheckRequest{
+		ClientID: e.Lease.ClientID,
+		Purpose:  e.Purpose,
+		VPCID:    e.VPCID,
+	})
+	if err != nil {
+		return dhcp.OwnerStatusUnknown
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, max(timeout, time.Second))
+	defer cancel()
+	msg, err := nc.RequestWithContext(reqCtx, dhcp.TopicOwnerCheck, payload)
+	if err != nil {
+		return dhcp.OwnerStatusUnknown
+	}
+	var reply dhcp.OwnerCheckReply
+	if err := json.Unmarshal(msg.Data, &reply); err != nil {
+		return dhcp.OwnerStatusUnknown
+	}
+	return dhcp.ParseOwnerStatus(reply.Status).String()
+}
+
+// leaseNodeLabel recovers the node that took the lease from option 60, which
+// carries "<vendor class>/<node>".
+func leaseNodeLabel(e dhcp.Entry) string {
+	_, node, found := strings.Cut(e.Lease.VendorClass, "/")
+	if !found {
+		return "-"
+	}
+	return node
+}
+
+// formatLeaseExpiry renders the remaining lease time, flagging one the server
+// has already aged out.
+func formatLeaseExpiry(e dhcp.Entry) string {
+	expiry := e.Lease.ExpiresAt()
+	if expiry.IsZero() {
+		return "-"
+	}
+	remaining := time.Until(expiry).Round(time.Second)
+	if remaining <= 0 {
+		return "expired"
+	}
+	return remaining.String()
+}

--- a/cmd/spinifex/cmd/get_dhcp_leases_test.go
+++ b/cmd/spinifex/cmd/get_dhcp_leases_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseNodeLabel(t *testing.T) {
+	tests := []struct {
+		vendorClass string
+		want        string
+	}{
+		{vendorClass: "spinifex-vpcd/node1", want: "node1"},
+		{vendorClass: "spinifex-vpcd", want: "-"},
+		{vendorClass: "", want: "-"},
+	}
+
+	for _, tt := range tests {
+		got := leaseNodeLabel(dhcp.Entry{Lease: &dhcp.Lease{VendorClass: tt.vendorClass}})
+		assert.Equal(t, tt.want, got, "vendor class %q", tt.vendorClass)
+	}
+}
+
+func TestFormatLeaseExpiry(t *testing.T) {
+	// A lease the server has already aged out is the one an operator needs to
+	// spot, so it reads as a word rather than a negative duration.
+	aged := dhcp.Entry{Lease: &dhcp.Lease{
+		AcquiredAt:    time.Now().Add(-2 * time.Hour),
+		LeaseDuration: time.Hour,
+	}}
+	assert.Equal(t, "expired", formatLeaseExpiry(aged))
+
+	live := dhcp.Entry{Lease: &dhcp.Lease{
+		AcquiredAt:    time.Now(),
+		LeaseDuration: 30 * time.Minute,
+	}}
+	assert.Contains(t, formatLeaseExpiry(live), "m")
+
+	assert.Equal(t, "-", formatLeaseExpiry(dhcp.Entry{Lease: &dhcp.Lease{}}))
+}
+
+func TestListDHCPLeasesReadsEveryAZBucket(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+
+	for az, clientIDs := range map[string][]string{
+		"az2": {"eipalloc-2"},
+		"az1": {"eipalloc-1", "dhcp-gw-lrp-vpc-1"},
+	} {
+		store, err := dhcp.NewStore(t.Context(), js, az)
+		require.NoError(t, err)
+		for _, id := range clientIDs {
+			require.NoError(t, store.Put(t.Context(), dhcp.Entry{
+				Purpose: dhcp.PurposeEIP,
+				Lease:   &dhcp.Lease{ClientID: id, IP: net.ParseIP("192.168.1.5")},
+			}))
+		}
+	}
+
+	entries, err := listDHCPLeases(t.Context(), nc)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+
+	// Sorted by AZ then client-id, so the same cluster always prints the same way.
+	assert.Equal(t, []string{"az1", "az1", "az2"}, []string{entries[0].az, entries[1].az, entries[2].az})
+	assert.Equal(t, "dhcp-gw-lrp-vpc-1", entries[0].entry.Lease.ClientID)
+	assert.Equal(t, "eipalloc-1", entries[1].entry.Lease.ClientID)
+	assert.Equal(t, "eipalloc-2", entries[2].entry.Lease.ClientID)
+}
+
+func TestListDHCPLeasesWithoutBuckets(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+
+	entries, err := listDHCPLeases(t.Context(), nc)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestDHCPLeaseOwnerStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		reply any
+		want  string
+	}{
+		{name: "alive", reply: dhcp.OwnerCheckReply{Status: dhcp.OwnerStatusAlive}, want: "alive"},
+		{name: "gone", reply: dhcp.OwnerCheckReply{Status: dhcp.OwnerStatusGone}, want: "gone"},
+		{
+			name:  "lookup failed",
+			reply: dhcp.OwnerCheckReply{Status: dhcp.OwnerStatusUnknown, Error: "kv timeout"},
+			want:  "unknown",
+		},
+		// An unparseable reply says nothing about the resource, so it cannot read
+		// as gone — that would have the reaper release a live address.
+		{name: "garbage reply", reply: "not-a-reply", want: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, nc, _ := testutil.StartTestJetStream(t)
+			payload := []byte("not json")
+			if reply, ok := tt.reply.(dhcp.OwnerCheckReply); ok {
+				var err error
+				payload, err = json.Marshal(reply)
+				require.NoError(t, err)
+			}
+			sub, err := nc.Subscribe(dhcp.TopicOwnerCheck, func(msg *nats.Msg) {
+				_ = msg.Respond(payload)
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+			entry := dhcp.Entry{Purpose: dhcp.PurposeEIP, Lease: &dhcp.Lease{ClientID: "eipalloc-1"}}
+			assert.Equal(t, tt.want, dhcpLeaseOwnerStatus(t.Context(), nc, entry, time.Second))
+		})
+	}
+}
+
+// No daemon answering means the lease's owner is unproven, not gone.
+func TestDHCPLeaseOwnerStatusWithoutResponder(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+
+	entry := dhcp.Entry{Purpose: dhcp.PurposeEIP, Lease: &dhcp.Lease{ClientID: "eipalloc-1"}}
+	assert.Equal(t, "unknown", dhcpLeaseOwnerStatus(t.Context(), nc, entry, time.Second))
+}

--- a/docs/service-interfaces.yaml
+++ b/docs/service-interfaces.yaml
@@ -175,6 +175,7 @@ services:
     publishes:
       - "vpc.port-status"
       - "vpc.dhcp.lease-changed"
+      - "vpc.dhcp.owner-check"
     depends_on: []
 
   viperblockd:

--- a/docs/service-interfaces.yaml
+++ b/docs/service-interfaces.yaml
@@ -174,7 +174,7 @@ services:
       - "vpc.dhcp.release"
     publishes:
       - "vpc.port-status"
-      - "vpc.dhcp.lease-expired"
+      - "vpc.dhcp.lease-changed"
     depends_on: []
 
   viperblockd:

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1125,6 +1125,7 @@ func (d *Daemon) subscribeAll() error {
 		// vpcd holds the leases, but the records naming those addresses live
 		// here, so the reconcile request flows daemon-ward.
 		natsSub{dhcp.TopicLeaseChanged, d.handleDHCPLeaseChanged, "spinifex-workers"},
+		natsSub{dhcp.TopicOwnerCheck, d.handleDHCPOwnerCheck, "spinifex-workers"},
 	)
 
 	for _, s := range subs {

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1122,6 +1122,9 @@ func (d *Daemon) subscribeAll() error {
 		natsSub{"ec2.DisassociateAddress", handleNATSRequest(d.eipService.DisassociateAddress), "spinifex-workers"},
 		natsSub{"ec2.DescribeAddresses", handleNATSRequest(d.eipService.DescribeAddresses), "spinifex-workers"},
 		natsSub{"ec2.DescribeAddressesAttribute", handleNATSRequest(d.eipService.DescribeAddressesAttribute), "spinifex-workers"},
+		// vpcd holds the leases, but the records naming those addresses live
+		// here, so the reconcile request flows daemon-ward.
+		natsSub{dhcp.TopicLeaseChanged, d.handleDHCPLeaseChanged, "spinifex-workers"},
 	)
 
 	for _, s := range subs {

--- a/spinifex/daemon/daemon_dhcp_lease.go
+++ b/spinifex/daemon/daemon_dhcp_lease.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/nats-io/nats.go"
+)
+
+// leaseRebindTimeout bounds a single reconcile. It exceeds the vpc.add-nat
+// request-reply budget so a slow NAT commit reports its own error rather than
+// wearing a deadline from here.
+const leaseRebindTimeout = 60 * time.Second
+
+// eipPublicIPRebinder moves an allocation's public address. Asserted rather than
+// required so the disabled EIP stub (no external IPAM) is simply skipped.
+type eipPublicIPRebinder interface {
+	RebindPublicIP(ctx context.Context, allocationID, oldIP, newIP string) error
+}
+
+// handleDHCPLeaseChanged reconciles the record naming an address whose lease was
+// re-issued elsewhere. vpcd has already released the old address, so a failure
+// here means an API-visible record still advertises an address nothing holds —
+// hence the error goes back on the reply rather than only to the log.
+func (d *Daemon) handleDHCPLeaseChanged(msg *nats.Msg) {
+	var req dhcp.LeaseChangedRequest
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		respondLeaseChanged(msg, fmt.Errorf("decode lease-changed request: %w", err))
+		return
+	}
+	if req.ClientID == "" || req.NewIP == "" {
+		respondLeaseChanged(msg, fmt.Errorf("lease-changed request needs client_id and new_ip"))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), leaseRebindTimeout)
+	defer cancel()
+	respondLeaseChanged(msg, d.rebindLeaseRecord(ctx, req))
+}
+
+// rebindLeaseRecord dispatches to the service owning the moved address.
+func (d *Daemon) rebindLeaseRecord(ctx context.Context, req dhcp.LeaseChangedRequest) error {
+	switch req.Purpose {
+	case dhcp.PurposeEIP:
+		rebinder, ok := d.eipService.(eipPublicIPRebinder)
+		if !ok {
+			return fmt.Errorf("EIP service cannot rebind %s: external IPAM disabled", req.ClientID)
+		}
+		return rebinder.RebindPublicIP(ctx, req.ClientID, req.OldIP, req.NewIP)
+
+	case dhcp.PurposeENIPublic:
+		// The client-id is the ENI id when one is known, and the instance id
+		// otherwise; only the former identifies a record to move.
+		if d.vpcService == nil {
+			return fmt.Errorf("no VPC service to rebind ENI public IP for %s", req.ClientID)
+		}
+		return d.vpcService.RebindENIPublicIP(ctx, req.ClientID, req.OldIP, req.NewIP)
+
+	default:
+		return fmt.Errorf("no owner for %q lease %s: address moved %s -> %s",
+			req.Purpose, req.ClientID, req.OldIP, req.NewIP)
+	}
+}
+
+// respondLeaseChanged replies with err's text, or empty on success. A missing
+// reply subject means the caller published rather than requested, which would
+// silently drop the outcome, so it is logged.
+func respondLeaseChanged(msg *nats.Msg, err error) {
+	reply := dhcp.LeaseChangedReply{}
+	if err != nil {
+		reply.Error = err.Error()
+		slog.Error("daemon: dhcp lease rebind failed; a resource record still names a released address", "err", err)
+	}
+	data, marshalErr := json.Marshal(reply)
+	if marshalErr != nil {
+		slog.Error("daemon: marshal lease-changed reply failed", "err", marshalErr)
+		return
+	}
+	if msg.Reply == "" {
+		slog.Error("daemon: lease-changed request carried no reply subject", "outcome", string(data))
+		return
+	}
+	if respErr := msg.Respond(data); respErr != nil {
+		slog.Error("daemon: respond to lease-changed failed", "err", respErr)
+	}
+}

--- a/spinifex/daemon/daemon_dhcp_lease.go
+++ b/spinifex/daemon/daemon_dhcp_lease.go
@@ -66,6 +66,97 @@ func (d *Daemon) rebindLeaseRecord(ctx context.Context, req dhcp.LeaseChangedReq
 	}
 }
 
+// ownerCheckTimeout bounds one existence lookup. Short: the reaper runs on a
+// timer and an unanswered check keeps the lease, so waiting longer buys nothing.
+const ownerCheckTimeout = 15 * time.Second
+
+// eipAllocationChecker reports whether an allocation record survives. Asserted
+// rather than required so the disabled EIP stub is answered as unknown.
+type eipAllocationChecker interface {
+	AllocationExists(ctx context.Context, allocationID string) (bool, error)
+}
+
+// handleDHCPOwnerCheck answers whether the resource behind a lease still exists.
+// The reaper releases addresses on a "gone", so anything this cannot establish
+// with certainty is reported unknown.
+func (d *Daemon) handleDHCPOwnerCheck(msg *nats.Msg) {
+	var req dhcp.OwnerCheckRequest
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		respondOwnerCheck(msg, dhcp.OwnerStatusUnknown, fmt.Errorf("decode owner-check request: %w", err))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ownerCheckTimeout)
+	defer cancel()
+
+	status, err := d.leaseOwnerStatus(ctx, req)
+	respondOwnerCheck(msg, status, err)
+}
+
+// leaseOwnerStatus resolves a lease to its owning record, per purpose.
+func (d *Daemon) leaseOwnerStatus(ctx context.Context, req dhcp.OwnerCheckRequest) (string, error) {
+	switch req.Purpose {
+	case dhcp.PurposeEIP:
+		checker, ok := d.eipService.(eipAllocationChecker)
+		if !ok {
+			return dhcp.OwnerStatusUnknown, fmt.Errorf("EIP service cannot resolve %s: external IPAM disabled", req.ClientID)
+		}
+		return existsToStatus(checker.AllocationExists(ctx, req.ClientID))
+
+	case dhcp.PurposeENIPublic:
+		if d.vpcService == nil {
+			return dhcp.OwnerStatusUnknown, fmt.Errorf("no VPC service to resolve ENI %s", req.ClientID)
+		}
+		return existsToStatus(d.vpcService.ENIExists(ctx, req.ClientID))
+
+	case dhcp.PurposeGatewayLRP:
+		if d.vpcService == nil {
+			return dhcp.OwnerStatusUnknown, fmt.Errorf("no VPC service to resolve VPC %s", req.VPCID)
+		}
+		if req.VPCID == "" {
+			return dhcp.OwnerStatusUnknown, fmt.Errorf("gw-lrp lease %s carries no vpc_id", req.ClientID)
+		}
+		return existsToStatus(d.vpcService.VPCExists(ctx, req.VPCID))
+
+	default:
+		// A purpose this daemon does not know may well have a live owner it
+		// cannot see, so it is never reported gone.
+		return dhcp.OwnerStatusUnknown, fmt.Errorf("no owner lookup for %q lease %s", req.Purpose, req.ClientID)
+	}
+}
+
+func existsToStatus(exists bool, err error) (string, error) {
+	if err != nil {
+		return dhcp.OwnerStatusUnknown, err
+	}
+	if exists {
+		return dhcp.OwnerStatusAlive, nil
+	}
+	return dhcp.OwnerStatusGone, nil
+}
+
+// respondOwnerCheck replies with the verdict, carrying err's text when the
+// lookup failed. The error is informational — the status already says unknown.
+func respondOwnerCheck(msg *nats.Msg, status string, err error) {
+	reply := dhcp.OwnerCheckReply{Status: status}
+	if err != nil {
+		reply.Error = err.Error()
+		slog.Warn("daemon: dhcp lease owner check failed; reporting unknown", "err", err)
+	}
+	data, marshalErr := json.Marshal(reply)
+	if marshalErr != nil {
+		slog.Error("daemon: marshal owner-check reply failed", "err", marshalErr)
+		return
+	}
+	if msg.Reply == "" {
+		slog.Error("daemon: owner-check request carried no reply subject", "outcome", string(data))
+		return
+	}
+	if respErr := msg.Respond(data); respErr != nil {
+		slog.Error("daemon: respond to owner-check failed", "err", respErr)
+	}
+}
+
 // respondLeaseChanged replies with err's text, or empty on success. A missing
 // reply subject means the caller published rather than requested, which would
 // silently drop the outcome, so it is logged.

--- a/spinifex/daemon/daemon_dhcp_lease_test.go
+++ b/spinifex/daemon/daemon_dhcp_lease_test.go
@@ -1,0 +1,311 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	handlers_ec2_eip "github.com/mulgadc/spinifex/spinifex/handlers/ec2/eip"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubEIPService stands in for the EIP service without implementing either
+// optional interface, so it exercises the "external IPAM disabled" paths.
+type stubEIPService struct {
+	handlers_ec2_eip.EIPService
+}
+
+// stubEIPChecker answers allocation lookups only.
+type stubEIPChecker struct {
+	handlers_ec2_eip.EIPService
+
+	exists bool
+	err    error
+}
+
+func (s *stubEIPChecker) AllocationExists(context.Context, string) (bool, error) {
+	return s.exists, s.err
+}
+
+// stubEIPRebinder records the address move it was asked to make.
+type stubEIPRebinder struct {
+	handlers_ec2_eip.EIPService
+
+	oldIP, newIP string
+	err          error
+}
+
+func (s *stubEIPRebinder) RebindPublicIP(_ context.Context, _, oldIP, newIP string) error {
+	s.oldIP, s.newIP = oldIP, newIP
+	return s.err
+}
+
+func TestLeaseOwnerStatusEIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		checker *stubEIPChecker
+		want    string
+		wantErr bool
+	}{
+		{name: "allocation survives", checker: &stubEIPChecker{exists: true}, want: dhcp.OwnerStatusAlive},
+		{name: "allocation deleted", checker: &stubEIPChecker{}, want: dhcp.OwnerStatusGone},
+		{
+			name:    "lookup failed is never gone",
+			checker: &stubEIPChecker{err: errors.New("kv timeout")},
+			want:    dhcp.OwnerStatusUnknown,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Daemon{eipService: tt.checker}
+			status, err := d.leaseOwnerStatus(t.Context(), dhcp.OwnerCheckRequest{
+				ClientID: "eipalloc-1", Purpose: dhcp.PurposeEIP,
+			})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, status)
+		})
+	}
+}
+
+// A stub EIP service (no external IPAM) can prove nothing about an allocation,
+// so it must not be read as a deletion.
+func TestLeaseOwnerStatusEIPWithoutIPAMIsUnknown(t *testing.T) {
+	d := &Daemon{eipService: &stubEIPService{}}
+	status, err := d.leaseOwnerStatus(t.Context(), dhcp.OwnerCheckRequest{
+		ClientID: "eipalloc-1", Purpose: dhcp.PurposeEIP,
+	})
+	require.Error(t, err)
+	assert.Equal(t, dhcp.OwnerStatusUnknown, status)
+}
+
+func TestLeaseOwnerStatusWithoutVPCServiceIsUnknown(t *testing.T) {
+	d := &Daemon{}
+	for _, req := range []dhcp.OwnerCheckRequest{
+		{ClientID: "eni-1", Purpose: dhcp.PurposeENIPublic},
+		{ClientID: "dhcp-gw-lrp-vpc-1", Purpose: dhcp.PurposeGatewayLRP, VPCID: "vpc-1"},
+	} {
+		status, err := d.leaseOwnerStatus(t.Context(), req)
+		require.Error(t, err)
+		assert.Equal(t, dhcp.OwnerStatusUnknown, status)
+	}
+}
+
+// An unrecognised purpose may well have a live owner this daemon cannot see.
+func TestLeaseOwnerStatusUnknownPurposeIsUnknown(t *testing.T) {
+	d := &Daemon{}
+	status, err := d.leaseOwnerStatus(t.Context(), dhcp.OwnerCheckRequest{
+		ClientID: "x-1", Purpose: "natgw-external",
+	})
+	require.Error(t, err)
+	assert.Equal(t, dhcp.OwnerStatusUnknown, status)
+}
+
+func TestLeaseOwnerStatusVPCRecords(t *testing.T) {
+	d := createVPCTestDaemon(t)
+
+	out, err := d.vpcService.CreateVpc(t.Context(), &ec2.CreateVpcInput{
+		CidrBlock: aws.String("172.31.0.0/16"),
+	}, testAccountID)
+	require.NoError(t, err)
+	liveVPC := *out.Vpc.VpcId
+
+	status, err := d.leaseOwnerStatus(t.Context(), dhcp.OwnerCheckRequest{
+		ClientID: dhcp.GatewayLRPClientID(liveVPC), Purpose: dhcp.PurposeGatewayLRP, VPCID: liveVPC,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, dhcp.OwnerStatusAlive, status)
+
+	// A lease for a VPC that no longer has a record is the leak the reaper exists
+	// to clear, so it must read as gone rather than unknown.
+	status, err = d.leaseOwnerStatus(t.Context(), dhcp.OwnerCheckRequest{
+		ClientID: "dhcp-gw-lrp-vpc-deleted", Purpose: dhcp.PurposeGatewayLRP, VPCID: "vpc-deleted",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, dhcp.OwnerStatusGone, status)
+
+	status, err = d.leaseOwnerStatus(t.Context(), dhcp.OwnerCheckRequest{
+		ClientID: "eni-deleted", Purpose: dhcp.PurposeENIPublic,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, dhcp.OwnerStatusGone, status)
+}
+
+// Without a vpc_id there is nothing to look up, and guessing would risk
+// releasing a live gateway's address.
+func TestLeaseOwnerStatusGatewayWithoutVPCIDIsUnknown(t *testing.T) {
+	d := createVPCTestDaemon(t)
+
+	status, err := d.leaseOwnerStatus(t.Context(), dhcp.OwnerCheckRequest{
+		ClientID: "dhcp-gw-lrp-vpc-1", Purpose: dhcp.PurposeGatewayLRP,
+	})
+	require.Error(t, err)
+	assert.Equal(t, dhcp.OwnerStatusUnknown, status)
+}
+
+// ownerCheckRoundTrip drives the handler over NATS, so the reply encoding is
+// exercised the way the reaper sees it.
+func ownerCheckRoundTrip(t *testing.T, d *Daemon, payload []byte) dhcp.OwnerCheckReply {
+	t.Helper()
+	subject := "test.dhcp.owner-check." + t.Name()
+	sub, err := d.natsConn.Subscribe(subject, d.handleDHCPOwnerCheck)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	msg, err := d.natsConn.Request(subject, payload, 5*time.Second)
+	require.NoError(t, err)
+
+	var reply dhcp.OwnerCheckReply
+	require.NoError(t, json.Unmarshal(msg.Data, &reply))
+	return reply
+}
+
+func TestHandleDHCPOwnerCheckAnswersRequests(t *testing.T) {
+	d := createTestDaemon(t, sharedNATSURL)
+	d.eipService = &stubEIPChecker{exists: true}
+
+	req, err := json.Marshal(dhcp.OwnerCheckRequest{ClientID: "eipalloc-1", Purpose: dhcp.PurposeEIP})
+	require.NoError(t, err)
+
+	reply := ownerCheckRoundTrip(t, d, req)
+	assert.Equal(t, dhcp.OwnerStatusAlive, reply.Status)
+	assert.Empty(t, reply.Error)
+}
+
+func TestHandleDHCPOwnerCheckRejectsGarbage(t *testing.T) {
+	d := createTestDaemon(t, sharedNATSURL)
+
+	reply := ownerCheckRoundTrip(t, d, []byte("not json"))
+	assert.Equal(t, dhcp.OwnerStatusUnknown, reply.Status)
+	assert.Contains(t, reply.Error, "decode owner-check request")
+}
+
+// A published (rather than requested) check has nowhere to reply; it must be
+// logged instead of panicking on an empty subject.
+func TestRespondOwnerCheckWithoutReplySubject(t *testing.T) {
+	assert.NotPanics(t, func() {
+		respondOwnerCheck(&nats.Msg{}, dhcp.OwnerStatusGone, nil)
+		respondOwnerCheck(&nats.Msg{}, dhcp.OwnerStatusUnknown, errors.New("kv timeout"))
+	})
+}
+
+func TestRebindLeaseRecordEIP(t *testing.T) {
+	rebinder := &stubEIPRebinder{}
+	d := &Daemon{eipService: rebinder}
+
+	require.NoError(t, d.rebindLeaseRecord(t.Context(), dhcp.LeaseChangedRequest{
+		ClientID: "eipalloc-1", Purpose: dhcp.PurposeEIP,
+		OldIP: "192.168.1.139", NewIP: "192.168.1.134",
+	}))
+	assert.Equal(t, "192.168.1.139", rebinder.oldIP)
+	assert.Equal(t, "192.168.1.134", rebinder.newIP)
+}
+
+func TestRebindLeaseRecordErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		d    *Daemon
+		req  dhcp.LeaseChangedRequest
+	}{
+		{
+			name: "EIP service cannot rebind",
+			d:    &Daemon{eipService: &stubEIPService{}},
+			req:  dhcp.LeaseChangedRequest{ClientID: "eipalloc-1", Purpose: dhcp.PurposeEIP},
+		},
+		{
+			name: "no VPC service for ENI",
+			d:    &Daemon{},
+			req:  dhcp.LeaseChangedRequest{ClientID: "eni-1", Purpose: dhcp.PurposeENIPublic},
+		},
+		{
+			name: "no owner for purpose",
+			d:    &Daemon{},
+			req: dhcp.LeaseChangedRequest{
+				ClientID: "gw-1", Purpose: dhcp.PurposeGatewayLRP,
+				OldIP: "192.168.1.1", NewIP: "192.168.1.2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, tt.d.rebindLeaseRecord(t.Context(), tt.req))
+		})
+	}
+}
+
+// leaseChangedRoundTrip drives the handler over NATS, matching how vpcd calls it.
+func leaseChangedRoundTrip(t *testing.T, d *Daemon, payload []byte) dhcp.LeaseChangedReply {
+	t.Helper()
+	subject := "test.dhcp.lease-changed." + t.Name()
+	sub, err := d.natsConn.Subscribe(subject, d.handleDHCPLeaseChanged)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	msg, err := d.natsConn.Request(subject, payload, 5*time.Second)
+	require.NoError(t, err)
+
+	var reply dhcp.LeaseChangedReply
+	require.NoError(t, json.Unmarshal(msg.Data, &reply))
+	return reply
+}
+
+func TestHandleDHCPLeaseChangedRebinds(t *testing.T) {
+	d := createTestDaemon(t, sharedNATSURL)
+	rebinder := &stubEIPRebinder{}
+	d.eipService = rebinder
+
+	req, err := json.Marshal(dhcp.LeaseChangedRequest{
+		ClientID: "eipalloc-1", Purpose: dhcp.PurposeEIP,
+		OldIP: "192.168.1.139", NewIP: "192.168.1.134",
+	})
+	require.NoError(t, err)
+
+	reply := leaseChangedRoundTrip(t, d, req)
+	assert.Empty(t, reply.Error)
+	assert.Equal(t, "192.168.1.134", rebinder.newIP)
+}
+
+// vpcd needs the failure back on the reply: it has already released the old
+// address, so a silent error leaves a record naming an address nobody holds.
+func TestHandleDHCPLeaseChangedReportsFailures(t *testing.T) {
+	d := createTestDaemon(t, sharedNATSURL)
+	d.eipService = &stubEIPRebinder{err: errors.New("record vanished")}
+
+	req, err := json.Marshal(dhcp.LeaseChangedRequest{
+		ClientID: "eipalloc-1", Purpose: dhcp.PurposeEIP,
+		OldIP: "192.168.1.139", NewIP: "192.168.1.134",
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, leaseChangedRoundTrip(t, d, req).Error, "record vanished")
+}
+
+func TestHandleDHCPLeaseChangedRejectsIncompleteRequests(t *testing.T) {
+	d := createTestDaemon(t, sharedNATSURL)
+
+	assert.Contains(t, leaseChangedRoundTrip(t, d, []byte("not json")).Error, "decode lease-changed request")
+
+	req, err := json.Marshal(dhcp.LeaseChangedRequest{Purpose: dhcp.PurposeEIP, NewIP: "192.168.1.134"})
+	require.NoError(t, err)
+	assert.Contains(t, leaseChangedRoundTrip(t, d, req).Error, "needs client_id and new_ip")
+}
+
+func TestRespondLeaseChangedWithoutReplySubject(t *testing.T) {
+	assert.NotPanics(t, func() {
+		respondLeaseChanged(&nats.Msg{}, nil)
+		respondLeaseChanged(&nats.Msg{}, errors.New("rebind failed"))
+	})
+}

--- a/spinifex/daemon/daemon_handlers.go
+++ b/spinifex/daemon/daemon_handlers.go
@@ -76,6 +76,9 @@ func handleNATSRequest[I any, O any](serviceFn func(context.Context, *I, string)
 		defer span.End()
 
 		accountID := utils.AccountIDFromMsg(msg)
+		// Carried in ctx rather than the service signature so only the handlers
+		// that must deduplicate a retry have to look for it.
+		ctx = utils.WithIdempotencyKey(ctx, utils.IdempotencyKeyFromMsg(msg))
 		input := new(I)
 		if errResp := utils.UnmarshalJsonPayload(input, msg.Data); errResp != nil {
 			utils.MarkSpanError(span, errors.New(awserrors.ErrorInvalidParameterValue))

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -40,12 +40,15 @@ import (
 type EC2Handler func(action string, q map[string]string, gw *GatewayConfig, accountID string, r *http.Request) ([]byte, error)
 
 // requestContext returns r's context, or Background for a nil request
-// (some callers and tests dispatch without an *http.Request).
+// (some callers and tests dispatch without an *http.Request). The SDK's
+// invocation id rides along: it is repeated across retries of one call, so it
+// is what lets a mutation recognise its own resend instead of doing the work
+// twice.
 func requestContext(r *http.Request) context.Context {
 	if r == nil {
 		return context.Background()
 	}
-	return r.Context()
+	return utils.WithIdempotencyKey(r.Context(), r.Header.Get(utils.SDKInvocationIDHeader))
 }
 
 // ec2Handler creates a type-safe EC2Handler: allocates the input struct,

--- a/spinifex/handlers/ec2/eip/allocate_idempotency.go
+++ b/spinifex/handlers/ec2/eip/allocate_idempotency.go
@@ -1,0 +1,108 @@
+package handlers_ec2_eip
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	// KVBucketEIPIdempotency records the outcome of an AllocateAddress keyed by
+	// the caller's retry token, so a resend returns the first result instead of
+	// allocating again.
+	KVBucketEIPIdempotency = "spinifex-vpc-eip-idempotency"
+	// eipIdempotencyTTL outlives the SDK retry window without pinning keys
+	// forever. Entries age out on their own; nothing sweeps this bucket.
+	eipIdempotencyTTL = 30 * time.Minute
+)
+
+// allocateOnce collapses retries of a single AllocateAddress call. vpcd's DORA
+// ladder can outlast the AWS client read timeout, and EC2 AllocateAddress takes
+// no client token, so without this each SDK retry minted a fresh allocation ID
+// and took another upstream DHCP lease — returning one EIP to the caller and
+// stranding the rest with nothing to release them.
+func (s *EIPServiceImpl) allocateOnce(ctx context.Context, accountID string, alloc func() (*ec2.AllocateAddressOutput, error)) (*ec2.AllocateAddressOutput, error) {
+	key := utils.IdempotencyKeyFromContext(ctx)
+	if key == "" || s.idemKV == nil {
+		return alloc()
+	}
+	kvKey := utils.AccountKey(accountID, idempotencyKeyHash(key))
+
+	if out := s.cachedAllocation(ctx, kvKey); out != nil {
+		slog.WarnContext(ctx, "AllocateAddress: returning first result for a retried request",
+			"allocationId", *out.AllocationId, "accountID", accountID)
+		return out, nil
+	}
+
+	// Retries usually arrive while the first call is still in DORA, so the
+	// in-flight join is the common path and the KV record covers the rest.
+	res, err, _ := s.allocSF.Do(kvKey, func() (any, error) {
+		if out := s.cachedAllocation(ctx, kvKey); out != nil {
+			return out, nil
+		}
+		out, err := alloc()
+		if err != nil {
+			return nil, err
+		}
+		s.recordAllocation(ctx, kvKey, out)
+		return out, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	out, ok := res.(*ec2.AllocateAddressOutput)
+	if !ok {
+		return nil, fmt.Errorf("allocate address: unexpected singleflight result %T", res)
+	}
+	return out, nil
+}
+
+// idempotencyKeyHash renders a caller-supplied token as a KV-safe key. NATS
+// restricts the key alphabet, and the token comes off an HTTP header, so it is
+// hashed rather than trusted verbatim.
+func idempotencyKeyHash(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:16])
+}
+
+// cachedAllocation returns a previously recorded outcome, or nil when there is
+// none. A corrupt or unreadable record is treated as absent: re-allocating
+// costs an address, but failing the call outright would deny a legitimate one.
+func (s *EIPServiceImpl) cachedAllocation(ctx context.Context, kvKey string) *ec2.AllocateAddressOutput {
+	entry, err := s.idemKV.Get(ctx, kvKey)
+	if err != nil {
+		if !errors.Is(err, jetstream.ErrKeyNotFound) {
+			slog.WarnContext(ctx, "AllocateAddress: idempotency lookup failed; treating as a new request", "err", err)
+		}
+		return nil
+	}
+	var out ec2.AllocateAddressOutput
+	if err := json.Unmarshal(entry.Value(), &out); err != nil || out.AllocationId == nil {
+		slog.WarnContext(ctx, "AllocateAddress: unreadable idempotency record; treating as a new request", "err", err)
+		return nil
+	}
+	return &out
+}
+
+// recordAllocation stores the outcome so a retry arriving after the first call
+// completed still gets the same allocation. A write failure only costs the
+// dedupe, so the allocation itself is not unwound.
+func (s *EIPServiceImpl) recordAllocation(ctx context.Context, kvKey string, out *ec2.AllocateAddressOutput) {
+	data, err := json.Marshal(out)
+	if err != nil {
+		slog.WarnContext(ctx, "AllocateAddress: marshal idempotency record failed", "err", err)
+		return
+	}
+	if _, err := s.idemKV.Put(ctx, kvKey, data); err != nil {
+		slog.WarnContext(ctx, "AllocateAddress: recording idempotency key failed; a retry may allocate again", "err", err)
+	}
+}

--- a/spinifex/handlers/ec2/eip/allocate_idempotency_test.go
+++ b/spinifex/handlers/ec2/eip/allocate_idempotency_test.go
@@ -1,0 +1,154 @@
+package handlers_ec2_eip
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The SDK reuses amz-sdk-invocation-id across retries of one call, so a resend
+// must return the first allocation instead of drawing another address.
+func TestAllocateAddress_RetryReturnsFirstAllocation(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	ctx := utils.WithIdempotencyKey(t.Context(), "invocation-1")
+
+	first, err := svc.AllocateAddress(ctx, &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+	second, err := svc.AllocateAddress(ctx, &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+
+	assert.Equal(t, *first.AllocationId, *second.AllocationId)
+	assert.Equal(t, *first.PublicIp, *second.PublicIp)
+
+	got, err := svc.DescribeAddresses(t.Context(), &ec2.DescribeAddressesInput{}, testAccountID)
+	require.NoError(t, err)
+	assert.Len(t, got.Addresses, 1, "retry must not leave a second address held with no owner")
+}
+
+// Distinct calls carry distinct invocation ids and must still get their own EIP.
+func TestAllocateAddress_DifferentKeysAllocateSeparately(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	first, err := svc.AllocateAddress(utils.WithIdempotencyKey(t.Context(), "invocation-1"), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+	second, err := svc.AllocateAddress(utils.WithIdempotencyKey(t.Context(), "invocation-2"), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, *first.PublicIp, *second.PublicIp)
+}
+
+// Callers that send no token (an older SDK, a raw HTTP client) keep the
+// pre-existing behaviour rather than colliding on an empty key.
+func TestAllocateAddress_WithoutKeyAllocatesEachTime(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	first, err := svc.AllocateAddress(t.Context(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+	second, err := svc.AllocateAddress(t.Context(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, *first.PublicIp, *second.PublicIp)
+}
+
+// One account's token must not answer another's call.
+func TestAllocateAddress_KeyIsScopedPerAccount(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	ctx := utils.WithIdempotencyKey(t.Context(), "invocation-1")
+
+	first, err := svc.AllocateAddress(ctx, &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+	second, err := svc.AllocateAddress(ctx, &ec2.AllocateAddressInput{}, "210987654321")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, *first.PublicIp, *second.PublicIp)
+}
+
+// The retry usually arrives while the first DORA is still running, which the KV
+// record cannot cover — singleflight has to join it to the call in flight.
+func TestAllocateOnce_ConcurrentRetriesCollapse(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	ctx := utils.WithIdempotencyKey(t.Context(), "invocation-1")
+
+	var calls atomic.Int32
+	release := make(chan struct{})
+	alloc := func() (*ec2.AllocateAddressOutput, error) {
+		calls.Add(1)
+		<-release
+		return &ec2.AllocateAddressOutput{
+			AllocationId: aws.String("eipalloc-abc"),
+			PublicIp:     aws.String("198.51.100.11"),
+		}, nil
+	}
+
+	const attempts = 4
+	outs := make([]*ec2.AllocateAddressOutput, attempts)
+	errs := make([]error, attempts)
+	var wg sync.WaitGroup
+	for i := range attempts {
+		wg.Go(func() {
+			outs[i], errs[i] = svc.allocateOnce(ctx, testAccountID, alloc)
+		})
+	}
+	// The first alloc is pinned until every attempt has had time to join it, so
+	// all four are genuinely in flight together rather than run back to back.
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i := range attempts {
+		require.NoError(t, errs[i])
+		assert.Equal(t, "eipalloc-abc", *outs[i].AllocationId)
+	}
+	assert.Equal(t, int32(1), calls.Load(), "concurrent retries must share one allocation")
+}
+
+// A failed allocation must not be cached: the caller is entitled to retry and
+// get a real address once the fault clears.
+func TestAllocateOnce_FailureIsNotCached(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	ctx := utils.WithIdempotencyKey(t.Context(), "invocation-1")
+
+	_, err := svc.allocateOnce(ctx, testAccountID, func() (*ec2.AllocateAddressOutput, error) {
+		return nil, errors.New("pool unreachable")
+	})
+	require.Error(t, err)
+
+	out, err := svc.allocateOnce(ctx, testAccountID, func() (*ec2.AllocateAddressOutput, error) {
+		return &ec2.AllocateAddressOutput{
+			AllocationId: aws.String("eipalloc-abc"),
+			PublicIp:     aws.String("198.51.100.11"),
+		}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "eipalloc-abc", *out.AllocationId)
+}
+
+// Without a bucket the dedupe degrades to the in-flight join only, which must
+// not turn into a nil dereference.
+func TestAllocateOnce_WithoutBucketStillAllocates(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	svc.idemKV = nil
+
+	out, err := svc.allocateOnce(utils.WithIdempotencyKey(t.Context(), "invocation-1"), testAccountID,
+		func() (*ec2.AllocateAddressOutput, error) {
+			return &ec2.AllocateAddressOutput{AllocationId: aws.String("eipalloc-abc")}, nil
+		})
+	require.NoError(t, err)
+	assert.Equal(t, "eipalloc-abc", *out.AllocationId)
+}
+
+func TestIdempotencyKeyHash_IsStableAndKVSafe(t *testing.T) {
+	got := idempotencyKeyHash("some/token with spaces.and*wildcards")
+
+	assert.Equal(t, got, idempotencyKeyHash("some/token with spaces.and*wildcards"))
+	assert.NotEqual(t, got, idempotencyKeyHash("another token"))
+	assert.Regexp(t, `^[0-9a-f]{32}$`, got)
+}

--- a/spinifex/handlers/ec2/eip/lease_owner_test.go
+++ b/spinifex/handlers/ec2/eip/lease_owner_test.go
@@ -1,0 +1,60 @@
+package handlers_ec2_eip
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllocationExists(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	out, err := svc.AllocateAddress(t.Context(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+
+	exists, err := svc.AllocationExists(t.Context(), *out.AllocationId)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+// The lease store keys on the client-id alone, so the lookup has to work without
+// the owning account.
+func TestAllocationExistsIgnoresAccount(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	out, err := svc.AllocateAddress(t.Context(), &ec2.AllocateAddressInput{}, "210987654321")
+	require.NoError(t, err)
+
+	exists, err := svc.AllocationExists(t.Context(), *out.AllocationId)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+// A released allocation is what the reaper acts on, so this answer costs an
+// address if it is wrong.
+func TestAllocationExistsFalseAfterRelease(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	out, err := svc.AllocateAddress(t.Context(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+	_, err = svc.ReleaseAddress(t.Context(), &ec2.ReleaseAddressInput{AllocationId: out.AllocationId}, testAccountID)
+	require.NoError(t, err)
+
+	exists, err := svc.AllocationExists(t.Context(), *out.AllocationId)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestAllocationExistsUnknownID(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	exists, err := svc.AllocationExists(t.Context(), "eipalloc-missing")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestAllocationExistsRejectsEmptyID(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	_, err := svc.AllocationExists(t.Context(), "")
+	require.Error(t, err)
+}

--- a/spinifex/handlers/ec2/eip/lease_rebind.go
+++ b/spinifex/handlers/ec2/eip/lease_rebind.go
@@ -62,6 +62,30 @@ func (s *EIPServiceImpl) RebindPublicIP(ctx context.Context, allocationID, oldIP
 	return nil
 }
 
+// AllocationExists reports whether an allocation record survives, without
+// knowing its account. Used to decide whether a DHCP lease still has an owner,
+// so a listing failure is an error rather than a false — releasing an address on
+// a KV timeout would be worse than keeping an orphan.
+func (s *EIPServiceImpl) AllocationExists(ctx context.Context, allocationID string) (bool, error) {
+	if allocationID == "" {
+		return false, errors.New("allocation exists: allocationID required")
+	}
+	keys, err := s.eipKV.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("list EIP records: %w", err)
+	}
+	suffix := "." + allocationID
+	for _, k := range keys {
+		if k != utils.VersionKey && strings.HasSuffix(k, suffix) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // findByAllocationIDAnyAccount locates an allocation without knowing its
 // account. vpcd's lease store keys on the client-id alone, so the owning
 // account is not available at the point the lease moves.

--- a/spinifex/handlers/ec2/eip/lease_rebind.go
+++ b/spinifex/handlers/ec2/eip/lease_rebind.go
@@ -1,0 +1,90 @@
+package handlers_ec2_eip
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// RebindPublicIP moves an allocation onto newIP after vpcd's lease for it was
+// re-issued on a different address. The old address is already released
+// upstream by the time this runs, so refusing to move the record would leave
+// DescribeAddresses advertising an address nothing holds.
+func (s *EIPServiceImpl) RebindPublicIP(ctx context.Context, allocationID, oldIP, newIP string) error {
+	if allocationID == "" || newIP == "" {
+		return errors.New("rebind EIP: allocationID and newIP required")
+	}
+
+	record, key, revision, err := s.findByAllocationIDAnyAccount(ctx, allocationID)
+	if err != nil {
+		return err
+	}
+	// Already on newIP: a duplicate delivery. The NAT commit below is
+	// idempotent but the revision check is not, so stop here.
+	if record.PublicIp == newIP {
+		return nil
+	}
+	// Moving a record naming neither address would overwrite an allocation
+	// this lease does not own.
+	if oldIP != "" && record.PublicIp != oldIP {
+		return fmt.Errorf("rebind EIP %s: record holds %s, not the superseded %s", allocationID, record.PublicIp, oldIP)
+	}
+
+	// Only an associated EIP has a dnat_and_snat to move. AddEIP scrubs the
+	// predecessor row keyed on this logical IP, so committing the new external
+	// IP is sufficient. Request-reply: a failure here means the instance has no
+	// working ingress, so it must not be swallowed.
+	if record.ENIId != "" && record.PrivateIp != "" {
+		if err := utils.AddNAT(s.natsConn, record.VpcId, newIP, record.PrivateIp,
+			topology.Port(record.ENIId), record.MacAddress); err != nil {
+			return fmt.Errorf("rebind EIP %s: commit NAT for %s: %w", allocationID, newIP, err)
+		}
+	}
+
+	record.PublicIp = newIP
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("rebind EIP %s: marshal record: %w", allocationID, err)
+	}
+	if _, err := s.eipKV.Update(ctx, key, data, revision); err != nil {
+		return fmt.Errorf("rebind EIP %s onto %s: %w", allocationID, newIP, err)
+	}
+
+	slog.WarnContext(ctx, "EIP public address moved after its DHCP lease was re-issued",
+		"allocationId", allocationID, "oldIp", oldIP, "newIp", newIP, "eniId", record.ENIId)
+	return nil
+}
+
+// findByAllocationIDAnyAccount locates an allocation without knowing its
+// account. vpcd's lease store keys on the client-id alone, so the owning
+// account is not available at the point the lease moves.
+func (s *EIPServiceImpl) findByAllocationIDAnyAccount(ctx context.Context, allocationID string) (*EIPRecord, string, uint64, error) {
+	keys, err := s.eipKV.Keys(ctx)
+	if err != nil && !errors.Is(err, jetstream.ErrNoKeysFound) {
+		return nil, "", 0, fmt.Errorf("list EIP records: %w", err)
+	}
+
+	suffix := "." + allocationID
+	for _, k := range keys {
+		if k == utils.VersionKey || !strings.HasSuffix(k, suffix) {
+			continue
+		}
+		entry, err := s.eipKV.Get(ctx, k)
+		if err != nil {
+			return nil, "", 0, fmt.Errorf("get EIP record %s: %w", k, err)
+		}
+		var record EIPRecord
+		if err := json.Unmarshal(entry.Value(), &record); err != nil {
+			return nil, "", 0, fmt.Errorf("unmarshal EIP record %s: %w", k, err)
+		}
+		return &record, k, entry.Revision(), nil
+	}
+	return nil, "", 0, fmt.Errorf("no EIP record for allocation %s", allocationID)
+}

--- a/spinifex/handlers/ec2/eip/lease_rebind_test.go
+++ b/spinifex/handlers/ec2/eip/lease_rebind_test.go
@@ -1,0 +1,66 @@
+package handlers_ec2_eip
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An unassociated EIP has no dnat_and_snat, so the record move needs no vpcd.
+func TestRebindPublicIP_MovesUnassociatedRecord(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	out, err := svc.AllocateAddress(context.Background(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+	allocID, oldIP := *out.AllocationId, *out.PublicIp
+
+	require.NoError(t, svc.RebindPublicIP(t.Context(), allocID, oldIP, "198.51.100.99"))
+
+	got, err := svc.DescribeAddresses(context.Background(), &ec2.DescribeAddressesInput{}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, got.Addresses, 1)
+	assert.Equal(t, "198.51.100.99", *got.Addresses[0].PublicIp,
+		"DescribeAddresses must not keep reporting an address vpcd released")
+}
+
+// Duplicate delivery must not fail: the revision check would reject the second
+// write even though the record already holds the target address.
+func TestRebindPublicIP_IsIdempotent(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	out, err := svc.AllocateAddress(context.Background(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+	allocID, oldIP := *out.AllocationId, *out.PublicIp
+
+	require.NoError(t, svc.RebindPublicIP(t.Context(), allocID, oldIP, "198.51.100.99"))
+	require.NoError(t, svc.RebindPublicIP(t.Context(), allocID, oldIP, "198.51.100.99"))
+}
+
+// Moving a record that names neither address would overwrite an allocation this
+// lease does not own.
+func TestRebindPublicIP_RejectsMismatchedOldIP(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+	out, err := svc.AllocateAddress(context.Background(), &ec2.AllocateAddressInput{}, testAccountID)
+	require.NoError(t, err)
+
+	err = svc.RebindPublicIP(t.Context(), *out.AllocationId, "203.0.113.7", "198.51.100.99")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not the superseded 203.0.113.7")
+}
+
+// A lease that outlived its allocation must report, not silently pass.
+func TestRebindPublicIP_UnknownAllocationErrors(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	err := svc.RebindPublicIP(t.Context(), "eipalloc-missing", "198.51.100.11", "198.51.100.99")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no EIP record for allocation eipalloc-missing")
+}
+
+func TestRebindPublicIP_RejectsEmptyArgs(t *testing.T) {
+	svc, _ := setupTestEIP(t)
+
+	assert.Error(t, svc.RebindPublicIP(t.Context(), "", "198.51.100.11", "198.51.100.99"))
+	assert.Error(t, svc.RebindPublicIP(t.Context(), "eipalloc-1", "198.51.100.11", ""))
+}

--- a/spinifex/handlers/ec2/eip/service_impl.go
+++ b/spinifex/handlers/ec2/eip/service_impl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
+	"golang.org/x/sync/singleflight"
 )
 
 // Ensure EIPServiceImpl implements EIPService.
@@ -31,6 +32,12 @@ type EIPServiceImpl struct {
 	externalIPAM *handlers_ec2_vpc.ExternalIPAM
 	vpcService   handlers_ec2_vpc.VPCService
 	natsConn     *nats.Conn
+
+	// idemKV records AllocateAddress outcomes by retry token and allocSF joins
+	// a retry to the call still in flight. Together they stop one SDK-level
+	// retry from becoming a second allocation and a second DHCP lease.
+	idemKV  jetstream.KeyValue
+	allocSF singleflight.Group
 }
 
 // natEvent is the payload published to vpc.add-nat / vpc.delete-nat topics.
@@ -57,6 +64,14 @@ func NewEIPServiceImpl(ctx context.Context, natsConn *nats.Conn, externalIPAM *h
 		return nil, fmt.Errorf("migrate %s: %w", KVBucketEIPs, err)
 	}
 
+	// TTL'd, so a failure to create it is not worth refusing to serve EIPs over:
+	// a nil bucket only costs post-completion dedupe.
+	idemKV, err := kvutil.GetOrCreateBucketWithTTL(ctx, js, KVBucketEIPIdempotency, 1, eipIdempotencyTTL)
+	if err != nil {
+		slog.Warn("EIP service: idempotency bucket unavailable; a retried AllocateAddress may allocate twice",
+			"bucket", KVBucketEIPIdempotency, "err", err)
+	}
+
 	slog.Info("EIP service initialized with JetStream KV", "bucket", KVBucketEIPs)
 
 	return &EIPServiceImpl{
@@ -64,11 +79,20 @@ func NewEIPServiceImpl(ctx context.Context, natsConn *nats.Conn, externalIPAM *h
 		externalIPAM: externalIPAM,
 		vpcService:   vpcService,
 		natsConn:     natsConn,
+		idemKV:       idemKV,
 	}, nil
 }
 
-// AllocateAddress allocates a new Elastic IP from the external IPAM pool.
+// AllocateAddress allocates a new Elastic IP from the external IPAM pool. A
+// resend of the same call returns the first allocation rather than making
+// another, so a slow DORA cannot multiply EIPs via SDK retries.
 func (s *EIPServiceImpl) AllocateAddress(ctx context.Context, input *ec2.AllocateAddressInput, accountID string) (*ec2.AllocateAddressOutput, error) {
+	return s.allocateOnce(ctx, accountID, func() (*ec2.AllocateAddressOutput, error) {
+		return s.allocateAddress(ctx, input, accountID)
+	})
+}
+
+func (s *EIPServiceImpl) allocateAddress(ctx context.Context, input *ec2.AllocateAddressInput, accountID string) (*ec2.AllocateAddressOutput, error) {
 	allocID := utils.GenerateResourceID("eipalloc")
 
 	var publicIP, poolName string

--- a/spinifex/handlers/ec2/vpc/eni_lease_rebind.go
+++ b/spinifex/handlers/ec2/vpc/eni_lease_rebind.go
@@ -1,0 +1,85 @@
+package handlers_ec2_vpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// RebindENIPublicIP moves an auto-assigned public IP onto newIP after vpcd's
+// lease for it was re-issued on a different address. The old address is already
+// released upstream, so leaving the record alone would have
+// DescribeInstances report an address nothing holds.
+func (s *VPCServiceImpl) RebindENIPublicIP(ctx context.Context, eniID, oldIP, newIP string) error {
+	if eniID == "" || newIP == "" {
+		return errors.New("rebind ENI public IP: eniID and newIP required")
+	}
+
+	record, key, revision, err := s.findENIAnyAccount(ctx, eniID)
+	if err != nil {
+		return err
+	}
+	if record.PublicIpAddress == newIP {
+		return nil
+	}
+	if oldIP != "" && record.PublicIpAddress != oldIP {
+		return fmt.Errorf("rebind ENI %s: record holds %q, not the superseded %s", eniID, record.PublicIpAddress, oldIP)
+	}
+
+	// AddEIP scrubs the predecessor row keyed on this logical IP, so committing
+	// the new external IP is enough. Request-reply, because a failure leaves the
+	// instance with no working ingress.
+	if record.PrivateIpAddress != "" {
+		if err := utils.AddNAT(s.natsConn, record.VpcId, newIP, record.PrivateIpAddress,
+			topology.Port(eniID), record.MacAddress); err != nil {
+			return fmt.Errorf("rebind ENI %s: commit NAT for %s: %w", eniID, newIP, err)
+		}
+	}
+
+	record.PublicIpAddress = newIP
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("rebind ENI %s: marshal record: %w", eniID, err)
+	}
+	if _, err := s.eniKV.Update(ctx, key, data, revision); err != nil {
+		return fmt.Errorf("rebind ENI %s onto %s: %w", eniID, newIP, err)
+	}
+
+	slog.WarnContext(ctx, "ENI public address moved after its DHCP lease was re-issued",
+		"eniId", eniID, "oldIp", oldIP, "newIp", newIP, "instanceId", record.InstanceId)
+	return nil
+}
+
+// findENIAnyAccount locates an ENI without knowing its account. vpcd's lease
+// store keys on the client-id alone, so the owning account is not available at
+// the point the lease moves.
+func (s *VPCServiceImpl) findENIAnyAccount(ctx context.Context, eniID string) (*ENIRecord, string, uint64, error) {
+	keys, err := s.eniKV.Keys(ctx)
+	if err != nil && !errors.Is(err, jetstream.ErrNoKeysFound) {
+		return nil, "", 0, fmt.Errorf("list ENI records: %w", err)
+	}
+
+	suffix := "." + eniID
+	for _, k := range keys {
+		if k == utils.VersionKey || !strings.HasSuffix(k, suffix) {
+			continue
+		}
+		entry, err := s.eniKV.Get(ctx, k)
+		if err != nil {
+			return nil, "", 0, fmt.Errorf("get ENI record %s: %w", k, err)
+		}
+		var record ENIRecord
+		if err := json.Unmarshal(entry.Value(), &record); err != nil {
+			return nil, "", 0, fmt.Errorf("unmarshal ENI record %s: %w", k, err)
+		}
+		return &record, k, entry.Revision(), nil
+	}
+	return nil, "", 0, fmt.Errorf("no ENI record for %s", eniID)
+}

--- a/spinifex/handlers/ec2/vpc/eni_lease_rebind_test.go
+++ b/spinifex/handlers/ec2/vpc/eni_lease_rebind_test.go
@@ -1,0 +1,101 @@
+package handlers_ec2_vpc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubAddNAT answers vpc.add-nat, which RebindENIPublicIP drives request-reply.
+// Captured external IPs let a test assert the NAT followed the record.
+func stubAddNAT(t *testing.T, nc *nats.Conn, fail string) *[]string {
+	t.Helper()
+	seen := &[]string{}
+	sub, err := nc.Subscribe("vpc.add-nat", func(msg *nats.Msg) {
+		var evt struct {
+			ExternalIP string `json:"external_ip"`
+		}
+		_ = json.Unmarshal(msg.Data, &evt)
+		*seen = append(*seen, evt.ExternalIP)
+		reply := map[string]any{"success": fail == "", "error": fail}
+		data, _ := json.Marshal(reply)
+		require.NoError(t, msg.Respond(data))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return seen
+}
+
+func TestRebindENIPublicIP_MovesRecordAndNAT(t *testing.T) {
+	svc, nc := setupTestVPCServiceWithNC(t)
+	seen := stubAddNAT(t, nc, "")
+	vpcID := createTestVPC(t, svc, "10.0.0.0/16")
+	subnetID := createTestSubnet(t, svc, vpcID, "10.0.1.0/24")
+	eniID := createTestENI(t, svc, subnetID)
+	require.NoError(t, svc.UpdateENIPublicIP(testAccountID, eniID, "192.168.1.135", "wan"))
+
+	require.NoError(t, svc.RebindENIPublicIP(t.Context(), eniID, "192.168.1.135", "192.168.1.146"))
+
+	out, err := svc.DescribeNetworkInterfaces(context.Background(), &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: []*string{aws.String(eniID)},
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.NetworkInterfaces, 1)
+	require.NotNil(t, out.NetworkInterfaces[0].Association)
+	assert.Equal(t, "192.168.1.146", *out.NetworkInterfaces[0].Association.PublicIp,
+		"DescribeNetworkInterfaces must not keep reporting an address vpcd released")
+	assert.Contains(t, *seen, "192.168.1.146", "the dnat_and_snat must follow the record")
+}
+
+// A NAT commit failure leaves the instance with no working ingress, so the
+// record must not be moved to advertise an address that does not route.
+func TestRebindENIPublicIP_NATFailureLeavesRecord(t *testing.T) {
+	svc, nc := setupTestVPCServiceWithNC(t)
+	stubAddNAT(t, nc, "ovn unreachable")
+	vpcID := createTestVPC(t, svc, "10.0.0.0/16")
+	subnetID := createTestSubnet(t, svc, vpcID, "10.0.1.0/24")
+	eniID := createTestENI(t, svc, subnetID)
+	require.NoError(t, svc.UpdateENIPublicIP(testAccountID, eniID, "192.168.1.135", "wan"))
+
+	err := svc.RebindENIPublicIP(t.Context(), eniID, "192.168.1.135", "192.168.1.146")
+	require.Error(t, err)
+
+	record, _, _, findErr := svc.findENIAnyAccount(t.Context(), eniID)
+	require.NoError(t, findErr)
+	assert.Equal(t, "192.168.1.135", record.PublicIpAddress)
+}
+
+func TestRebindENIPublicIP_IsIdempotent(t *testing.T) {
+	svc, nc := setupTestVPCServiceWithNC(t)
+	stubAddNAT(t, nc, "")
+	vpcID := createTestVPC(t, svc, "10.0.0.0/16")
+	subnetID := createTestSubnet(t, svc, vpcID, "10.0.1.0/24")
+	eniID := createTestENI(t, svc, subnetID)
+	require.NoError(t, svc.UpdateENIPublicIP(testAccountID, eniID, "192.168.1.135", "wan"))
+
+	require.NoError(t, svc.RebindENIPublicIP(t.Context(), eniID, "192.168.1.135", "192.168.1.146"))
+	require.NoError(t, svc.RebindENIPublicIP(t.Context(), eniID, "192.168.1.135", "192.168.1.146"))
+}
+
+func TestRebindENIPublicIP_RejectsMismatchAndUnknown(t *testing.T) {
+	svc, nc := setupTestVPCServiceWithNC(t)
+	stubAddNAT(t, nc, "")
+	vpcID := createTestVPC(t, svc, "10.0.0.0/16")
+	subnetID := createTestSubnet(t, svc, vpcID, "10.0.1.0/24")
+	eniID := createTestENI(t, svc, subnetID)
+	require.NoError(t, svc.UpdateENIPublicIP(testAccountID, eniID, "192.168.1.135", "wan"))
+
+	err := svc.RebindENIPublicIP(t.Context(), eniID, "203.0.113.7", "192.168.1.146")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not the superseded 203.0.113.7")
+
+	err = svc.RebindENIPublicIP(t.Context(), "eni-missing", "192.168.1.135", "192.168.1.146")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no ENI record for eni-missing")
+}

--- a/spinifex/handlers/ec2/vpc/lease_owner.go
+++ b/spinifex/handlers/ec2/vpc/lease_owner.go
@@ -1,0 +1,50 @@
+package handlers_ec2_vpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ENIExists reports whether an ENI record survives, without knowing its
+// account. Used to decide whether a DHCP lease still has an owner, so a listing
+// failure is an error rather than a false — releasing an address on a KV
+// timeout would be worse than keeping an orphan.
+func (s *VPCServiceImpl) ENIExists(ctx context.Context, eniID string) (bool, error) {
+	if eniID == "" {
+		return false, errors.New("ENI exists: eniID required")
+	}
+	return keyWithSuffixExists(ctx, s.eniKV, eniID)
+}
+
+// VPCExists reports whether a VPC record survives, without knowing its account.
+// Same contract as ENIExists.
+func (s *VPCServiceImpl) VPCExists(ctx context.Context, vpcID string) (bool, error) {
+	if vpcID == "" {
+		return false, errors.New("VPC exists: vpcID required")
+	}
+	return keyWithSuffixExists(ctx, s.vpcKV, vpcID)
+}
+
+// keyWithSuffixExists looks for an account-scoped key ending in the resource id.
+// Keys alone are enough — the record's contents do not change the verdict.
+func keyWithSuffixExists(ctx context.Context, kv jetstream.KeyValue, resourceID string) (bool, error) {
+	keys, err := kv.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("list records for %s: %w", resourceID, err)
+	}
+	suffix := "." + resourceID
+	for _, k := range keys {
+		if k != utils.VersionKey && strings.HasSuffix(k, suffix) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/spinifex/handlers/ec2/vpc/lease_owner_test.go
+++ b/spinifex/handlers/ec2/vpc/lease_owner_test.go
@@ -1,0 +1,69 @@
+package handlers_ec2_vpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVPCExists(t *testing.T) {
+	svc := setupTestVPCService(t)
+	vpcID := createTestVPC(t, svc, "10.0.0.0/16")
+
+	exists, err := svc.VPCExists(t.Context(), vpcID)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+// A gw-lrp lease outliving its VPC is exactly the leak the reaper is for, so a
+// deleted VPC has to read as absent.
+func TestVPCExistsFalseAfterDelete(t *testing.T) {
+	svc := setupTestVPCService(t)
+	vpcID := createTestVPC(t, svc, "10.0.0.0/16")
+	_, err := svc.DeleteVpc(context.Background(), &ec2.DeleteVpcInput{VpcId: aws.String(vpcID)}, testAccountID)
+	require.NoError(t, err)
+
+	exists, err := svc.VPCExists(t.Context(), vpcID)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestVPCExistsUnknownID(t *testing.T) {
+	svc := setupTestVPCService(t)
+
+	exists, err := svc.VPCExists(t.Context(), "vpc-missing")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestENIExists(t *testing.T) {
+	svc := setupTestVPCService(t)
+	vpcID := createTestVPC(t, svc, "10.0.0.0/16")
+	subnetID := createTestSubnet(t, svc, vpcID, "10.0.1.0/24")
+	eniID := createTestENI(t, svc, subnetID)
+
+	exists, err := svc.ENIExists(t.Context(), eniID)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestENIExistsUnknownID(t *testing.T) {
+	svc := setupTestVPCService(t)
+
+	exists, err := svc.ENIExists(t.Context(), "eni-missing")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestLeaseOwnerLookupsRejectEmptyIDs(t *testing.T) {
+	svc := setupTestVPCService(t)
+
+	_, err := svc.VPCExists(t.Context(), "")
+	require.Error(t, err)
+	_, err = svc.ENIExists(t.Context(), "")
+	require.Error(t, err)
+}

--- a/spinifex/kvutil/kvutil.go
+++ b/spinifex/kvutil/kvutil.go
@@ -26,16 +26,34 @@ func GetOrCreateBucket(ctx context.Context, js jetstream.KeyValueManager, bucket
 	return GetOrCreateBucketWithReplicas(ctx, js, bucket, history, utils.DefaultKVReplicas())
 }
 
+// GetOrCreateBucketWithTTL is GetOrCreateBucket for buckets whose entries
+// should age out on their own — request-dedupe records and other short-lived
+// state that would otherwise accumulate without a sweeper. TTL applies at
+// creation only, like Replicas.
+func GetOrCreateBucketWithTTL(ctx context.Context, js jetstream.KeyValueManager, bucket string, history int, ttl time.Duration) (jetstream.KeyValue, error) {
+	return getOrCreateBucket(ctx, js, jetstream.KeyValueConfig{
+		Bucket:   bucket,
+		History:  utils.SafeIntToUint8(history),
+		Replicas: max(utils.DefaultKVReplicas(), 1),
+		TTL:      ttl,
+	})
+}
+
 // GetOrCreateBucketWithReplicas creates or opens a KV bucket at the given
 // replica count (clamped to a minimum of 1). The replica count applies to
 // creation only: an existing bucket is opened with the config it already has,
 // so one created before the cluster grew is upgraded on rebalance, not here.
 func GetOrCreateBucketWithReplicas(ctx context.Context, js jetstream.KeyValueManager, bucket string, history, replicas int) (jetstream.KeyValue, error) {
-	kv, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+	return getOrCreateBucket(ctx, js, jetstream.KeyValueConfig{
 		Bucket:   bucket,
 		History:  utils.SafeIntToUint8(history),
 		Replicas: max(replicas, 1),
 	})
+}
+
+func getOrCreateBucket(ctx context.Context, js jetstream.KeyValueManager, cfg jetstream.KeyValueConfig) (jetstream.KeyValue, error) {
+	bucket := cfg.Bucket
+	kv, err := js.CreateKeyValue(ctx, cfg)
 	if err == nil {
 		return kv, nil
 	}

--- a/spinifex/network/external/dhcp/acquire_budget_internal_test.go
+++ b/spinifex/network/external/dhcp/acquire_budget_internal_test.go
@@ -1,0 +1,30 @@
+package dhcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// botocore sends no retry token and defaults to a 60s read timeout, so a DORA
+// that outlasts it turns one AllocateAddress into two leases with no way to tell
+// the retry from a second request. The ladder has to answer first.
+func TestAcquireLadderFitsInsideClientReadTimeout(t *testing.T) {
+	const clientReadTimeout = 60 * time.Second
+
+	total := time.Duration(0)
+	for _, d := range defaultAcquireSchedule {
+		// Each attempt can run up to a second over its nominal timeout from the
+		// per-attempt jitter.
+		total += d + acquireAttemptJitter
+	}
+	assert.Less(t, total, clientReadTimeout,
+		"acquire ladder totals %s, which must stay inside a %s client read timeout", total, clientReadTimeout)
+	assert.Less(t, defaultAcquireBudget, clientReadTimeout,
+		"the acquire budget must not outlast the client either")
+	assert.Less(t, defaultRPCTimeout, clientReadTimeout,
+		"the daemon must hear the outcome before its caller gives up")
+	assert.Greater(t, defaultRPCTimeout, defaultAcquireBudget,
+		"the RPC must outlast the acquire, or a slow DORA reports a timeout instead of its own error")
+}

--- a/spinifex/network/external/dhcp/lrp_allocator_test.go
+++ b/spinifex/network/external/dhcp/lrp_allocator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/network/external"
 	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +40,30 @@ func TestDHCPGatewayLRPAllocatorAllocate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, dhcp.PurposeGatewayLRP, entry.Purpose)
 	assert.Equal(t, "vpc-1", entry.VPCID)
+}
+
+// chaddr is a derived HashMAC and option 61 carries that same MAC, so option 12
+// is the only field that can tell an upstream lease table which host took the
+// lease. Without the node prefix the table cannot be grouped by host.
+func TestDHCPGatewayLRPAllocatorHostnameCarriesNodeName(t *testing.T) {
+	fake := dhcp.NewFake()
+	_, nc, _ := testutil.StartTestJetStream(t)
+	store, err := dhcp.NewStore(t.Context(), testutil.NewJetStream(t, nc), "az1")
+	require.NoError(t, err)
+	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{Client: fake, Store: store, NodeName: "banksia"})
+	require.NoError(t, err)
+	t.Cleanup(mgr.Stop)
+	require.NoError(t, mgr.Start(context.Background()))
+
+	pool := &external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
+	_, _, _, _, err = dhcp.NewDHCPGatewayLRPAllocator(mgr).Allocate(context.Background(), "vpc-1", pool)
+	require.NoError(t, err)
+
+	held, ok := fake.HeldLease(dhcp.GatewayLRPClientID("vpc-1"))
+	require.True(t, ok)
+	assert.Equal(t, "banksia-dhcp-gw-lrp-vpc-1", held.Hostname)
+	// One value per host, so the upstream table can group on option 60 directly.
+	assert.Equal(t, "mulga-spinifex/banksia", held.VendorClass)
 }
 
 func TestDHCPGatewayLRPAllocatorIdempotent(t *testing.T) {

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -49,6 +50,9 @@ type ManagerConfig struct {
 	// IfaceIPs lists the IPs bound to a named interface; tests override.
 	// Used to detect MAC-keyed upstream routers on interface-MAC pools.
 	IfaceIPs func(iface string) ([]net.IP, error)
+	// NodeName labels outbound option 12 so upstream lease tables group by the
+	// host that took the lease. Defaults to the OS hostname.
+	NodeName string
 }
 
 // Manager owns active DHCP leases in vpcd: one renewal goroutine per
@@ -61,6 +65,7 @@ type Manager struct {
 	acquireSchedule []time.Duration
 	acquireBudget   time.Duration
 	ifaceIPs        func(iface string) ([]net.IP, error)
+	nodeName        string
 
 	sf singleflight.Group
 
@@ -108,6 +113,11 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if ifaceIPs == nil {
 		ifaceIPs = defaultIfaceIPs
 	}
+	nodeName := cfg.NodeName
+	if nodeName == "" {
+		// A missing hostname only costs attribution, so it is not fatal.
+		nodeName, _ = os.Hostname()
+	}
 	return &Manager{
 		client:          cfg.Client,
 		store:           cfg.Store,
@@ -115,8 +125,29 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 		acquireSchedule: schedule,
 		acquireBudget:   budget,
 		ifaceIPs:        ifaceIPs,
+		nodeName:        nodeName,
 		loops:           map[string]*leaseLoop{},
 	}, nil
+}
+
+// leaseHostname composes option 12 as "<node>-<client-id>". chaddr is a derived
+// HashMAC and option 61 carries that same MAC, so without this the upstream
+// lease table has no field identifying which physical host took the lease.
+func (m *Manager) leaseHostname(clientID string) string {
+	if m.nodeName == "" {
+		return clientID
+	}
+	return m.nodeName + "-" + clientID
+}
+
+// leaseVendorClass tags option 60 with the node. Option 12 already carries the
+// node, but it is unique per lease; this keeps one value per host so an upstream
+// lease table can group on it directly.
+func (m *Manager) leaseVendorClass() string {
+	if m.nodeName == "" {
+		return defaultVendorClass
+	}
+	return defaultVendorClass + "/" + m.nodeName
 }
 
 // Start scans the KV bucket and spawns a renewal goroutine per live lease,
@@ -147,6 +178,10 @@ func (m *Manager) Start(ctx context.Context) error {
 			continue
 		}
 		if !e.Lease.ExpiresAt().After(now) {
+			// Dropping the KV entry alone abandons the binding rather than
+			// returning it: a server that ages leases by liveness keeps the
+			// address for as long as anything answers ARP for it.
+			m.releaseExpiredUpstream(ctx, e.Lease)
 			if delErr := m.store.Delete(ctx, e.Lease.ClientID); delErr != nil {
 				slog.Warn("dhcp manager: drop expired lease failed", "client_id", e.Lease.ClientID, "err", delErr)
 			}
@@ -155,6 +190,27 @@ func (m *Manager) Start(ctx context.Context) error {
 		m.spawnLoop(e, true)
 	}
 	return nil
+}
+
+// expiredReleaseTimeout bounds the best-effort RELEASE sent for a lease that
+// already expired locally. Adoption must not stall behind an unreachable
+// server, so this is deliberately short.
+const expiredReleaseTimeout = 5 * time.Second
+
+// releaseExpiredUpstream returns an already-expired lease to the server on a
+// best-effort basis. Failure is logged and swallowed: the KV entry is dropped
+// either way, and a lease persisted without raw offer/ack bytes cannot be
+// reconstructed, so it is skipped rather than attempted and logged as an error.
+func (m *Manager) releaseExpiredUpstream(ctx context.Context, l *Lease) {
+	if l == nil || len(l.RawOffer) == 0 || len(l.RawACK) == 0 {
+		return
+	}
+	relCtx, cancel := context.WithTimeout(ctx, expiredReleaseTimeout)
+	defer cancel()
+	if err := m.client.Release(relCtx, l); err != nil {
+		slog.Warn("dhcp manager: release of expired lease failed; address may be stranded upstream",
+			"client_id", l.ClientID, "ip", l.IP, "err", err)
+	}
 }
 
 // Stop cancels every renewal goroutine and waits for them to exit.
@@ -427,8 +483,12 @@ func (m *Manager) handleReleaseMsg(msg *nats.Msg) {
 		case err == nil:
 			clientID = entry.Lease.ClientID
 		case errors.Is(err, jetstream.ErrKeyNotFound):
-			slog.Warn("dhcp manager: release for unknown IP", "pool", req.PoolName, "ip", req.IP)
-			_ = msg.Respond(emptyReleaseReply)
+			// Answering SUCCESS here told the caller the address was freed when
+			// nothing went on the wire, so the upstream lease sat stranded and
+			// silent. Callers log-and-continue on a release error, so failing
+			// loudly surfaces the strand without wedging teardown.
+			slog.Warn("dhcp manager: release for untracked IP; nothing sent upstream", "pool", req.PoolName, "ip", req.IP)
+			respondReleaseErr(msg, fmt.Sprintf("no tracked lease for ip %s in pool %q; upstream lease may be stranded", req.IP, req.PoolName))
 			return
 		default:
 			respondReleaseErr(msg, fmt.Sprintf("lookup release ip: %v", err))
@@ -479,11 +539,19 @@ func (m *Manager) acquireLocked(ctx context.Context, req acquireWireRequest) (*E
 	if err != nil {
 		return nil, err
 	}
+	hostname := req.Hostname
+	if hostname == "" {
+		hostname = m.leaseHostname(req.ClientID)
+	}
+	vendorClass := req.VendorClass
+	if vendorClass == "" {
+		vendorClass = m.leaseVendorClass()
+	}
 	lease, err := m.acquireWithBackoff(ctx, AcquireRequest{
 		Bridge:      req.Bridge,
 		ClientID:    req.ClientID,
-		Hostname:    req.Hostname,
-		VendorClass: req.VendorClass,
+		Hostname:    hostname,
+		VendorClass: vendorClass,
 		HWAddr:      hw,
 		UseIfaceMAC: req.UseIfaceMAC,
 	})

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -235,7 +235,12 @@ const staleReleaseTimeout = 5 * time.Second
 // The server may already have rebound the address to someone else, in which case
 // a conformant one drops a RELEASE whose chaddr does not match the binding.
 func (m *Manager) releaseStaleUpstream(ctx context.Context, l *Lease) {
-	if l == nil || len(l.RawOffer) == 0 || len(l.RawACK) == 0 {
+	if l == nil {
+		return
+	}
+	if len(l.RawOffer) == 0 || len(l.RawACK) == 0 {
+		slog.Warn("dhcp manager: stale lease has no raw offer/ack; cannot release, address stays bound upstream",
+			"client_id", l.ClientID, "ip", l.IP)
 		return
 	}
 	relCtx, cancel := context.WithTimeout(ctx, staleReleaseTimeout)
@@ -243,7 +248,13 @@ func (m *Manager) releaseStaleUpstream(ctx context.Context, l *Lease) {
 	if err := m.client.Release(relCtx, l); err != nil {
 		slog.Warn("dhcp manager: release of stale lease failed; address may be stranded upstream",
 			"client_id", l.ClientID, "ip", l.IP, "err", err)
+		return
 	}
+	// A server drops a RELEASE whose chaddr does not match its binding, and says
+	// nothing. The chaddr is logged so a still-bound address can be traced to a
+	// mismatch rather than to a RELEASE that was never sent.
+	slog.Info("dhcp manager: released stale lease upstream",
+		"client_id", l.ClientID, "ip", l.IP, "chaddr", l.HWAddr.String())
 }
 
 // Stop cancels every renewal goroutine and waits for them to exit.
@@ -760,6 +771,9 @@ func (m *Manager) handleRelease(ctx context.Context, clientID string) error {
 
 	if err := m.client.Release(ctx, entry.Lease); err != nil {
 		slog.Warn("dhcp manager: client release failed; deleting KV entry anyway", "client_id", clientID, "err", err)
+	} else if entry.Lease != nil {
+		slog.Info("dhcp manager: released lease upstream",
+			"client_id", clientID, "ip", entry.Lease.IP, "chaddr", entry.Lease.HWAddr.String())
 	}
 	return m.store.Delete(ctx, clientID)
 }

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -74,9 +74,16 @@ type Manager struct {
 	closed       bool
 	parentCtx    context.Context
 	parentCancel context.CancelFunc
+	ipChangeHook IPChangeHook
 
 	wg sync.WaitGroup
 }
+
+// IPChangeHook rebinds whatever the caller bound to a lease's old address
+// after the lease came back on a different IP. A re-DORA following a NAK or an
+// expiry is free to land anywhere in the server's pool, and the manager owns
+// only the lease — not the datapath configured from it.
+type IPChangeHook func(ctx context.Context, e Entry, oldIP net.IP) error
 
 // leaseLoop is the handle stored in Manager.loops. Pointer-identity lets
 // run() distinguish its own loop from a successor (e.g. re-acquired lease
@@ -130,6 +137,23 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	}, nil
 }
 
+// SetIPChangeHook registers the datapath rebind callback. It is a setter rather
+// than a ManagerConfig field because the managers that own the datapath are
+// constructed after the DHCP manager is already running.
+func (m *Manager) SetIPChangeHook(h IPChangeHook) {
+	m.mu.Lock()
+	m.ipChangeHook = h
+	m.mu.Unlock()
+}
+
+// ipChange copies the hook under the lock so lease loops never invoke it while
+// holding m.mu — a hook that calls back into the manager would deadlock.
+func (m *Manager) ipChange() IPChangeHook {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ipChangeHook
+}
+
 // leaseHostname composes option 12 as "<node>-<client-id>". chaddr is a derived
 // HashMAC and option 61 carries that same MAC, so without this the upstream
 // lease table has no field identifying which physical host took the lease.
@@ -181,7 +205,7 @@ func (m *Manager) Start(ctx context.Context) error {
 			// Dropping the KV entry alone abandons the binding rather than
 			// returning it: a server that ages leases by liveness keeps the
 			// address for as long as anything answers ARP for it.
-			m.releaseExpiredUpstream(ctx, e.Lease)
+			m.releaseStaleUpstream(ctx, e.Lease)
 			if delErr := m.store.Delete(ctx, e.Lease.ClientID); delErr != nil {
 				slog.Warn("dhcp manager: drop expired lease failed", "client_id", e.Lease.ClientID, "err", delErr)
 			}
@@ -192,23 +216,26 @@ func (m *Manager) Start(ctx context.Context) error {
 	return nil
 }
 
-// expiredReleaseTimeout bounds the best-effort RELEASE sent for a lease that
-// already expired locally. Adoption must not stall behind an unreachable
-// server, so this is deliberately short.
-const expiredReleaseTimeout = 5 * time.Second
+// staleReleaseTimeout bounds the best-effort RELEASE sent for a lease this
+// manager has stopped tracking. Adoption and renewal must not stall behind an
+// unreachable server, so this is deliberately short.
+const staleReleaseTimeout = 5 * time.Second
 
-// releaseExpiredUpstream returns an already-expired lease to the server on a
-// best-effort basis. Failure is logged and swallowed: the KV entry is dropped
+// releaseStaleUpstream returns a lease the manager no longer holds — expired, or
+// superseded by a re-DORA onto a different address — to the server on a
+// best-effort basis. Failure is logged and swallowed: the local entry is gone
 // either way, and a lease persisted without raw offer/ack bytes cannot be
 // reconstructed, so it is skipped rather than attempted and logged as an error.
-func (m *Manager) releaseExpiredUpstream(ctx context.Context, l *Lease) {
+// The server may already have rebound the address to someone else, in which case
+// a conformant one drops a RELEASE whose chaddr does not match the binding.
+func (m *Manager) releaseStaleUpstream(ctx context.Context, l *Lease) {
 	if l == nil || len(l.RawOffer) == 0 || len(l.RawACK) == 0 {
 		return
 	}
-	relCtx, cancel := context.WithTimeout(ctx, expiredReleaseTimeout)
+	relCtx, cancel := context.WithTimeout(ctx, staleReleaseTimeout)
 	defer cancel()
 	if err := m.client.Release(relCtx, l); err != nil {
-		slog.Warn("dhcp manager: release of expired lease failed; address may be stranded upstream",
+		slog.Warn("dhcp manager: release of stale lease failed; address may be stranded upstream",
 			"client_id", l.ClientID, "ip", l.IP, "err", err)
 	}
 }
@@ -374,9 +401,39 @@ func (m *Manager) doAcquire(ctx context.Context, e *Entry) error {
 	if err != nil {
 		return err
 	}
-	e.Lease = lease
+	return m.applyLease(ctx, e, lease)
+}
+
+// applyLease persists a replacement lease for e and reconciles an address change.
+// A re-DORA after a NAK or an expiry can return a different IP; the old address
+// then has no renewer and no owner, so it is handed back and whatever was bound
+// to it is told to follow. Without both halves each such event permanently burns
+// one address: squatted by the datapath, renewed by nobody, released by nobody.
+func (m *Manager) applyLease(ctx context.Context, e *Entry, fresh *Lease) error {
+	old := e.Lease
+	e.Lease = fresh
 	if err := m.store.Put(ctx, *e); err != nil {
-		return fmt.Errorf("persist re-acquired lease: %w", err)
+		return fmt.Errorf("persist lease: %w", err)
+	}
+	if old == nil || fresh == nil || old.IP.Equal(fresh.IP) {
+		return nil
+	}
+
+	slog.Error("dhcp manager: lease IP changed mid-life; rebinding datapath",
+		"client_id", fresh.ClientID, "purpose", e.Purpose, "old_ip", old.IP, "new_ip", fresh.IP)
+	m.releaseStaleUpstream(ctx, old)
+
+	hook := m.ipChange()
+	if hook == nil {
+		slog.Error("dhcp manager: no IP change hook registered; datapath still bound to the old address",
+			"client_id", fresh.ClientID, "old_ip", old.IP, "new_ip", fresh.IP)
+		return nil
+	}
+	// The new lease is held either way, so a failed rebind must not fail the
+	// lease loop — dropping the lease here would strand the new address too.
+	if err := hook(ctx, *e, old.IP); err != nil {
+		slog.Error("dhcp manager: rebind to new lease IP failed; datapath still on the old address",
+			"client_id", fresh.ClientID, "old_ip", old.IP, "new_ip", fresh.IP, "err", err)
 	}
 	return nil
 }
@@ -432,9 +489,10 @@ func (m *Manager) doRenew(ctx context.Context, e *Entry) error {
 	if err != nil {
 		return err
 	}
-	e.Lease = renewed
-	if err := m.store.Put(ctx, *e); err != nil {
-		return fmt.Errorf("persist renewed lease: %w", err)
+	// A rebind is a broadcast REQUEST; the answering server is free to hand back
+	// a different address, so this goes through the same reconcile as a re-DORA.
+	if err := m.applyLease(ctx, e, renewed); err != nil {
+		return err
 	}
 	return nil
 }

--- a/spinifex/network/external/dhcp/manager.go
+++ b/spinifex/network/external/dhcp/manager.go
@@ -26,13 +26,16 @@ const renewJitter = time.Second
 // background until the server comes back (per plan §Failure modes).
 const postExpiryBackoff = 30 * time.Second
 
-// defaultAcquireSchedule is the per-attempt timeout schedule for the
-// outer DORA backoff. Mirrors the deleted dhcp_manager.go retransmit
-// schedule — recovers under STP convergence on a freshly-up bridge.
-var defaultAcquireSchedule = []time.Duration{4 * time.Second, 8 * time.Second, 16 * time.Second, 32 * time.Second}
+// defaultAcquireSchedule is the per-attempt timeout schedule for the outer DORA
+// backoff. Four attempts still ride out STP convergence on a freshly-up bridge,
+// but the total is held under an AWS client's read timeout: botocore defaults to
+// 60s and sends no retry token, so a ladder that outlasts it turns one
+// AllocateAddress into two leases with no way to tell them apart.
+var defaultAcquireSchedule = []time.Duration{4 * time.Second, 8 * time.Second, 12 * time.Second, 16 * time.Second}
 
-// defaultAcquireBudget caps the wallclock for the full DORA loop.
-const defaultAcquireBudget = 90 * time.Second
+// defaultAcquireBudget caps the wallclock for the full DORA loop. Sized to leave
+// the daemon room to answer inside a 60s client read timeout, per the schedule.
+const defaultAcquireBudget = 45 * time.Second
 
 // acquireAttemptJitter is the ± window applied to each per-attempt
 // timeout so concurrent acquires across vpcds don't synchronise.
@@ -75,6 +78,7 @@ type Manager struct {
 	parentCtx    context.Context
 	parentCancel context.CancelFunc
 	ipChangeHook IPChangeHook
+	leaseOwner   LeaseOwner
 
 	wg sync.WaitGroup
 }
@@ -174,9 +178,10 @@ func (m *Manager) leaseVendorClass() string {
 	return defaultVendorClass + "/" + m.nodeName
 }
 
-// Start scans the KV bucket and spawns a renewal goroutine per live lease,
-// re-issuing a RENEW to confirm the upstream binding (RFC 2131 INIT-REBOOT).
-// Expired entries are deleted. Repeated calls return an error.
+// Start scans the KV bucket and spawns a renewal goroutine per lease, re-issuing
+// a RENEW to confirm the upstream binding (RFC 2131 INIT-REBOOT). Leases that
+// expired while the manager was down get a loop too, which re-DORAs immediately.
+// Repeated calls return an error.
 func (m *Manager) Start(ctx context.Context) error {
 	m.mu.Lock()
 	if m.closed {
@@ -201,17 +206,18 @@ func (m *Manager) Start(ctx context.Context) error {
 		if e.Lease == nil {
 			continue
 		}
-		if !e.Lease.ExpiresAt().After(now) {
-			// Dropping the KV entry alone abandons the binding rather than
-			// returning it: a server that ages leases by liveness keeps the
-			// address for as long as anything answers ARP for it.
-			m.releaseStaleUpstream(ctx, e.Lease)
-			if delErr := m.store.Delete(ctx, e.Lease.ClientID); delErr != nil {
-				slog.Warn("dhcp manager: drop expired lease failed", "client_id", e.Lease.ClientID, "err", delErr)
-			}
-			continue
+		expired := !e.Lease.ExpiresAt().After(now)
+		if expired {
+			// Deleting the entry here would strand whatever was configured from
+			// it: the caller still holds the resource, so the datapath keeps
+			// forwarding on an address nothing renews. The loop re-DORAs on its
+			// first pass instead, and the IP change hook rebinds from there.
+			slog.Warn("dhcp manager: lease expired while stopped; re-acquiring",
+				"client_id", e.Lease.ClientID, "purpose", e.Purpose, "ip", e.Lease.IP)
 		}
-		m.spawnLoop(e, true)
+		// A reaffirm RENEW is pointless on a lease the server has already aged
+		// out, and would only delay the re-DORA behind its timeout.
+		m.spawnLoop(e, !expired)
 	}
 	return nil
 }

--- a/spinifex/network/external/dhcp/manager_test.go
+++ b/spinifex/network/external/dhcp/manager_test.go
@@ -110,6 +110,130 @@ func TestManagerStartReleasesExpiredLeaseUpstream(t *testing.T) {
 	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
 }
 
+// seedLiveLease puts a BOUND lease for clientID in the store and returns it.
+func seedLiveLease(t *testing.T, fake *dhcp.Fake, store *dhcp.Store, clientID, purpose, vpcID string) *dhcp.Lease {
+	t.Helper()
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := fake.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: clientID, HWAddr: hw,
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{
+		Purpose: purpose, PoolName: "wan", VPCID: vpcID, Lease: lease,
+	}))
+	return lease
+}
+
+// renewOnto makes Renew answer with the same lease moved to ip — what a server
+// does when it NAKs the renew and the rebind lands elsewhere in the pool.
+func renewOnto(fake *dhcp.Fake, ip net.IP) {
+	fake.RenewHook = func(l *dhcp.Lease) (*dhcp.Lease, error) {
+		moved := *l
+		moved.IP = ip
+		moved.AcquiredAt = time.Now()
+		return &moved, nil
+	}
+}
+
+// A lease that comes back on a different IP must hand the old address back and
+// tell the datapath, or the old one is squatted with nothing renewing it.
+func TestManagerRenewOntoNewIPReleasesOldAndFiresHook(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "az1", fake, time.Now)
+	old := seedLiveLease(t, fake, store, "dhcp-gw-lrp-vpc-1", dhcp.PurposeGatewayLRP, "vpc-1")
+	oldIP := old.IP
+	newIP := net.IPv4(192, 0, 2, 200)
+	renewOnto(fake, newIP)
+
+	var mu sync.Mutex
+	var gotOld, gotNew net.IP
+	var gotVPC string
+	mgr.SetIPChangeHook(func(_ context.Context, e dhcp.Entry, prev net.IP) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotOld, gotNew, gotVPC = prev, e.Lease.IP, e.VPCID
+		return nil
+	})
+
+	require.NoError(t, mgr.Start(context.Background()))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return gotNew != nil
+	}, 5*time.Second, 10*time.Millisecond, "hook never fired for the moved lease")
+
+	mu.Lock()
+	assert.Equal(t, oldIP.String(), gotOld.String())
+	assert.Equal(t, newIP.String(), gotNew.String())
+	assert.Equal(t, "vpc-1", gotVPC)
+	mu.Unlock()
+	assert.Equal(t, 1, fake.ReleaseCount(), "the superseded address must be released upstream")
+
+	entry, err := store.Get(t.Context(), "dhcp-gw-lrp-vpc-1")
+	require.NoError(t, err)
+	assert.Equal(t, newIP.String(), entry.Lease.IP.String(), "KV must hold the new address")
+}
+
+// The common case: a renewal that keeps its address must not release anything
+// or churn the datapath.
+func TestManagerRenewSameIPDoesNotReleaseOrFireHook(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "az1", fake, time.Now)
+	seedLiveLease(t, fake, store, "dhcp-gw-lrp-vpc-1", dhcp.PurposeGatewayLRP, "vpc-1")
+
+	var hookCalls atomic.Int32
+	mgr.SetIPChangeHook(func(context.Context, dhcp.Entry, net.IP) error {
+		hookCalls.Add(1)
+		return nil
+	})
+
+	require.NoError(t, mgr.Start(context.Background()))
+	require.Eventually(t, func() bool { return fake.RenewCount() >= 1 }, 5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, 0, fake.ReleaseCount())
+	assert.Equal(t, int32(0), hookCalls.Load())
+}
+
+// A failing rebind must not cost the new lease as well — the manager holds it
+// either way, so dropping it here would strand both addresses.
+func TestManagerRenewOntoNewIPKeepsLeaseWhenHookFails(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "az1", fake, time.Now)
+	seedLiveLease(t, fake, store, "dhcp-gw-lrp-vpc-1", dhcp.PurposeGatewayLRP, "vpc-1")
+	newIP := net.IPv4(192, 0, 2, 200)
+	renewOnto(fake, newIP)
+
+	var called atomic.Bool
+	mgr.SetIPChangeHook(func(context.Context, dhcp.Entry, net.IP) error {
+		called.Store(true)
+		return errors.New("ovn unreachable")
+	})
+
+	require.NoError(t, mgr.Start(context.Background()))
+	require.Eventually(t, func() bool { return called.Load() }, 5*time.Second, 10*time.Millisecond)
+
+	entry, err := store.Get(t.Context(), "dhcp-gw-lrp-vpc-1")
+	require.NoError(t, err)
+	assert.Equal(t, newIP.String(), entry.Lease.IP.String())
+	assert.Equal(t, 1, mgr.LoopCount(), "the lease loop must survive a failed rebind")
+}
+
+// No registered hook still releases the superseded address: the leak half must
+// not depend on a datapath owner being wired up.
+func TestManagerRenewOntoNewIPReleasesOldWithoutHook(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "az1", fake, time.Now)
+	seedLiveLease(t, fake, store, "eipalloc-1", dhcp.PurposeEIP, "")
+	renewOnto(fake, net.IPv4(192, 0, 2, 201))
+
+	require.NoError(t, mgr.Start(context.Background()))
+	require.Eventually(t, func() bool { return fake.ReleaseCount() == 1 }, 5*time.Second, 10*time.Millisecond,
+		"superseded address must be released even with no hook registered")
+
+	entry, err := store.Get(t.Context(), "eipalloc-1")
+	require.NoError(t, err)
+	assert.Equal(t, "192.0.2.201", entry.Lease.IP.String())
+}
+
 // A release that fails must not strand the KV entry too, and must not abort
 // adoption of the remaining leases.
 func TestManagerStartDropsExpiredLeaseWhenReleaseFails(t *testing.T) {

--- a/spinifex/network/external/dhcp/manager_test.go
+++ b/spinifex/network/external/dhcp/manager_test.go
@@ -61,7 +61,9 @@ func TestManagerStartScansAndReaffirms(t *testing.T) {
 	assert.Equal(t, 2, mgr.LoopCount())
 }
 
-func TestManagerStartDropsExpiredLeases(t *testing.T) {
+// Deleting an expired lease at startup leaves whatever was configured from it
+// forwarding on an address nothing holds, so the lease is re-acquired instead.
+func TestManagerStartReacquiresExpiredLeases(t *testing.T) {
 	fake := dhcp.NewFake()
 	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
 	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
@@ -78,18 +80,21 @@ func TestManagerStartDropsExpiredLeases(t *testing.T) {
 	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "default", Lease: expired}))
 
 	require.NoError(t, mgr.Start(context.Background()))
-	_, err := store.Get(t.Context(), "eipalloc-old")
-	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
+
+	require.Eventually(t, func() bool { return fake.AcquireCount() == 1 }, time.Second, 10*time.Millisecond,
+		"an expired lease whose resource still exists must be re-DORA'd, not dropped")
+	entry, err := store.Get(t.Context(), "eipalloc-old")
+	require.NoError(t, err)
+	assert.Equal(t, "192.0.2.100", entry.Lease.IP.String(), "the KV record must name the new address")
+	assert.Equal(t, 1, mgr.LoopCount())
+	// A reaffirm RENEW on a lease the server has already aged out only delays
+	// the re-DORA behind its timeout.
 	assert.Equal(t, 0, fake.RenewCount())
-	assert.Equal(t, 0, mgr.LoopCount())
-	// No raw offer/ack, so nclient4 could not rebuild the lease; the release is
-	// skipped rather than attempted and logged as a failure.
-	assert.Equal(t, 0, fake.ReleaseCount())
 }
 
-// Dropping the KV entry without a RELEASE abandons the address instead of
-// returning it, and an upstream server that ages leases by liveness then holds
-// it indefinitely. That is how 20 addresses were stranded on the office LAN.
+// The re-DORA can land elsewhere, and the expired address is then held by
+// nobody: an upstream server that ages leases by liveness keeps it indefinitely.
+// That is how 20 addresses were stranded on the office LAN.
 func TestManagerStartReleasesExpiredLeaseUpstream(t *testing.T) {
 	fake := dhcp.NewFake()
 	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
@@ -100,14 +105,46 @@ func TestManagerStartReleasesExpiredLeaseUpstream(t *testing.T) {
 		Bridge: "br-wan", ClientID: "eipalloc-stale", HWAddr: hw,
 	})
 	require.NoError(t, err)
+	lease.IP = net.IPv4(192, 0, 2, 50)
 	lease.AcquiredAt = fixed.Add(-2 * time.Hour)
 	lease.LeaseDuration = time.Hour
 	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "wan", Lease: lease}))
 
 	require.NoError(t, mgr.Start(context.Background()))
-	assert.Equal(t, 1, fake.ReleaseCount(), "expired lease must be returned upstream before the KV entry is dropped")
-	_, err = store.Get(t.Context(), "eipalloc-stale")
-	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
+
+	require.Eventually(t, func() bool { return fake.ReleaseCount() == 1 }, time.Second, 10*time.Millisecond,
+		"the superseded address must be returned upstream once the re-DORA lands elsewhere")
+	entry, err := store.Get(t.Context(), "eipalloc-stale")
+	require.NoError(t, err)
+	assert.Equal(t, "192.0.2.100", entry.Lease.IP.String())
+}
+
+// An expired lease that comes back on the same address needs no release and no
+// rebind — the datapath is already correct.
+func TestManagerStartReacquireOntoSameIPDoesNotRelease(t *testing.T) {
+	fake := dhcp.NewFake()
+	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
+
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := fake.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eipalloc-same", HWAddr: hw,
+	})
+	require.NoError(t, err)
+	lease.AcquiredAt = fixed.Add(-2 * time.Hour)
+	lease.LeaseDuration = time.Hour
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "wan", Lease: lease}))
+
+	hookCalls := 0
+	mgr.SetIPChangeHook(func(context.Context, dhcp.Entry, net.IP) error {
+		hookCalls++
+		return nil
+	})
+	require.NoError(t, mgr.Start(context.Background()))
+
+	require.Eventually(t, func() bool { return fake.AcquireCount() == 2 }, time.Second, 10*time.Millisecond)
+	assert.Zero(t, fake.ReleaseCount())
+	assert.Zero(t, hookCalls)
 }
 
 // seedLiveLease puts a BOUND lease for clientID in the store and returns it.
@@ -234,9 +271,9 @@ func TestManagerRenewOntoNewIPReleasesOldWithoutHook(t *testing.T) {
 	assert.Equal(t, "192.0.2.201", entry.Lease.IP.String())
 }
 
-// A release that fails must not strand the KV entry too, and must not abort
-// adoption of the remaining leases.
-func TestManagerStartDropsExpiredLeaseWhenReleaseFails(t *testing.T) {
+// The release of the superseded address is best-effort: failing it must not cost
+// the new lease, which is the only address the resource now has.
+func TestManagerStartKeepsNewLeaseWhenStaleReleaseFails(t *testing.T) {
 	fake := dhcp.NewFake()
 	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
 	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
@@ -246,14 +283,18 @@ func TestManagerStartDropsExpiredLeaseWhenReleaseFails(t *testing.T) {
 		Bridge: "br-wan", ClientID: "eipalloc-stale", HWAddr: hw,
 	})
 	require.NoError(t, err)
+	lease.IP = net.IPv4(192, 0, 2, 50)
 	lease.AcquiredAt = fixed.Add(-2 * time.Hour)
 	lease.LeaseDuration = time.Hour
 	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "wan", Lease: lease}))
 	fake.ReleaseHook = func(*dhcp.Lease) error { return errors.New("upstream unreachable") }
 
 	require.NoError(t, mgr.Start(context.Background()))
-	_, err = store.Get(t.Context(), "eipalloc-stale")
-	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
+
+	require.Eventually(t, func() bool {
+		entry, getErr := store.Get(t.Context(), "eipalloc-stale")
+		return getErr == nil && entry.Lease.IP.String() == "192.0.2.100"
+	}, time.Second, 10*time.Millisecond, "the re-acquired address must be persisted despite the failed release")
 }
 
 func TestManagerStartTwiceErrors(t *testing.T) {

--- a/spinifex/network/external/dhcp/manager_test.go
+++ b/spinifex/network/external/dhcp/manager_test.go
@@ -1,11 +1,14 @@
 package dhcp_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -117,6 +120,90 @@ func TestManagerStartReleasesExpiredLeaseUpstream(t *testing.T) {
 	entry, err := store.Get(t.Context(), "eipalloc-stale")
 	require.NoError(t, err)
 	assert.Equal(t, "192.0.2.100", entry.Lease.IP.String())
+}
+
+// captureLogs redirects the default logger for the test and returns an accessor
+// for what has been written so far.
+func captureLogs(t *testing.T) func() string {
+	t.Helper()
+	var mu sync.Mutex
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&lockedWriter{mu: &mu, w: buf}, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return buf.String()
+	}
+}
+
+// lockedWriter serialises writes from the lease loops, which log concurrently.
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}
+
+// A stale lease with no raw packets cannot be released, and the address then
+// stays bound upstream with nothing renewing it. Silence there is what made a
+// live leak untraceable, so the skip must be logged.
+func TestManagerStaleReleaseWithoutRawPacketsIsLogged(t *testing.T) {
+	fake := dhcp.NewFake()
+	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
+
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := fake.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eipalloc-nopackets", HWAddr: hw,
+	})
+	require.NoError(t, err)
+	lease.IP = net.IPv4(192, 0, 2, 50)
+	lease.AcquiredAt = fixed.Add(-2 * time.Hour)
+	lease.LeaseDuration = time.Hour
+	lease.RawOffer, lease.RawACK = nil, nil
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "wan", Lease: lease}))
+
+	logs := captureLogs(t)
+	require.NoError(t, mgr.Start(context.Background()))
+
+	require.Eventually(t, func() bool { return fake.AcquireCount() == 2 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs(), "cannot release, address stays bound upstream")
+	}, time.Second, 10*time.Millisecond)
+	assert.Zero(t, fake.ReleaseCount(), "a lease with no raw packets cannot be released")
+	assert.Contains(t, logs(), "192.0.2.50")
+}
+
+// A release that reached the server records the chaddr it used, so an address
+// still bound afterwards can be traced to a chaddr the server did not match.
+func TestManagerStaleReleaseLogsChaddr(t *testing.T) {
+	fake := dhcp.NewFake()
+	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
+
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := fake.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eipalloc-chaddr", HWAddr: hw,
+	})
+	require.NoError(t, err)
+	lease.IP = net.IPv4(192, 0, 2, 50)
+	lease.AcquiredAt = fixed.Add(-2 * time.Hour)
+	lease.LeaseDuration = time.Hour
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "wan", Lease: lease}))
+
+	logs := captureLogs(t)
+	require.NoError(t, mgr.Start(context.Background()))
+
+	require.Eventually(t, func() bool { return fake.ReleaseCount() == 1 }, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return strings.Contains(logs(), "released stale lease upstream") },
+		time.Second, 10*time.Millisecond)
+	assert.Contains(t, logs(), "02:00:00:aa:bb:cc")
 }
 
 // An expired lease that comes back on the same address needs no release and no

--- a/spinifex/network/external/dhcp/manager_test.go
+++ b/spinifex/network/external/dhcp/manager_test.go
@@ -82,6 +82,54 @@ func TestManagerStartDropsExpiredLeases(t *testing.T) {
 	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
 	assert.Equal(t, 0, fake.RenewCount())
 	assert.Equal(t, 0, mgr.LoopCount())
+	// No raw offer/ack, so nclient4 could not rebuild the lease; the release is
+	// skipped rather than attempted and logged as a failure.
+	assert.Equal(t, 0, fake.ReleaseCount())
+}
+
+// Dropping the KV entry without a RELEASE abandons the address instead of
+// returning it, and an upstream server that ages leases by liveness then holds
+// it indefinitely. That is how 20 addresses were stranded on the office LAN.
+func TestManagerStartReleasesExpiredLeaseUpstream(t *testing.T) {
+	fake := dhcp.NewFake()
+	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
+
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := fake.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eipalloc-stale", HWAddr: hw,
+	})
+	require.NoError(t, err)
+	lease.AcquiredAt = fixed.Add(-2 * time.Hour)
+	lease.LeaseDuration = time.Hour
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "wan", Lease: lease}))
+
+	require.NoError(t, mgr.Start(context.Background()))
+	assert.Equal(t, 1, fake.ReleaseCount(), "expired lease must be returned upstream before the KV entry is dropped")
+	_, err = store.Get(t.Context(), "eipalloc-stale")
+	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
+}
+
+// A release that fails must not strand the KV entry too, and must not abort
+// adoption of the remaining leases.
+func TestManagerStartDropsExpiredLeaseWhenReleaseFails(t *testing.T) {
+	fake := dhcp.NewFake()
+	fixed := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	mgr, store, _ := newTestManager(t, "az1", fake, func() time.Time { return fixed })
+
+	hw, _ := net.ParseMAC("02:00:00:aa:bb:cc")
+	lease, err := fake.Acquire(context.Background(), dhcp.AcquireRequest{
+		Bridge: "br-wan", ClientID: "eipalloc-stale", HWAddr: hw,
+	})
+	require.NoError(t, err)
+	lease.AcquiredAt = fixed.Add(-2 * time.Hour)
+	lease.LeaseDuration = time.Hour
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{Purpose: "eip", PoolName: "wan", Lease: lease}))
+	fake.ReleaseHook = func(*dhcp.Lease) error { return errors.New("upstream unreachable") }
+
+	require.NoError(t, mgr.Start(context.Background()))
+	_, err = store.Get(t.Context(), "eipalloc-stale")
+	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound)
 }
 
 func TestManagerStartTwiceErrors(t *testing.T) {

--- a/spinifex/network/external/dhcp/nats_client.go
+++ b/spinifex/network/external/dhcp/nats_client.go
@@ -11,6 +11,12 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+// defaultRPCTimeout bounds a DORA RPC. It sits above the manager's acquire
+// budget so a failing acquire reports its own error rather than a timeout, and
+// below the 60s read timeout an AWS client defaults to, so the caller hears the
+// outcome instead of giving up and retrying into a second lease.
+const defaultRPCTimeout = 50 * time.Second
+
 // NATSClient is the daemon-side DHCP wrapper: marshals acquire/release RPC
 // calls over NATS to the bridge-owning vpcd.
 type NATSClient struct {
@@ -18,12 +24,11 @@ type NATSClient struct {
 	timeout time.Duration
 }
 
-// NewNATSClient wraps nc with the given RPC timeout. timeout <= 0
-// defaults to 60s — DORA + raw_offer/ack persistence can take seconds
-// on a busy upstream server.
+// NewNATSClient wraps nc with the given RPC timeout. timeout <= 0 defaults to
+// defaultRPCTimeout.
 func NewNATSClient(nc *nats.Conn, timeout time.Duration) *NATSClient {
 	if timeout <= 0 {
-		timeout = 60 * time.Second
+		timeout = defaultRPCTimeout
 	}
 	return &NATSClient{nc: nc, timeout: timeout}
 }

--- a/spinifex/network/external/dhcp/nclient4.go
+++ b/spinifex/network/external/dhcp/nclient4.go
@@ -118,6 +118,20 @@ func resolveHWAddr(bridge, clientID string, hwAddr net.HardwareAddr, useIfaceMAC
 	return hw, nil
 }
 
+// releaseHWAddr picks the chaddr for a RELEASE. A server matches a RELEASE to a
+// binding on chaddr, so the only address that can work is the one the lease was
+// taken with, which the record already carries.
+//
+// This differs from resolveHWAddr only for a UseIfaceMAC lease whose interface
+// MAC has changed since: re-resolving live would send an address the binding
+// never had, and the address would stay held with the server saying nothing.
+func releaseHWAddr(lease *Lease) (net.HardwareAddr, error) {
+	if len(lease.HWAddr) == 6 && !isZeroMAC(lease.HWAddr) {
+		return lease.HWAddr, nil
+	}
+	return resolveHWAddr(lease.Bridge, lease.ClientID, lease.HWAddr, lease.UseIfaceMAC)
+}
+
 // isZeroMAC reports whether hw is all zeros, the placeholder a lease carries
 // when no hardware address was ever recorded for it.
 func isZeroMAC(hw net.HardwareAddr) bool {
@@ -229,8 +243,8 @@ func (c *NClient4Client) Release(_ context.Context, lease *Lease) error {
 	if err != nil {
 		return fmt.Errorf("dhcp release: %w", err)
 	}
-	// Must match what took the lease out, so it resolves the same way Acquire did.
-	hwAddr, err := resolveHWAddr(lease.Bridge, lease.ClientID, lease.HWAddr, lease.UseIfaceMAC)
+	// Must match what took the lease out, so it comes from the lease itself.
+	hwAddr, err := releaseHWAddr(lease)
 	if err != nil {
 		return fmt.Errorf("dhcp release: %w", err)
 	}

--- a/spinifex/network/external/dhcp/nclient4_internal_test.go
+++ b/spinifex/network/external/dhcp/nclient4_internal_test.go
@@ -156,6 +156,57 @@ func TestResolveHWAddrUsesTheInterfaceMACWhenConfigured(t *testing.T) {
 	})
 }
 
+// A server matches a RELEASE on chaddr, so it has to be the address the lease
+// was taken with. Re-resolving a UseIfaceMAC lease against an interface whose
+// MAC has since changed would send one the binding never had, and the server
+// drops such a RELEASE without a word.
+func TestReleaseHWAddrComesFromTheLease(t *testing.T) {
+	stored, err := net.ParseMAC("02:6e:c3:e4:67:f3")
+	if err != nil {
+		t.Fatalf("parse mac: %v", err)
+	}
+
+	t.Run("a stored chaddr wins over the live interface MAC", func(t *testing.T) {
+		got, err := releaseHWAddr(&Lease{
+			Bridge: "mulga-no-such-iface0", ClientID: "dhcp-gw-lrp-vpc-1",
+			HWAddr: stored, UseIfaceMAC: true,
+		})
+		if err != nil {
+			t.Fatalf("releaseHWAddr: %v", err)
+		}
+		if !bytes.Equal(got, stored) {
+			t.Fatalf("hw addr = %s, want the lease's own %s", got, stored)
+		}
+	})
+
+	t.Run("a lease with no chaddr falls back to the derived one", func(t *testing.T) {
+		got, err := releaseHWAddr(&Lease{Bridge: "br-wan", ClientID: "dhcp-gw-lrp-vpc-1"})
+		if err != nil {
+			t.Fatalf("releaseHWAddr: %v", err)
+		}
+		want, err := DeriveMAC("dhcp-gw-lrp-vpc-1")
+		if err != nil {
+			t.Fatalf("derive mac: %v", err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("hw addr = %s, want the derived %s", got, want)
+		}
+	})
+
+	t.Run("an all-zero chaddr is not passed through", func(t *testing.T) {
+		got, err := releaseHWAddr(&Lease{
+			Bridge: "br-wan", ClientID: "dhcp-gw-lrp-vpc-1",
+			HWAddr: net.HardwareAddr{0, 0, 0, 0, 0, 0},
+		})
+		if err != nil {
+			t.Fatalf("releaseHWAddr: %v", err)
+		}
+		if isZeroMAC(got) {
+			t.Fatal("want a repaired chaddr rather than all zeros")
+		}
+	})
+}
+
 // rawDHCPv4Message returns a syntactically valid, arbitrary DHCPv4 wire
 // message for use as a Lease's RawOffer/RawACK. Renew and Release only need
 // something reconstructNClient4Lease can parse before chaddr resolution runs.

--- a/spinifex/network/external/dhcp/pool_allocator_test.go
+++ b/spinifex/network/external/dhcp/pool_allocator_test.go
@@ -107,12 +107,17 @@ func TestDHCPPoolAllocatorRejectsPoolMismatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "pool mismatch")
 }
 
-func TestDHCPPoolAllocatorReleaseUnknownIPIsNoop(t *testing.T) {
+// An untracked IP must not report success. Answering SUCCESS with nothing sent
+// upstream is what let stranded leases accumulate unnoticed; every caller of
+// Release logs and continues, so surfacing the error costs no teardown progress.
+func TestDHCPPoolAllocatorReleaseUnknownIPErrors(t *testing.T) {
 	fake := dhcp.NewFake()
 	pool := external.ExternalPoolConfig{Name: "wan", Source: external.SourceDHCP, BindBridge: "br-wan"}
 	allocator, _ := newPoolAllocator(t, fake, pool)
 
 	addr := netip.MustParseAddr("198.51.100.99")
-	assert.NoError(t, allocator.Release(context.Background(), "wan", addr, ""))
+	err := allocator.Release(context.Background(), "wan", addr, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tracked lease for ip 198.51.100.99")
 	assert.Equal(t, 0, fake.ReleaseCount())
 }

--- a/spinifex/network/external/dhcp/reaper.go
+++ b/spinifex/network/external/dhcp/reaper.go
@@ -1,0 +1,112 @@
+package dhcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// OwnerStatus is the verdict on the resource a lease was taken for.
+type OwnerStatus int
+
+const (
+	// OwnerUnknown means the owning resource could not be determined. Leases in
+	// this state are always kept: a KV timeout must never read as a deletion.
+	OwnerUnknown OwnerStatus = iota
+	// OwnerAlive means the resource still exists and needs its address.
+	OwnerAlive
+	// OwnerGone means the resource is gone, so the lease holds an address
+	// nothing will ever use or release.
+	OwnerGone
+)
+
+func (s OwnerStatus) String() string {
+	switch s {
+	case OwnerAlive:
+		return "alive"
+	case OwnerGone:
+		return "gone"
+	default:
+		return "unknown"
+	}
+}
+
+// LeaseOwner resolves a lease back to the resource that justifies it. The
+// manager holds leases but knows nothing about EIPs, ENIs or VPCs, so both the
+// lookup and the datapath teardown belong to the caller.
+type LeaseOwner interface {
+	// Status reports whether the lease's resource still exists. An error is
+	// reported as OwnerUnknown by the caller, never as OwnerGone.
+	Status(ctx context.Context, e Entry) (OwnerStatus, error)
+	// Discard removes whatever the lease configured, before the address goes
+	// back. Called only for OwnerGone, and must be idempotent.
+	Discard(ctx context.Context, e Entry) error
+}
+
+// SetLeaseOwner installs the resolver ReapOrphans consults. Without one,
+// ReapOrphans reports every lease as unknown and reaps nothing.
+func (m *Manager) SetLeaseOwner(o LeaseOwner) {
+	m.mu.Lock()
+	m.leaseOwner = o
+	m.mu.Unlock()
+}
+
+// leaseOwnerRef copies the resolver out from under the lock, so a Discard that
+// calls back into the manager cannot deadlock against it.
+func (m *Manager) leaseOwnerRef() LeaseOwner {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.leaseOwner
+}
+
+// ReapOrphans releases leases whose owning resource no longer exists. Every
+// other leak in this subsystem ends with an address held by nobody, so this is
+// the only path that returns one without an operator. Returns the number
+// released.
+func (m *Manager) ReapOrphans(ctx context.Context) (int, error) {
+	owner := m.leaseOwnerRef()
+	if owner == nil {
+		return 0, nil
+	}
+	entries, err := m.store.List(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list leases to reap: %w", err)
+	}
+
+	reaped := 0
+	for _, e := range entries {
+		if e.Lease == nil {
+			continue
+		}
+		status, err := owner.Status(ctx, e)
+		if err != nil {
+			slog.Warn("dhcp reaper: owner lookup failed; keeping lease",
+				"client_id", e.Lease.ClientID, "purpose", e.Purpose, "err", err)
+			continue
+		}
+		if status != OwnerGone {
+			continue
+		}
+
+		// The datapath goes first: releasing the address while a router port
+		// still answers ARP for it invites a duplicate-IP conflict the moment
+		// the server hands it out again.
+		if err := owner.Discard(ctx, e); err != nil {
+			slog.Error("dhcp reaper: discarding orphaned datapath failed; keeping lease",
+				"client_id", e.Lease.ClientID, "purpose", e.Purpose, "ip", e.Lease.IP, "err", err)
+			continue
+		}
+		if err := m.handleRelease(ctx, e.Lease.ClientID); err != nil {
+			slog.Error("dhcp reaper: release failed",
+				"client_id", e.Lease.ClientID, "ip", e.Lease.IP, "err", err)
+			continue
+		}
+		slog.Warn("dhcp reaper: released lease whose owner is gone",
+			"client_id", e.Lease.ClientID, "purpose", e.Purpose, "vpc_id", e.VPCID, "ip", e.Lease.IP)
+		reaped++
+	}
+	if reaped > 0 {
+		slog.Info("dhcp reaper: swept orphaned leases", "released", reaped, "total", len(entries))
+	}
+	return reaped, nil
+}

--- a/spinifex/network/external/dhcp/reaper.go
+++ b/spinifex/network/external/dhcp/reaper.go
@@ -59,6 +59,16 @@ func (m *Manager) leaseOwnerRef() LeaseOwner {
 	return m.leaseOwner
 }
 
+// Leases returns every lease this manager holds. For callers that reconcile a
+// datapath against the addresses actually leased.
+func (m *Manager) Leases(ctx context.Context) ([]Entry, error) {
+	entries, err := m.store.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list leases: %w", err)
+	}
+	return entries, nil
+}
+
 // ReapOrphans releases leases whose owning resource no longer exists. Every
 // other leak in this subsystem ends with an address held by nobody, so this is
 // the only path that returns one without an operator. Returns the number

--- a/spinifex/network/external/dhcp/reaper_test.go
+++ b/spinifex/network/external/dhcp/reaper_test.go
@@ -1,0 +1,205 @@
+package dhcp_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubOwner records what the reaper asked about and answers from a table.
+type stubOwner struct {
+	mu        sync.Mutex
+	status    map[string]dhcp.OwnerStatus
+	statusErr map[string]error
+	discardEr map[string]error
+	asked     []string
+	discarded []string
+}
+
+func newStubOwner() *stubOwner {
+	return &stubOwner{
+		status:    map[string]dhcp.OwnerStatus{},
+		statusErr: map[string]error{},
+		discardEr: map[string]error{},
+	}
+}
+
+func (s *stubOwner) Status(_ context.Context, e dhcp.Entry) (dhcp.OwnerStatus, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.asked = append(s.asked, e.Lease.ClientID)
+	if err := s.statusErr[e.Lease.ClientID]; err != nil {
+		return dhcp.OwnerUnknown, err
+	}
+	return s.status[e.Lease.ClientID], nil
+}
+
+func (s *stubOwner) Discard(_ context.Context, e dhcp.Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.discardEr[e.Lease.ClientID]; err != nil {
+		return err
+	}
+	s.discarded = append(s.discarded, e.Lease.ClientID)
+	return nil
+}
+
+func (s *stubOwner) discardedIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.discarded...)
+}
+
+func TestReapOrphansReleasesLeaseWhoseOwnerIsGone(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "ap-southeast-2a", fake, nil)
+	seedLiveLease(t, fake, store, "eipalloc-gone", dhcp.PurposeEIP, "")
+
+	owner := newStubOwner()
+	owner.status["eipalloc-gone"] = dhcp.OwnerGone
+	mgr.SetLeaseOwner(owner)
+
+	reaped, err := mgr.ReapOrphans(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+	assert.Equal(t, 1, fake.ReleaseCount(), "the address must go back upstream, not just out of KV")
+
+	entries, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+	assert.Equal(t, []string{"eipalloc-gone"}, owner.discardedIDs())
+}
+
+func TestReapOrphansKeepsLiveLease(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "ap-southeast-2a", fake, nil)
+	seedLiveLease(t, fake, store, "eipalloc-live", dhcp.PurposeEIP, "")
+
+	owner := newStubOwner()
+	owner.status["eipalloc-live"] = dhcp.OwnerAlive
+	mgr.SetLeaseOwner(owner)
+
+	reaped, err := mgr.ReapOrphans(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, reaped)
+	assert.Zero(t, fake.ReleaseCount())
+
+	entries, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+// A lookup that fails must read as "keep". Treating an unreachable daemon as
+// "gone" would release every address in the pool at once.
+func TestReapOrphansKeepsLeaseWhenOwnerLookupFails(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "ap-southeast-2a", fake, nil)
+	seedLiveLease(t, fake, store, "eipalloc-unknown", dhcp.PurposeEIP, "")
+
+	owner := newStubOwner()
+	owner.statusErr["eipalloc-unknown"] = errors.New("no responders")
+	mgr.SetLeaseOwner(owner)
+
+	reaped, err := mgr.ReapOrphans(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, reaped)
+	assert.Zero(t, fake.ReleaseCount())
+
+	entries, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+// An unknown verdict is the default, so a responder that answers with neither
+// alive nor gone must not cost an address.
+func TestReapOrphansKeepsLeaseOnUnknownStatus(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "ap-southeast-2a", fake, nil)
+	seedLiveLease(t, fake, store, "eipalloc-maybe", dhcp.PurposeEIP, "")
+
+	owner := newStubOwner()
+	owner.status["eipalloc-maybe"] = dhcp.OwnerUnknown
+	mgr.SetLeaseOwner(owner)
+
+	reaped, err := mgr.ReapOrphans(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, reaped)
+
+	entries, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+// Releasing an address while a router port still answers ARP for it invites a
+// duplicate-IP conflict, so a failed teardown has to stop the release.
+func TestReapOrphansKeepsLeaseWhenDiscardFails(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "ap-southeast-2a", fake, nil)
+	seedLiveLease(t, fake, store, "dhcp-gw-lrp-vpc-1", dhcp.PurposeGatewayLRP, "vpc-1")
+
+	owner := newStubOwner()
+	owner.status["dhcp-gw-lrp-vpc-1"] = dhcp.OwnerGone
+	owner.discardEr["dhcp-gw-lrp-vpc-1"] = errors.New("ovsdb unreachable")
+	mgr.SetLeaseOwner(owner)
+
+	reaped, err := mgr.ReapOrphans(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, reaped)
+	assert.Zero(t, fake.ReleaseCount())
+
+	entries, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+func TestReapOrphansWithoutOwnerIsNoOp(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "ap-southeast-2a", fake, nil)
+	seedLiveLease(t, fake, store, "eipalloc-1", dhcp.PurposeEIP, "")
+
+	reaped, err := mgr.ReapOrphans(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, reaped)
+
+	entries, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+// One orphan among several must not stop the rest of the sweep.
+func TestReapOrphansSweepsIndependently(t *testing.T) {
+	fake := dhcp.NewFake()
+	mgr, store, _ := newTestManager(t, "ap-southeast-2a", fake, nil)
+	seedLiveLease(t, fake, store, "eipalloc-live", dhcp.PurposeEIP, "")
+	seedLiveLease(t, fake, store, "eipalloc-gone", dhcp.PurposeEIP, "")
+	seedLiveLease(t, fake, store, "eipalloc-unknown", dhcp.PurposeEIP, "")
+
+	owner := newStubOwner()
+	owner.status["eipalloc-live"] = dhcp.OwnerAlive
+	owner.status["eipalloc-gone"] = dhcp.OwnerGone
+	owner.statusErr["eipalloc-unknown"] = errors.New("timeout")
+	mgr.SetLeaseOwner(owner)
+
+	reaped, err := mgr.ReapOrphans(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped)
+
+	entries, err := store.List(t.Context())
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	held := []string{entries[0].Lease.ClientID, entries[1].Lease.ClientID}
+	assert.ElementsMatch(t, []string{"eipalloc-live", "eipalloc-unknown"}, held)
+}
+
+func TestParseOwnerStatus(t *testing.T) {
+	assert.Equal(t, dhcp.OwnerAlive, dhcp.ParseOwnerStatus(dhcp.OwnerStatusAlive))
+	assert.Equal(t, dhcp.OwnerGone, dhcp.ParseOwnerStatus(dhcp.OwnerStatusGone))
+	assert.Equal(t, dhcp.OwnerUnknown, dhcp.ParseOwnerStatus(dhcp.OwnerStatusUnknown))
+	assert.Equal(t, dhcp.OwnerUnknown, dhcp.ParseOwnerStatus("something-newer"), "an unrecognised verdict must never read as gone")
+	assert.Equal(t, "gone", dhcp.OwnerGone.String())
+}

--- a/spinifex/network/external/dhcp/wire.go
+++ b/spinifex/network/external/dhcp/wire.go
@@ -16,7 +16,30 @@ const (
 	// currently holds. Invoked on cluster teardown so an env reset returns
 	// its leases to the upstream pool instead of stranding them until TTL.
 	TopicDrain = "vpc.dhcp.drain"
+	// TopicLeaseChanged announces that a lease came back on a different
+	// address. Flows the opposite way to the others — vpcd asks the daemon to
+	// reconcile, because the records naming these addresses (an EIP's
+	// PublicIp, an ENI's PublicIpAddress) live daemon-side.
+	TopicLeaseChanged = "vpc.dhcp.lease-changed"
 )
+
+// LeaseChangedRequest asks the owner of a lease's resource record to move it
+// onto NewIP. Purpose selects the owning record; ClientID is that record's id
+// (an allocation id for EIPs, an ENI id for auto-assigned public IPs).
+type LeaseChangedRequest struct {
+	ClientID string `json:"client_id"`
+	Purpose  string `json:"purpose"`
+	PoolName string `json:"pool_name,omitempty"`
+	VPCID    string `json:"vpc_id,omitempty"`
+	OldIP    string `json:"old_ip"`
+	NewIP    string `json:"new_ip"`
+}
+
+// LeaseChangedReply carries an empty Error on success. A failure means the
+// record still names an address vpcd no longer holds, so callers surface it.
+type LeaseChangedReply struct {
+	Error string `json:"error,omitempty"`
+}
 
 // acquireWireRequest is the JSON payload sent by daemon-side
 // NATSClient.RequestAcquire and consumed by Manager.handleAcquireMsg.

--- a/spinifex/network/external/dhcp/wire.go
+++ b/spinifex/network/external/dhcp/wire.go
@@ -21,6 +21,10 @@ const (
 	// reconcile, because the records naming these addresses (an EIP's
 	// PublicIp, an ENI's PublicIpAddress) live daemon-side.
 	TopicLeaseChanged = "vpc.dhcp.lease-changed"
+	// TopicOwnerCheck asks whether the resource a lease was taken for still
+	// exists. Daemon-ward for the same reason as TopicLeaseChanged: vpcd holds
+	// the leases, the daemon holds the records.
+	TopicOwnerCheck = "vpc.dhcp.owner-check"
 )
 
 // LeaseChangedRequest asks the owner of a lease's resource record to move it
@@ -39,6 +43,43 @@ type LeaseChangedRequest struct {
 // record still names an address vpcd no longer holds, so callers surface it.
 type LeaseChangedReply struct {
 	Error string `json:"error,omitempty"`
+}
+
+// OwnerCheckRequest asks whether the resource behind a lease still exists.
+// ClientID is the resource's own id for EIP and ENI-public leases; VPCID
+// identifies a gateway LRP lease.
+type OwnerCheckRequest struct {
+	ClientID string `json:"client_id"`
+	Purpose  string `json:"purpose"`
+	VPCID    string `json:"vpc_id,omitempty"`
+}
+
+// OwnerCheckReply reports "alive", "gone" or "unknown". Anything the responder
+// cannot answer stays unknown, which the reaper treats as keep — a lookup
+// failure must never be read as a deletion.
+type OwnerCheckReply struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// Wire values for OwnerCheckReply.Status.
+const (
+	OwnerStatusAlive   = "alive"
+	OwnerStatusGone    = "gone"
+	OwnerStatusUnknown = "unknown"
+)
+
+// ParseOwnerStatus maps a wire status onto OwnerStatus. Anything unrecognised
+// is unknown, so a newer responder's verdict is never mistaken for "gone".
+func ParseOwnerStatus(s string) OwnerStatus {
+	switch s {
+	case OwnerStatusAlive:
+		return OwnerAlive
+	case OwnerStatusGone:
+		return OwnerGone
+	default:
+		return OwnerUnknown
+	}
 }
 
 // acquireWireRequest is the JSON payload sent by daemon-side

--- a/spinifex/network/external/igw.go
+++ b/spinifex/network/external/igw.go
@@ -48,6 +48,10 @@ type IGWManager interface {
 	// SNATs the instance, so the reroute alone lets the inbound connection's reply
 	// (and instance-initiated egress) bypass the subnet drop gate. Idempotent.
 	EnsureEIPInstanceEgress(ctx context.Context, vpcID, subnetID, instanceIP string) error
+	// RebindGatewayIP moves the VPC gateway LRP onto a new external address
+	// after its DHCP lease came back on a different IP. Idempotent; a no-op
+	// when no gateway port is attached.
+	RebindGatewayIP(ctx context.Context, vpcID, newIP string, prefixLen int) error
 }
 
 // RoutedIngressHooks deliver host-side ingress plumbing in routed-NAT mode:
@@ -280,6 +284,60 @@ func (m *igwManager) ensureRoutedLeg(ctx context.Context, vpcID, gwLrpIP string)
 			return fmt.Errorf("install routed ingress route %s via %s: %w", vpcCIDR, gwLrpIP, err)
 		}
 	}
+	return nil
+}
+
+// RebindGatewayIP repoints the VPC gateway LRP at newIP. The LRP address is
+// otherwise written once at attach and never revisited, so a lease re-issued on
+// a different IP would leave the port answering ARP for an address nothing
+// renews — burning it upstream and losing egress once the server reassigns it.
+func (m *igwManager) RebindGatewayIP(ctx context.Context, vpcID, newIP string, prefixLen int) error {
+	switch {
+	case vpcID == "":
+		return errors.New("RebindGatewayIP: vpcID required")
+	case newIP == "":
+		return errors.New("RebindGatewayIP: newIP required")
+	case prefixLen <= 0:
+		return fmt.Errorf("RebindGatewayIP: vpc %s: prefixLen must be positive, got %d", vpcID, prefixLen)
+	}
+
+	// A gw-lrp lease only exists because AttachIGW allocated one, so a missing
+	// port means either an unreachable OVSDB or a detach that kept the lease —
+	// both leave an address held with no owner, so neither is swallowed here.
+	gwPortName := topology.GatewayRouterPort(vpcID)
+	lrp, err := m.ovn.GetLogicalRouterPort(ctx, gwPortName)
+	if err != nil {
+		return fmt.Errorf("get gateway port %s to rebind onto %s: %w", gwPortName, newIP, err)
+	}
+	if lrp == nil {
+		return fmt.Errorf("gateway port %s absent; cannot rebind vpc %s onto %s", gwPortName, vpcID, newIP)
+	}
+
+	network := fmt.Sprintf("%s/%d", newIP, prefixLen)
+	if len(lrp.Networks) == 1 && lrp.Networks[0] == network && lrp.ExternalIDs[gatewayIPExtIDKey] == newIP {
+		return nil
+	}
+	oldNetworks := lrp.Networks
+	lrp.Networks = []string{network}
+	if lrp.ExternalIDs == nil {
+		lrp.ExternalIDs = map[string]string{}
+	}
+	lrp.ExternalIDs[gatewayIPExtIDKey] = newIP
+	if err := m.ovn.UpdateLogicalRouterPort(ctx, lrp); err != nil {
+		return fmt.Errorf("rebind gateway port %s to %s: %w", gwPortName, network, err)
+	}
+
+	// Routed mode pins the VPC SNAT and the host ingress route to the transit
+	// IP. AddSNAT scrubs a stale row whose external IP changed, and the ingress
+	// hook rewrites its route, so re-running the leg is enough.
+	if err := m.ensureRoutedLeg(ctx, vpcID, newIP); err != nil {
+		return err
+	}
+	if err := m.barrier(); err != nil {
+		return fmt.Errorf("flows barrier after rebinding %s: %w", gwPortName, err)
+	}
+	slog.Warn("external: gateway LRP rebound after DHCP lease moved",
+		"vpc_id", vpcID, "gw_port", gwPortName, "old_networks", oldNetworks, "new_network", network)
 	return nil
 }
 

--- a/spinifex/network/external/igw_test.go
+++ b/spinifex/network/external/igw_test.go
@@ -156,6 +156,82 @@ func TestAttachIGW_Centralized_AllocatesGwLrpIP(t *testing.T) {
 	assert.Equal(t, "192.168.1.240", lrp.ExternalIDs[gatewayIPExtIDKey])
 }
 
+// The LRP address is written once at attach, so a lease re-issued on a new IP
+// leaves the port answering ARP for an address nothing renews.
+func TestRebindGatewayIP_MovesLRPAndStamp(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
+	pool := &ExternalPoolConfig{Name: "p", PrefixLen: 23}
+	mgr, _ := newTestIGWManager(t, m, policy.NATModeCentralized, pool,
+		fixedNexthopAllocator{ip: "192.168.1.115", prefix: 23, nexthop: "192.168.1.1"}, []string{"chassis-a"})
+	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
+
+	require.NoError(t, mgr.RebindGatewayIP(ctx, "vpc-1", "192.168.1.146", 23))
+
+	lrp, err := m.GetLogicalRouterPort(ctx, topology.GatewayRouterPort("vpc-1"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.168.1.146/23"}, lrp.Networks, "the old address must not linger on the port")
+	assert.Equal(t, "192.168.1.146", lrp.ExternalIDs[gatewayIPExtIDKey])
+}
+
+func TestRebindGatewayIP_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
+	pool := &ExternalPoolConfig{Name: "p", PrefixLen: 23}
+	mgr, barrierCalls := newTestIGWManager(t, m, policy.NATModeCentralized, pool,
+		fixedNexthopAllocator{ip: "192.168.1.115", prefix: 23, nexthop: "192.168.1.1"}, []string{"chassis-a"})
+	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
+	before := *barrierCalls
+
+	// Rebinding to the address already on the port must not touch OVN at all.
+	require.NoError(t, mgr.RebindGatewayIP(ctx, "vpc-1", "192.168.1.115", 23))
+	assert.Equal(t, before, *barrierCalls, "a no-op rebind must not wait on the flows barrier")
+}
+
+// Routed mode pins the VPC SNAT to the transit IP, so a rebind must move it or
+// egress keeps leaving via the released address.
+func TestRebindGatewayIP_RoutedMovesSNAT(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
+	pool := &ExternalPoolConfig{Name: "p", PrefixLen: 23}
+	mgr, _ := newTestIGWManager(t, m, policy.NATModeRouted, pool,
+		fixedNexthopAllocator{ip: "10.99.0.10", prefix: 24, nexthop: "10.99.0.1"}, []string{"chassis-a"})
+	require.NoError(t, mgr.AttachIGW(ctx, IGWSpec{VPCID: "vpc-1", InternetGatewayID: "igw-1"}))
+
+	require.NoError(t, mgr.RebindGatewayIP(ctx, "vpc-1", "10.99.0.20", 24))
+
+	snat, err := m.FindNATByLogicalIP(ctx, topology.VPCRouter("vpc-1"), "snat", "10.0.0.0/16")
+	require.NoError(t, err)
+	require.NotNil(t, snat)
+	assert.Equal(t, "10.99.0.20", snat.ExternalIP)
+}
+
+// A gw-lrp lease only exists because a port was attached, so a missing port is
+// an unreachable OVSDB or a detach that kept the lease. Both mean an address is
+// held with no owner and must surface rather than read as "nothing to do".
+func TestRebindGatewayIP_MissingLRPErrors(t *testing.T) {
+	m := mock.New()
+	seedVPCRouter(t, m, "vpc-1", "10.0.0.0/16")
+	mgr, _ := newTestIGWManager(t, m, policy.NATModeCentralized, nil, LinkLocalAllocator{}, nil)
+
+	err := mgr.RebindGatewayIP(context.Background(), "vpc-1", "192.168.1.146", 23)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), topology.GatewayRouterPort("vpc-1"))
+}
+
+func TestRebindGatewayIP_RejectsBadArgs(t *testing.T) {
+	ctx := context.Background()
+	m := mock.New()
+	mgr, _ := newTestIGWManager(t, m, policy.NATModeCentralized, nil, LinkLocalAllocator{}, nil)
+
+	assert.Error(t, mgr.RebindGatewayIP(ctx, "", "192.168.1.146", 23))
+	assert.Error(t, mgr.RebindGatewayIP(ctx, "vpc-1", "", 23))
+	assert.Error(t, mgr.RebindGatewayIP(ctx, "vpc-1", "192.168.1.146", 0))
+}
+
 func TestAttachIGW_IsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	m := mock.New()

--- a/spinifex/utils/idempotency.go
+++ b/spinifex/utils/idempotency.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+)
+
+// IdempotencyKeyHeader carries a caller-stable retry token over the gateway →
+// NATS hop. The AWS SDKs repeat one amz-sdk-invocation-id across every retry of
+// a single call, which is the only thing that distinguishes a resent mutation
+// from a genuinely new one — EC2's AllocateAddress takes no client token.
+const IdempotencyKeyHeader = "Spinifex-Idempotency-Key"
+
+// SDKInvocationIDHeader is the HTTP header the AWS SDKs stamp with an id that
+// stays fixed across retries of one call (it is the attempt counter in
+// amz-sdk-request that changes).
+const SDKInvocationIDHeader = "amz-sdk-invocation-id"
+
+type idempotencyKeyCtxKey struct{}
+
+// WithIdempotencyKey attaches key to ctx. An empty key is dropped so callers
+// need not branch.
+func WithIdempotencyKey(ctx context.Context, key string) context.Context {
+	if key == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, idempotencyKeyCtxKey{}, key)
+}
+
+// IdempotencyKeyFromContext returns the retry token, or "" when the caller sent
+// none. An absent key means "treat this as a new request".
+func IdempotencyKeyFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	key, _ := ctx.Value(idempotencyKeyCtxKey{}).(string)
+	return key
+}
+
+// IdempotencyKeyFromMsg reads the token off an inbound NATS request.
+func IdempotencyKeyFromMsg(msg *nats.Msg) string {
+	if msg == nil || msg.Header == nil {
+		return ""
+	}
+	return msg.Header.Get(IdempotencyKeyHeader)
+}

--- a/spinifex/utils/idempotency_test.go
+++ b/spinifex/utils/idempotency_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdempotencyKeyFromContext(t *testing.T) {
+	assert.Empty(t, IdempotencyKeyFromContext(context.Background()))
+	assert.Equal(t, "abc", IdempotencyKeyFromContext(WithIdempotencyKey(context.Background(), "abc")))
+}
+
+func TestIdempotencyKeyFromMsg(t *testing.T) {
+	assert.Empty(t, IdempotencyKeyFromMsg(nil))
+	assert.Empty(t, IdempotencyKeyFromMsg(&nats.Msg{}))
+
+	msg := &nats.Msg{Header: nats.Header{}}
+	msg.Header.Set(IdempotencyKeyHeader, "abc")
+	assert.Equal(t, "abc", IdempotencyKeyFromMsg(msg))
+}
+
+// The token is set on the HTTP request and consumed by the service behind NATS,
+// so it has to survive the hop or the dedupe never sees it.
+func TestNATSRequest_ForwardsIdempotencyKey(t *testing.T) {
+	ns := startTestNATSServer(t)
+
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	defer nc.Close()
+
+	type resp struct {
+		Key string `json:"key"`
+	}
+	_, err = nc.Subscribe("test.idem", func(msg *nats.Msg) {
+		data, _ := json.Marshal(resp{Key: IdempotencyKeyFromMsg(msg)})
+		_ = msg.Respond(data)
+	})
+	require.NoError(t, err)
+
+	ctx := WithIdempotencyKey(context.Background(), "invocation-1")
+	got, err := NATSRequest[resp](ctx, nc, "test.idem", struct{}{}, 2*time.Second, "111122223333")
+	require.NoError(t, err)
+	assert.Equal(t, "invocation-1", got.Key)
+
+	// No key in context must leave the header unset rather than send an empty one.
+	got, err = NATSRequest[resp](context.Background(), nc, "test.idem", struct{}{}, 2*time.Second, "111122223333")
+	require.NoError(t, err)
+	assert.Empty(t, got.Key)
+}

--- a/spinifex/utils/nats.go
+++ b/spinifex/utils/nats.go
@@ -255,6 +255,11 @@ func NATSRequest[Out any](ctx context.Context, conn *nats.Conn, subject string, 
 	reqMsg := nats.NewMsg(subject)
 	reqMsg.Data = jsonData
 	reqMsg.Header.Set(AccountIDHeader, accountID)
+	// Forwarded here so every NATS-backed service inherits the caller's retry
+	// token without widening its signature.
+	if key := IdempotencyKeyFromContext(ctx); key != "" {
+		reqMsg.Header.Set(IdempotencyKeyHeader, key)
+	}
 	InjectTraceContext(ctx, reqMsg.Header)
 	for _, h := range headers {
 		if h.Key != "" {

--- a/spinifex/vpcd/lease_datapath_reconcile.go
+++ b/spinifex/vpcd/lease_datapath_reconcile.go
@@ -1,0 +1,44 @@
+package vpcd
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+)
+
+// reconcileGatewayLeases points every VPC gateway port at the address its lease
+// actually holds. The two can diverge without any lease ever changing: an LRP
+// configured by a static pool keeps its address when the pool is switched to
+// DHCP, so the VPC forwards on an address nothing leases while the lease it does
+// hold goes unused. Both addresses are then effectively lost.
+//
+// RebindGatewayIP is idempotent, so a port already on its lease address costs an
+// OVSDB read and nothing more.
+func reconcileGatewayLeases(ctx context.Context, mgr *dhcp.Manager, igwMgr external.IGWManager) {
+	if mgr == nil || igwMgr == nil {
+		return
+	}
+	entries, err := mgr.Leases(ctx)
+	if err != nil {
+		slog.Warn("vpcd: cannot reconcile gateway leases", "err", err)
+		return
+	}
+
+	for _, e := range entries {
+		if e.Purpose != dhcp.PurposeGatewayLRP || e.Lease == nil {
+			continue
+		}
+		if e.VPCID == "" {
+			slog.Warn("vpcd: gw-lrp lease carries no vpc_id; cannot reconcile",
+				"client_id", e.Lease.ClientID, "ip", e.Lease.IP)
+			continue
+		}
+		prefixLen, _ := e.Lease.SubnetMask.Size()
+		if err := igwMgr.RebindGatewayIP(ctx, e.VPCID, e.Lease.IP.String(), prefixLen); err != nil {
+			slog.Error("vpcd: reconciling gateway port to its lease address failed",
+				"vpc_id", e.VPCID, "lease_ip", e.Lease.IP, "err", err)
+		}
+	}
+}

--- a/spinifex/vpcd/lease_datapath_reconcile_test.go
+++ b/spinifex/vpcd/lease_datapath_reconcile_test.go
@@ -1,0 +1,139 @@
+package vpcd
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/mock"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedGatewayLease puts a gw-lrp lease in a real store and returns the manager
+// holding it, so the reconcile runs against the same surface production uses.
+func seedGatewayLease(t *testing.T, vpcID, ip string) *dhcp.Manager {
+	t.Helper()
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	store, err := dhcp.NewStore(t.Context(), js, "az1")
+	require.NoError(t, err)
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{
+		Purpose: dhcp.PurposeGatewayLRP,
+		VPCID:   vpcID,
+		Lease: &dhcp.Lease{
+			ClientID:   dhcp.GatewayLRPClientID(vpcID),
+			IP:         net.ParseIP(ip),
+			SubnetMask: net.CIDRMask(23, 32),
+		},
+	}))
+	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{Client: dhcp.NewFake(), Store: store})
+	require.NoError(t, err)
+	t.Cleanup(mgr.Stop)
+	return mgr
+}
+
+func gatewayRouterWithPort(t *testing.T, vpcID, network string) *mock.Client {
+	t.Helper()
+	m := mock.New()
+	require.NoError(t, m.CreateLogicalRouter(context.Background(), &nbdb.LogicalRouter{
+		Name:        topology.VPCRouter(vpcID),
+		ExternalIDs: map[string]string{"spinifex:vpc_id": vpcID, "spinifex:cidr": "172.31.0.0/16"},
+	}))
+	require.NoError(t, m.CreateLogicalRouterPort(context.Background(), topology.VPCRouter(vpcID), &nbdb.LogicalRouterPort{
+		Name:     topology.GatewayRouterPort(vpcID),
+		Networks: []string{network},
+	}))
+	return m
+}
+
+// Flipping a pool from static to DHCP leaves the port on its static address
+// while the new lease goes unused, so both addresses are lost with no lease
+// event to correct it.
+func TestReconcileGatewayLeasesMovesDriftedPort(t *testing.T) {
+	m := gatewayRouterWithPort(t, "vpc-1", "192.168.1.240/23")
+	mgr := seedGatewayLease(t, "vpc-1", "192.168.1.150")
+
+	reconcileGatewayLeases(context.Background(), mgr, newHookIGWManager(t, m))
+
+	lrp, err := m.GetLogicalRouterPort(context.Background(), topology.GatewayRouterPort("vpc-1"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.168.1.150/23"}, lrp.Networks)
+	assert.Equal(t, "192.168.1.150", lrp.ExternalIDs["spinifex:gateway_ip"])
+}
+
+func TestReconcileGatewayLeasesLeavesMatchingPort(t *testing.T) {
+	m := gatewayRouterWithPort(t, "vpc-1", "192.168.1.150/23")
+	mgr := seedGatewayLease(t, "vpc-1", "192.168.1.150")
+
+	reconcileGatewayLeases(context.Background(), mgr, newHookIGWManager(t, m))
+
+	lrp, err := m.GetLogicalRouterPort(context.Background(), topology.GatewayRouterPort("vpc-1"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.168.1.150/23"}, lrp.Networks)
+}
+
+// An EIP lease has no gateway port, so the reconcile must not touch one.
+func TestReconcileGatewayLeasesIgnoresOtherPurposes(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	store, err := dhcp.NewStore(t.Context(), js, "az1")
+	require.NoError(t, err)
+	require.NoError(t, store.Put(t.Context(), dhcp.Entry{
+		Purpose: dhcp.PurposeEIP,
+		Lease:   &dhcp.Lease{ClientID: "eipalloc-1", IP: net.ParseIP("192.168.1.5")},
+	}))
+	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{Client: dhcp.NewFake(), Store: store})
+	require.NoError(t, err)
+	t.Cleanup(mgr.Stop)
+
+	m := gatewayRouterWithPort(t, "vpc-1", "192.168.1.240/23")
+	reconcileGatewayLeases(context.Background(), mgr, newHookIGWManager(t, m))
+
+	lrp, err := m.GetLogicalRouterPort(context.Background(), topology.GatewayRouterPort("vpc-1"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.168.1.240/23"}, lrp.Networks)
+}
+
+// A missing port errors inside RebindGatewayIP; the sweep must carry on to the
+// remaining leases rather than abort on the first failure.
+func TestReconcileGatewayLeasesContinuesPastFailure(t *testing.T) {
+	m := gatewayRouterWithPort(t, "vpc-2", "192.168.1.240/23")
+	_, nc, _ := testutil.StartTestJetStream(t)
+	js := testutil.NewJetStream(t, nc)
+	store, err := dhcp.NewStore(t.Context(), js, "az1")
+	require.NoError(t, err)
+	for _, vpcID := range []string{"vpc-missing", "vpc-2"} {
+		require.NoError(t, store.Put(t.Context(), dhcp.Entry{
+			Purpose: dhcp.PurposeGatewayLRP,
+			VPCID:   vpcID,
+			Lease: &dhcp.Lease{
+				ClientID:   dhcp.GatewayLRPClientID(vpcID),
+				IP:         net.ParseIP("192.168.1.150"),
+				SubnetMask: net.CIDRMask(23, 32),
+			},
+		}))
+	}
+	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{Client: dhcp.NewFake(), Store: store})
+	require.NoError(t, err)
+	t.Cleanup(mgr.Stop)
+
+	reconcileGatewayLeases(context.Background(), mgr, newHookIGWManager(t, m))
+
+	lrp, err := m.GetLogicalRouterPort(context.Background(), topology.GatewayRouterPort("vpc-2"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.168.1.150/23"}, lrp.Networks)
+}
+
+func TestReconcileGatewayLeasesWithoutManagerIsNoOp(t *testing.T) {
+	m := gatewayRouterWithPort(t, "vpc-1", "192.168.1.240/23")
+	reconcileGatewayLeases(context.Background(), nil, newHookIGWManager(t, m))
+
+	lrp, err := m.GetLogicalRouterPort(context.Background(), topology.GatewayRouterPort("vpc-1"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.168.1.240/23"}, lrp.Networks)
+}

--- a/spinifex/vpcd/lease_ip_change_test.go
+++ b/spinifex/vpcd/lease_ip_change_test.go
@@ -2,8 +2,10 @@ package vpcd
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/network/external"
 	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
@@ -11,6 +13,8 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
 	"github.com/mulgadc/spinifex/spinifex/network/policy"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +58,8 @@ func TestLeaseIPChangeHookRebindsGatewayLRP(t *testing.T) {
 		Networks: []string{"192.168.1.115/23"},
 	}))
 
-	hook := leaseIPChangeHook(newHookIGWManager(t, m))
+	// nil conn: a gateway lease is rebound in-process, never over NATS.
+	hook := leaseIPChangeHook(newHookIGWManager(t, m), nil)
 	entry := gwLeaseEntry(dhcp.PurposeGatewayLRP, "vpc-1", "dhcp-gw-lrp-vpc-1", "192.168.1.146")
 	require.NoError(t, hook(context.Background(), entry, net.ParseIP("192.168.1.115")))
 
@@ -63,23 +68,71 @@ func TestLeaseIPChangeHookRebindsGatewayLRP(t *testing.T) {
 	assert.Equal(t, []string{"192.168.1.146/23"}, lrp.Networks)
 }
 
-// EIP, ENI-public and NATGW addresses are API-visible resources recorded outside
-// vpcd, so the hook must report the divergence rather than silently repoint a
-// datapath while DescribeAddresses still returns the old IP.
-func TestLeaseIPChangeHookReportsUnhandledPurposes(t *testing.T) {
-	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()))
+// EIP and ENI-public addresses are API-visible records owned daemon-side, so
+// the hook must hand the move over rather than repoint a datapath while
+// DescribeAddresses still returns the old IP.
+func TestLeaseIPChangeHookRequestsRecordRebind(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
 
-	for _, purpose := range []string{dhcp.PurposeEIP, dhcp.PurposeENIPublic, dhcp.PurposeNATGWExternal} {
-		entry := gwLeaseEntry(purpose, "", "eipalloc-1", "192.168.1.146")
-		err := hook(context.Background(), entry, net.ParseIP("192.168.1.115"))
-		require.Error(t, err, "purpose %q must not be silently accepted", purpose)
-		assert.Contains(t, err.Error(), "192.168.1.115")
-		assert.Contains(t, err.Error(), "192.168.1.146")
+	got := make(chan dhcp.LeaseChangedRequest, 1)
+	sub, err := nc.Subscribe(dhcp.TopicLeaseChanged, func(msg *nats.Msg) {
+		var req dhcp.LeaseChangedRequest
+		require.NoError(t, json.Unmarshal(msg.Data, &req))
+		got <- req
+		reply, _ := json.Marshal(dhcp.LeaseChangedReply{})
+		require.NoError(t, msg.Respond(reply))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()), nc)
+	entry := gwLeaseEntry(dhcp.PurposeEIP, "vpc-1", "eipalloc-1", "192.168.1.146")
+	entry.PoolName = "wan"
+	require.NoError(t, hook(context.Background(), entry, net.ParseIP("192.168.1.115")))
+
+	select {
+	case req := <-got:
+		assert.Equal(t, "eipalloc-1", req.ClientID)
+		assert.Equal(t, dhcp.PurposeEIP, req.Purpose)
+		assert.Equal(t, "wan", req.PoolName)
+		assert.Equal(t, "192.168.1.115", req.OldIP)
+		assert.Equal(t, "192.168.1.146", req.NewIP)
+	case <-time.After(5 * time.Second):
+		t.Fatal("no lease-changed request published")
 	}
 }
 
+// A rejected rebind means the record still names a released address, so the
+// hook must not report success.
+func TestLeaseIPChangeHookSurfacesRebindRejection(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+
+	sub, err := nc.Subscribe(dhcp.TopicLeaseChanged, func(msg *nats.Msg) {
+		reply, _ := json.Marshal(dhcp.LeaseChangedReply{Error: "no EIP record for allocation eipalloc-1"})
+		require.NoError(t, msg.Respond(reply))
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()), nc)
+	entry := gwLeaseEntry(dhcp.PurposeEIP, "", "eipalloc-1", "192.168.1.146")
+	err = hook(context.Background(), entry, net.ParseIP("192.168.1.115"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no EIP record for allocation eipalloc-1")
+}
+
+// No responder must not read as success either — nothing moved the record.
+func TestLeaseIPChangeHookErrorsWithoutResponder(t *testing.T) {
+	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()), nil)
+
+	entry := gwLeaseEntry(dhcp.PurposeENIPublic, "", "eni-1", "192.168.1.146")
+	err := hook(context.Background(), entry, net.ParseIP("192.168.1.115"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "eni-1")
+}
+
 func TestLeaseIPChangeHookRejectsGatewayLeaseWithoutVPC(t *testing.T) {
-	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()))
+	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()), nil)
 
 	entry := gwLeaseEntry(dhcp.PurposeGatewayLRP, "", "dhcp-gw-lrp-vpc-1", "192.168.1.146")
 	err := hook(context.Background(), entry, net.ParseIP("192.168.1.115"))

--- a/spinifex/vpcd/lease_ip_change_test.go
+++ b/spinifex/vpcd/lease_ip_change_test.go
@@ -1,0 +1,88 @@
+package vpcd
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/mock"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+	"github.com/mulgadc/spinifex/spinifex/network/policy"
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newHookIGWManager(t *testing.T, m *mock.Client) external.IGWManager {
+	t.Helper()
+	nat, err := policy.NewNATManager(m, policy.NATModeCentralized)
+	require.NoError(t, err)
+	mgr, err := external.NewIGWManager(external.IGWManagerConfig{
+		OVN:       m,
+		Routes:    policy.NewRouteManager(m),
+		NAT:       nat,
+		Pool:      &external.ExternalPoolConfig{Name: "wan", PrefixLen: 23},
+		Allocator: external.LinkLocalAllocator{},
+		NATMode:   policy.NATModeCentralized,
+	})
+	require.NoError(t, err)
+	return mgr
+}
+
+func gwLeaseEntry(purpose, vpcID, clientID, ip string) dhcp.Entry {
+	return dhcp.Entry{
+		Purpose: purpose,
+		VPCID:   vpcID,
+		Lease: &dhcp.Lease{
+			ClientID:   clientID,
+			IP:         net.ParseIP(ip),
+			SubnetMask: net.CIDRMask(23, 32),
+		},
+	}
+}
+
+func TestLeaseIPChangeHookRebindsGatewayLRP(t *testing.T) {
+	m := mock.New()
+	require.NoError(t, m.CreateLogicalRouter(context.Background(), &nbdb.LogicalRouter{
+		Name:        topology.VPCRouter("vpc-1"),
+		ExternalIDs: map[string]string{"spinifex:vpc_id": "vpc-1", "spinifex:cidr": "172.31.0.0/16"},
+	}))
+	require.NoError(t, m.CreateLogicalRouterPort(context.Background(), topology.VPCRouter("vpc-1"), &nbdb.LogicalRouterPort{
+		Name:     topology.GatewayRouterPort("vpc-1"),
+		Networks: []string{"192.168.1.115/23"},
+	}))
+
+	hook := leaseIPChangeHook(newHookIGWManager(t, m))
+	entry := gwLeaseEntry(dhcp.PurposeGatewayLRP, "vpc-1", "dhcp-gw-lrp-vpc-1", "192.168.1.146")
+	require.NoError(t, hook(context.Background(), entry, net.ParseIP("192.168.1.115")))
+
+	lrp, err := m.GetLogicalRouterPort(context.Background(), topology.GatewayRouterPort("vpc-1"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"192.168.1.146/23"}, lrp.Networks)
+}
+
+// EIP, ENI-public and NATGW addresses are API-visible resources recorded outside
+// vpcd, so the hook must report the divergence rather than silently repoint a
+// datapath while DescribeAddresses still returns the old IP.
+func TestLeaseIPChangeHookReportsUnhandledPurposes(t *testing.T) {
+	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()))
+
+	for _, purpose := range []string{dhcp.PurposeEIP, dhcp.PurposeENIPublic, dhcp.PurposeNATGWExternal} {
+		entry := gwLeaseEntry(purpose, "", "eipalloc-1", "192.168.1.146")
+		err := hook(context.Background(), entry, net.ParseIP("192.168.1.115"))
+		require.Error(t, err, "purpose %q must not be silently accepted", purpose)
+		assert.Contains(t, err.Error(), "192.168.1.115")
+		assert.Contains(t, err.Error(), "192.168.1.146")
+	}
+}
+
+func TestLeaseIPChangeHookRejectsGatewayLeaseWithoutVPC(t *testing.T) {
+	hook := leaseIPChangeHook(newHookIGWManager(t, mock.New()))
+
+	entry := gwLeaseEntry(dhcp.PurposeGatewayLRP, "", "dhcp-gw-lrp-vpc-1", "192.168.1.146")
+	err := hook(context.Background(), entry, net.ParseIP("192.168.1.115"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no vpc_id")
+}

--- a/spinifex/vpcd/lease_reaper.go
+++ b/spinifex/vpcd/lease_reaper.go
@@ -1,0 +1,119 @@
+package vpcd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external"
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	// leaseReapInterval paces the orphan sweep. Well under the shortest lease a
+	// server is likely to hand out, so an orphan is reclaimed long before an
+	// operator would notice the pool shrinking.
+	leaseReapInterval = 10 * time.Minute
+	// leaseReapStartDelay lets the cluster settle first. A resource created
+	// moments before vpcd started may not have its record committed yet, and a
+	// sweep that raced it would read a live lease as an orphan.
+	leaseReapStartDelay = 2 * time.Minute
+	// ownerCheckTimeout bounds one existence lookup. An unanswered check keeps
+	// the lease, so there is nothing to gain from waiting longer.
+	ownerCheckTimeout = 20 * time.Second
+)
+
+// leaseOwnerResolver answers the reaper's "does this still have an owner?"
+// question and tears down the orphaned datapath. The records live daemon-side,
+// so the lookup is an RPC; the teardown is local, because the gateway port is
+// vpcd's to remove.
+type leaseOwnerResolver struct {
+	nc     *nats.Conn
+	igwMgr external.IGWManager
+}
+
+var _ dhcp.LeaseOwner = (*leaseOwnerResolver)(nil)
+
+// Status asks the daemon whether the lease's resource survives. Every failure
+// path returns OwnerUnknown, so an unreachable daemon costs a sweep rather than
+// a fleet of released addresses.
+func (r *leaseOwnerResolver) Status(ctx context.Context, e dhcp.Entry) (dhcp.OwnerStatus, error) {
+	if e.Lease == nil {
+		return dhcp.OwnerUnknown, errors.New("owner check: nil lease")
+	}
+	if r.nc == nil {
+		return dhcp.OwnerUnknown, fmt.Errorf("no NATS connection to resolve owner of %s", e.Lease.ClientID)
+	}
+	payload, err := json.Marshal(dhcp.OwnerCheckRequest{
+		ClientID: e.Lease.ClientID,
+		Purpose:  e.Purpose,
+		VPCID:    e.VPCID,
+	})
+	if err != nil {
+		return dhcp.OwnerUnknown, fmt.Errorf("marshal owner-check for %s: %w", e.Lease.ClientID, err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, ownerCheckTimeout)
+	defer cancel()
+	msg, err := r.nc.RequestWithContext(reqCtx, dhcp.TopicOwnerCheck, payload)
+	if err != nil {
+		return dhcp.OwnerUnknown, fmt.Errorf("owner-check for %s: %w", e.Lease.ClientID, err)
+	}
+	var reply dhcp.OwnerCheckReply
+	if err := json.Unmarshal(msg.Data, &reply); err != nil {
+		return dhcp.OwnerUnknown, fmt.Errorf("decode owner-check reply for %s: %w", e.Lease.ClientID, err)
+	}
+	status := dhcp.ParseOwnerStatus(reply.Status)
+	if reply.Error != "" {
+		return status, fmt.Errorf("owner-check for %s: %s", e.Lease.ClientID, reply.Error)
+	}
+	return status, nil
+}
+
+// Discard removes what the lease configured. Only a gateway LRP lease has a
+// datapath of its own: an EIP or ENI-public address is already gone with the
+// record that named it, and DetachIGW covers the port, its routes and its NAT.
+func (r *leaseOwnerResolver) Discard(ctx context.Context, e dhcp.Entry) error {
+	if e.Purpose != dhcp.PurposeGatewayLRP {
+		return nil
+	}
+	if e.VPCID == "" {
+		return fmt.Errorf("gw-lrp lease %s carries no vpc_id; cannot detach", e.Lease.ClientID)
+	}
+	if r.igwMgr == nil {
+		return fmt.Errorf("no IGW manager to detach orphaned gateway for %s", e.VPCID)
+	}
+	slog.Warn("vpcd: detaching gateway for a VPC that no longer exists",
+		"vpc_id", e.VPCID, "gateway_ip", e.Lease.IP)
+	return r.igwMgr.DetachIGW(ctx, e.VPCID)
+}
+
+// runLeaseReaper sweeps orphaned leases on a timer until ctx ends. Timing lives
+// here rather than in the manager so the schedule is the caller's to set.
+func runLeaseReaper(ctx context.Context, mgr *dhcp.Manager, interval, startDelay time.Duration) {
+	if mgr == nil {
+		return
+	}
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(startDelay):
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		if _, err := mgr.ReapOrphans(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			slog.Warn("vpcd: dhcp orphan sweep failed", "err", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/spinifex/vpcd/lease_reaper_test.go
+++ b/spinifex/vpcd/lease_reaper_test.go
@@ -1,0 +1,145 @@
+package vpcd
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/network/external/dhcp"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/mock"
+	"github.com/mulgadc/spinifex/spinifex/network/ovn/nbdb"
+	"github.com/mulgadc/spinifex/spinifex/network/topology"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// respondOwnerCheck stands in for the daemon, returning a fixed verdict and
+// recording what it was asked.
+func serveOwnerCheck(t *testing.T, nc *nats.Conn, reply dhcp.OwnerCheckReply) *dhcp.OwnerCheckRequest {
+	t.Helper()
+	seen := &dhcp.OwnerCheckRequest{}
+	sub, err := nc.Subscribe(dhcp.TopicOwnerCheck, func(msg *nats.Msg) {
+		_ = json.Unmarshal(msg.Data, seen)
+		data, _ := json.Marshal(reply)
+		_ = msg.Respond(data)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return seen
+}
+
+func eipLeaseEntry(clientID, ip string) dhcp.Entry {
+	return dhcp.Entry{
+		Purpose: dhcp.PurposeEIP,
+		Lease:   &dhcp.Lease{ClientID: clientID, IP: net.ParseIP(ip)},
+	}
+}
+
+func TestLeaseOwnerResolverReportsGone(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	seen := serveOwnerCheck(t, nc, dhcp.OwnerCheckReply{Status: dhcp.OwnerStatusGone})
+
+	resolver := &leaseOwnerResolver{nc: nc}
+	status, err := resolver.Status(context.Background(), eipLeaseEntry("eipalloc-1", "192.168.1.5"))
+	require.NoError(t, err)
+	assert.Equal(t, dhcp.OwnerGone, status)
+	assert.Equal(t, "eipalloc-1", seen.ClientID)
+	assert.Equal(t, dhcp.PurposeEIP, seen.Purpose)
+}
+
+func TestLeaseOwnerResolverReportsAlive(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	serveOwnerCheck(t, nc, dhcp.OwnerCheckReply{Status: dhcp.OwnerStatusAlive})
+
+	resolver := &leaseOwnerResolver{nc: nc}
+	status, err := resolver.Status(context.Background(), eipLeaseEntry("eipalloc-1", "192.168.1.5"))
+	require.NoError(t, err)
+	assert.Equal(t, dhcp.OwnerAlive, status)
+}
+
+// No responder must read as unknown, never as gone: an unreachable daemon would
+// otherwise release every address the cluster holds.
+func TestLeaseOwnerResolverUnansweredIsUnknown(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+
+	resolver := &leaseOwnerResolver{nc: nc}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	status, err := resolver.Status(ctx, eipLeaseEntry("eipalloc-1", "192.168.1.5"))
+	require.Error(t, err)
+	assert.Equal(t, dhcp.OwnerUnknown, status)
+}
+
+// A responder that reports a lookup failure alongside a status must not be read
+// as a verdict.
+func TestLeaseOwnerResolverSurfacesResponderError(t *testing.T) {
+	_, nc, _ := testutil.StartTestJetStream(t)
+	serveOwnerCheck(t, nc, dhcp.OwnerCheckReply{Status: dhcp.OwnerStatusUnknown, Error: "KV timeout"})
+
+	resolver := &leaseOwnerResolver{nc: nc}
+	status, err := resolver.Status(context.Background(), eipLeaseEntry("eipalloc-1", "192.168.1.5"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KV timeout")
+	assert.Equal(t, dhcp.OwnerUnknown, status)
+}
+
+func TestLeaseOwnerResolverRejectsNilLease(t *testing.T) {
+	resolver := &leaseOwnerResolver{}
+	status, err := resolver.Status(context.Background(), dhcp.Entry{Purpose: dhcp.PurposeEIP})
+	require.Error(t, err)
+	assert.Equal(t, dhcp.OwnerUnknown, status)
+}
+
+// A gateway lease configured a router port, so the port goes before the address
+// does — otherwise OVN keeps answering ARP for an address back in the pool.
+func TestLeaseOwnerResolverDiscardDetachesGateway(t *testing.T) {
+	m := mock.New()
+	require.NoError(t, m.CreateLogicalRouter(context.Background(), &nbdb.LogicalRouter{
+		Name:        topology.VPCRouter("vpc-1"),
+		ExternalIDs: map[string]string{"spinifex:vpc_id": "vpc-1", "spinifex:cidr": "172.31.0.0/16"},
+	}))
+	require.NoError(t, m.CreateLogicalRouterPort(context.Background(), topology.VPCRouter("vpc-1"), &nbdb.LogicalRouterPort{
+		Name:     topology.GatewayRouterPort("vpc-1"),
+		Networks: []string{"192.168.1.150/23"},
+	}))
+
+	resolver := &leaseOwnerResolver{igwMgr: newHookIGWManager(t, m)}
+	entry := gwLeaseEntry(dhcp.PurposeGatewayLRP, "vpc-1", "dhcp-gw-lrp-vpc-1", "192.168.1.150")
+	require.NoError(t, resolver.Discard(context.Background(), entry))
+
+	_, err := m.GetLogicalRouterPort(context.Background(), topology.GatewayRouterPort("vpc-1"))
+	require.Error(t, err, "the orphaned gateway port must be gone before the address is released")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// An EIP or ENI-public address has no datapath of its own left to remove: it
+// went with the record that named it.
+func TestLeaseOwnerResolverDiscardIsNoOpForNonGateway(t *testing.T) {
+	resolver := &leaseOwnerResolver{}
+	require.NoError(t, resolver.Discard(context.Background(), eipLeaseEntry("eipalloc-1", "192.168.1.5")))
+}
+
+func TestLeaseOwnerResolverDiscardRejectsGatewayWithoutVPC(t *testing.T) {
+	resolver := &leaseOwnerResolver{igwMgr: newHookIGWManager(t, mock.New())}
+	entry := gwLeaseEntry(dhcp.PurposeGatewayLRP, "", "dhcp-gw-lrp-vpc-1", "192.168.1.150")
+	require.Error(t, resolver.Discard(context.Background(), entry))
+}
+
+func TestRunLeaseReaperStopsWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runLeaseReaper(ctx, nil, time.Millisecond, time.Millisecond)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reaper did not stop when its context ended")
+	}
+}

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -602,6 +602,12 @@ func launchService(cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("construct IGW manager: %w", err)
 	}
+	// The lease loop can land on a different address after a NAK or an expiry.
+	// Registered here rather than at manager construction because the IGW
+	// manager that owns the gateway datapath does not exist until now.
+	if dhcpMgr != nil {
+		dhcpMgr.SetIPChangeHook(leaseIPChangeHook(igwMgr))
+	}
 	eipMgr, err := external.NewEIPManager(natMgr, waitForFlowsHV)
 	if err != nil {
 		return fmt.Errorf("construct EIP manager: %w", err)
@@ -765,6 +771,28 @@ func startDHCPManagerIfNeeded(ctx context.Context, nc *nats.Conn, js jetstream.J
 	}
 	slog.Info("vpcd: dhcp manager started", "az", cfg.AZ, "subscriptions", len(subs))
 	return mgr, subs, nil
+}
+
+// leaseIPChangeHook rebinds the datapath when a lease is re-issued on a new
+// address. Only gateway-LRP leases are handled here: their address is internal
+// transit plumbing vpcd owns outright. EIP, ENI-public and NATGW addresses are
+// API-visible resources whose records live outside vpcd, so those are reported
+// instead of silently repointed.
+func leaseIPChangeHook(igwMgr external.IGWManager) dhcp.IPChangeHook {
+	return func(ctx context.Context, e dhcp.Entry, oldIP net.IP) error {
+		if e.Lease == nil {
+			return errors.New("lease ip change: nil lease")
+		}
+		if e.Purpose != dhcp.PurposeGatewayLRP {
+			return fmt.Errorf("no rebind handler for %q lease %s: address moved %s -> %s and the resource record still names %s",
+				e.Purpose, e.Lease.ClientID, oldIP, e.Lease.IP, oldIP)
+		}
+		if e.VPCID == "" {
+			return fmt.Errorf("gw-lrp lease %s carries no vpc_id; cannot rebind", e.Lease.ClientID)
+		}
+		prefixLen, _ := e.Lease.SubnetMask.Size()
+		return igwMgr.RebindGatewayIP(ctx, e.VPCID, e.Lease.IP.String(), prefixLen)
+	}
 }
 
 // pickGatewayAllocator returns a DHCPGatewayLRPAllocator for DHCP-sourced pools; otherwise StaticRangeAllocator.

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -608,6 +608,10 @@ func launchService(cfg *Config) error {
 	// manager that owns the gateway datapath does not exist until now.
 	if dhcpMgr != nil {
 		dhcpMgr.SetIPChangeHook(leaseIPChangeHook(igwMgr, nc))
+		// Nothing else returns an address whose resource was deleted out from
+		// under its lease, so the sweep runs for the life of the daemon.
+		dhcpMgr.SetLeaseOwner(&leaseOwnerResolver{nc: nc, igwMgr: igwMgr})
+		go runLeaseReaper(ctx, dhcpMgr, leaseReapInterval, leaseReapStartDelay)
 	}
 	eipMgr, err := external.NewEIPManager(natMgr, waitForFlowsHV)
 	if err != nil {

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -2,6 +2,7 @@ package vpcd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -606,7 +607,7 @@ func launchService(cfg *Config) error {
 	// Registered here rather than at manager construction because the IGW
 	// manager that owns the gateway datapath does not exist until now.
 	if dhcpMgr != nil {
-		dhcpMgr.SetIPChangeHook(leaseIPChangeHook(igwMgr))
+		dhcpMgr.SetIPChangeHook(leaseIPChangeHook(igwMgr, nc))
 	}
 	eipMgr, err := external.NewEIPManager(natMgr, waitForFlowsHV)
 	if err != nil {
@@ -773,26 +774,74 @@ func startDHCPManagerIfNeeded(ctx context.Context, nc *nats.Conn, js jetstream.J
 	return mgr, subs, nil
 }
 
-// leaseIPChangeHook rebinds the datapath when a lease is re-issued on a new
-// address. Only gateway-LRP leases are handled here: their address is internal
-// transit plumbing vpcd owns outright. EIP, ENI-public and NATGW addresses are
-// API-visible resources whose records live outside vpcd, so those are reported
-// instead of silently repointed.
-func leaseIPChangeHook(igwMgr external.IGWManager) dhcp.IPChangeHook {
+// leaseRecordRebindTimeout bounds the daemon-side record reconcile. Larger than
+// the daemon's own budget so its error text wins over a deadline from here.
+const leaseRecordRebindTimeout = 75 * time.Second
+
+// leaseIPChangeHook rebinds whatever was bound to a lease's old address after it
+// moved. Gateway-LRP leases are internal transit plumbing vpcd owns outright, so
+// they are rebound in-process. EIP and ENI-public addresses are API-visible and
+// their records live daemon-side, so those go over TopicLeaseChanged.
+func leaseIPChangeHook(igwMgr external.IGWManager, nc *nats.Conn) dhcp.IPChangeHook {
 	return func(ctx context.Context, e dhcp.Entry, oldIP net.IP) error {
 		if e.Lease == nil {
 			return errors.New("lease ip change: nil lease")
 		}
-		if e.Purpose != dhcp.PurposeGatewayLRP {
-			return fmt.Errorf("no rebind handler for %q lease %s: address moved %s -> %s and the resource record still names %s",
-				e.Purpose, e.Lease.ClientID, oldIP, e.Lease.IP, oldIP)
+		if e.Purpose == dhcp.PurposeGatewayLRP {
+			if e.VPCID == "" {
+				return fmt.Errorf("gw-lrp lease %s carries no vpc_id; cannot rebind", e.Lease.ClientID)
+			}
+			prefixLen, _ := e.Lease.SubnetMask.Size()
+			return igwMgr.RebindGatewayIP(ctx, e.VPCID, e.Lease.IP.String(), prefixLen)
 		}
-		if e.VPCID == "" {
-			return fmt.Errorf("gw-lrp lease %s carries no vpc_id; cannot rebind", e.Lease.ClientID)
-		}
-		prefixLen, _ := e.Lease.SubnetMask.Size()
-		return igwMgr.RebindGatewayIP(ctx, e.VPCID, e.Lease.IP.String(), prefixLen)
+		return requestLeaseRecordRebind(ctx, nc, e, oldIP)
 	}
+}
+
+// requestLeaseRecordRebind asks the daemon to move the resource record naming
+// the old address. The old address is already released, so a failed or
+// unanswered request means an API-visible record advertises an address nothing
+// holds — it is returned so the manager logs it against the lease.
+func requestLeaseRecordRebind(ctx context.Context, nc *nats.Conn, e dhcp.Entry, oldIP net.IP) error {
+	if nc == nil {
+		return fmt.Errorf("no NATS connection to rebind %q lease %s (%s -> %s)",
+			e.Purpose, e.Lease.ClientID, oldIP, e.Lease.IP)
+	}
+	payload, err := json.Marshal(dhcp.LeaseChangedRequest{
+		ClientID: e.Lease.ClientID,
+		Purpose:  e.Purpose,
+		PoolName: e.PoolName,
+		VPCID:    e.VPCID,
+		OldIP:    ipString(oldIP),
+		NewIP:    ipString(e.Lease.IP),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal lease-changed request for %s: %w", e.Lease.ClientID, err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, leaseRecordRebindTimeout)
+	defer cancel()
+	msg, err := nc.RequestWithContext(reqCtx, dhcp.TopicLeaseChanged, payload)
+	if err != nil {
+		return fmt.Errorf("request rebind of %q lease %s (%s -> %s): %w",
+			e.Purpose, e.Lease.ClientID, oldIP, e.Lease.IP, err)
+	}
+	var reply dhcp.LeaseChangedReply
+	if err := json.Unmarshal(msg.Data, &reply); err != nil {
+		return fmt.Errorf("decode rebind reply for %s: %w", e.Lease.ClientID, err)
+	}
+	if reply.Error != "" {
+		return fmt.Errorf("rebind of %q lease %s rejected: %s", e.Purpose, e.Lease.ClientID, reply.Error)
+	}
+	return nil
+}
+
+// ipString renders an IP for the wire, tolerating nil.
+func ipString(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
 }
 
 // pickGatewayAllocator returns a DHCPGatewayLRPAllocator for DHCP-sourced pools; otherwise StaticRangeAllocator.

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -744,9 +744,13 @@ func startDHCPManagerIfNeeded(ctx context.Context, nc *nats.Conn, js jetstream.J
 	if err != nil {
 		return nil, nil, fmt.Errorf("create dhcp lease store: %w", err)
 	}
+	// Labels option 12 with this host so the upstream lease table groups by the
+	// node that took each lease.
+	nodeName, _ := os.Hostname()
 	mgr, err := dhcp.NewManager(dhcp.ManagerConfig{
-		Client: dhcp.NewNClient4(0),
-		Store:  store,
+		Client:   dhcp.NewNClient4(0),
+		Store:    store,
+		NodeName: nodeName,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("create dhcp manager: %w", err)

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -612,6 +612,9 @@ func launchService(cfg *Config) error {
 		// under its lease, so the sweep runs for the life of the daemon.
 		dhcpMgr.SetLeaseOwner(&leaseOwnerResolver{nc: nc, igwMgr: igwMgr})
 		go runLeaseReaper(ctx, dhcpMgr, leaseReapInterval, leaseReapStartDelay)
+		// Leases and gateway ports can already disagree by the time this vpcd
+		// starts, and no lease event will ever fire to correct them.
+		reconcileGatewayLeases(ctx, dhcpMgr, igwMgr)
 	}
 	eipMgr, err := external.NewEIPManager(natMgr, waitForFlowsHV)
 	if err != nil {


### PR DESCRIPTION
Nine related leaks in the external DHCP pool, each of which permanently burns an upstream address. They all end the same way: an address stays leased on the upstream server with nothing in Spinifex renewing or releasing it, so the pool shrinks every time. The last five were found by live-verifying the first four on env12.

Fixes mulga-jbmim, mulga-nwiac, mulga-2tp7i, mulga-mwdrn, mulga-j19gj, mulga-9exe6, mulga-7qyzj, mulga-575zd, mulga-655iu, mulga-eygsz.

## Release stranded leases, label them with the owning node (`980977d1`, mulga-jbmim)

A lease whose owner is gone was left held. Releases now go out for stale entries, and each lease records the node holding it so a drain knows what is its own.

## Rebind the datapath when a lease moves (`290dec60`, mulga-nwiac)

A renew NAK, a rebind NAK, then expiry sends the client back through DORA, and the server is free to answer with a different address. `AttachIGW` set the gateway LRP address once and never revisited it, so the old address stayed on the router with no renewer and no release while the new one was renewed forever attached to nothing. One address lost per cycle.

The DHCP manager now detects an IP change on any lease refresh, releases the superseded address, and calls an `IPChangeHook` to move whatever was configured from the old lease. For a `gw-lrp` lease that is `IGWManager.RebindGatewayIP`, which moves the LRP address, re-stamps the external-ID, and re-runs the routed leg. A failed rebind logs loudly but does not drop the new lease — dropping it would strand both addresses.

This also closes an RFC 2131 violation: the router was forwarding on an address the server had NAKed.

## Reconcile API-visible records when a lease moves (`8225a8e4`, mulga-2tp7i)

EIP and ENI-public addresses are the same problem one layer up, but their records live daemon-side, so an in-vpcd rebind would only be half a fix — `DescribeAddresses` would keep reporting an address vpcd had released. vpcd now requests a reconcile over `vpc.dhcp.lease-changed`; the daemon moves the record and commits the replacement NAT.

The NAT is committed before the record is written, so a NAT failure never leaves a record advertising an address that does not route. `policy.AddEIP` already scrubs the predecessor `dnat_and_snat` keyed on logical IP, so one `vpc.add-nat` is enough — no delete event is needed.

## Dedupe retried AllocateAddress (`fb008037`, mulga-mwdrn)

EC2 `AllocateAddress` carries no ClientToken, and the acquire backoff ladder (~62s) outlasts the botocore default 60s read timeout, so the client retried a call that had in fact succeeded. Each retry minted a fresh allocation ID and took another lease; the caller kept one EIP and the rest were held by nobody. Observed live on env12: one CLI invocation, three allocation IDs, two addresses.

Retries are now keyed on the SDK's `amz-sdk-invocation-id`, which is stable across attempts of one call. The gateway lifts it off the request, `NATSRequest` forwards it as a header, and the daemon restores it to the context, so the EIP service sees the same token on every attempt. `singleflight` joins a retry to the call still in flight — the usual case, since the retry fires while DORA is still running — and a 30-minute TTL'd KV bucket answers retries that arrive after the first call finished. Callers that send no token behave exactly as before.


## Re-acquire an expired lease at startup (`eddf9e76`, mulga-j19gj)

`Manager.Start` deleted a lease that had aged out while vpcd was down. Whatever was configured from it — a gateway LRP, an EIP NAT — kept the address, so the datapath forwarded on an address nothing renewed and nothing had released. The entry is now kept and the loop re-DORAs on its first pass, with the IP-change hook rebinding from there; the reaffirm RENEW is skipped, since the server has already aged the lease out and the attempt would only delay the re-DORA.

## Reap leases whose owning resource is gone (`eddf9e76`, mulga-9exe6)

Nothing swept a lease after its EIP, ENI or VPC record was deleted, so it was renewed forever. The manager now takes a `LeaseOwner`, and vpcd sweeps every 10 minutes (first pass 2 minutes after start) over `vpc.dhcp.owner-check`, which the daemon answers from the record buckets: `AllocationExists`, `ENIExists`, `VPCExists`.

Every inconclusive answer is `unknown`, never `gone` — a KV timeout must not release a live address. On a `gone`, the datapath is torn down first (`DetachIGW` for a `gw-lrp`) and only then is the address released, so the server never re-offers an address a router port still answers ARP for. Any failure keeps the lease.

## Bring the acquire ladder inside botocore's read timeout (`eddf9e76`, mulga-7qyzj)

The `amz-sdk-invocation-id` dedupe is inert for botocore and aws-cli v2, which send no such header — confirmed with `aws --debug`. A body-hash window was rejected instead: two deliberate back-to-back `AllocateAddress` calls are byte-identical, and real AWS allocates twice.

The remaining lever is time. The per-attempt ladder is now 4/8/12/16s with a 45s wall-clock budget and a 50s RPC timeout, so the daemon answers before botocore's 60s read timeout fires and the retry never happens. Four attempts still ride out STP convergence on a freshly-up bridge. The reaper is the backstop for anything that slips through.

## Reconcile gateway ports onto their lease address at startup (`6946760c`, mulga-575zd)

A gateway LRP configured from a static pool keeps its address when the pool is switched to `source = "dhcp"`, so the VPC forwards on an address nothing leases while the lease it holds goes unused — two addresses lost per VPC, with no lease event to correct it, since the leases are healthy and renewing. vpcd now sweeps every `gw-lrp` lease at startup and rebinds the port to the address the lease actually holds. `RebindGatewayIP` is idempotent, so a port already in agreement costs one OVSDB read.

## Show held leases in the CLI (`ee195e97`, mulga-655iu)

`spx get dhcp-leases` lists every per-AZ lease bucket with the resource each lease was taken for and whether that resource still exists. `--orphans` filters to leases whose owner is gone; `--skip-owner-check` skips the lookup. Buckets are enumerated rather than derived from config, so an AZ that has left the local config still shows what it is holding.

## Make the outcome of a stale release observable (`7cf97158`)

A stale RELEASE was logged only when the transport failed, so a lease with no raw offer/ack was skipped in silence and a RELEASE the server ignored looked identical to one it honoured. The skip now warns, and a successful release logs the chaddr it used — the field a server matches a RELEASE against. Found when `192.168.1.136` stayed bound upstream on env12 after a verification tool rewrote a record's chaddr in place: the release did go out, with the new chaddr, and the server dropped it without a trace on either side.

`8347986d` closes the underlying gap (mulga-eygsz): the RELEASE chaddr now comes from the lease record rather than being re-resolved live. Only a `UseIfaceMAC` lease whose interface MAC changed after acquire could diverge, and nothing sets that flag today — chaddr is `HashMAC(client-id)` and lives in the KV record, so the normal re-DORA and restart paths were never affected.

## Testing

`GOWORK=off make preflight` passes. New unit coverage:

- `dhcp/manager_test.go` — renew onto a new IP releases the old and fires the hook; same IP does neither; the lease survives a failing hook; the old address is released even with no hook registered.
- `network/external/igw_test.go` — `RebindGatewayIP` moves the LRP and the stamp, is idempotent, moves the SNAT in routed mode, errors on a missing LRP, rejects bad arguments.
- `vpcd/lease_ip_change_test.go` — gateway leases rebind locally, other purposes go out over NATS, a rejection is surfaced, a missing responder errors, a gateway lease with no VPC is refused.
- `eip/lease_rebind_test.go`, `vpc/eni_lease_rebind_test.go` — record moves, idempotency, mismatched and unknown inputs.
- `eip/allocate_idempotency_test.go` — a repeated token returns the first allocation and leaves one address held; different tokens and different accounts allocate separately; no token behaves as today; concurrent retries collapse to one allocation; a failure is not cached; a missing bucket still allocates.
- `utils/idempotency_test.go` — the token survives the NATS hop, and an absent token leaves the header unset.
- `dhcp/reaper_test.go` — a gone owner is discarded then released; alive, lookup-error, unknown and failed-discard all keep the lease; no resolver is a no-op.
- `dhcp/acquire_budget_internal_test.go` — the ladder including jitter, the wall-clock budget and the RPC timeout all sit under 60s, and the RPC timeout stays above the budget so the client reports its own error.
- `dhcp/manager_test.go` — an expired lease at startup is re-acquired rather than dropped, the stale address is released after the new one lands, a re-acquire onto the same IP releases nothing, and a failed stale release keeps the new lease.
- `vpcd/lease_reaper_test.go` — no responder and a responder error both read as unknown; a gateway discard removes the LRP; other purposes discard nothing; the sweep stops with its context.
- `vpcd/lease_datapath_reconcile_test.go` — a drifted port moves and is re-stamped, a matching port is untouched, other purposes are ignored, and the sweep continues past a failing VPC.
- `daemon/daemon_dhcp_lease_test.go` — owner-check and lease-changed round-trips over NATS; every branch that cannot prove a deletion reports unknown.
- `eip/lease_owner_test.go`, `vpc/lease_owner_test.go` — existence lookups treat a listing failure as an error, not a false.
- `cmd/spinifex/cmd/get_dhcp_leases_test.go` — buckets are enumerated across AZs and sorted, and an unreachable or unparseable owner check reads as unknown.
- `dhcp/manager_test.go` — a stale release with no raw packets warns and releases nothing; a release that goes out logs its chaddr.
- `dhcp/nclient4_internal_test.go` — the RELEASE chaddr is the lease's own even when the interface MAC would resolve differently, and an absent or all-zero one is still repaired.

## Notes for review

`RebindGatewayIP` returning an error on a missing LRP is deliberate, not a no-op: a `gw-lrp` lease only exists because `AttachIGW` allocated one, so an absent port means either an unreachable OVSDB or a detach that kept the lease. Both leave an address held with no owner.

The reaper's `Discard` runs before the release, not after: releasing while a router port still answers ARP for the address invites a duplicate-IP conflict as soon as the server hands it out again.

## Live verification on env12

Deployed `v1.14.0-16-gfb008037` to env12 (single node, bottlebrush) and flipped its external pool from `source = "static"` to `source = "dhcp"` on `br-wan` so leases came from the real upstream server.

**mulga-mwdrn** — `AllocateAddress` calls pinned to one `amz-sdk-invocation-id`:

| case | result |
|---|---|
| two serial calls | both returned `eipalloc-8cee841af0ee7a5b5` / `192.168.1.141`; one address held |
| three concurrent calls | all returned `eipalloc-4b4799fdbb9a80a06` / `192.168.1.140` (singleflight join) |
| different id | separate allocation, as it must |

Four `returning first result for a retried request` lines in the daemon log, no second lease.

**mulga-nwiac and mulga-2tp7i** — forced a real renew-refusal, expiry and re-DORA by rewriting one lease record with a fresh chaddr and elapsed T1/T2:

```
lease IP changed mid-life; rebinding datapath  client_id=dhcp-gw-lrp-vpc-3aff7c9f006dda6a7 purpose=gw-lrp old_ip=192.168.1.141 new_ip=192.168.1.135
lease IP changed mid-life; rebinding datapath  client_id=eipalloc-d4dab53e39d320a01        purpose=eip    old_ip=192.168.1.139 new_ip=192.168.1.134
```

The datapath followed both:

```
gw-vpc-3aff7c9f006dda6a7  ["192.168.1.135/23"]  spinifex:gateway_ip=192.168.1.135
eipalloc-d4dab53e39d320a01  192.168.1.134    (DescribeAddresses)
```

**Release path** — released `192.168.1.141`, and an IGW attach two minutes later was handed the same address back by the upstream server, so the RELEASE genuinely reached it.

### Second round: `v1.14.0-20-g989ed9a0`

**mulga-575zd** — both live VPCs had drifted after the pool was flipped to DHCP. The startup reconcile healed them:

```
external: gateway LRP rebound after DHCP lease moved  vpc_id=vpc-24fbfbc5512ccd984  old_networks=["192.168.1.240/23"]  new_network="192.168.1.150/23"
external: gateway LRP rebound after DHCP lease moved  vpc_id=vpc-9f77460b73c3b9d53  old_networks=["192.168.1.239/23"]  new_network="192.168.1.145/23"
```

Both ports and their `spinifex:gateway_ip` stamps now match the held leases.

**mulga-j19gj** — stopped vpcd, aged a `gw-lrp` lease out with a fresh chaddr, started vpcd:

```
dhcp manager: lease expired while stopped; re-acquiring   client_id=dhcp-gw-lrp-vpc-a22d6f9d21e958b24 ip=192.168.1.136
dhcp manager: lease IP changed mid-life; rebinding datapath  old_ip=192.168.1.136 new_ip=192.168.1.138
external: gateway LRP rebound after DHCP lease moved      new_network="192.168.1.138/23"
```

The lease was re-acquired instead of dropped, and the port followed it.

**mulga-9exe6** — produced a genuine orphan through the public API rather than by editing state: with vpcd stopped, `delete-vpc` removed the record while the `gw-lrp` lease stayed held on `192.168.1.138`. On start, `spx get dhcp-leases` showed `OWNER=gone`, and the first sweep cleared it:

```
dhcp reaper: released lease whose owner is gone  client_id=dhcp-gw-lrp-vpc-a22d6f9d21e958b24 purpose=gw-lrp ip=192.168.1.138
dhcp reaper: swept orphaned leases  released=1 total=3
```

The gateway LRP was torn down before the release, and the two healthy leases were left alone. Test VPC and IGW cleaned up afterwards; env12 is back to its two legitimate leases with matching ports.

## Known limitation

The retry dedupe keys on `amz-sdk-invocation-id`, which only the AWS SDK v2 generation sends (Go v2, Java v2, JS v3, Rust). **botocore and aws-cli v2 send no such header**, confirmed with `aws --debug` on env12, and EC2 `AllocateAddress` has no ClientToken for them to use instead. Those callers are covered indirectly: the acquire ladder now finishes inside their 60s read timeout, so the retry never fires, and the reaper releases any duplicate that still gets through.

## Correction to an earlier claim

An earlier revision of this description called `192.168.1.150` / `vpc-24fbfbc5512ccd984` an orphaned lease. It is not: the VPC is alive in the system account (`000000000000`), which the account-scoped `describe-vpcs` used at the time did not show. The real fault was address drift — the port was on `192.168.1.240` while the lease held `.150` — which is mulga-575zd above.
