### PR TITLE
feat: schedule RDS automated backups and sweep them past retention

### DIFF
--- a/spinifex/config/config.go
+++ b/spinifex/config/config.go
@@ -175,6 +175,24 @@ type RDSConfig struct {
 	// passes to agree; raise it to give EC2's own VM auto-restart more room
 	// before a customer sees the instance reported as failed.
 	FailureGraceSeconds int `json:"FailureGraceSeconds" mapstructure:"failure_grace_seconds"`
+
+	// The upper bound on a DB instance's BackupRetentionPeriod, and what a create
+	// that names none gets. Zero takes the built-in 7 for both. Retention length
+	// does not change the physical footprint of a backed-up volume — any snapshot
+	// latches viperblock chunk GC off for the life of the volume — so a short
+	// retention buys nothing but a smaller restore surface.
+	BackupRetentionCapDays int `json:"BackupRetentionCapDays" mapstructure:"backup_retention_cap_days"`
+	BackupRetentionDays    int `json:"BackupRetentionDays" mapstructure:"backup_retention_days"`
+
+	// The daily UTC blocks an unnamed backup or maintenance window is assigned
+	// inside, as hh24:mi-hh24:mi. They must not overlap: the windows derived from
+	// them must not either. Empty takes the built-in 03:00-11:00 and 11:00-19:00.
+	BackupWindowBlock      string `json:"BackupWindowBlock" mapstructure:"backup_window_block"`
+	MaintenanceWindowBlock string `json:"MaintenanceWindowBlock" mapstructure:"maintenance_window_block"`
+
+	// How many automated snapshots one retention pass may delete. Zero takes the
+	// built-in bound; a pass that under-collects is corrected two minutes later.
+	BackupSweepDeleteLimit int `json:"BackupSweepDeleteLimit" mapstructure:"backup_sweep_delete_limit"`
 }
 
 // RDSDefaultSystemVPCSupernet anchors the RDS system VPC address space at

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1067,6 +1067,7 @@ func (d *Daemon) subscribeAll() error {
 			natsSub{handlers_rds.SubjectDescribeDBSnapshots, handleNATSRequest(d.rdsService.DescribeDBSnapshots), "spinifex-workers"},
 			natsSub{handlers_rds.SubjectDeleteDBSnapshot, handleNATSRequest(d.rdsService.DeleteDBSnapshot), "spinifex-workers"},
 			natsSub{handlers_rds.SubjectRestoreDBInstanceFromDBSnapshot, handleNATSRequest(d.rdsService.RestoreDBInstanceFromDBSnapshot), "spinifex-workers"},
+			natsSub{handlers_rds.SubjectDescribeDBInstanceAutomatedBackups, handleNATSRequest(d.rdsService.DescribeDBInstanceAutomatedBackups), "spinifex-workers"},
 			natsSub{handlers_rds.SubjectDescribeEvents, handleNATSRequest(d.rdsService.DescribeEvents), "spinifex-workers"},
 			natsSub{handlers_rds.SubjectAddTagsToResource, handleNATSRequest(d.rdsService.AddTagsToResource), "spinifex-workers"},
 			natsSub{handlers_rds.SubjectRemoveTagsFromResource, handleNATSRequest(d.rdsService.RemoveTagsFromResource), "spinifex-workers"},
@@ -1743,7 +1744,15 @@ func (d *Daemon) startCluster() error {
 			reapers = append(reapers, d.eksService.NewBillableReaper(d.nodeRunningVMs))
 			reapers = append(reapers, d.eksService.NewDeletingReaper())
 		}
-		gc := vm.NewGarbageCollector(d.jsManager.KVHealthy, reapers...)
+		// The RDS automated-backup retention sweep is the one reaper here that
+		// deletes customer data, which is why it rides this backstop rather than the
+		// RDS reconciler: the KV-health gate above is what stops it reaping against a
+		// desired state it cannot read.
+		if d.rdsService != nil {
+			reapers = append(reapers, d.rdsService.NewBackupRetentionReaper())
+		}
+		gc := vm.NewGarbageCollector(d.jsManager.KVHealthy, reapers...).
+			WithLeaderElection(d.clusterSweepLease)
 		gc.Start(d.ctx)
 	}
 
@@ -1755,6 +1764,17 @@ func (d *Daemon) startCluster() error {
 	d.awaitShutdown()
 
 	return nil
+}
+
+// clusterSweepLease gates the GC's cluster-wide reapers so exactly one node runs
+// them. The RDS reconciler's lease is that election — cluster-singular, held
+// continuously, and re-evaluated on its own ticker — so being its holder is the
+// whole answer. Without it every ClusterWide reaper is skipped outright.
+func (d *Daemon) clusterSweepLease() (func(), bool) {
+	if d.rdsReconciler == nil {
+		return func() {}, false
+	}
+	return d.rdsReconciler.AcquireClusterLease()
 }
 
 // leakedVolumeInstances returns the set of instance IDs this node owns whose

--- a/spinifex/daemon/rds_deps.go
+++ b/spinifex/daemon/rds_deps.go
@@ -66,6 +66,13 @@ func (d *Daemon) buildRDSDeps() handlers_rds.Deps {
 		GatewayCACert:    gatewayCA,
 		BootstrapTimeout: time.Duration(d.config.RDS.BootstrapTimeoutSeconds) * time.Second,
 		FailureGrace:     time.Duration(d.config.RDS.FailureGraceSeconds) * time.Second,
+		Backup: handlers_rds.BackupPolicy{
+			RetentionCapDays:       int64(d.config.RDS.BackupRetentionCapDays),
+			RetentionDays:          int64(d.config.RDS.BackupRetentionDays),
+			BackupWindowBlock:      d.config.RDS.BackupWindowBlock,
+			MaintenanceWindowBlock: d.config.RDS.MaintenanceWindowBlock,
+			SweepDeleteLimit:       d.config.RDS.BackupSweepDeleteLimit,
+		},
 	}
 }
 

--- a/spinifex/gateway/rds/handler.go
+++ b/spinifex/gateway/rds/handler.go
@@ -56,12 +56,6 @@ func typed[In any](handler func(context.Context, *In, *nats.Conn, Caller) (any, 
 	}
 }
 
-// An action whose body lands in a later phase: the caller learns it is
-// recognised and simply not ready — never a silent success.
-func pending() Handler {
-	return rejectWith(awserrors.ErrorNotImplemented)
-}
-
 // Recognised but deliberately outside v1, so a client sees "not offered" rather
 // than "you typo'd the action name".
 func unsupported() Handler {
@@ -75,8 +69,8 @@ func rejectWith(code string) Handler {
 	}
 }
 
-// The whole namespace is registered from day one, not-yet-built actions as
-// explicit stubs, so an unimplemented action stays distinct from an unknown one.
+// The whole namespace is registered from day one, so an action outside v1 stays
+// distinct from an unknown one.
 var actions = map[string]Handler{
 	// Instance lifecycle.
 	"CreateDBInstance":    typed(CreateDBInstance),
@@ -94,7 +88,7 @@ var actions = map[string]Handler{
 	"RestoreDBInstanceFromDBSnapshot": typed(RestoreDBInstanceFromDBSnapshot),
 
 	// Automated backups.
-	"DescribeDBInstanceAutomatedBackups": pending(),
+	"DescribeDBInstanceAutomatedBackups": typed(DescribeDBInstanceAutomatedBackups),
 
 	// Subnet groups.
 	"CreateDBSubnetGroup":    typed(CreateDBSubnetGroup),

--- a/spinifex/gateway/rds/handler_test.go
+++ b/spinifex/gateway/rds/handler_test.go
@@ -115,6 +115,7 @@ var liveActions = []string{
 	"DescribeDBParameters", "DeleteDBParameterGroup",
 	"CreateDBSnapshot", "DescribeDBSnapshots", "DeleteDBSnapshot",
 	"RestoreDBInstanceFromDBSnapshot",
+	"DescribeDBInstanceAutomatedBackups",
 }
 
 // What is under test in this file is the action table and the XML envelope, not
@@ -152,6 +153,8 @@ func newStubbedNATS(t *testing.T) *nats.Conn {
 	respondWith(t, nc, handlers_rds.SubjectDeleteDBSnapshot, &rds.DeleteDBSnapshotOutput{})
 	respondWith(t, nc, handlers_rds.SubjectRestoreDBInstanceFromDBSnapshot,
 		&rds.RestoreDBInstanceFromDBSnapshotOutput{DBInstance: &rds.DBInstance{DBInstanceIdentifier: aws.String("orders-db-restored")}})
+	respondWith(t, nc, handlers_rds.SubjectDescribeDBInstanceAutomatedBackups,
+		&rds.DescribeDBInstanceAutomatedBackupsOutput{})
 	return nc
 }
 
@@ -198,13 +201,6 @@ func TestDispatch_LiveActionsAreNotPending(t *testing.T) {
 		require.NoError(t, err, "action %q", action)
 		assert.Contains(t, string(body), "<"+action+"Result", "action %q", action)
 	}
-}
-
-func TestDispatch_PendingActionIsNotImplemented(t *testing.T) {
-	_, err := Dispatch(t.Context(), "DescribeDBInstanceAutomatedBackups",
-		map[string]string{"Action": "DescribeDBInstanceAutomatedBackups"}, nil, testCaller)
-	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorNotImplemented, err.Error())
 }
 
 func TestDispatch_OutOfScopeActionIsNotSupported(t *testing.T) {

--- a/spinifex/gateway/rds/snapshot.go
+++ b/spinifex/gateway/rds/snapshot.go
@@ -26,3 +26,10 @@ func DeleteDBSnapshot(ctx context.Context, input *rds.DeleteDBSnapshotInput, nc 
 func RestoreDBInstanceFromDBSnapshot(ctx context.Context, input *rds.RestoreDBInstanceFromDBSnapshotInput, nc *nats.Conn, caller Caller) (any, error) {
 	return handlers_rds.NewNATSService(nc).RestoreDBInstanceFromDBSnapshot(ctx, input, caller.AccountID)
 }
+
+// One DBInstanceAutomatedBackup per instance with automated backups. The
+// individual snapshots stay listable through DescribeDBSnapshots with
+// --snapshot-type automated, which is where AWS puts them too.
+func DescribeDBInstanceAutomatedBackups(ctx context.Context, input *rds.DescribeDBInstanceAutomatedBackupsInput, nc *nats.Conn, caller Caller) (any, error) {
+	return handlers_rds.NewNATSService(nc).DescribeDBInstanceAutomatedBackups(ctx, input, caller.AccountID)
+}

--- a/spinifex/handlers/rds/backup.go
+++ b/spinifex/handlers/rds/backup.go
@@ -1,0 +1,518 @@
+package handlers_rds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Automated backups (D11 Phase A): one snapshot per instance per day inside its
+// backup window, taken through rds-8's snapshot path and swept past
+// BackupRetentionPeriod. PITR, WAL archiving and LatestRestorableTime are Phase B
+// and stay unreported, so nothing here implies continuous recovery.
+
+const (
+	// AWS's own bound is 35 days; this platform's is 7 (D11 Phase A). The cost of
+	// a retained snapshot here is metadata and restore surface, not chunks: any
+	// snapshot latches viperblock chunk GC off for the life of the source volume,
+	// so one day and seven pin exactly the same data.
+	defaultBackupRetentionCapDays = 7
+
+	// Automated backups are on by default, at the full cap. A shorter default
+	// would pay the whole storage cost above for a fraction of the coverage.
+	defaultBackupRetentionDays = 7
+
+	// The UTC blocks an unnamed window is assigned inside. Deliberately disjoint:
+	// the two derived windows then cannot overlap, which is the pair AWS refuses
+	// to accept and the pair that would quiesce an engine mid-maintenance.
+	defaultBackupWindowBlock      = "03:00-11:00" //nolint:gosec // a UTC window block, not a credential
+	defaultMaintenanceWindowBlock = "11:00-19:00"
+
+	// How many automated snapshots one retention pass may delete. A pass that
+	// under-collects is corrected by the next one two minutes later; a pass that
+	// walks an unbounded number of snapshots is not.
+	defaultSweepDeleteLimit = 32
+
+	// Automated snapshots own this identifier namespace, as in AWS. A customer
+	// identifier beginning with it is rejected so the two cannot collide.
+	automatedSnapshotPrefix = "rds:"
+	// AWS's own stamp: rds:{db}-{YYYY-MM-DD-HH-MM}.
+	automatedSnapshotTimeLayout = "2006-01-02-15-04"
+
+	// The index key's stamp. Fixed width and UTC, so lexical key order is
+	// chronological order and the sweep needs no per-entry read to sort.
+	automatedBackupKeyLayout = "20060102T150405Z"
+
+	// How long after a failed or skipped backup the next attempt inside the same
+	// window is allowed, doubling per consecutive failure up to eight minutes.
+	// The window is 30 minutes, so this is a handful of attempts and then silence
+	// until the next one — a missed window is never backfilled.
+	automatedBackupRetryBase     = time.Minute
+	automatedBackupRetryShiftCap = 3
+)
+
+// The operator-tunable half of rds-9: bounds and defaults, never a per-instance
+// setting — those live on the DB instance record.
+type BackupPolicy struct {
+	// The upper bound ModifyDBInstance and CreateDBInstance accept. Zero takes
+	// defaultBackupRetentionCapDays.
+	RetentionCapDays int64
+	// What a create that names no BackupRetentionPeriod gets. Zero takes
+	// defaultBackupRetentionDays; a create asking for 0 explicitly still disables
+	// automated backups.
+	RetentionDays int64
+	// The daily UTC blocks unnamed windows are assigned inside, in the same
+	// hh24:mi-hh24:mi form the customer's own window uses. Empty takes the
+	// defaults above.
+	BackupWindowBlock      string
+	MaintenanceWindowBlock string
+	// The per-pass bound on automated-snapshot deletions. Zero takes
+	// defaultSweepDeleteLimit.
+	SweepDeleteLimit int
+}
+
+func (s *Service) retentionCapDays() int64 {
+	if s.deps.Backup.RetentionCapDays > 0 {
+		return s.deps.Backup.RetentionCapDays
+	}
+	return defaultBackupRetentionCapDays
+}
+
+// Clamped to the cap, so lowering the cap on an existing cluster cannot hand new
+// instances a retention the same cluster would reject on modify.
+func (s *Service) defaultRetentionDays() int64 {
+	if s.deps.Backup.RetentionDays > 0 {
+		return min(s.deps.Backup.RetentionDays, s.retentionCapDays())
+	}
+	return min(defaultBackupRetentionDays, s.retentionCapDays())
+}
+
+func (s *Service) sweepDeleteLimit() int {
+	if s.deps.Backup.SweepDeleteLimit > 0 {
+		return s.deps.Backup.SweepDeleteLimit
+	}
+	return defaultSweepDeleteLimit
+}
+
+// A misconfigured block falls back to the built-in one rather than failing every
+// create on the node: the block is an operator setting, and refusing to place a
+// window because of it would take the whole RDS surface down.
+func (s *Service) backupWindowBlock() dailyWindow {
+	return s.windowBlock(s.deps.Backup.BackupWindowBlock, defaultBackupWindowBlock, "backup")
+}
+
+func (s *Service) maintenanceWindowBlock() dailyWindow {
+	return s.windowBlock(s.deps.Backup.MaintenanceWindowBlock, defaultMaintenanceWindowBlock, "maintenance")
+}
+
+func (s *Service) windowBlock(configured, fallback, kind string) dailyWindow {
+	if configured != "" {
+		if block, err := parseDailyWindow("block", configured); err == nil {
+			return block
+		}
+		slog.Warn("rds: the configured "+kind+" window block is malformed; using the built-in block",
+			"block", configured, "fallback", fallback)
+	}
+	block, err := parseDailyWindow("block", fallback)
+	if err != nil {
+		// Unreachable: the fallbacks are constants this package's tests parse.
+		panic("rds: built-in " + kind + " window block is malformed: " + err.Error())
+	}
+	return block
+}
+
+// The window in force for this instance. A record that names one uses it; one
+// that does not — a record written before rds-9, or an instance whose create
+// named neither — takes the deterministic assignment, which is the same value
+// this phase persists at create.
+func (s *Service) resolvedBackupWindow(rec *DBInstanceRecord) (dailyWindow, error) {
+	if rec.PreferredBackupWindow == "" {
+		return assignDailyWindow(s.backupWindowBlock(), rec.DBInstanceIdentifier), nil
+	}
+	return parseDailyWindow("PreferredBackupWindow", rec.PreferredBackupWindow)
+}
+
+func (s *Service) resolvedMaintenanceWindow(rec *DBInstanceRecord) (weeklyWindow, error) {
+	if rec.PreferredMaintenanceWindow == "" {
+		return assignWeeklyWindow(s.maintenanceWindowBlock(), rec.DBInstanceIdentifier), nil
+	}
+	return parseWeeklyWindow("PreferredMaintenanceWindow", rec.PreferredMaintenanceWindow)
+}
+
+// The windows as a describe reports them. A record written before rds-9 carries
+// neither, so the derived window is reported rather than an empty string: it is
+// the window the scheduler will actually use, and reporting nothing would have the
+// customer believe no backup is scheduled.
+func (s *Service) reportedBackupWindow(rec *DBInstanceRecord) string {
+	window, err := s.resolvedBackupWindow(rec)
+	if err != nil {
+		// Malformed and therefore not a window the scheduler will honour either, so
+		// it is reported verbatim rather than replaced with a plausible one.
+		return rec.PreferredBackupWindow
+	}
+	return window.String()
+}
+
+func (s *Service) reportedMaintenanceWindow(rec *DBInstanceRecord) string {
+	window, err := s.resolvedMaintenanceWindow(rec)
+	if err != nil {
+		return rec.PreferredMaintenanceWindow
+	}
+	return window.String()
+}
+
+// The states a backup can be taken from: available needs a quiesce, and stopped
+// was sealed by its own graceful stop and is backed up in place.
+var backupCapableStatuses = []Status{StatusAvailable, StatusStopped}
+
+// Fires this instance's automated backup when its window is open and none has
+// succeeded since the window opened, reporting whether it took one. Called from
+// the leader-elected reconciler pass, which is what makes it cluster-singular;
+// rds-8's per-instance in-flight guard is what makes it safe anyway.
+func (s *Service) runBackupWindow(ctx context.Context, kv jetstream.KeyValue, rev uint64,
+	accountID string, rec *DBInstanceRecord) (bool, error) {
+	now := time.Now().UTC()
+	window, err := s.resolvedBackupWindow(rec)
+	if err != nil {
+		// A stored window this plane cannot parse is corruption, not a schedule:
+		// firing on a guessed window would back up at an hour the customer never
+		// asked for, so the instance is left alone and the fault is logged.
+		slog.WarnContext(ctx, "rds: the stored backup window is malformed; no automated backup will be taken",
+			"dbInstance", rec.DBInstanceIdentifier, "window", rec.PreferredBackupWindow, "err", err)
+		return false, nil
+	}
+	if !s.backupDue(rec, window, now) {
+		return false, nil
+	}
+
+	// Skipped rather than queued: a backup is a point-in-time copy, so one taken
+	// after a reboot finishes is the next window's backup, not this one's.
+	if !slices.Contains(backupCapableStatuses, rec.Status) {
+		return false, s.recordBackupDeferred(ctx, kv, accountID, rec, window.openedAt(now),
+			fmt.Sprintf("The automated backup was skipped because the DB instance is %s.", rec.Status))
+	}
+	if rec.DataVolumeID == "" {
+		return false, s.recordBackupDeferred(ctx, kv, accountID, rec, window.openedAt(now),
+			"The automated backup was skipped because the DB instance has no data volume.")
+	}
+
+	if err := s.takeAutomatedBackup(ctx, kv, rev, accountID, rec, now); err != nil {
+		// D-rds-9: the database is healthy and stays available. The failure is
+		// counted and evented so it is visible, and retried while the window is
+		// open; it never reaches rds-6's recovery ladder.
+		return false, s.recordBackupFailure(ctx, kv, accountID, rec, err)
+	}
+	return true, nil
+}
+
+// Whether the window is open and nothing has already fired in it. Retention 0
+// disables scheduling outright, which is also what makes the sweep remove the
+// instance's whole automated set.
+func (s *Service) backupDue(rec *DBInstanceRecord, window dailyWindow, now time.Time) bool {
+	if rec.BackupRetentionPeriod <= 0 || !window.contains(now) {
+		return false
+	}
+	opened := window.openedAt(now)
+	// The stamp, not a timer: leader churn, a daemon restart, or two nodes briefly
+	// believing they hold the lease all read the same "already fired".
+	if rec.LastAutomatedBackupAt != nil && !rec.LastAutomatedBackupAt.Before(opened) {
+		return false
+	}
+	if rec.LastAutomatedBackupFailureAt != nil && !rec.LastAutomatedBackupFailureAt.Before(opened) {
+		return !now.Before(rec.LastAutomatedBackupFailureAt.Add(backupRetryDelay(rec.AutomatedBackupFailures)))
+	}
+	return true
+}
+
+func backupRetryDelay(failures int) time.Duration {
+	return automatedBackupRetryBase << min(max(failures-1, 0), automatedBackupRetryShiftCap)
+}
+
+// Takes the snapshot through rds-8's path, indexes it, and stamps the window as
+// fired. The index is written before the stamp: an indexed backup with no stamp
+// costs one duplicate snapshot at worst and is swept on schedule, while a stamped
+// backup with no index would be invisible to retention for the life of the
+// instance.
+func (s *Service) takeAutomatedBackup(ctx context.Context, kv jetstream.KeyValue, rev uint64,
+	accountID string, rec *DBInstanceRecord, now time.Time) error {
+	record, err := s.snapshotDBInstance(ctx, kv, rev, accountID, rec, &validatedSnapshot{
+		DBSnapshotIdentifier: AutomatedSnapshotIdentifier(rec.DBInstanceIdentifier, now),
+		DBInstanceIdentifier: rec.DBInstanceIdentifier,
+		SnapshotType:         SnapshotTypeAutomated,
+	})
+	if err != nil {
+		return err
+	}
+
+	entry := AutomatedBackupRecord{
+		DBInstanceIdentifier: rec.DBInstanceIdentifier,
+		DBSnapshotIdentifier: record.DBSnapshotIdentifier,
+		CreatedAt:            record.CreatedAt,
+	}
+	key := AutomatedBackupKey(rec.DBInstanceIdentifier, AutomatedBackupStamp(record.CreatedAt))
+	if err := putJSON(ctx, kv, key, &entry); err != nil {
+		return err
+	}
+
+	return s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
+		stored.LastAutomatedBackupAt = &now
+		stored.AutomatedBackupFailures = 0
+		stored.LastAutomatedBackupFailureAt = nil
+	})
+}
+
+// Counts the failure and reports it against the DB instance, leaving its status
+// alone. The stamp is what paces the retry inside the window; the count is what
+// makes a backup that has been failing for days visible and testable.
+func (s *Service) recordBackupFailure(ctx context.Context, kv jetstream.KeyValue, accountID string,
+	rec *DBInstanceRecord, cause error) error {
+	now := time.Now().UTC()
+	slog.WarnContext(ctx, "rds: an automated backup failed; the DB instance is unaffected",
+		"dbInstance", rec.DBInstanceIdentifier, "accountId", accountID,
+		"failures", rec.AutomatedBackupFailures+1, "err", cause)
+	s.RecordEvent(ctx, accountID, EventSourceTypeDBInstance, rec.DBInstanceIdentifier,
+		fmt.Sprintf("The automated backup could not be taken: %v", cause),
+		EventCategoryBackup, EventCategoryFailure)
+	return s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
+		stored.AutomatedBackupFailures++
+		stored.LastAutomatedBackupFailureAt = &now
+	})
+}
+
+// A window this instance could not be backed up in, evented once and then paced
+// by the same backoff a failure is. Reported without incrementing the failure
+// count: nothing about the backup failed, the instance was busy elsewhere.
+func (s *Service) recordBackupDeferred(ctx context.Context, kv jetstream.KeyValue, accountID string,
+	rec *DBInstanceRecord, opened time.Time, message string) error {
+	now := time.Now().UTC()
+	if rec.LastAutomatedBackupFailureAt == nil || rec.LastAutomatedBackupFailureAt.Before(opened) {
+		s.RecordEvent(ctx, accountID, EventSourceTypeDBInstance, rec.DBInstanceIdentifier,
+			message, EventCategoryBackup, EventCategoryNotification)
+	}
+	return s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
+		stored.LastAutomatedBackupFailureAt = &now
+	})
+}
+
+// Drains a deferred modify inside the maintenance window, matching AWS: a class
+// change or a storage grow recorded with ApplyImmediately=false takes the
+// database down here rather than never. Reports whether it started one.
+//
+// Only the transition into modifying happens on this pass. The apply itself is
+// left to the reconciler's own resume of a modifying instance, which is the
+// single drain through applyPendingModifications — so a deferred change is
+// applied by exactly the code an immediate one uses, and one instance's VM
+// replace does not hold up the whole fleet's pass.
+func (s *Service) runMaintenanceWindow(ctx context.Context, kv jetstream.KeyValue, rev uint64,
+	accountID string, rec *DBInstanceRecord) (bool, error) {
+	pending := rec.PendingModifiedValues
+	if pending.empty() || pending.growingFilesystem() || rec.Status != StatusAvailable {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	window, err := s.resolvedMaintenanceWindow(rec)
+	if err != nil {
+		slog.WarnContext(ctx, "rds: the stored maintenance window is malformed; the deferred modify is not applied",
+			"dbInstance", rec.DBInstanceIdentifier, "window", rec.PreferredMaintenanceWindow, "err", err)
+		return false, nil
+	}
+	if !window.contains(now) {
+		return false, nil
+	}
+	opened := window.openedAt(now)
+	if rec.LastMaintenanceWindowAt != nil && !rec.LastMaintenanceWindowAt.Before(opened) {
+		return false, nil
+	}
+
+	rec.LastMaintenanceWindowAt = &now
+	rec.TransitionStartedAt = &now
+	rec.Status = StatusModifying
+	rec.UpdatedAt = now
+	if err := updateJSON(ctx, kv, DBInstanceKey(rec.DBInstanceIdentifier), rev, rec); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			// Something else moved the record between the read and here; the next
+			// pass re-reads and the window is still open.
+			return false, nil
+		}
+		return false, err
+	}
+
+	s.RecordEvent(ctx, accountID, EventSourceTypeDBInstance, rec.DBInstanceIdentifier,
+		"Applying the modification recorded earlier; the database is unavailable while it is applied.",
+		EventCategoryConfigurationChange, EventCategoryMaintenance)
+	slog.InfoContext(ctx, "rds: maintenance window opened a deferred modify",
+		"dbInstance", rec.DBInstanceIdentifier, "accountId", accountID, "window", window.String())
+	return true, nil
+}
+
+// AWS's own name for an automated snapshot, minute-precise so a retry inside the
+// same window never collides with the attempt that failed.
+func AutomatedSnapshotIdentifier(dbInstanceIdentifier string, at time.Time) string {
+	return automatedSnapshotPrefix + dbInstanceIdentifier + "-" + at.UTC().Format(automatedSnapshotTimeLayout)
+}
+
+func AutomatedBackupStamp(at time.Time) string {
+	return at.UTC().Format(automatedBackupKeyLayout)
+}
+
+// The customer's view of the automated backup set: one entry per instance that
+// has automated backups, as AWS reports it. The individual snapshots stay
+// listable through DescribeDBSnapshots --snapshot-type automated.
+func (s *Service) DescribeDBInstanceAutomatedBackups(ctx context.Context,
+	input *rds.DescribeDBInstanceAutomatedBackupsInput, accountID string) (*rds.DescribeDBInstanceAutomatedBackupsOutput, error) {
+	wanted, err := validateDescribeAutomatedBackupsRequest(input)
+	if err != nil {
+		return nil, err
+	}
+	kv, err := s.bucket(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := []string{wanted}
+	if wanted == "" {
+		if ids, err = ListDBInstanceIDs(ctx, kv); err != nil {
+			return nil, err
+		}
+		slices.Sort(ids)
+	}
+
+	backups := make([]*rds.DBInstanceAutomatedBackup, 0, len(ids))
+	for _, id := range ids {
+		var rec DBInstanceRecord
+		found, err := getJSON(ctx, kv, DBInstanceKey(id), &rec)
+		if err != nil {
+			return nil, err
+		}
+		// A named instance that does not exist is an error, as it is on every other
+		// RDS describe; one deleted between the listing and this read is simply gone.
+		if !found {
+			if wanted != "" {
+				return nil, awserrors.Errorf(awserrors.ErrorDBInstanceNotFound, "DB instance %s not found", id)
+			}
+			continue
+		}
+		if rec.BackupRetentionPeriod <= 0 {
+			continue
+		}
+		stamps, err := ListAutomatedBackupStamps(ctx, kv, id)
+		if err != nil {
+			return nil, err
+		}
+		backups = append(backups, s.projectAutomatedBackup(&rec, len(stamps)))
+	}
+	return &rds.DescribeDBInstanceAutomatedBackupsOutput{DBInstanceAutomatedBackups: backups}, nil
+}
+
+// D19: a filter this phase cannot honour is rejected rather than dropped, since a
+// silently unfiltered list reads as a complete answer. Returns the DB instance to
+// report on, empty for every one.
+func validateDescribeAutomatedBackupsRequest(input *rds.DescribeDBInstanceAutomatedBackupsInput) (string, error) {
+	if input == nil {
+		return "", nil
+	}
+	if len(input.Filters) > 0 {
+		return "", unimplemented("Filters", "DescribeDBInstanceAutomatedBackups filters on DBInstanceIdentifier only")
+	}
+	if aws.StringValue(input.DbiResourceId) != "" {
+		return "", unimplemented("DbiResourceId", "a DB instance has no resource ID distinct from its identifier here")
+	}
+	if aws.StringValue(input.DBInstanceAutomatedBackupsArn) != "" {
+		return "", unimplemented("DBInstanceAutomatedBackupsArn",
+			"cross-region automated backup replication is not offered, so no replicated backup has an ARN")
+	}
+	return aws.StringValue(input.DBInstanceIdentifier), nil
+}
+
+// RestoreWindow and LatestRestorableTime are deliberately absent: this phase
+// backs discrete daily snapshots, and reporting a restore window would tell a
+// client it can recover to any instant inside it (D11 Phase B).
+func (s *Service) projectAutomatedBackup(rec *DBInstanceRecord, snapshots int) *rds.DBInstanceAutomatedBackup {
+	// AWS's own vocabulary: creating until the first snapshot exists, active once
+	// one does. retained — an automated backup outliving its instance — is not
+	// offered, because it would pin the source data volume indefinitely (D10).
+	status := "creating"
+	if snapshots > 0 {
+		status = "active"
+	}
+	out := &rds.DBInstanceAutomatedBackup{
+		DBInstanceIdentifier:  aws.String(rec.DBInstanceIdentifier),
+		DBInstanceArn:         aws.String(DBInstanceARN(s.region, rec.AccountID, rec.DBInstanceIdentifier)),
+		Region:                aws.String(s.region),
+		Status:                aws.String(status),
+		Engine:                aws.String(rec.Engine),
+		EngineVersion:         aws.String(rec.EngineVersion),
+		AllocatedStorage:      aws.Int64(rec.AllocatedStorage),
+		StorageType:           aws.String(rec.StorageType),
+		Encrypted:             aws.Bool(rec.StorageEncrypted),
+		MasterUsername:        aws.String(rec.MasterUsername),
+		Port:                  aws.Int64(rec.Port),
+		BackupRetentionPeriod: aws.Int64(rec.BackupRetentionPeriod),
+		InstanceCreateTime:    aws.Time(rec.CreatedAt),
+	}
+	if rec.VpcID != "" {
+		out.VpcId = aws.String(rec.VpcID)
+	}
+	return out
+}
+
+// The bounds a customer-supplied retention has to be inside. Checked wherever it
+// is accepted, so a value that would fail in a window nobody is watching fails in
+// the call that set it instead.
+func (s *Service) validateRetentionPeriod(days int64) error {
+	if days < 0 || days > s.retentionCapDays() {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"BackupRetentionPeriod must be between 0 and %d days", s.retentionCapDays())
+	}
+	return nil
+}
+
+// The pair, validated together: AWS refuses a backup window that overlaps the
+// maintenance window, and the non-overlap check needs both to exist — which is
+// also why an unnamed window is assigned rather than left empty.
+func (s *Service) validateWindows(identifier, backup, maintenance string) (string, string, error) {
+	backupWindow := assignDailyWindow(s.backupWindowBlock(), identifier)
+	if backup != "" {
+		parsed, err := parseDailyWindow("PreferredBackupWindow", backup)
+		if err != nil {
+			return "", "", err
+		}
+		backupWindow = parsed
+	}
+	maintenanceWindow := assignWeeklyWindow(s.maintenanceWindowBlock(), identifier)
+	if maintenance != "" {
+		parsed, err := parseWeeklyWindow("PreferredMaintenanceWindow", maintenance)
+		if err != nil {
+			return "", "", err
+		}
+		maintenanceWindow = parsed
+	}
+	if backupWindow.overlaps(maintenanceWindow) {
+		return "", "", awserrors.Errorf(awserrors.ErrorInvalidParameterCombination,
+			"PreferredBackupWindow %s overlaps PreferredMaintenanceWindow %s",
+			backupWindow.String(), maintenanceWindow.String())
+	}
+	// Returned in AWS's canonical text rather than as the customer typed it, so a
+	// describe reads back the same string a later modify would compare against.
+	return backupWindow.String(), maintenanceWindow.String(), nil
+}
+
+// Rejects the namespace automated snapshots own, so a customer snapshot can
+// never collide with one the scheduler mints.
+func rejectAutomatedNamespace(id string) error {
+	if strings.HasPrefix(id, automatedSnapshotPrefix) {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"DBSnapshotIdentifier may not begin with %q; that namespace belongs to automated backups",
+			automatedSnapshotPrefix)
+	}
+	return nil
+}

--- a/spinifex/handlers/rds/backup.go
+++ b/spinifex/handlers/rds/backup.go
@@ -135,17 +135,46 @@ func (s *Service) windowBlock(configured, fallback, kind string) dailyWindow {
 // named neither — takes the deterministic assignment, which is the same value
 // this phase persists at create.
 func (s *Service) resolvedBackupWindow(rec *DBInstanceRecord) (dailyWindow, error) {
-	if rec.PreferredBackupWindow == "" {
-		return assignDailyWindow(s.backupWindowBlock(), rec.DBInstanceIdentifier), nil
+	if rec.PreferredBackupWindow != "" {
+		return parseDailyWindow("PreferredBackupWindow", rec.PreferredBackupWindow)
 	}
-	return parseDailyWindow("PreferredBackupWindow", rec.PreferredBackupWindow)
+	// Assigned clear of the window the record does name, the same way the request
+	// that stored one and not the other resolved the pair — otherwise the two
+	// passes would be scheduled over each other on exactly those records.
+	block := s.backupWindowBlock()
+	maintenance, ok := storedMaintenanceWindow(rec)
+	if !ok {
+		return assignDailyWindow(block, rec.DBInstanceIdentifier), nil
+	}
+	return assignDailyWindowClearOf(block, rec.DBInstanceIdentifier, maintenance), nil
 }
 
 func (s *Service) resolvedMaintenanceWindow(rec *DBInstanceRecord) (weeklyWindow, error) {
-	if rec.PreferredMaintenanceWindow == "" {
-		return assignWeeklyWindow(s.maintenanceWindowBlock(), rec.DBInstanceIdentifier), nil
+	if rec.PreferredMaintenanceWindow != "" {
+		return parseWeeklyWindow("PreferredMaintenanceWindow", rec.PreferredMaintenanceWindow)
 	}
-	return parseWeeklyWindow("PreferredMaintenanceWindow", rec.PreferredMaintenanceWindow)
+	block := s.maintenanceWindowBlock()
+	backup, ok := s.scheduledBackupWindow(rec)
+	if !ok {
+		return assignWeeklyWindow(block, rec.DBInstanceIdentifier), nil
+	}
+	return assignWeeklyWindowClearOf(block, rec.DBInstanceIdentifier, backup), nil
+}
+
+// The windows the passes will actually fire on, when there are any. A window
+// neither named nor parseable is nothing to assign around: the pass that owns it
+// will not fire on it either.
+func storedMaintenanceWindow(rec *DBInstanceRecord) (weeklyWindow, bool) {
+	if rec.PreferredMaintenanceWindow == "" {
+		return weeklyWindow{}, false
+	}
+	window, err := parseWeeklyWindow("PreferredMaintenanceWindow", rec.PreferredMaintenanceWindow)
+	return window, err == nil
+}
+
+func (s *Service) scheduledBackupWindow(rec *DBInstanceRecord) (dailyWindow, bool) {
+	window, err := s.resolvedBackupWindow(rec)
+	return window, err == nil
 }
 
 // The windows as a describe reports them. A record written before rds-9 carries
@@ -480,7 +509,7 @@ func (s *Service) validateRetentionPeriod(days int64) error {
 // maintenance window, and the non-overlap check needs both to exist — which is
 // also why an unnamed window is assigned rather than left empty.
 func (s *Service) validateWindows(identifier, backup, maintenance string) (string, string, error) {
-	backupWindow := assignDailyWindow(s.backupWindowBlock(), identifier)
+	var backupWindow dailyWindow
 	if backup != "" {
 		parsed, err := parseDailyWindow("PreferredBackupWindow", backup)
 		if err != nil {
@@ -488,13 +517,26 @@ func (s *Service) validateWindows(identifier, backup, maintenance string) (strin
 		}
 		backupWindow = parsed
 	}
-	maintenanceWindow := assignWeeklyWindow(s.maintenanceWindowBlock(), identifier)
+	var maintenanceWindow weeklyWindow
 	if maintenance != "" {
 		parsed, err := parseWeeklyWindow("PreferredMaintenanceWindow", maintenance)
 		if err != nil {
 			return "", "", err
 		}
 		maintenanceWindow = parsed
+	}
+	// A window the customer named is placed first and an assigned one goes around
+	// it. Assigning both independently and then rejecting the overlap would fail a
+	// request over a window the customer never sent — and deterministically, so the
+	// same identifier would fail forever.
+	switch {
+	case backup == "" && maintenance == "":
+		backupWindow = assignDailyWindow(s.backupWindowBlock(), identifier)
+		maintenanceWindow = assignWeeklyWindowClearOf(s.maintenanceWindowBlock(), identifier, backupWindow)
+	case backup == "":
+		backupWindow = assignDailyWindowClearOf(s.backupWindowBlock(), identifier, maintenanceWindow)
+	case maintenance == "":
+		maintenanceWindow = assignWeeklyWindowClearOf(s.maintenanceWindowBlock(), identifier, backupWindow)
 	}
 	if backupWindow.overlaps(maintenanceWindow) {
 		return "", "", awserrors.Errorf(awserrors.ErrorInvalidParameterCombination,

--- a/spinifex/handlers/rds/backup_sweep.go
+++ b/spinifex/handlers/rds/backup_sweep.go
@@ -128,6 +128,8 @@ func (s *Service) sweepInstanceBackups(ctx context.Context, kv jetstream.KeyValu
 	retention := time.Duration(0)
 	if found {
 		retention = time.Duration(rec.BackupRetentionPeriod) * oneDay
+	} else if err := confirmDBInstanceGone(ctx, kv, dbInstanceIdentifier); err != nil {
+		return 0, err
 	}
 
 	entries, err := s.loadAutomatedBackups(ctx, kv, dbInstanceIdentifier, stamps)
@@ -161,6 +163,25 @@ func (s *Service) sweepInstanceBackups(ctx context.Context, kv jetstream.KeyValu
 		}
 	}
 	return reaped, errors.Join(failures...)
+}
+
+// The corroboration the purge-everything branch needs before it runs. A single
+// absent key is not proof the instance is gone — a read served by a lagging
+// replica reads the same way — and that branch removes a live instance's whole
+// backup set, newest included. The bucket listing is a second, independent read
+// path, so an identifier it still names fails this instance's sweep instead.
+func confirmDBInstanceGone(ctx context.Context, kv jetstream.KeyValue, dbInstanceIdentifier string) error {
+	ids, err := ListDBInstanceIDs(ctx, kv)
+	if err != nil {
+		return err
+	}
+	if slices.Contains(ids, dbInstanceIdentifier) {
+		return fmt.Errorf("rds: the record of %s could not be read while its bucket still names it; "+
+			"its automated backups are left alone", dbInstanceIdentifier)
+	}
+	slog.WarnContext(ctx, "rds: removing the whole automated backup set of a DB instance that no longer exists",
+		"dbInstance", dbInstanceIdentifier)
+	return nil
 }
 
 // The index entries of one instance, oldest first. An entry whose snapshot record

--- a/spinifex/handlers/rds/backup_sweep.go
+++ b/spinifex/handlers/rds/backup_sweep.go
@@ -1,0 +1,325 @@
+package handlers_rds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// The retention sweep is a cluster-wide vm.Reaper rather than a reconciler tick,
+// because it is the one part of rds-9 that deletes customer data. The shared GC
+// backstop buys it the two properties that matters most for: it is skipped
+// entirely while KV is unhealthy, so it can never reap against a desired state it
+// cannot read, and cluster-wide scope is leader-gated by the framework. Backup
+// *creation* stays in the RDS reconciler, where the per-instance state it reads
+// already lives.
+type BackupRetentionReaper struct {
+	svc *Service
+	// The per-pass bound on deletions. Under-collecting for one interval is free;
+	// a sweep that walks the whole object store every two minutes is not.
+	limit int
+}
+
+var _ vm.Reaper = (*BackupRetentionReaper)(nil)
+
+func (s *Service) NewBackupRetentionReaper() *BackupRetentionReaper {
+	return &BackupRetentionReaper{svc: s, limit: s.sweepDeleteLimit()}
+}
+
+func (r *BackupRetentionReaper) Class() string         { return "rds-backup-retention" }
+func (r *BackupRetentionReaper) Scope() vm.ReaperScope { return vm.ScopeClusterWide }
+
+// Sweeps every account's automated backups past their retention, and reclaims the
+// retained data volumes nothing references any more. Drives from the RDS KV index
+// rather than from a snapshot scan: a bucket-wide ListObjectsV2 per pass would
+// grow without bound with the fleet, and the same cost lands on viperblock's own
+// GC safety scan.
+func (r *BackupRetentionReaper) Sweep(ctx context.Context) (int, error) {
+	js, err := r.svc.js()
+	if err != nil {
+		return 0, err
+	}
+	// A truncated listing must never read as "no accounts": that would leave every
+	// tenant's retention unenforced while looking like a clean pass.
+	buckets, err := AccountBucketNames(ctx, js)
+	if err != nil {
+		return 0, fmt.Errorf("rds: enumerate account buckets: %w", err)
+	}
+
+	reaped := 0
+	var failures []error
+	for _, bucket := range buckets {
+		if reaped >= r.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return reaped, err
+		}
+		kv, err := js.KeyValue(ctx, bucket)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("open %s: %w", bucket, err))
+			continue
+		}
+		accountID := AccountIDFromBucketName(bucket)
+		swept, err := r.sweepAccount(ctx, kv, accountID, r.limit-reaped)
+		reaped += swept
+		if err != nil {
+			failures = append(failures, fmt.Errorf("sweep %s: %w", bucket, err))
+		}
+	}
+	return reaped, errors.Join(failures...)
+}
+
+// One account: the over-retention automated snapshots of every instance, then the
+// retained volumes whose last snapshot is gone.
+func (r *BackupRetentionReaper) sweepAccount(ctx context.Context, kv jetstream.KeyValue,
+	accountID string, budget int) (int, error) {
+	indexed, err := ListAutomatedBackups(ctx, kv)
+	if err != nil {
+		return 0, err
+	}
+
+	reaped := 0
+	var failures []error
+	for _, id := range slices.Sorted(maps.Keys(indexed)) {
+		if reaped >= budget {
+			return reaped, errors.Join(failures...)
+		}
+		swept, err := r.svc.sweepInstanceBackups(ctx, kv, accountID, id, indexed[id], budget-reaped)
+		reaped += swept
+		if err != nil {
+			failures = append(failures, fmt.Errorf("DB instance %s: %w", id, err))
+		}
+	}
+
+	// The backstop for a crash between rds-8's last DeleteDBSnapshot and the
+	// inline volume delete that follows it: nothing else references the volume by
+	// then, so without this it is orphaned permanently.
+	volumes, err := r.svc.reclaimOrphanedVolumes(ctx, kv)
+	if err != nil {
+		failures = append(failures, err)
+	}
+	return reaped + volumes, errors.Join(failures...)
+}
+
+// Removes this instance's automated snapshots older than its retention. Two rules
+// bound it: an in-use snapshot is skipped rather than failed, and the newest
+// available snapshot is never deleted while automated backups are on — if backup
+// creation has been failing for a week, strict retention would delete the whole
+// backup set at the exact moment a backup matters most.
+func (s *Service) sweepInstanceBackups(ctx context.Context, kv jetstream.KeyValue,
+	accountID, dbInstanceIdentifier string, stamps []string, budget int) (int, error) {
+	var rec DBInstanceRecord
+	found, err := getJSON(ctx, kv, DBInstanceKey(dbInstanceIdentifier), &rec)
+	if err != nil {
+		return 0, err
+	}
+	// An index outliving its instance is a teardown that did not finish. Everything
+	// goes, newest included: nothing can restore an instance that no longer exists,
+	// and the alternative is a data volume pinned for good.
+	retention := time.Duration(0)
+	if found {
+		retention = time.Duration(rec.BackupRetentionPeriod) * oneDay
+	}
+
+	entries, err := s.loadAutomatedBackups(ctx, kv, dbInstanceIdentifier, stamps)
+	if err != nil {
+		return 0, err
+	}
+	keep := ""
+	// Retention 0 means automated backups are off, and the point of turning them
+	// off is to make the volume GC-eligible again — so the last one goes too.
+	if retention > 0 {
+		keep = newestAvailableBackup(entries)
+	}
+
+	cutoff := time.Now().UTC().Add(-retention)
+	reaped := 0
+	var failures []error
+	for _, entry := range entries {
+		if reaped >= budget {
+			break
+		}
+		if entry.DBSnapshotIdentifier == keep || entry.CreatedAt.After(cutoff) {
+			continue
+		}
+		deleted, err := s.deleteAutomatedBackup(ctx, kv, accountID, entry)
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		if deleted {
+			reaped++
+		}
+	}
+	return reaped, errors.Join(failures...)
+}
+
+// The index entries of one instance, oldest first. An entry whose snapshot record
+// is gone is a half-finished delete: the entry is removed so the index stops
+// naming it, and it counts as nothing reaped because no data went with it.
+func (s *Service) loadAutomatedBackups(ctx context.Context, kv jetstream.KeyValue,
+	dbInstanceIdentifier string, stamps []string) ([]automatedBackup, error) {
+	slices.Sort(stamps)
+	entries := make([]automatedBackup, 0, len(stamps))
+	for _, stamp := range stamps {
+		var entry AutomatedBackupRecord
+		found, err := getJSON(ctx, kv, AutomatedBackupKey(dbInstanceIdentifier, stamp), &entry)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		var snapshot DBSnapshotRecord
+		found, err = getJSON(ctx, kv, DBSnapshotKey(entry.DBSnapshotIdentifier), &snapshot)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			if err := s.dropAutomatedBackupIndex(ctx, kv, dbInstanceIdentifier, stamp); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		// The snapshot record is the authority on age, not the index key: the key is
+		// a naming convention, and the record is what a restore reads.
+		entry.CreatedAt = snapshot.CreatedAt
+		entries = append(entries, automatedBackup{AutomatedBackupRecord: entry, stamp: stamp, snapshot: &snapshot})
+	}
+	return entries, nil
+}
+
+// An index entry paired with the snapshot record it points at.
+type automatedBackup struct {
+	AutomatedBackupRecord
+
+	stamp    string
+	snapshot *DBSnapshotRecord
+}
+
+// The newest snapshot retention must not remove. Only an available one counts: a
+// snapshot still being cut is not yet something the customer could restore from,
+// so keeping it instead would leave them with nothing.
+func newestAvailableBackup(entries []automatedBackup) string {
+	newest := ""
+	var at time.Time
+	for _, entry := range entries {
+		if entry.snapshot.Status != SnapshotStatusAvailable {
+			continue
+		}
+		if newest == "" || entry.CreatedAt.After(at) {
+			newest, at = entry.DBSnapshotIdentifier, entry.CreatedAt
+		}
+	}
+	return newest
+}
+
+// Removes one automated snapshot and its index entry. Reports false when the
+// snapshot is still being read from — an instance restored from it is still
+// running — which is a skip rather than a failure: the next pass retries, and the
+// entry stays so it is not lost from the index.
+func (s *Service) deleteAutomatedBackup(ctx context.Context, kv jetstream.KeyValue,
+	accountID string, entry automatedBackup) (bool, error) {
+	err := s.removeDBSnapshot(ctx, kv, accountID, entry.snapshot)
+	switch {
+	// Both readings of "not now": a snapshot an instance restored from it is still
+	// reading, and one still being cut. Neither is a failure — the next pass
+	// retries, and the index entry stays so the backup is not lost from it.
+	case awserrors.IsErrorCode(err, awserrors.ErrorDBSnapshotInvalidState):
+		slog.DebugContext(ctx, "rds: an over-retention automated backup cannot be removed yet; leaving it",
+			"dbSnapshot", entry.DBSnapshotIdentifier, "accountId", accountID, "status", entry.snapshot.Status)
+		return false, nil
+	case awserrors.IsErrorCode(err, awserrors.ErrorDBSnapshotNotFound):
+		// Deleted between the index read and here; only the entry is left to clear.
+	case err != nil:
+		return false, fmt.Errorf("rds: delete the automated backup %s: %w", entry.DBSnapshotIdentifier, err)
+	}
+
+	if err := s.dropAutomatedBackupIndex(ctx, kv, entry.DBInstanceIdentifier, entry.stamp); err != nil {
+		return false, err
+	}
+	slog.InfoContext(ctx, "rds: automated backup swept past its retention",
+		"dbSnapshot", entry.DBSnapshotIdentifier, "dbInstance", entry.DBInstanceIdentifier,
+		"accountId", accountID, "createdAt", entry.CreatedAt)
+	return true, nil
+}
+
+// Last, always: while the entry exists the snapshot is still findable by the
+// sweep, and every step above tolerates work it has already done.
+func (s *Service) dropAutomatedBackupIndex(ctx context.Context, kv jetstream.KeyValue,
+	dbInstanceIdentifier, stamp string) error {
+	key := AutomatedBackupKey(dbInstanceIdentifier, stamp)
+	if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("rds: clear the automated-backup index entry %s: %w", key, err)
+	}
+	return nil
+}
+
+// Removes every automated backup of one instance whatever its retention says.
+// Two callers, both of which mean "there is nothing left to retain for": a
+// BackupRetentionPeriod=0 modify, which turns the feature off, and the teardown
+// of the instance itself, whose automated backups would otherwise pin its data
+// volume after the instance is gone (D10).
+func (s *Service) purgeAutomatedBackups(ctx context.Context, kv jetstream.KeyValue,
+	accountID, dbInstanceIdentifier string) error {
+	stamps, err := ListAutomatedBackupStamps(ctx, kv, dbInstanceIdentifier)
+	if err != nil {
+		return err
+	}
+	entries, err := s.loadAutomatedBackups(ctx, kv, dbInstanceIdentifier, stamps)
+	if err != nil {
+		return err
+	}
+	var failures []error
+	for _, entry := range entries {
+		if _, err := s.deleteAutomatedBackup(ctx, kv, accountID, entry); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// Deletes the data volumes retained for snapshots that no longer exist. rds-8
+// deletes the volume inline on the last DeleteDBSnapshot, so this only ever fires
+// for a crash between those two steps — which is precisely what a KV-health-gated
+// cluster-wide sweep is for.
+func (s *Service) reclaimOrphanedVolumes(ctx context.Context, kv jetstream.KeyValue) (int, error) {
+	ids, err := ListRetainedVolumeIDs(ctx, kv)
+	if err != nil {
+		return 0, err
+	}
+	reclaimed := 0
+	var failures []error
+	for _, id := range ids {
+		var retained RetainedVolumeRecord
+		found, err := getJSON(ctx, kv, RetainedVolumeKey(id), &retained)
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		// Every record is re-checked against the volume store rather than trusted:
+		// the holders it was written with are a past reading, and a volume whose last
+		// snapshot went in a crashed delete still names it.
+		if !found {
+			continue
+		}
+		released, err := s.reclaimRetainedVolume(ctx, kv, &retained)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("reclaim %s: %w", id, err))
+			continue
+		}
+		if released {
+			reclaimed++
+		}
+	}
+	return reclaimed, errors.Join(failures...)
+}

--- a/spinifex/handlers/rds/backup_sweep_test.go
+++ b/spinifex/handlers/rds/backup_sweep_test.go
@@ -1,6 +1,7 @@
 package handlers_rds
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -169,6 +171,43 @@ func TestSweep_RemovesEverythingWhenTheInstanceIsGone(t *testing.T) {
 	assert.Equal(t, 2, h.sweep(t))
 	assert.False(t, h.snapshotExists(t, newest))
 	assert.False(t, h.snapshotExists(t, older))
+}
+
+// A KV read served by a lagging replica reads exactly like a finished teardown,
+// and the branch it would select deletes a live instance's whole backup set. The
+// bucket listing is the corroboration that stops it.
+func TestSweep_LeavesTheBackupSetWhenTheRecordCannotBeRead(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(7))
+	newest := h.seedBackup(t, time.Hour)
+	older := h.seedBackup(t, 30*oneDay)
+
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	stale := missingKey{KeyValue: kv, key: DBInstanceKey(testDBID)}
+
+	reaped, err := h.svc.sweepInstanceBackups(t.Context(), stale, testAccountID, testDBID,
+		h.automatedStamps(t, testDBID), defaultSweepDeleteLimit)
+	require.Error(t, err, "an unreadable record is not proof the instance is gone")
+	assert.Zero(t, reaped)
+	assert.True(t, h.snapshotExists(t, newest))
+	assert.True(t, h.snapshotExists(t, older), "not even the over-retention one goes on an unread record")
+	assert.Len(t, h.automatedStamps(t, testDBID), 2)
+}
+
+// A bucket read that misses one key while every other read succeeds, which is
+// what a stale replica looks like from here.
+type missingKey struct {
+	jetstream.KeyValue
+
+	key string
+}
+
+func (m missingKey) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	if key == m.key {
+		return nil, jetstream.ErrKeyNotFound
+	}
+	return m.KeyValue.Get(ctx, key)
 }
 
 // An instance restored from the snapshot is still reading through it. That is a

--- a/spinifex/handlers/rds/backup_sweep_test.go
+++ b/spinifex/handlers/rds/backup_sweep_test.go
@@ -1,0 +1,373 @@
+package handlers_rds
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Seeds one automated backup exactly as a fired window leaves it: the snapshot
+// record, an EC2 snapshot holding the source volume, and the index entry the
+// retention sweep drives from.
+func seedAutomatedBackup(t *testing.T, svc *Service, snaps *fakeSnapshots,
+	accountID, dbID string, age time.Duration, status string) string {
+	t.Helper()
+	kv, err := svc.bucket(t.Context(), accountID)
+	require.NoError(t, err)
+
+	createdAt := time.Now().UTC().Add(-age)
+	id := AutomatedSnapshotIdentifier(dbID, createdAt)
+	stamp := AutomatedBackupStamp(createdAt)
+	ec2Snapshot := "snap-" + stamp
+
+	snaps.holding = append(snaps.holding, ec2Snapshot)
+	require.NoError(t, putJSON(t.Context(), kv, DBSnapshotKey(id), &DBSnapshotRecord{
+		DBSnapshotIdentifier: id,
+		DBInstanceIdentifier: dbID,
+		AccountID:            accountID,
+		SnapshotType:         SnapshotTypeAutomated,
+		Status:               status,
+		SnapshotID:           ec2Snapshot,
+		SourceVolumeID:       "vol-rdsdata01",
+		CreatedAt:            createdAt,
+	}))
+	require.NoError(t, putJSON(t.Context(), kv, AutomatedBackupKey(dbID, stamp), &AutomatedBackupRecord{
+		DBInstanceIdentifier: dbID,
+		DBSnapshotIdentifier: id,
+		CreatedAt:            createdAt,
+	}))
+	return id
+}
+
+func (h *snapshotHarness) seedBackup(t *testing.T, age time.Duration) string {
+	t.Helper()
+	return seedAutomatedBackup(t, h.svc, h.snaps, testAccountID, testDBID, age, SnapshotStatusAvailable)
+}
+
+func (h *snapshotHarness) sweep(t *testing.T) int {
+	t.Helper()
+	reaped, err := h.svc.NewBackupRetentionReaper().Sweep(t.Context())
+	require.NoError(t, err)
+	return reaped
+}
+
+func (h *snapshotHarness) snapshotExists(t *testing.T, id string) bool {
+	t.Helper()
+	_, found := h.snapshot(t, id)
+	return found
+}
+
+// An instance with backups on, whose window is closed so the sweep is the only
+// thing acting on its backup set.
+func retainingRecord(days int64) DBInstanceRecord {
+	rec := availableRecord()
+	rec.BackupRetentionPeriod = days
+	rec.PreferredBackupWindow = closedBackupWindow(time.Now().UTC())
+	return rec
+}
+
+// The GC framework gives the sweep the two properties it needs: it is skipped
+// while KV is unhealthy, and cluster-wide scope is leader-gated by the framework
+// rather than by anything here.
+func TestBackupRetentionReaper_IsAClusterWideReaper(t *testing.T) {
+	reaper := NewService(nil, testRegion).NewBackupRetentionReaper()
+	assert.Equal(t, "rds-backup-retention", reaper.Class())
+	assert.Equal(t, vm.ScopeClusterWide, reaper.Scope())
+	assert.Equal(t, defaultSweepDeleteLimit, reaper.limit)
+
+	tuned := NewService(nil, testRegion).WithDeps(Deps{Backup: BackupPolicy{SweepDeleteLimit: 4}})
+	assert.Equal(t, 4, tuned.NewBackupRetentionReaper().limit)
+}
+
+func TestSweep_RemovesOnlyTheBackupsPastRetention(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(7))
+
+	fresh := h.seedBackup(t, oneDay)
+	recent := h.seedBackup(t, 3*oneDay)
+	stale := h.seedBackup(t, 8*oneDay)
+	ancient := h.seedBackup(t, 30*oneDay)
+
+	assert.Equal(t, 2, h.sweep(t))
+
+	assert.True(t, h.snapshotExists(t, fresh))
+	assert.True(t, h.snapshotExists(t, recent))
+	assert.False(t, h.snapshotExists(t, stale))
+	assert.False(t, h.snapshotExists(t, ancient))
+
+	// The index goes with the snapshot, or the next pass would keep finding a
+	// backup that no longer exists.
+	assert.Len(t, h.automatedStamps(t, testDBID), 2)
+	// And the EC2 snapshots behind them, which is what actually frees the chunks.
+	assert.Len(t, h.snaps.deleted, 2)
+}
+
+// If backup creation has been failing for a week, strict retention would delete
+// the whole backup set at the moment a backup matters most.
+func TestSweep_NeverDeletesTheNewestBackupWhileBackupsAreOn(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(1))
+
+	newest := h.seedBackup(t, 5*oneDay)
+	older := h.seedBackup(t, 9*oneDay)
+
+	assert.Equal(t, 1, h.sweep(t))
+	assert.True(t, h.snapshotExists(t, newest), "the last restorable copy is kept even past its retention")
+	assert.False(t, h.snapshotExists(t, older))
+
+	// And it stays kept: a sweep that eventually got round to it would be the same
+	// data loss one pass later.
+	assert.Equal(t, 0, h.sweep(t))
+	assert.True(t, h.snapshotExists(t, newest))
+}
+
+// A snapshot still being cut is not something the customer could restore from, so
+// keeping it instead of the newest available one would leave them with nothing.
+func TestSweep_KeepsTheNewestAvailableRatherThanTheNewest(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(1))
+
+	creating := seedAutomatedBackup(t, h.svc, h.snaps, testAccountID, testDBID, 3*oneDay, SnapshotStatusCreating)
+	available := h.seedBackup(t, 5*oneDay)
+
+	assert.Equal(t, 0, h.sweep(t))
+	assert.True(t, h.snapshotExists(t, available), "the newest available backup is the one retention keeps")
+	assert.True(t, h.snapshotExists(t, creating), "a snapshot still being cut is skipped, not failed")
+	assert.Empty(t, h.snaps.deleted)
+}
+
+// The point of turning automated backups off is to make the data volume
+// GC-eligible again, so the last one goes too.
+func TestSweep_RemovesEverythingWhenBackupsAreOff(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(0))
+
+	newest := h.seedBackup(t, time.Hour)
+	older := h.seedBackup(t, 2*oneDay)
+
+	assert.Equal(t, 2, h.sweep(t))
+	assert.False(t, h.snapshotExists(t, newest))
+	assert.False(t, h.snapshotExists(t, older))
+	assert.Empty(t, h.automatedStamps(t, testDBID))
+}
+
+// An index outliving its instance is a teardown that did not finish. Nothing can
+// restore an instance that no longer exists, and the alternative is a data volume
+// pinned for good.
+func TestSweep_RemovesEverythingWhenTheInstanceIsGone(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+
+	newest := h.seedBackup(t, time.Hour)
+	older := h.seedBackup(t, 2*oneDay)
+
+	assert.Equal(t, 2, h.sweep(t))
+	assert.False(t, h.snapshotExists(t, newest))
+	assert.False(t, h.snapshotExists(t, older))
+}
+
+// An instance restored from the snapshot is still reading through it. That is a
+// skip rather than a failure: the next pass retries, and the index entry stays so
+// the backup is not lost from it.
+func TestSweep_SkipsABackupStillInUse(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(0))
+	inUse := h.seedBackup(t, 2*oneDay)
+	h.snaps.deleteErr = awserrors.Errorf(awserrors.ErrorInvalidSnapshotInUse,
+		"the snapshot is in use by vol-restored01")
+
+	reaped, err := h.svc.NewBackupRetentionReaper().Sweep(t.Context())
+	require.NoError(t, err, "a snapshot in use is not a sweep failure")
+	assert.Zero(t, reaped)
+	assert.True(t, h.snapshotExists(t, inUse))
+	assert.Len(t, h.automatedStamps(t, testDBID), 1, "the entry stays so the backup is still findable")
+
+	// Once the reader is gone the next pass collects it.
+	h.snaps.deleteErr = nil
+	assert.Equal(t, 1, h.sweep(t))
+	assert.False(t, h.snapshotExists(t, inUse))
+}
+
+// A pass that under-collects is corrected by the next one two minutes later; a
+// pass that walks an unbounded number of snapshots is not.
+func TestSweep_IsBoundedPerPassAndResumes(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	h.svc = h.svc.WithDeps(Deps{
+		LoadCA:    newTestCA(t),
+		Launch:    h.launch.deps(),
+		Network:   h.network,
+		Snapshots: h.snaps,
+		Backup:    BackupPolicy{SweepDeleteLimit: 1},
+	})
+	seedInstance(t, h.svc, retainingRecord(0))
+	for _, age := range []time.Duration{oneDay, 2 * oneDay, 3 * oneDay} {
+		h.seedBackup(t, age)
+	}
+
+	assert.Equal(t, 1, h.sweep(t))
+	assert.Len(t, h.automatedStamps(t, testDBID), 2)
+	assert.Equal(t, 1, h.sweep(t))
+	assert.Equal(t, 1, h.sweep(t))
+	assert.Empty(t, h.automatedStamps(t, testDBID))
+	assert.Equal(t, 0, h.sweep(t))
+}
+
+// A half-finished delete: the snapshot went and the entry did not. The entry is
+// cleared so the index stops naming it, and nothing is counted as reaped because
+// no data went with it.
+func TestSweep_DropsAnIndexEntryWhoseSnapshotIsGone(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(7))
+
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	createdAt := time.Now().UTC().Add(-2 * oneDay)
+	stamp := AutomatedBackupStamp(createdAt)
+	require.NoError(t, putJSON(t.Context(), kv, AutomatedBackupKey(testDBID, stamp), &AutomatedBackupRecord{
+		DBInstanceIdentifier: testDBID,
+		DBSnapshotIdentifier: AutomatedSnapshotIdentifier(testDBID, createdAt),
+		CreatedAt:            createdAt,
+	}))
+
+	assert.Equal(t, 0, h.sweep(t))
+	assert.Empty(t, h.automatedStamps(t, testDBID))
+}
+
+// Every tenant's retention is enforced on the same pass, so one account's backlog
+// cannot leave another's unenforced.
+func TestSweep_CoversEveryAccount(t *testing.T) {
+	const otherAccount = "210987654321"
+	h := newSnapshotHarness(t, false)
+
+	mine := h.seedBackup(t, 2*oneDay)
+	theirs := seedAutomatedBackup(t, h.svc, h.snaps, otherAccount, "billing-db", 2*oneDay, SnapshotStatusAvailable)
+
+	assert.Equal(t, 2, h.sweep(t))
+	assert.False(t, h.snapshotExists(t, mine))
+
+	kv, err := h.svc.bucket(t.Context(), otherAccount)
+	require.NoError(t, err)
+	var rec DBSnapshotRecord
+	found, err := getJSON(t.Context(), kv, DBSnapshotKey(theirs), &rec)
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+// A truncated listing must never read as "no accounts": that would leave every
+// tenant's retention unenforced while looking like a clean pass.
+func TestSweep_FailsWhenTheAccountBucketsCannotBeEnumerated(t *testing.T) {
+	_, err := NewService(nil, testRegion).NewBackupRetentionReaper().Sweep(t.Context())
+	require.Error(t, err)
+}
+
+// The backstop for a crash between rds-8's last DeleteDBSnapshot and the inline
+// volume delete that follows it: nothing else references the volume by then.
+func TestSweep_ReclaimsAnOrphanedRetainedVolume(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	require.NoError(t, putJSON(t.Context(), kv, RetainedVolumeKey("vol-orphan01"), &RetainedVolumeRecord{
+		VolumeID:             "vol-orphan01",
+		AccountID:            testAccountID,
+		DBInstanceIdentifier: testDBID,
+		RetainedAt:           time.Now().UTC().Add(-time.Hour),
+	}))
+
+	assert.Equal(t, 1, h.sweep(t))
+	assert.Equal(t, []string{"vol-orphan01"}, h.launch.volumes.deleted)
+
+	var retained RetainedVolumeRecord
+	found, err := getJSON(t.Context(), kv, RetainedVolumeKey("vol-orphan01"), &retained)
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+// The volume store's index is the authority, not the holder list the record was
+// written with: a snapshot taken since would read as "nothing holds it", and one
+// deleted since would pin the volume for good.
+func TestSweep_ReChecksTheHoldersRatherThanTrustingTheRecord(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	require.NoError(t, putJSON(t.Context(), kv, RetainedVolumeKey("vol-held01"), &RetainedVolumeRecord{
+		VolumeID:  "vol-held01",
+		AccountID: testAccountID,
+		Snapshots: []string{"snap-gone01"},
+	}))
+	// A holder the record does not name, taken after it was written.
+	h.snaps.holding = append(h.snaps.holding, "snap-9999")
+
+	assert.Equal(t, 0, h.sweep(t))
+	assert.Empty(t, h.launch.volumes.deleted, "a volume a snapshot still reads through must not go")
+
+	var stored RetainedVolumeRecord
+	found, err := getJSON(t.Context(), kv, RetainedVolumeKey("vol-held01"), &stored)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, []string{"snap-9999"}, stored.Snapshots)
+}
+
+// The volume store refusing a delete without naming a holder means "unknown", not
+// "nobody". It is recorded and re-checked rather than failing the pass, so a
+// disagreement between the two indexes never wedges the sweep.
+func TestSweep_RetainsAVolumeTheVolumeStoreRefusesToRelease(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	require.NoError(t, putJSON(t.Context(), kv, RetainedVolumeKey("vol-held01"), &RetainedVolumeRecord{
+		VolumeID:  "vol-held01",
+		AccountID: testAccountID,
+		Snapshots: []string{"snap-gone01"},
+	}))
+	h.launch.volumes.deleteErr = awserrors.Errorf(awserrors.ErrorVolumeInUse, "the volume is in use")
+
+	assert.Equal(t, 0, h.sweep(t))
+
+	var stored RetainedVolumeRecord
+	found, err := getJSON(t.Context(), kv, RetainedVolumeKey("vol-held01"), &stored)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, stored.HoldersUnresolved, "the disagreement is recorded so the next pass re-checks")
+}
+
+// Turning automated backups off sweeps the set that exists rather than leaving it
+// to expire against a retention that is now zero.
+func TestModifyDBInstance_SweepsTheAutomatedBackupsWhenRetentionGoesToZero(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, retainingRecord(7))
+	swept := h.seedBackup(t, time.Hour)
+
+	_, err := h.svc.ModifyDBInstance(t.Context(), &rds.ModifyDBInstanceInput{
+		DBInstanceIdentifier:  aws.String(testDBID),
+		BackupRetentionPeriod: aws.Int64(0),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	assert.Zero(t, h.instance(t, testDBID).BackupRetentionPeriod)
+	assert.False(t, h.snapshotExists(t, swept))
+	assert.Empty(t, h.automatedStamps(t, testDBID))
+}
+
+// D10: an automated backup outliving its instance would pin the instance's data
+// volume for good, so teardown sweeps the set before releasing the volume.
+func TestDeleteDBInstance_SweepsTheAutomatedBackups(t *testing.T) {
+	h := newLifecycleHarness(t, false)
+	seedInstance(t, h.svc, availableRecord())
+	swept := seedAutomatedBackup(t, h.svc, h.snaps, testAccountID, testDBID, oneDay, SnapshotStatusAvailable)
+
+	_, err := h.svc.DeleteDBInstance(t.Context(), skipFinalSnapshot(), testAccountID)
+	require.NoError(t, err)
+
+	_, found := h.snapshotRecord(t, swept)
+	assert.False(t, found)
+	// Nothing holds the data volume once the automated set is gone, so it is
+	// deleted rather than retained.
+	assert.Equal(t, []string{"vol-rdsdata01"}, h.volumes.deleted)
+	_, found = h.retainedVolume(t, "vol-rdsdata01")
+	assert.False(t, found)
+}

--- a/spinifex/handlers/rds/backup_test.go
+++ b/spinifex/handlers/rds/backup_test.go
@@ -1,6 +1,7 @@
 package handlers_rds
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -223,6 +224,79 @@ func TestValidateWindows_AssignsStableNonOverlappingWindows(t *testing.T) {
 		assigned[backup] = true
 	}
 	assert.Greater(t, len(assigned), 1, "the fleet's quiesce load should spread across the block")
+}
+
+// A window the customer never sent must never be the reason their request is
+// refused. Naming one window inside the other's block is the ordinary Terraform
+// shape — backup_window set, maintenance_window left out — and assigning the
+// second one on top of it would fail the same identifier deterministically,
+// forever.
+func TestValidateWindows_AssignsAroundACustomerNamedWindow(t *testing.T) {
+	svc := NewService(nil, testRegion)
+	// Inside the other window's block, which is where a collision is possible at
+	// all: an hour of the maintenance block covers two of its assignable slots.
+	const insideMaintenanceBlock = "13:00-14:00"
+	const insideBackupBlock = "wed:04:00-wed:05:00"
+
+	for i := range 200 {
+		id := fmt.Sprintf("orders-db-%d", i)
+
+		backup, maintenance, err := svc.validateWindows(id, insideMaintenanceBlock, "")
+		require.NoError(t, err, "%s: a named backup window must not be refused over an assigned one", id)
+		assert.Equal(t, insideMaintenanceBlock, backup, "%s: the named window is kept as named", id)
+		assertWindowsDoNotOverlap(t, id, backup, maintenance)
+
+		backup, maintenance, err = svc.validateWindows(id, "", insideBackupBlock)
+		require.NoError(t, err, "%s: a named maintenance window must not be refused over an assigned one", id)
+		assert.Equal(t, insideBackupBlock, maintenance)
+		assertWindowsDoNotOverlap(t, id, backup, maintenance)
+	}
+
+	// Stable, like every other assignment: stepping off the named window must not
+	// make the result depend on when it was resolved.
+	first, second, err := svc.validateWindows(testDBID, insideMaintenanceBlock, "")
+	require.NoError(t, err)
+	again, alsoAgain, err := svc.validateWindows(testDBID, insideMaintenanceBlock, "")
+	require.NoError(t, err)
+	assert.Equal(t, first, again)
+	assert.Equal(t, second, alsoAgain)
+}
+
+// A pair the customer named in full is still refused — the assignment moving out
+// of the way is for windows the platform chose, not for the ones it was given.
+func TestValidateWindows_StillRejectsAPairTheCustomerNamed(t *testing.T) {
+	_, _, err := NewService(nil, testRegion).
+		validateWindows(testDBID, "13:00-14:00", "wed:13:30-wed:14:30")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterCombination)
+}
+
+// The window a record does not carry is derived the same way the request that
+// stored the other one derived it. Anything else would schedule the two passes
+// over each other on exactly the records that name one window.
+func TestResolvedWindows_AssignAroundTheStoredWindow(t *testing.T) {
+	svc := NewService(nil, testRegion)
+
+	for i := range 200 {
+		id := fmt.Sprintf("orders-db-%d", i)
+
+		backupOnly := &DBInstanceRecord{DBInstanceIdentifier: id, PreferredBackupWindow: "13:00-14:00"}
+		assertWindowsDoNotOverlap(t, id, svc.reportedBackupWindow(backupOnly), svc.reportedMaintenanceWindow(backupOnly))
+
+		maintenanceOnly := &DBInstanceRecord{DBInstanceIdentifier: id, PreferredMaintenanceWindow: "wed:04:00-wed:05:00"}
+		assertWindowsDoNotOverlap(t, id,
+			svc.reportedBackupWindow(maintenanceOnly), svc.reportedMaintenanceWindow(maintenanceOnly))
+	}
+}
+
+func assertWindowsDoNotOverlap(t *testing.T, id, backup, maintenance string) {
+	t.Helper()
+	backupWindow, err := parseDailyWindow("PreferredBackupWindow", backup)
+	require.NoError(t, err)
+	maintenanceWindow, err := parseWeeklyWindow("PreferredMaintenanceWindow", maintenance)
+	require.NoError(t, err)
+	assert.False(t, backupWindow.overlaps(maintenanceWindow),
+		"%s: %s and %s should not overlap", id, backup, maintenance)
 }
 
 // An operator's typo cannot be allowed to fail every create on the node, so the
@@ -463,6 +537,28 @@ func TestRunBackupWindow_IgnoresAMalformedStoredWindow(t *testing.T) {
 	assert.False(t, h.runBackupPass(t))
 	assert.Empty(t, h.snaps.created)
 	assert.Nil(t, h.instance(t, testDBID).LastAutomatedBackupFailureAt)
+}
+
+// The other half of the pair is resolved for the overlap check, not to be
+// written down. A record that carried no maintenance window before the modify
+// still carries none after it: reporting one back would show as drift in the next
+// plan of a config that never set it.
+func TestModifyDBInstance_DoesNotPersistTheWindowItWasNotGiven(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := retainingRecord(7)
+	rec.PreferredMaintenanceWindow = ""
+	seedInstance(t, h.svc, rec)
+
+	out, err := h.svc.ModifyDBInstance(t.Context(), &rds.ModifyDBInstanceInput{
+		DBInstanceIdentifier:  aws.String(testDBID),
+		PreferredBackupWindow: aws.String("13:00-14:00"),
+	}, testAccountID)
+	require.NoError(t, err, "a backup window inside the maintenance block is not a rejection")
+	assert.Equal(t, "13:00-14:00", aws.StringValue(out.DBInstance.PreferredBackupWindow))
+
+	stored := h.instance(t, testDBID)
+	assert.Equal(t, "13:00-14:00", stored.PreferredBackupWindow)
+	assert.Empty(t, stored.PreferredMaintenanceWindow, "a window the request did not name is not stored")
 }
 
 // A record written before rds-9 carries no window at all, and still has to be

--- a/spinifex/handlers/rds/backup_test.go
+++ b/spinifex/handlers/rds/backup_test.go
@@ -1,0 +1,856 @@
+package handlers_rds
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A daily window that is open at now, exactly the 30-minute minimum wide.
+func openBackupWindow(now time.Time) string {
+	start := sinceMidnight(now.Add(-15 * time.Minute))
+	return formatClock(start) + "-" + formatClock(start+windowSlot)
+}
+
+// A daily window that is closed at now, well clear of it on both sides.
+func closedBackupWindow(now time.Time) string {
+	start := sinceMidnight(now.Add(2 * time.Hour))
+	return formatClock(start) + "-" + formatClock(start+time.Hour)
+}
+
+func openMaintenanceWindow(now time.Time) string {
+	start := sinceSunday(now.Add(-15 * time.Minute))
+	return formatWeekdayClock(start) + "-" + formatWeekdayClock(start+windowSlot)
+}
+
+func closedMaintenanceWindow(now time.Time) string {
+	start := sinceSunday(now.Add(2 * time.Hour))
+	return formatWeekdayClock(start) + "-" + formatWeekdayClock(start+time.Hour)
+}
+
+// An instance the scheduler will back up: available, with a data volume, backups
+// on, and a window that is open right now.
+func backupReadyRecord() DBInstanceRecord {
+	rec := availableRecord()
+	rec.BackupRetentionPeriod = 7
+	rec.PreferredBackupWindow = openBackupWindow(time.Now().UTC())
+	rec.PreferredMaintenanceWindow = closedMaintenanceWindow(time.Now().UTC())
+	return rec
+}
+
+// The revision the record is at, which is what the scheduled passes CAS against.
+func instanceRevision(t *testing.T, svc *Service, id string) (*DBInstanceRecord, uint64) {
+	t.Helper()
+	kv, err := svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	rec, rev, err := svc.getDBInstance(t.Context(), kv, id)
+	require.NoError(t, err)
+	return rec, rev
+}
+
+// Runs one backup pass the way the reconciler does: re-read at its revision,
+// then fire.
+func (h *snapshotHarness) runBackupPass(t *testing.T) bool {
+	t.Helper()
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	rec, rev := instanceRevision(t, h.svc, testDBID)
+	fired, err := h.svc.runBackupWindow(t.Context(), kv, rev, testAccountID, rec)
+	require.NoError(t, err)
+	return fired
+}
+
+func (h *snapshotHarness) runMaintenancePass(t *testing.T) bool {
+	t.Helper()
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	rec, rev := instanceRevision(t, h.svc, testDBID)
+	fired, err := h.svc.runMaintenanceWindow(t.Context(), kv, rev, testAccountID, rec)
+	require.NoError(t, err)
+	return fired
+}
+
+func (h *snapshotHarness) automatedStamps(t *testing.T, id string) []string {
+	t.Helper()
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	stamps, err := ListAutomatedBackupStamps(t.Context(), kv, id)
+	require.NoError(t, err)
+	return stamps
+}
+
+func TestParseDailyWindow_RejectsWhatAWSRejects(t *testing.T) {
+	cases := map[string]string{
+		"NoSeparator":      "0300-0400",
+		"TooManyParts":     "03:00-04:00-05:00",
+		"SingleDigitHour":  "3:00-4:00",
+		"NoMinutes":        "03-04",
+		"HourOutOfRange":   "24:00-25:00",
+		"MinuteOutOfRange": "03:60-04:00",
+		"NotDigits":        "aa:bb-cc:dd",
+		// A zero-length window is the degenerate reading of a wrap, so it has to
+		// fail the minimum rather than be measured as a whole day.
+		"ZeroLength":  "03:00-03:00",
+		"TooShort":    "03:00-03:15",
+		"WeekdayForm": "sun:03:00-sun:04:00",
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseDailyWindow("PreferredBackupWindow", value)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+		})
+	}
+}
+
+func TestParseDailyWindow_AcceptsAWindowThatWrapsMidnight(t *testing.T) {
+	window, err := parseDailyWindow("PreferredBackupWindow", "23:45-00:15")
+	require.NoError(t, err)
+	assert.Equal(t, windowSlot, window.length())
+	assert.Equal(t, "23:45-00:15", window.String())
+
+	assert.True(t, window.contains(time.Date(2026, 7, 30, 23, 50, 0, 0, time.UTC)))
+	assert.True(t, window.contains(time.Date(2026, 7, 31, 0, 5, 0, 0, time.UTC)))
+	assert.False(t, window.contains(time.Date(2026, 7, 30, 23, 40, 0, 0, time.UTC)))
+	assert.False(t, window.contains(time.Date(2026, 7, 31, 0, 20, 0, 0, time.UTC)))
+
+	// The instant it opened is yesterday's, which is what stops a backup taken at
+	// 23:50 from firing again at 00:05 the next morning.
+	assert.Equal(t, time.Date(2026, 7, 30, 23, 45, 0, 0, time.UTC),
+		window.openedAt(time.Date(2026, 7, 31, 0, 5, 0, 0, time.UTC)))
+}
+
+func TestParseWeeklyWindow_RejectsWhatAWSRejects(t *testing.T) {
+	cases := map[string]string{
+		"NoDay":          "03:00-04:00",
+		"UnknownDay":     "xyz:03:00-xyz:04:00",
+		"FullDayName":    "sunday:03:00-sunday:04:00",
+		"PartialDayName": "un:03:00-un:04:00",
+		"UnpaddedClock":  "sun:3:00-sun:4:00",
+		"ZeroLength":     "sun:03:00-sun:03:00",
+		"TooShort":       "sun:03:00-sun:03:15",
+		"MalformedClock": "mon:03:00-mon:0245",
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseWeeklyWindow("PreferredMaintenanceWindow", value)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+		})
+	}
+}
+
+func TestParseWeeklyWindow_AcceptsAWindowThatWrapsTheWeek(t *testing.T) {
+	window, err := parseWeeklyWindow("PreferredMaintenanceWindow", "sat:23:45-sun:00:15")
+	require.NoError(t, err)
+	assert.Equal(t, windowSlot, window.length())
+	assert.Equal(t, "sat:23:45-sun:00:15", window.String())
+
+	// Saturday the 1st of August 2026 at 23:50, and the Sunday minutes after it.
+	assert.True(t, window.contains(time.Date(2026, 8, 1, 23, 50, 0, 0, time.UTC)))
+	assert.True(t, window.contains(time.Date(2026, 8, 2, 0, 5, 0, 0, time.UTC)))
+	assert.False(t, window.contains(time.Date(2026, 8, 2, 0, 20, 0, 0, time.UTC)))
+	assert.Equal(t, time.Date(2026, 8, 1, 23, 45, 0, 0, time.UTC),
+		window.openedAt(time.Date(2026, 8, 2, 0, 5, 0, 0, time.UTC)))
+}
+
+// AWS refuses the pair rather than the individual window, because the two would
+// collide the week the maintenance window's day comes round.
+func TestValidateWindows_RejectsAnOverlappingPair(t *testing.T) {
+	svc := NewService(nil, testRegion)
+
+	_, _, err := svc.validateWindows(testDBID, "03:00-04:00", "mon:03:30-mon:04:30")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterCombination)
+
+	// The same times on a day the backup window cannot reach are still refused: the
+	// overlap is in the time of day, whatever weekday it falls on.
+	_, _, err = svc.validateWindows(testDBID, "03:00-04:00", "sat:03:30-sat:04:30")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterCombination)
+}
+
+// Canonical text, not the customer's: a describe has to read back the string a
+// later modify compares against, or every modify would look like a change.
+func TestValidateWindows_ReturnsTheCanonicalText(t *testing.T) {
+	backup, maintenance, err := NewService(nil, testRegion).
+		validateWindows(testDBID, "03:00-04:00", "SUN:05:00-sun:06:00")
+	require.NoError(t, err)
+	assert.Equal(t, "03:00-04:00", backup)
+	assert.Equal(t, "sun:05:00-sun:06:00", maintenance)
+}
+
+// The assignment stands in for AWS's random one. It has to be stable, because a
+// window that moved whenever the record was rewritten would back up at an hour
+// the customer never saw.
+func TestValidateWindows_AssignsStableNonOverlappingWindows(t *testing.T) {
+	svc := NewService(nil, testRegion)
+	block := svc.backupWindowBlock()
+	maintenanceBlock := svc.maintenanceWindowBlock()
+
+	assigned := map[string]bool{}
+	for _, id := range []string{"orders-db", "billing-db", "sessions-db", "audit-db", "reporting-db"} {
+		backup, maintenance, err := svc.validateWindows(id, "", "")
+		require.NoError(t, err)
+
+		again, _, err := svc.validateWindows(id, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, backup, again, "the assignment for %s has to be stable", id)
+
+		backupWindow, err := parseDailyWindow("PreferredBackupWindow", backup)
+		require.NoError(t, err)
+		maintenanceWindow, err := parseWeeklyWindow("PreferredMaintenanceWindow", maintenance)
+		require.NoError(t, err)
+
+		assert.Equal(t, windowSlot, backupWindow.length())
+		assert.Equal(t, windowSlot, maintenanceWindow.length())
+		assert.True(t, withinSegments(block.segments(), backupWindow.start),
+			"%s: the backup window %s should start inside %s", id, backup, block)
+		assert.True(t, withinSegments(maintenanceBlock.segments(), maintenanceWindow.start%oneDay),
+			"%s: the maintenance window %s should start inside %s", id, maintenance, maintenanceBlock)
+		// The two default blocks are disjoint, which is what keeps a derived pair
+		// from being the pair AWS itself would refuse.
+		assert.False(t, backupWindow.overlaps(maintenanceWindow))
+
+		assigned[backup] = true
+	}
+	assert.Greater(t, len(assigned), 1, "the fleet's quiesce load should spread across the block")
+}
+
+// An operator's typo cannot be allowed to fail every create on the node, so the
+// built-in block is used and the fault is logged instead.
+func TestWindowBlock_FallsBackToTheBuiltInBlock(t *testing.T) {
+	svc := NewService(nil, testRegion).WithDeps(Deps{Backup: BackupPolicy{
+		BackupWindowBlock:      "not-a-window",
+		MaintenanceWindowBlock: "19:00",
+	}})
+
+	builtIn, err := parseDailyWindow("block", defaultBackupWindowBlock)
+	require.NoError(t, err)
+	assert.Equal(t, builtIn, svc.backupWindowBlock())
+
+	builtIn, err = parseDailyWindow("block", defaultMaintenanceWindowBlock)
+	require.NoError(t, err)
+	assert.Equal(t, builtIn, svc.maintenanceWindowBlock())
+}
+
+func TestValidateRetentionPeriod_BoundsTheRetention(t *testing.T) {
+	svc := NewService(nil, testRegion)
+	require.NoError(t, svc.validateRetentionPeriod(0))
+	require.NoError(t, svc.validateRetentionPeriod(defaultBackupRetentionCapDays))
+
+	err := svc.validateRetentionPeriod(defaultBackupRetentionCapDays + 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+	require.Error(t, svc.validateRetentionPeriod(-1))
+
+	// A cap lowered below the configured default hands new instances the cap, not a
+	// retention the same cluster would reject on modify.
+	capped := NewService(nil, testRegion).WithDeps(Deps{Backup: BackupPolicy{
+		RetentionCapDays: 3,
+		RetentionDays:    7,
+	}})
+	assert.Equal(t, int64(3), capped.defaultRetentionDays())
+	require.Error(t, capped.validateRetentionPeriod(4))
+}
+
+// The stamp, not a timer: this is what makes the pass fire exactly once per
+// window across leader churn and daemon restarts, and what stops a missed window
+// from being backfilled.
+func TestBackupDue_FiresOncePerWindowAndNeverBackfills(t *testing.T) {
+	window, err := parseDailyWindow("PreferredBackupWindow", "03:00-03:30")
+	require.NoError(t, err)
+	svc := NewService(nil, testRegion)
+
+	inWindow := time.Date(2026, 7, 30, 3, 10, 0, 0, time.UTC)
+	opened := window.openedAt(inWindow)
+	rec := &DBInstanceRecord{DBInstanceIdentifier: testDBID, BackupRetentionPeriod: 7}
+
+	assert.True(t, svc.backupDue(rec, window, inWindow))
+
+	// Already fired in this window: every later pass inside it, on any node, reads
+	// the same stamp and stands down.
+	fired := opened.Add(time.Minute)
+	rec.LastAutomatedBackupAt = &fired
+	assert.False(t, svc.backupDue(rec, window, inWindow))
+	assert.False(t, svc.backupDue(rec, window, inWindow.Add(19*time.Minute)))
+
+	// The next day's window is a new one.
+	assert.True(t, svc.backupDue(rec, window, inWindow.Add(oneDay)))
+
+	// Outside the window nothing fires, however long ago the last backup was: a
+	// window that was missed is never caught up on.
+	stale := opened.Add(-30 * oneDay)
+	rec.LastAutomatedBackupAt = &stale
+	assert.False(t, svc.backupDue(rec, window, inWindow.Add(2*time.Hour)))
+	assert.True(t, svc.backupDue(rec, window, inWindow))
+
+	// Retention 0 turns scheduling off outright.
+	rec.LastAutomatedBackupAt = nil
+	rec.BackupRetentionPeriod = 0
+	assert.False(t, svc.backupDue(rec, window, inWindow))
+}
+
+// A failure inside the window is retried, but paced: the window is 30 minutes, so
+// the backoff is what keeps a broken backup from re-quiescing the engine on every
+// two-minute pass.
+func TestBackupDue_PacesRetriesInsideTheWindow(t *testing.T) {
+	window, err := parseDailyWindow("PreferredBackupWindow", "03:00-03:30")
+	require.NoError(t, err)
+	svc := NewService(nil, testRegion)
+
+	inWindow := time.Date(2026, 7, 30, 3, 10, 0, 0, time.UTC)
+	failed := inWindow
+	rec := &DBInstanceRecord{
+		DBInstanceIdentifier:         testDBID,
+		BackupRetentionPeriod:        7,
+		AutomatedBackupFailures:      1,
+		LastAutomatedBackupFailureAt: &failed,
+	}
+
+	assert.False(t, svc.backupDue(rec, window, inWindow.Add(30*time.Second)))
+	assert.True(t, svc.backupDue(rec, window, inWindow.Add(time.Minute)))
+
+	// Doubling per consecutive failure, capped, so a persistently failing backup
+	// settles at a handful of attempts per window rather than one per pass.
+	assert.Equal(t, time.Minute, backupRetryDelay(1))
+	assert.Equal(t, 2*time.Minute, backupRetryDelay(2))
+	assert.Equal(t, 8*time.Minute, backupRetryDelay(4))
+	assert.Equal(t, 8*time.Minute, backupRetryDelay(40))
+	// A deferred backup carries no failure count, and still has to be paced.
+	assert.Equal(t, time.Minute, backupRetryDelay(0))
+}
+
+func TestRunBackupWindow_TakesIndexesAndStampsTheBackup(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, backupReadyRecord())
+
+	require.True(t, h.runBackupPass(t))
+
+	// One EC2 snapshot, taken through rds-8's path: the engine was quiesced and let
+	// go again rather than copied mid-write.
+	require.Len(t, h.snaps.created, 1)
+	issued := make([]string, 0, 2)
+	for _, cmd := range h.agent.received() {
+		issued = append(issued, cmd.Type)
+	}
+	assert.Equal(t, []string{CommandQuiesce, CommandUnquiesce}, issued)
+
+	stamps := h.automatedStamps(t, testDBID)
+	require.Len(t, stamps, 1, "the backup has to be indexed, or retention can never find it")
+
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	var entry AutomatedBackupRecord
+	found, err := getJSON(t.Context(), kv, AutomatedBackupKey(testDBID, stamps[0]), &entry)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, strings.HasPrefix(entry.DBSnapshotIdentifier, automatedSnapshotPrefix+testDBID+"-"),
+		"an automated snapshot takes AWS's own name: %s", entry.DBSnapshotIdentifier)
+
+	snapshot, found := h.snapshot(t, entry.DBSnapshotIdentifier)
+	require.True(t, found)
+	assert.Equal(t, SnapshotTypeAutomated, snapshot.SnapshotType)
+	assert.Equal(t, SnapshotStatusAvailable, snapshot.Status)
+
+	// The instance is where it was found, with the window stamped as fired.
+	rec := h.instance(t, testDBID)
+	assert.Equal(t, StatusAvailable, rec.Status)
+	require.NotNil(t, rec.LastAutomatedBackupAt)
+	assert.Zero(t, rec.AutomatedBackupFailures)
+	assert.Nil(t, rec.LastAutomatedBackupFailureAt)
+}
+
+// The window fires once however many passes run inside it, which is what a
+// two-minute reconciler and a leader handover both look like from here.
+func TestRunBackupWindow_FiresOncePerWindow(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, backupReadyRecord())
+
+	require.True(t, h.runBackupPass(t))
+	assert.False(t, h.runBackupPass(t))
+	assert.False(t, h.runBackupPass(t))
+
+	assert.Len(t, h.snaps.created, 1)
+	assert.Len(t, h.automatedStamps(t, testDBID), 1)
+}
+
+func TestRunBackupWindow_DoesNotFireOutsideTheWindow(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	rec.PreferredBackupWindow = closedBackupWindow(time.Now().UTC())
+	seedInstance(t, h.svc, rec)
+
+	assert.False(t, h.runBackupPass(t))
+	assert.Empty(t, h.snaps.created)
+	assert.Empty(t, h.automatedStamps(t, testDBID))
+}
+
+func TestRunBackupWindow_DoesNotFireWithBackupsDisabled(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	rec.BackupRetentionPeriod = 0
+	seedInstance(t, h.svc, rec)
+
+	assert.False(t, h.runBackupPass(t))
+	assert.Empty(t, h.snaps.created)
+	assert.Nil(t, h.instance(t, testDBID).LastAutomatedBackupAt)
+}
+
+// A backup is a point in time, so one taken after the reboot finishes belongs to
+// the next window rather than this one. The skip is evented, because a customer
+// looking for last night's backup has to be able to see why there is none.
+func TestRunBackupWindow_SkipsAnInstanceItCannotBackUp(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	rec.Status = StatusRebooting
+	seedInstance(t, h.svc, rec)
+
+	assert.False(t, h.runBackupPass(t))
+	assert.Empty(t, h.snaps.created)
+
+	stored := h.instance(t, testDBID)
+	assert.Equal(t, StatusRebooting, stored.Status, "a skipped backup does not touch the instance")
+	assert.Nil(t, stored.LastAutomatedBackupAt)
+	require.NotNil(t, stored.LastAutomatedBackupFailureAt)
+	assert.Zero(t, stored.AutomatedBackupFailures, "nothing failed; the instance was busy elsewhere")
+
+	messages := eventMessages(h.events(t, EventSourceTypeDBInstance, testDBID))
+	assert.Contains(t, messages, "The automated backup was skipped because the DB instance is rebooting.")
+
+	// Evented once per window rather than once per pass, so a long reboot does not
+	// bury the event ring.
+	assert.False(t, h.runBackupPass(t))
+	assert.Len(t, h.events(t, EventSourceTypeDBInstance, testDBID), len(messages))
+}
+
+// D-rds-9: a failed backup is a backup fault, never an instance fault. The
+// database stays available and the failure is counted so it is visible.
+func TestRunBackupWindow_CountsAFailureAndLeavesTheInstanceAvailable(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, backupReadyRecord())
+	h.snaps.createErr = assert.AnError
+
+	assert.False(t, h.runBackupPass(t))
+
+	rec := h.instance(t, testDBID)
+	assert.Equal(t, StatusAvailable, rec.Status)
+	assert.Equal(t, 1, rec.AutomatedBackupFailures)
+	require.NotNil(t, rec.LastAutomatedBackupFailureAt)
+	assert.Nil(t, rec.LastAutomatedBackupAt)
+	assert.Empty(t, h.automatedStamps(t, testDBID), "a failed backup leaves nothing in the index")
+
+	messages := strings.Join(eventMessages(h.events(t, EventSourceTypeDBInstance, testDBID)), "\n")
+	assert.Contains(t, messages, "The automated backup could not be taken")
+}
+
+// A stored window this plane cannot parse is corruption rather than a schedule:
+// firing on a guessed window would back up at an hour nobody asked for.
+func TestRunBackupWindow_IgnoresAMalformedStoredWindow(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	rec.PreferredBackupWindow = "0300-0400"
+	seedInstance(t, h.svc, rec)
+
+	assert.False(t, h.runBackupPass(t))
+	assert.Empty(t, h.snaps.created)
+	assert.Nil(t, h.instance(t, testDBID).LastAutomatedBackupFailureAt)
+}
+
+// A record written before rds-9 carries no window at all, and still has to be
+// backed up — on the window a describe reports for it.
+func TestResolvedBackupWindow_DerivesAWindowForARecordWithoutOne(t *testing.T) {
+	svc := NewService(nil, testRegion)
+	rec := &DBInstanceRecord{DBInstanceIdentifier: testDBID}
+
+	window, err := svc.resolvedBackupWindow(rec)
+	require.NoError(t, err)
+	assert.Equal(t, assignDailyWindow(svc.backupWindowBlock(), testDBID), window)
+	assert.Equal(t, window.String(), svc.reportedBackupWindow(rec))
+
+	maintenance, err := svc.resolvedMaintenanceWindow(rec)
+	require.NoError(t, err)
+	assert.Equal(t, maintenance.String(), svc.reportedMaintenanceWindow(rec))
+
+	// A malformed stored window is reported verbatim: it is not one the scheduler
+	// will honour either, so replacing it with a plausible one would mislead.
+	rec.PreferredBackupWindow = "0300-0400"
+	assert.Equal(t, "0300-0400", svc.reportedBackupWindow(rec))
+}
+
+// AWS applies a deferred class change or storage grow in the maintenance window
+// rather than never. Only the transition happens here; the apply itself is the
+// reconciler's single drain through applyPendingModifications.
+func TestRunMaintenanceWindow_OpensADeferredModify(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	rec.PreferredMaintenanceWindow = openMaintenanceWindow(time.Now().UTC())
+	rec.PendingModifiedValues = &PendingModifiedValues{
+		DBInstanceClass: "db.t3.large",
+		RequestedAt:     time.Now().UTC().Add(-time.Hour),
+	}
+	seedInstance(t, h.svc, rec)
+
+	require.True(t, h.runMaintenancePass(t))
+
+	stored := h.instance(t, testDBID)
+	assert.Equal(t, StatusModifying, stored.Status)
+	require.NotNil(t, stored.LastMaintenanceWindowAt)
+	require.NotNil(t, stored.TransitionStartedAt)
+	require.NotNil(t, stored.PendingModifiedValues, "the values are drained by the reconciler, not here")
+	assert.Equal(t, "db.t3.large", stored.PendingModifiedValues.DBInstanceClass)
+
+	messages := strings.Join(eventMessages(h.events(t, EventSourceTypeDBInstance, testDBID)), "\n")
+	assert.Contains(t, messages, "Applying the modification recorded earlier")
+}
+
+func TestRunMaintenanceWindow_StandsDownWhenThereIsNothingToApply(t *testing.T) {
+	now := time.Now().UTC()
+	cases := map[string]func(*DBInstanceRecord){
+		"NothingPending": func(rec *DBInstanceRecord) { rec.PendingModifiedValues = nil },
+		"WindowClosed": func(rec *DBInstanceRecord) {
+			rec.PreferredMaintenanceWindow = closedMaintenanceWindow(now)
+		},
+		"NotAvailable": func(rec *DBInstanceRecord) { rec.Status = StatusRebooting },
+		// A grow already past its volume modify is resumed by the reconciler
+		// whatever the window says, so it must not be re-opened here.
+		"GrowingFilesystem": func(rec *DBInstanceRecord) {
+			rec.PendingModifiedValues.FilesystemGrowPending = true
+		},
+		"MalformedWindow": func(rec *DBInstanceRecord) { rec.PreferredMaintenanceWindow = "sunday:03:00" },
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := newSnapshotHarness(t, false)
+			rec := backupReadyRecord()
+			rec.PreferredMaintenanceWindow = openMaintenanceWindow(now)
+			rec.PendingModifiedValues = &PendingModifiedValues{DBInstanceClass: "db.t3.large"}
+			mutate(&rec)
+			seedInstance(t, h.svc, rec)
+
+			assert.False(t, h.runMaintenancePass(t))
+			assert.NotEqual(t, StatusModifying, h.instance(t, testDBID).Status)
+		})
+	}
+}
+
+func TestRunMaintenanceWindow_OpensOncePerWindow(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	rec.PreferredMaintenanceWindow = openMaintenanceWindow(time.Now().UTC())
+	rec.PendingModifiedValues = &PendingModifiedValues{DBInstanceClass: "db.t3.large"}
+	seedInstance(t, h.svc, rec)
+
+	require.True(t, h.runMaintenancePass(t))
+
+	// Back to available with the change still pending — the shape a failed apply
+	// leaves behind. The window has already fired, so it is not re-opened.
+	stored := h.instance(t, testDBID)
+	stored.Status = StatusAvailable
+	seedInstance(t, h.svc, stored)
+	assert.False(t, h.runMaintenancePass(t))
+}
+
+func TestAutomatedSnapshotIdentifier_TakesAWSsOwnName(t *testing.T) {
+	at := time.Date(2026, 7, 30, 3, 25, 45, 0, time.UTC)
+	assert.Equal(t, "rds:orders-db-2026-07-30-03-25", AutomatedSnapshotIdentifier(testDBID, at))
+	// Minute-precise, so a retry inside the same window never collides with the
+	// attempt that failed.
+	assert.NotEqual(t, AutomatedSnapshotIdentifier(testDBID, at),
+		AutomatedSnapshotIdentifier(testDBID, at.Add(time.Minute)))
+	// Fixed width and UTC, so the index's lexical order is chronological.
+	assert.Equal(t, "20260730T032545Z", AutomatedBackupStamp(at))
+	assert.Less(t, AutomatedBackupStamp(at), AutomatedBackupStamp(at.Add(time.Minute)))
+}
+
+// Automated backups own the rds: namespace, as in AWS, so a customer snapshot can
+// never collide with one the scheduler mints.
+func TestCreateDBSnapshot_RejectsTheAutomatedNamespace(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	h.seedSnapshotSource(t)
+
+	in := snapshotInput()
+	in.DBSnapshotIdentifier = aws.String("rds:orders-db-2026-07-30-03-25")
+
+	_, err := h.svc.CreateDBSnapshot(t.Context(), in, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+	assert.Contains(t, err.Error(), automatedSnapshotPrefix)
+	assert.Empty(t, h.snaps.created)
+}
+
+func TestDescribeDBInstanceAutomatedBackups_ReportsTheBackupSet(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, backupReadyRecord())
+
+	// Before the first snapshot the backup set exists but has nothing in it, which
+	// is what AWS calls creating.
+	out, err := h.svc.DescribeDBInstanceAutomatedBackups(t.Context(),
+		&rds.DescribeDBInstanceAutomatedBackupsInput{}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.DBInstanceAutomatedBackups, 1)
+	assert.Equal(t, "creating", aws.StringValue(out.DBInstanceAutomatedBackups[0].Status))
+
+	require.True(t, h.runBackupPass(t))
+
+	out, err = h.svc.DescribeDBInstanceAutomatedBackups(t.Context(),
+		&rds.DescribeDBInstanceAutomatedBackupsInput{DBInstanceIdentifier: aws.String(testDBID)}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.DBInstanceAutomatedBackups, 1)
+
+	backup := out.DBInstanceAutomatedBackups[0]
+	assert.Equal(t, "active", aws.StringValue(backup.Status))
+	assert.Equal(t, testDBID, aws.StringValue(backup.DBInstanceIdentifier))
+	assert.Equal(t, DBInstanceARN(testRegion, testAccountID, testDBID), aws.StringValue(backup.DBInstanceArn))
+	assert.Equal(t, int64(7), aws.Int64Value(backup.BackupRetentionPeriod))
+	assert.Equal(t, testRegion, aws.StringValue(backup.Region))
+
+	// D11 Phase B: this phase backs discrete daily snapshots. A restore window
+	// would tell a client it can recover to any instant inside it.
+	assert.Nil(t, backup.RestoreWindow)
+}
+
+func TestDescribeDBInstanceAutomatedBackups_SkipsAnInstanceWithBackupsOff(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	rec.BackupRetentionPeriod = 0
+	seedInstance(t, h.svc, rec)
+
+	out, err := h.svc.DescribeDBInstanceAutomatedBackups(t.Context(),
+		&rds.DescribeDBInstanceAutomatedBackupsInput{}, testAccountID)
+	require.NoError(t, err)
+	assert.Empty(t, out.DBInstanceAutomatedBackups)
+}
+
+func TestDescribeDBInstanceAutomatedBackups_RejectsAnUnknownInstance(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+
+	_, err := h.svc.DescribeDBInstanceAutomatedBackups(t.Context(),
+		&rds.DescribeDBInstanceAutomatedBackupsInput{DBInstanceIdentifier: aws.String("no-such-db")}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorDBInstanceNotFound)
+}
+
+// D19: a filter this phase cannot honour is rejected, because a silently
+// unfiltered list reads as a complete answer.
+func TestDescribeDBInstanceAutomatedBackups_RejectsUnimplementedFilters(t *testing.T) {
+	cases := map[string]*rds.DescribeDBInstanceAutomatedBackupsInput{
+		"Filters": {Filters: []*rds.Filter{{
+			Name:   aws.String("db-instance-id"),
+			Values: aws.StringSlice([]string{testDBID}),
+		}}},
+		"DbiResourceId":                 {DbiResourceId: aws.String("db-ABCDEF")},
+		"DBInstanceAutomatedBackupsArn": {DBInstanceAutomatedBackupsArn: aws.String("arn:aws:rds:::auto-backup:x")},
+	}
+
+	h := newSnapshotHarness(t, false)
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := h.svc.DescribeDBInstanceAutomatedBackups(t.Context(), input, testAccountID)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+		})
+	}
+}
+
+// The window pass has to be part of the leader's own account loop: a backup
+// nothing calls is a backup that is never taken.
+func TestReconciler_RunsTheBackupWindowOnItsAccountPass(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	now := time.Now().UTC()
+	rec.Agent = AgentState{InstanceID: testInstance, EngineHealth: EngineHealthHealthy, LastSeen: &now}
+	seedInstance(t, h.svc, rec)
+
+	require.NoError(t, NewReconciler(h.svc, "node-a").reconcileOnce(t.Context()))
+
+	assert.Len(t, h.snaps.created, 1)
+	assert.Len(t, h.automatedStamps(t, testDBID), 1)
+	assert.NotNil(t, h.instance(t, testDBID).LastAutomatedBackupAt)
+}
+
+// The GC framework's cluster-wide gate is the reconciler's own lease. Without it
+// the retention sweep would delete customer data from every node at once.
+func TestReconciler_ClusterLeaseFollowsLeadership(t *testing.T) {
+	h := newReconcileHarness(t)
+
+	release, ok := h.rec.AcquireClusterLease()
+	require.NotNil(t, release)
+	assert.False(t, ok, "a node that does not hold the lease does not sweep")
+
+	h.rec.evaluateLeadership(t.Context())
+	release, ok = h.rec.AcquireClusterLease()
+	require.True(t, ok)
+
+	// The lease is held continuously rather than claimed per sweep, so releasing
+	// the GC's handle must not hand leadership away.
+	release()
+	_, ok = h.rec.AcquireClusterLease()
+	assert.True(t, ok)
+}
+
+// Automated backups are on by default at the full cap: a shorter default would
+// pay the whole storage cost of retaining a snapshot for a fraction of the cover.
+func TestValidateCreateRequest_DefaultsTheBackupSettings(t *testing.T) {
+	svc := newCreateValidator()
+	req, err := svc.validateCreateRequest(validCreateInput())
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(defaultBackupRetentionDays), req.BackupRetentionPeriod)
+	backup, maintenance, err := svc.validateWindows(testDBInstanceID, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, backup, req.PreferredBackupWindow)
+	assert.Equal(t, maintenance, req.PreferredMaintenanceWindow)
+}
+
+func TestValidateCreateRequest_AcceptsTheBackupSettings(t *testing.T) {
+	input := validCreateInput()
+	input.BackupRetentionPeriod = aws.Int64(3)
+	input.PreferredBackupWindow = aws.String("03:00-04:00")
+	input.PreferredMaintenanceWindow = aws.String("sun:05:00-sun:06:00")
+
+	req, err := newCreateValidator().validateCreateRequest(input)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), req.BackupRetentionPeriod)
+	assert.Equal(t, "03:00-04:00", req.PreferredBackupWindow)
+	assert.Equal(t, "sun:05:00-sun:06:00", req.PreferredMaintenanceWindow)
+
+	// A create asking for 0 explicitly turns automated backups off, which the
+	// default may not do on its behalf.
+	input.BackupRetentionPeriod = aws.Int64(0)
+	req, err = newCreateValidator().validateCreateRequest(input)
+	require.NoError(t, err)
+	assert.Zero(t, req.BackupRetentionPeriod)
+}
+
+// A retention or a window that would fail in a window nobody is watching fails in
+// the call that set it instead.
+func TestValidateCreateRequest_RejectsBadBackupSettings(t *testing.T) {
+	cases := map[string]func(*rds.CreateDBInstanceInput){
+		"RetentionOverCap":  func(in *rds.CreateDBInstanceInput) { in.BackupRetentionPeriod = aws.Int64(35) },
+		"NegativeRetention": func(in *rds.CreateDBInstanceInput) { in.BackupRetentionPeriod = aws.Int64(-1) },
+		"MalformedBackupWindow": func(in *rds.CreateDBInstanceInput) {
+			in.PreferredBackupWindow = aws.String("3am-4am")
+		},
+		"MalformedMaintenanceWindow": func(in *rds.CreateDBInstanceInput) {
+			in.PreferredMaintenanceWindow = aws.String("05:00-06:00")
+		},
+		"OverlappingWindows": func(in *rds.CreateDBInstanceInput) {
+			in.PreferredBackupWindow = aws.String("03:00-04:00")
+			in.PreferredMaintenanceWindow = aws.String("wed:03:30-wed:04:30")
+		},
+	}
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			input := validCreateInput()
+			mutate(input)
+			_, err := newCreateValidator().validateCreateRequest(input)
+			require.Error(t, err)
+		})
+	}
+}
+
+// The window is persisted at create rather than derived on every read, so it
+// survives a change to the configured block the way AWS's assigned window does.
+func TestCreateDBInstance_PersistsTheBackupSettings(t *testing.T) {
+	h := newCreateHarness(t, "")
+
+	_, err := h.svc.CreateDBInstance(t.Context(), validCreateInput(), testAccountID)
+	require.NoError(t, err)
+
+	rec := h.record(t, testDBInstanceID)
+	assert.Equal(t, int64(defaultBackupRetentionDays), rec.BackupRetentionPeriod)
+	assert.NotEmpty(t, rec.PreferredBackupWindow)
+	assert.NotEmpty(t, rec.PreferredMaintenanceWindow)
+
+	window, err := parseDailyWindow("PreferredBackupWindow", rec.PreferredBackupWindow)
+	require.NoError(t, err)
+	assert.Equal(t, windowSlot, window.length())
+}
+
+// Retention 0 is an answer, not an absence: a client that sees no
+// BackupRetentionPeriod cannot tell "backups are off" from "not reported".
+func TestDescribeDBInstances_ReportsTheBackupSettingsIncludingZero(t *testing.T) {
+	h := newCreateHarness(t, "")
+	rec := seedCreated(t, h, testDBInstanceID)
+
+	out, err := h.svc.DescribeDBInstances(t.Context(), &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(testDBInstanceID),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.DBInstances, 1)
+	assert.Equal(t, rec.BackupRetentionPeriod, aws.Int64Value(out.DBInstances[0].BackupRetentionPeriod))
+	assert.Equal(t, rec.PreferredBackupWindow, aws.StringValue(out.DBInstances[0].PreferredBackupWindow))
+	assert.Equal(t, rec.PreferredMaintenanceWindow,
+		aws.StringValue(out.DBInstances[0].PreferredMaintenanceWindow))
+
+	rec.BackupRetentionPeriod = 0
+	seedInstance(t, h.svc, rec)
+	out, err = h.svc.DescribeDBInstances(t.Context(), &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(testDBInstanceID),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.NotNil(t, out.DBInstances[0].BackupRetentionPeriod)
+	assert.Zero(t, aws.Int64Value(out.DBInstances[0].BackupRetentionPeriod))
+}
+
+// Restoring from last night's backup is the whole point of keeping it, so the
+// namespace refused wherever a name is minted has to be accepted as a reference.
+func TestRestoreDBInstanceFromDBSnapshot_RestoresFromAnAutomatedBackup(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	rec := backupReadyRecord()
+	// Everything a restore reproduces from the snapshot alone.
+	rec.DBInstanceClass = "db.t3.medium"
+	rec.AllocatedStorage = 20
+	rec.StorageType = storageTypeGP3
+	rec.StorageEncrypted = true
+	rec.VpcID = testDefaultVPC
+	rec.VpcSecurityGroupIDs = []string{testDefaultSG}
+	seedInstance(t, h.svc, rec)
+	require.True(t, h.runBackupPass(t))
+
+	stamps := h.automatedStamps(t, testDBID)
+	require.Len(t, stamps, 1)
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	var entry AutomatedBackupRecord
+	found, err := getJSON(t.Context(), kv, AutomatedBackupKey(testDBID, stamps[0]), &entry)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	out, err := h.svc.RestoreDBInstanceFromDBSnapshot(t.Context(), &rds.RestoreDBInstanceFromDBSnapshotInput{
+		DBInstanceIdentifier: aws.String(testRestoredID),
+		DBSnapshotIdentifier: aws.String(entry.DBSnapshotIdentifier),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.NotNil(t, out.DBInstance)
+	assert.Equal(t, entry.DBSnapshotIdentifier, h.instance(t, testRestoredID).RestoredFromDBSnapshot)
+}
+
+// Only the retention sweep removes an automated backup, as in AWS: a customer
+// delete-db-snapshot against one is refused rather than silently accepted.
+func TestDeleteDBSnapshot_RefusesAnAutomatedBackup(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	seedInstance(t, h.svc, backupReadyRecord())
+	require.True(t, h.runBackupPass(t))
+
+	stamps := h.automatedStamps(t, testDBID)
+	require.Len(t, stamps, 1)
+
+	_, err := h.svc.DeleteDBSnapshot(t.Context(), &rds.DeleteDBSnapshotInput{
+		DBSnapshotIdentifier: aws.String(AutomatedSnapshotIdentifier(testDBID, time.Now().UTC())),
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+	assert.Len(t, h.automatedStamps(t, testDBID), 1)
+}

--- a/spinifex/handlers/rds/create.go
+++ b/spinifex/handlers/rds/create.go
@@ -24,7 +24,7 @@ const firstVMGeneration = 1
 // record. The instance is returned at status=creating; the reconciler flips it
 // to available on the first healthy agent heartbeat (D7).
 func (s *Service) CreateDBInstance(ctx context.Context, input *rds.CreateDBInstanceInput, accountID string) (out *rds.CreateDBInstanceOutput, err error) {
-	req, err := validateCreateRequest(input)
+	req, err := s.validateCreateRequest(input)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,12 @@ func newDBInstanceRecord(accountID string, req *validatedCreate, placement *endp
 		DBSubnetGroupName:    req.DBSubnetGroupName,
 		DBParameterGroupName: req.DBParameterGroupName,
 		DeletionProtection:   req.DeletionProtection,
-		Tags:                 req.Tags,
+
+		BackupRetentionPeriod:      req.BackupRetentionPeriod,
+		PreferredBackupWindow:      req.PreferredBackupWindow,
+		PreferredMaintenanceWindow: req.PreferredMaintenanceWindow,
+
+		Tags: req.Tags,
 		Bootstrap: BootstrapState{
 			MasterUserPassword: req.MasterPassword,
 			ResolvedParameters: parameters,

--- a/spinifex/handlers/rds/create_test.go
+++ b/spinifex/handlers/rds/create_test.go
@@ -384,6 +384,10 @@ func TestCreateDBInstance_RequiresADefaultVPCWithASubnet(t *testing.T) {
 	assert.False(t, h.recordExists(t, testDBInstanceID))
 }
 
+// Create validation reads the backup policy off the service, so these cases
+// need one. A zero policy carries the built-in defaults.
+func newCreateValidator() *Service { return NewService(nil, testRegion) }
+
 // D19: a parameter that would create a false safety, security or availability
 // guarantee is rejected rather than silently dropped.
 func TestValidateCreateRequest_RejectsUnimplementedParameters(t *testing.T) {
@@ -395,9 +399,6 @@ func TestValidateCreateRequest_RejectsUnimplementedParameters(t *testing.T) {
 		{"MultiAZ", func(in *rds.CreateDBInstanceInput) { in.MultiAZ = aws.Bool(true) }, "MultiAZ"},
 		{"PubliclyAccessible", func(in *rds.CreateDBInstanceInput) { in.PubliclyAccessible = aws.Bool(true) }, "PubliclyAccessible"},
 		{"StorageEncryptedFalse", func(in *rds.CreateDBInstanceInput) { in.StorageEncrypted = aws.Bool(false) }, "StorageEncrypted"},
-		{"BackupRetentionPeriod", func(in *rds.CreateDBInstanceInput) { in.BackupRetentionPeriod = aws.Int64(7) }, "BackupRetentionPeriod"},
-		{"PreferredBackupWindow", func(in *rds.CreateDBInstanceInput) { in.PreferredBackupWindow = aws.String("03:00-04:00") }, "PreferredBackupWindow"},
-		{"PreferredMaintenanceWindow", func(in *rds.CreateDBInstanceInput) { in.PreferredMaintenanceWindow = aws.String("sun:05:00-sun:06:00") }, "PreferredMaintenanceWindow"},
 		{"IAMDatabaseAuth", func(in *rds.CreateDBInstanceInput) { in.EnableIAMDatabaseAuthentication = aws.Bool(true) }, "EnableIAMDatabaseAuthentication"},
 		{"Iops", func(in *rds.CreateDBInstanceInput) { in.Iops = aws.Int64(3000) }, "Iops"},
 		{"KmsKeyId", func(in *rds.CreateDBInstanceInput) { in.KmsKeyId = aws.String("arn:aws:kms:::key/abc") }, "KmsKeyId"},
@@ -413,7 +414,7 @@ func TestValidateCreateRequest_RejectsUnimplementedParameters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			input := validCreateInput()
 			tc.mutate(input)
-			_, err := validateCreateRequest(input)
+			_, err := newCreateValidator().validateCreateRequest(input)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
 			assert.Contains(t, err.Error(), tc.wantErr)
@@ -427,7 +428,7 @@ func TestValidateCreateRequest_AcceptsDeletionProtection(t *testing.T) {
 	input := validCreateInput()
 	input.DeletionProtection = aws.Bool(true)
 
-	req, err := validateCreateRequest(input)
+	req, err := newCreateValidator().validateCreateRequest(input)
 	require.NoError(t, err)
 	assert.True(t, req.DeletionProtection)
 }
@@ -464,7 +465,7 @@ func TestValidateCreateRequest_RejectsMalformedRequests(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			input := validCreateInput()
 			tc.mutate(input)
-			_, err := validateCreateRequest(input)
+			_, err := newCreateValidator().validateCreateRequest(input)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantError)
 		})
@@ -476,7 +477,7 @@ func TestValidateCreateRequest_AcceptsTheImplicitDefaultParameterGroup(t *testin
 	input.DBParameterGroupName = aws.String("default.postgres18")
 	input.Port = aws.Int64(6543)
 
-	req, err := validateCreateRequest(input)
+	req, err := newCreateValidator().validateCreateRequest(input)
 	require.NoError(t, err)
 	assert.Equal(t, "default.postgres18", req.DBParameterGroupName)
 	assert.Equal(t, int64(6543), req.Port)
@@ -494,6 +495,6 @@ func TestValidateCreateRequest_AcceptsInertParameters(t *testing.T) {
 	input.MonitoringInterval = aws.Int64(60)
 	input.StorageEncrypted = aws.Bool(true)
 
-	_, err := validateCreateRequest(input)
+	_, err := newCreateValidator().validateCreateRequest(input)
 	require.NoError(t, err)
 }

--- a/spinifex/handlers/rds/delete.go
+++ b/spinifex/handlers/rds/delete.go
@@ -190,6 +190,13 @@ func (s *Service) teardownDBInstance(ctx context.Context, kv jetstream.KeyValue,
 	if err := s.takeFinalSnapshot(ctx, kv, accountID, rec, finalSnapshotCreator); err != nil {
 		return err
 	}
+	// Before the volume is released, so the automated backups are no longer holding
+	// its chunks when that decides between deleting and retaining it. AWS keeps
+	// automated backups after a delete as a separate resource; doing that here
+	// would pin the data volume indefinitely under rds-8's retention rule (D10).
+	if err := s.purgeAutomatedBackups(ctx, kv, accountID, rec.DBInstanceIdentifier); err != nil {
+		return fmt.Errorf("rds: sweep the automated backups of %s: %w", rec.DBInstanceIdentifier, err)
+	}
 	if err := s.releaseDataVolume(ctx, kv, accountID, rec); err != nil {
 		return err
 	}
@@ -240,8 +247,11 @@ func (s *Service) reserveFinalSnapshot(ctx context.Context, kv jetstream.KeyValu
 		return finalSnapshotReservation{}, nil
 	}
 
+	// Manual, deliberately: the customer named it, so only the customer removes it
+	// — which is also what keeps rds-9's retention sweep away from it.
 	record := newDBSnapshotRecord(accountID, rec, &validatedSnapshot{
 		DBSnapshotIdentifier: identifier,
+		SnapshotType:         SnapshotTypeManual,
 		Tags:                 rec.Tags,
 	})
 	record.FinalSnapshot = true

--- a/spinifex/handlers/rds/describe.go
+++ b/spinifex/handlers/rds/describe.go
@@ -113,15 +113,12 @@ func (s *Service) projectDBInstance(rec *DBInstanceRecord) *rds.DBInstance {
 			Status:             aws.String("active"),
 		})
 	}
-	if rec.BackupRetentionPeriod > 0 {
-		out.BackupRetentionPeriod = aws.Int64(rec.BackupRetentionPeriod)
-	}
-	if rec.PreferredBackupWindow != "" {
-		out.PreferredBackupWindow = aws.String(rec.PreferredBackupWindow)
-	}
-	if rec.PreferredMaintenanceWindow != "" {
-		out.PreferredMaintenanceWindow = aws.String(rec.PreferredMaintenanceWindow)
-	}
+	// Always reported, zero included: the Terraform provider reads all three back,
+	// and an absent backup_retention_period on an instance with backups disabled is
+	// a perpetual diff rather than an honest omission.
+	out.BackupRetentionPeriod = aws.Int64(rec.BackupRetentionPeriod)
+	out.PreferredBackupWindow = aws.String(s.reportedBackupWindow(rec))
+	out.PreferredMaintenanceWindow = aws.String(s.reportedMaintenanceWindow(rec))
 	// AWS has no dedicated failure-reason field on a DB instance, so the reason a
 	// failed instance carries is reported the one place a human-readable status
 	// message fits. Absent while the instance is healthy, as AWS leaves it.

--- a/spinifex/handlers/rds/events.go
+++ b/spinifex/handlers/rds/events.go
@@ -55,6 +55,7 @@ const (
 	EventCategoryCreation            = "creation"
 	EventCategoryDeletion            = "deletion"
 	EventCategoryFailure             = "failure"
+	EventCategoryMaintenance         = "maintenance"
 	EventCategoryNotification        = "notification"
 	EventCategoryRecovery            = "recovery"
 )

--- a/spinifex/handlers/rds/modify.go
+++ b/spinifex/handlers/rds/modify.go
@@ -268,6 +268,7 @@ func (s *Service) planBackupSettings(input *rds.ModifyDBInstanceInput, rec *DBIn
 	if backup == "" && maintenance == "" {
 		return nil
 	}
+	named := struct{ backup, maintenance bool }{backup != "", maintenance != ""}
 	if backup == "" {
 		backup = rec.PreferredBackupWindow
 	}
@@ -278,12 +279,17 @@ func (s *Service) planBackupSettings(input *rds.ModifyDBInstanceInput, rec *DBIn
 	if err != nil {
 		return err
 	}
+	// Only a window the request named is planned. The other side of the pair was
+	// resolved for the overlap check alone, and on a record that carries none that
+	// is an assignment — persisting it would report a window back to a customer who
+	// never set one, and show as drift in their next plan.
+	//
 	// Compared against the stored value in canonical form, so a request repeating
 	// the current window in different text is dropped rather than rewritten.
-	if resolvedBackup != rec.PreferredBackupWindow {
+	if named.backup && resolvedBackup != rec.PreferredBackupWindow {
 		plan.PreferredBackupWindow = resolvedBackup
 	}
-	if resolvedMaintenance != rec.PreferredMaintenanceWindow {
+	if named.maintenance && resolvedMaintenance != rec.PreferredMaintenanceWindow {
 		plan.PreferredMaintenanceWindow = resolvedMaintenance
 	}
 	return nil

--- a/spinifex/handlers/rds/modify.go
+++ b/spinifex/handlers/rds/modify.go
@@ -16,11 +16,6 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
-// AWS's bound on automated-backup retention. Nothing consumes it until rds-9,
-// but accepting a value outside the range would store a setting that fails
-// later, in a window nobody is watching.
-const maxBackupRetentionDays = 35
-
 // The resolved effect of a ModifyDBInstance request: what changes now and what
 // is left for a maintenance window. Every field is a *difference* from the
 // stored record — Terraform sends the whole body on every apply, so a field
@@ -224,7 +219,7 @@ func (s *Service) planModify(ctx context.Context, input *rds.ModifyDBInstanceInp
 	if input.DeletionProtection != nil && aws.BoolValue(input.DeletionProtection) != rec.DeletionProtection {
 		plan.DeletionProtection = input.DeletionProtection
 	}
-	if err := planBackupSettings(input, rec, plan); err != nil {
+	if err := s.planBackupSettings(input, rec, plan); err != nil {
 		return nil, err
 	}
 	return plan, nil
@@ -253,25 +248,43 @@ func (s *Service) planSecurityGroups(ctx context.Context, accountID string, rec 
 	return requested, nil
 }
 
-// The rds-9 fields. Stored rather than acted on here, but still bounds-checked:
-// a value outside AWS's range would fail in a maintenance window nobody is
-// watching rather than in the call that set it.
-func planBackupSettings(input *rds.ModifyDBInstanceInput, rec *DBInstanceRecord, plan *modifyPlan) error {
+// The rds-9 fields, now validated and effective rather than record-only. Both
+// windows are resolved as a pair even when the request names one, because AWS's
+// non-overlap rule is about the pair: a request moving the backup window onto the
+// stored maintenance window has to be rejected too.
+func (s *Service) planBackupSettings(input *rds.ModifyDBInstanceInput, rec *DBInstanceRecord, plan *modifyPlan) error {
 	if input.BackupRetentionPeriod != nil {
 		days := aws.Int64Value(input.BackupRetentionPeriod)
-		if days < 0 || days > maxBackupRetentionDays {
-			return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
-				"BackupRetentionPeriod must be between 0 and %d days", maxBackupRetentionDays)
+		if err := s.validateRetentionPeriod(days); err != nil {
+			return err
 		}
 		if days != rec.BackupRetentionPeriod {
 			plan.BackupRetentionPeriod = aws.Int64(days)
 		}
 	}
-	if window := aws.StringValue(input.PreferredBackupWindow); window != "" && window != rec.PreferredBackupWindow {
-		plan.PreferredBackupWindow = window
+
+	backup := aws.StringValue(input.PreferredBackupWindow)
+	maintenance := aws.StringValue(input.PreferredMaintenanceWindow)
+	if backup == "" && maintenance == "" {
+		return nil
 	}
-	if window := aws.StringValue(input.PreferredMaintenanceWindow); window != "" && window != rec.PreferredMaintenanceWindow {
-		plan.PreferredMaintenanceWindow = window
+	if backup == "" {
+		backup = rec.PreferredBackupWindow
+	}
+	if maintenance == "" {
+		maintenance = rec.PreferredMaintenanceWindow
+	}
+	resolvedBackup, resolvedMaintenance, err := s.validateWindows(rec.DBInstanceIdentifier, backup, maintenance)
+	if err != nil {
+		return err
+	}
+	// Compared against the stored value in canonical form, so a request repeating
+	// the current window in different text is dropped rather than rewritten.
+	if resolvedBackup != rec.PreferredBackupWindow {
+		plan.PreferredBackupWindow = resolvedBackup
+	}
+	if resolvedMaintenance != rec.PreferredMaintenanceWindow {
+		plan.PreferredMaintenanceWindow = resolvedMaintenance
 	}
 	return nil
 }
@@ -326,7 +339,34 @@ func (s *Service) applyImmediateModify(ctx context.Context, kv jetstream.KeyValu
 
 	s.RecordEvent(ctx, accountID, EventSourceTypeDBInstance, rec.DBInstanceIdentifier,
 		"DB instance configuration changed.", EventCategoryConfigurationChange)
+
+	// Turning automated backups off has to remove the backups too, or the setting
+	// is cosmetic: while any snapshot of the data volume survives, viperblock's
+	// chunk GC stays latched off and the volume never reclaims an overwritten
+	// chunk. It takes effect on the volume's next attach, because that guard is
+	// cached for the life of the VB process.
+	if plan.BackupRetentionPeriod != nil && *plan.BackupRetentionPeriod == 0 {
+		s.disableAutomatedBackups(ctx, kv, accountID, rec.DBInstanceIdentifier)
+	}
 	return nil
+}
+
+// Sweeps an instance's automated backups after a BackupRetentionPeriod=0 modify.
+// The retention change itself has already landed, so a sweep that cannot finish
+// is reported rather than allowed to fail the modify: the retention reaper reads
+// the same zero retention and removes whatever is left, including the newest.
+func (s *Service) disableAutomatedBackups(ctx context.Context, kv jetstream.KeyValue, accountID, id string) {
+	if err := s.purgeAutomatedBackups(ctx, kv, accountID, id); err != nil {
+		slog.WarnContext(ctx, "rds: sweeping the automated backups of a disabled instance failed; the retention reaper will finish it",
+			"dbInstance", id, "accountId", accountID, "err", err)
+		s.RecordEvent(ctx, accountID, EventSourceTypeDBInstance, id,
+			"Automated backups are disabled; the existing automated backups are still being removed.",
+			EventCategoryBackup, EventCategoryNotification)
+		return
+	}
+	s.RecordEvent(ctx, accountID, EventSourceTypeDBInstance, id,
+		"Automated backups are disabled and the existing automated backups have been removed.",
+		EventCategoryBackup, EventCategoryConfigurationChange)
 }
 
 // Changing a database's ingress is routine day-two work, and the ENI already

--- a/spinifex/handlers/rds/reconciler.go
+++ b/spinifex/handlers/rds/reconciler.go
@@ -98,6 +98,13 @@ func (r *Reconciler) Run(ctx context.Context) {
 	}
 }
 
+// The shared GC backstop's cluster-wide gate. The reconciler's lease is already
+// cluster-singular and held continuously rather than claimed per sweep, so
+// holding it is the whole answer and there is nothing for the caller to release.
+func (r *Reconciler) AcquireClusterLease() (func(), bool) {
+	return func() {}, r.isLeader()
+}
+
 func (r *Reconciler) isLeader() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -200,6 +207,9 @@ func (r *Reconciler) reconcileAccount(ctx context.Context, kv jetstream.KeyValue
 	var failures []error
 	for _, id := range ids {
 		if err := r.reconcileInstance(ctx, kv, accountID, id); err != nil {
+			failures = append(failures, awserrors.Errorf(id, "%w", err))
+		}
+		if err := r.reconcileWindows(ctx, kv, accountID, id); err != nil {
 			failures = append(failures, awserrors.Errorf(id, "%w", err))
 		}
 	}
@@ -410,6 +420,30 @@ func (r *Reconciler) reconcileBackingUp(ctx context.Context, kv jetstream.KeyVal
 	slog.WarnContext(ctx, "rds reconciler: a snapshot left its instance in backing-up; returning it",
 		"dbInstance", rec.DBInstanceIdentifier, "accountId", accountID, "resume", resume)
 	return r.transition(ctx, kv, rev, rec, resume, "")
+}
+
+// The two scheduled passes (rds-9): the automated backup its backup window is
+// due, and the deferred modify its maintenance window opens. Both ride the leader
+// lease, and both are driven from a persisted stamp rather than a timer, so a
+// leader change cannot fire either of them twice for one window.
+//
+// The record is re-read rather than carried over from the status pass above,
+// which may have transitioned the instance — a backup must not be started against
+// a status that has since moved.
+func (r *Reconciler) reconcileWindows(ctx context.Context, kv jetstream.KeyValue, accountID, id string) error {
+	var rec DBInstanceRecord
+	rev, found, err := getJSONRevision(ctx, kv, DBInstanceKey(id), &rec)
+	if err != nil || !found {
+		return err
+	}
+	// A backup holds the instance in backing-up and a maintenance apply moves it to
+	// modifying, so the two can never run together: whichever fires owns the pass.
+	fired, err := r.svc.runBackupWindow(ctx, kv, rev, accountID, &rec)
+	if fired || err != nil {
+		return err
+	}
+	_, err = r.svc.runMaintenanceWindow(ctx, kv, rev, accountID, &rec)
+	return err
 }
 
 // Settles the DB snapshot records a create never finished writing. The EC2

--- a/spinifex/handlers/rds/records.go
+++ b/spinifex/handlers/rds/records.go
@@ -25,11 +25,29 @@ type DBInstanceRecord struct {
 	// Blocks DeleteDBInstance outright (D18). Settable at create and modify.
 	DeletionProtection bool `json:"deletionProtection,omitempty"`
 
-	// Stored by ModifyDBInstance but not yet acted on: rds-9's backup and
-	// maintenance machinery is what consumes them.
+	// The backup policy in force. Both windows are stored in AWS's canonical text
+	// so a describe reads back the string a later modify compares against; an
+	// empty one is derived from the instance identifier rather than left unset.
 	BackupRetentionPeriod      int64  `json:"backupRetentionPeriod,omitempty"`
 	PreferredBackupWindow      string `json:"preferredBackupWindow,omitempty"`
 	PreferredMaintenanceWindow string `json:"preferredMaintenanceWindow,omitempty"`
+
+	// When the last automated backup succeeded. Persisted rather than held in
+	// leader memory, so leader churn, a daemon restart, or two nodes briefly
+	// believing they hold the lease cannot fire a second backup for one window.
+	LastAutomatedBackupAt *time.Time `json:"lastAutomatedBackupAt,omitempty"`
+
+	// When the last automated backup failed or was skipped, and how many have
+	// failed in a row. The stamp paces retries inside a window; the count makes a
+	// persistently failing backup visible and resets on the first success. Neither
+	// moves the instance out of available — a failed backup is an event, not an
+	// instance failure.
+	LastAutomatedBackupFailureAt *time.Time `json:"lastAutomatedBackupFailureAt,omitempty"`
+	AutomatedBackupFailures      int        `json:"automatedBackupFailures,omitempty"`
+
+	// When the maintenance window last opened a deferred modify, holding a window
+	// to one apply exactly as the backup stamp does.
+	LastMaintenanceWindowAt *time.Time `json:"lastMaintenanceWindowAt,omitempty"`
 
 	// What a modify asked for and has not yet delivered. Nil once everything is
 	// in effect, which is also what tells the reconciler a modify is finished.
@@ -265,6 +283,16 @@ var _ TaggedRecord = (*DBSnapshotRecord)(nil)
 func (r *DBSnapshotRecord) GetTags() map[string]string { return r.Tags }
 
 func (r *DBSnapshotRecord) SetTags(tags map[string]string) { r.Tags = tags }
+
+// The backups/{db}/automated/{ts} index entry. Deliberately thin: it exists so
+// the retention sweep can enumerate one instance's automated backups without a
+// bucket-wide snapshot scan, and everything else it needs — age, status, source
+// volume — is read from the db-snapshots record this names.
+type AutomatedBackupRecord struct {
+	DBInstanceIdentifier string    `json:"dbInstanceIdentifier"`
+	DBSnapshotIdentifier string    `json:"dbSnapshotIdentifier"`
+	CreatedAt            time.Time `json:"createdAt"`
+}
 
 // A data volume that outlived its DB instance because a COW snapshot still
 // references its chunks (D10). The last DeleteDBSnapshot to empty Snapshots

--- a/spinifex/handlers/rds/restore.go
+++ b/spinifex/handlers/rds/restore.go
@@ -30,7 +30,7 @@ func (s *Service) RestoreDBInstanceFromDBSnapshot(ctx context.Context, input *rd
 	if err := validateDBInstanceIdentifier(aws.StringValue(input.DBInstanceIdentifier)); err != nil {
 		return nil, err
 	}
-	if err := validateDBSnapshotIdentifier(aws.StringValue(input.DBSnapshotIdentifier)); err != nil {
+	if err := validateDBSnapshotReference(aws.StringValue(input.DBSnapshotIdentifier)); err != nil {
 		return nil, err
 	}
 	if err := rejectUnimplementedRestore(input); err != nil {

--- a/spinifex/handlers/rds/service.go
+++ b/spinifex/handlers/rds/service.go
@@ -54,6 +54,9 @@ type Deps struct {
 	// Overrides how long an instance may be observed dark before the classifier
 	// calls it failed. Zero takes defaultFailureGrace.
 	FailureGrace time.Duration
+	// Bounds and defaults for automated backups and the two scheduled windows.
+	// Every zero field takes the built-in default.
+	Backup BackupPolicy
 }
 
 // The RDS control plane's KV-backed handler set. One per daemon.

--- a/spinifex/handlers/rds/service_nats.go
+++ b/spinifex/handlers/rds/service_nats.go
@@ -111,6 +111,12 @@ func (s *NATSService) RestoreDBInstanceFromDBSnapshot(ctx context.Context, input
 		SubjectRestoreDBInstanceFromDBSnapshot, input, restoreTimeout, accountID)
 }
 
+func (s *NATSService) DescribeDBInstanceAutomatedBackups(ctx context.Context,
+	input *rds.DescribeDBInstanceAutomatedBackupsInput, accountID string) (*rds.DescribeDBInstanceAutomatedBackupsOutput, error) {
+	return utils.NATSRequest[rds.DescribeDBInstanceAutomatedBackupsOutput](ctx, s.nc,
+		SubjectDescribeDBInstanceAutomatedBackups, input, defaultTimeout, accountID)
+}
+
 func (s *NATSService) DescribeEvents(ctx context.Context, input *rds.DescribeEventsInput, accountID string) (*rds.DescribeEventsOutput, error) {
 	return utils.NATSRequest[rds.DescribeEventsOutput](ctx, s.nc,
 		SubjectDescribeEvents, input, defaultTimeout, accountID)

--- a/spinifex/handlers/rds/snapshot.go
+++ b/spinifex/handlers/rds/snapshot.go
@@ -63,9 +63,29 @@ func (s *Service) CreateDBSnapshot(ctx context.Context, input *rds.CreateDBSnaps
 	if err != nil {
 		return nil, err
 	}
+	record, err := s.snapshotDBInstance(ctx, kv, rev, accountID, rec, req)
+	if err != nil {
+		return nil, err
+	}
+	return &rds.CreateDBSnapshotOutput{DBSnapshot: s.projectDBSnapshot(record)}, nil
+}
+
+// The one snapshot path (D10). A customer's CreateDBSnapshot and an rds-9
+// automated backup differ only in who asks and in the type stamped on the record;
+// the quiesce, the node-addressed EC2 snapshot, the db-snapshots record and the
+// per-instance in-flight guard are the same for both.
+//
+// rev is the revision the caller read the DB instance at: the CAS that moves it
+// into backing-up is what serialises the two kinds of snapshot against each other
+// and against a lifecycle op.
+func (s *Service) snapshotDBInstance(ctx context.Context, kv jetstream.KeyValue, rev uint64,
+	accountID string, rec *DBInstanceRecord, req *validatedSnapshot) (*DBSnapshotRecord, error) {
+	if s.deps.Snapshots == nil {
+		return nil, errors.New("rds: no snapshot service configured")
+	}
 	if rec.DataVolumeID == "" {
 		return nil, awserrors.Errorf(awserrors.ErrorDBInstanceInvalidState,
-			"DB instance %s has no data volume to snapshot", req.DBInstanceIdentifier)
+			"DB instance %s has no data volume to snapshot", rec.DBInstanceIdentifier)
 	}
 	// Checked before the instance is moved to backing-up, so a request naming a
 	// taken identifier leaves the instance where it was.
@@ -113,9 +133,9 @@ func (s *Service) CreateDBSnapshot(ctx context.Context, input *rds.CreateDBSnaps
 		"DB snapshot created.", EventCategoryBackup, EventCategoryCreation)
 	slog.InfoContext(ctx, "rds: DB snapshot created",
 		"dbSnapshot", req.DBSnapshotIdentifier, "dbInstance", rec.DBInstanceIdentifier,
-		"snapshotId", snapshotID, "crashConsistent", crashConsistent)
+		"snapshotType", record.SnapshotType, "snapshotId", snapshotID, "crashConsistent", crashConsistent)
 
-	return &rds.CreateDBSnapshotOutput{DBSnapshot: s.projectDBSnapshot(&record)}, nil
+	return &record, nil
 }
 
 // Quiesces the engine, snapshots the data volume, and releases the engine again
@@ -258,33 +278,47 @@ func (s *Service) DeleteDBSnapshot(ctx context.Context, input *rds.DeleteDBSnaps
 	if err != nil {
 		return nil, err
 	}
+	if err := s.removeDBSnapshot(ctx, kv, accountID, rec); err != nil {
+		return nil, err
+	}
+	// AWS answers with the snapshot as it last stood, the way a delete of a DB
+	// instance answers with the record it just removed.
+	return &rds.DeleteDBSnapshotOutput{DBSnapshot: s.projectDBSnapshot(rec)}, nil
+}
+
+// Removes a DB snapshot, its EC2 data and — when this was the last reference — the
+// data volume behind it. Shared with rds-9's retention sweep, which cannot go
+// through DeleteDBSnapshot: that rejects the rds: namespace automated snapshots
+// live in, so a customer can never delete one by hand.
+func (s *Service) removeDBSnapshot(ctx context.Context, kv jetstream.KeyValue, accountID string, rec *DBSnapshotRecord) error {
+	if s.deps.Snapshots == nil {
+		return errors.New("rds: no snapshot service configured")
+	}
+	id := rec.DBSnapshotIdentifier
 	// A snapshot still being taken has no data to remove and an in-flight writer
 	// that would recreate the record; the reconciler resolves it either way.
 	if rec.Status != SnapshotStatusAvailable {
-		return nil, awserrors.Errorf(awserrors.ErrorDBSnapshotInvalidState,
+		return awserrors.Errorf(awserrors.ErrorDBSnapshotInvalidState,
 			"DB snapshot %s is %s; it must be %s to be deleted", id, rec.Status, SnapshotStatusAvailable)
 	}
 
 	if err := s.deleteEC2Snapshot(ctx, kv, accountID, rec); err != nil {
-		return nil, err
+		return err
 	}
 	// After the EC2 snapshot, so the volume store no longer sees this reference
 	// when it decides whether the volume is still held.
 	if err := s.releaseRetainedVolume(ctx, kv, rec); err != nil {
-		return nil, err
+		return err
 	}
 	// Last: while it exists the snapshot is still nameable, and a retry re-runs
 	// the steps above, each of which tolerates work it has already done.
 	if err := kv.Delete(ctx, DBSnapshotKey(id)); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return nil, fmt.Errorf("rds: delete the DB snapshot record for %s: %w", id, err)
+		return fmt.Errorf("rds: delete the DB snapshot record for %s: %w", id, err)
 	}
 
 	s.RecordEvent(ctx, accountID, EventSourceTypeDBSnapshot, id, "DB snapshot deleted.", EventCategoryDeletion)
 	slog.InfoContext(ctx, "rds: DB snapshot deleted", "dbSnapshot", id, "snapshotId", rec.SnapshotID)
-
-	// AWS answers with the snapshot as it last stood, the way a delete of a DB
-	// instance answers with the record it just removed.
-	return &rds.DeleteDBSnapshotOutput{DBSnapshot: s.projectDBSnapshot(rec)}, nil
+	return nil
 }
 
 // A snapshot with a volume still reading through it cannot go, which is exactly
@@ -349,38 +383,59 @@ func (s *Service) releaseRetainedVolume(ctx context.Context, kv jetstream.KeyVal
 	if err != nil || !found {
 		return err
 	}
+	_, err = s.reclaimRetainedVolume(ctx, kv, &retained)
+	return err
+}
 
-	holders, err := s.snapshotsHolding(ctx, rec.SourceVolumeID)
+// Deletes a retained data volume once nothing holds it, or records the holders it
+// still has. Reports whether the volume actually went, which is what lets rds-9's
+// reaper count the ones it reclaimed.
+func (s *Service) reclaimRetainedVolume(ctx context.Context, kv jetstream.KeyValue,
+	retained *RetainedVolumeRecord) (bool, error) {
+	holders, err := s.snapshotsHolding(ctx, retained.VolumeID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(holders) > 0 {
 		retained.Snapshots = holders
 		retained.HoldersUnresolved = false
-		return putJSON(ctx, kv, RetainedVolumeKey(rec.SourceVolumeID), &retained)
+		return false, putJSON(ctx, kv, RetainedVolumeKey(retained.VolumeID), retained)
 	}
 
 	if s.deps.Launch.Volume == nil {
-		return errors.New("rds: no volume service configured")
+		return false, errors.New("rds: no volume service configured")
 	}
 	_, err = s.deps.Launch.Volume.DeleteVolume(ctx, &ec2.DeleteVolumeInput{
-		VolumeId: aws.String(rec.SourceVolumeID),
+		VolumeId: aws.String(retained.VolumeID),
 	}, utils.GlobalAccountID)
-	if err != nil && !awserrors.IsNotFound(err) {
-		return fmt.Errorf("rds: delete the retained data volume %s: %w", rec.SourceVolumeID, err)
+	switch {
+	case err == nil || awserrors.IsNotFound(err):
+	case awserrors.IsErrorCode(err, awserrors.ErrorVolumeInUse):
+		// The volume store's index sees a reference the enumeration above did not.
+		// The disagreement is recorded rather than returned, so the volume is
+		// re-checked on a later pass instead of failing this caller — which for a
+		// DeleteDBSnapshot has already removed the snapshot by now.
+		retained.HoldersUnresolved = true
+		return false, putJSON(ctx, kv, RetainedVolumeKey(retained.VolumeID), retained)
+	default:
+		return false, fmt.Errorf("rds: delete the retained data volume %s: %w", retained.VolumeID, err)
 	}
-	if err := kv.Delete(ctx, RetainedVolumeKey(rec.SourceVolumeID)); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
-		return fmt.Errorf("rds: clear the retained-volume record for %s: %w", rec.SourceVolumeID, err)
+	if err := kv.Delete(ctx, RetainedVolumeKey(retained.VolumeID)); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return false, fmt.Errorf("rds: clear the retained-volume record for %s: %w", retained.VolumeID, err)
 	}
 	slog.InfoContext(ctx, "rds: retained data volume reclaimed; its last snapshot is gone",
-		"volumeId", rec.SourceVolumeID, "dbSnapshot", rec.DBSnapshotIdentifier)
-	return nil
+		"volumeId", retained.VolumeID, "dbInstance", retained.DBInstanceIdentifier)
+	return true, nil
 }
 
-// The request as CreateDBSnapshot resolved it.
+// The request as CreateDBSnapshot resolved it, or as rds-9's scheduler and the
+// delete path's final-snapshot reservation construct it. SnapshotType is what the
+// record is stamped with, and the only thing separating an automated backup from
+// a manual snapshot once it exists.
 type validatedSnapshot struct {
 	DBSnapshotIdentifier string
 	DBInstanceIdentifier string
+	SnapshotType         string
 	Tags                 map[string]string
 }
 
@@ -403,6 +458,7 @@ func validateCreateSnapshotRequest(input *rds.CreateDBSnapshotInput) (*validated
 	return &validatedSnapshot{
 		DBSnapshotIdentifier: aws.StringValue(input.DBSnapshotIdentifier),
 		DBInstanceIdentifier: aws.StringValue(input.DBInstanceIdentifier),
+		SnapshotType:         SnapshotTypeManual,
 		Tags:                 tagMap,
 	}, nil
 }
@@ -432,10 +488,33 @@ func validateDescribeSnapshotsRequest(input *rds.DescribeDBSnapshotsInput) (stri
 	}
 }
 
+// A name the caller is minting: a customer snapshot, or a final snapshot at
+// delete. The rds: namespace belongs to automated backups, so it is refused
+// wherever a name is created — and accepted by validateDBSnapshotReference, which
+// is what a restore from an automated backup goes through.
+func validateDBSnapshotIdentifier(id string) error {
+	// Ahead of the name rules, which would reject the colon too but as an opaque
+	// "may contain only lowercase letters, digits and hyphens".
+	if err := rejectAutomatedNamespace(id); err != nil {
+		return err
+	}
+	return validateDBSnapshotName(id)
+}
+
+// A reference to a snapshot that already exists. An automated backup carries the
+// prefix this plane minted it with, and restoring from one is the whole point of
+// keeping it, so the namespace is accepted here.
+func validateDBSnapshotReference(id string) error {
+	if rest, ok := strings.CutPrefix(id, automatedSnapshotPrefix); ok {
+		return validateDBSnapshotName(rest)
+	}
+	return validateDBSnapshotName(id)
+}
+
 // AWS's own rules. The character set is deliberately the DB instance
 // identifier's rather than AWS's laxer one, so every name a snapshot can be
 // created under is also a name DeleteDBInstance accepts for a final snapshot.
-func validateDBSnapshotIdentifier(id string) error {
+func validateDBSnapshotName(id string) error {
 	switch {
 	case id == "":
 		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue, "DBSnapshotIdentifier is required")
@@ -466,7 +545,7 @@ func newDBSnapshotRecord(accountID string, rec *DBInstanceRecord, req *validated
 		DBSnapshotIdentifier:    req.DBSnapshotIdentifier,
 		DBInstanceIdentifier:    rec.DBInstanceIdentifier,
 		AccountID:               accountID,
-		SnapshotType:            SnapshotTypeManual,
+		SnapshotType:            req.SnapshotType,
 		Status:                  SnapshotStatusCreating,
 		SourceVolumeID:          rec.DataVolumeID,
 		Engine:                  rec.Engine,

--- a/spinifex/handlers/rds/store.go
+++ b/spinifex/handlers/rds/store.go
@@ -70,10 +70,10 @@ func DBSnapshotKey(dbSnapshotIdentifier string) string {
 }
 
 // A JetStream KV key admits no colon, and an automated backup's snapshot
-// identifier carries the rds: prefix AWS gives it. The colon is mapped to "=",
-// which is a legal key character and one no RDS identifier may contain, so the
-// mapping is reversible and a manual snapshot's key is unchanged.
-const kvKeyColon = "="
+// identifier carries the rds: prefix AWS gives it. The colon is mapped to ".",
+// the separator other stores compose keys from, and one no RDS identifier may
+// contain — so the mapping is reversible and a manual snapshot's key is unchanged.
+const kvKeyColon = "."
 
 func kvKeySegment(identifier string) string {
 	return strings.ReplaceAll(identifier, ":", kvKeyColon)

--- a/spinifex/handlers/rds/store.go
+++ b/spinifex/handlers/rds/store.go
@@ -66,7 +66,21 @@ func DBSnapshotsPrefix() string {
 }
 
 func DBSnapshotKey(dbSnapshotIdentifier string) string {
-	return DBSnapshotsPrefix() + dbSnapshotIdentifier
+	return DBSnapshotsPrefix() + kvKeySegment(dbSnapshotIdentifier)
+}
+
+// A JetStream KV key admits no colon, and an automated backup's snapshot
+// identifier carries the rds: prefix AWS gives it. The colon is mapped to "=",
+// which is a legal key character and one no RDS identifier may contain, so the
+// mapping is reversible and a manual snapshot's key is unchanged.
+const kvKeyColon = "="
+
+func kvKeySegment(identifier string) string {
+	return strings.ReplaceAll(identifier, ":", kvKeyColon)
+}
+
+func kvKeySegmentIdentifier(segment string) string {
+	return strings.ReplaceAll(segment, kvKeyColon, ":")
 }
 
 func DBSubnetGroupsPrefix() string {
@@ -99,8 +113,12 @@ func DBParameterGroupParamKey(name, param string) string {
 
 // Kept separate from db-snapshots/ so the retention sweep enumerates only
 // automated backups, ordered lexically by their timestamp suffix.
+func AutomatedBackupsRootPrefix() string {
+	return "backups/"
+}
+
 func AutomatedBackupsPrefix(dbInstanceIdentifier string) string {
-	return fmt.Sprintf("backups/%s/automated/", dbInstanceIdentifier)
+	return fmt.Sprintf("%s%s/automated/", AutomatedBackupsRootPrefix(), dbInstanceIdentifier)
 }
 
 func AutomatedBackupKey(dbInstanceIdentifier, ts string) string {
@@ -127,8 +145,10 @@ func EventsPrefix() string {
 	return "events/"
 }
 
+// The source identifier is escaped the same way a snapshot key is: an automated
+// backup's events hang off an identifier carrying a colon.
 func EventRingKey(sourceType, sourceIdentifier string) string {
-	return fmt.Sprintf("%s%s/%s", EventsPrefix(), sourceType, sourceIdentifier)
+	return fmt.Sprintf("%s%s/%s", EventsPrefix(), sourceType, kvKeySegment(sourceIdentifier))
 }
 
 // Entries are rewritten on every VM replace (each mints a new instance ID) and
@@ -234,7 +254,14 @@ func ListDBInstanceIDs(ctx context.Context, kv jetstream.KeyValue) ([]string, er
 // Manual and automated snapshots alike: the type is on the record, so a listing
 // filtered by it still has to read every one.
 func ListDBSnapshotIDs(ctx context.Context, kv jetstream.KeyValue) ([]string, error) {
-	return listNames(ctx, kv, DBSnapshotsPrefix())
+	names, err := listNames(ctx, kv, DBSnapshotsPrefix())
+	if err != nil {
+		return nil, err
+	}
+	for i, name := range names {
+		names[i] = kvKeySegmentIdentifier(name)
+	}
+	return names, nil
 }
 
 func ListDBSubnetGroupNames(ctx context.Context, kv jetstream.KeyValue) ([]string, error) {
@@ -284,6 +311,54 @@ func ListDBParameterOverrides(ctx context.Context, kv jetstream.KeyValue, group 
 		}
 	}
 	return out, nil
+}
+
+// Every account's automated-backup index, grouped by DB instance, from one
+// bucket listing: the retention sweep needs every instance's set, and a Keys call
+// per instance would cost one listing each.
+func ListAutomatedBackups(ctx context.Context, kv jetstream.KeyValue) (map[string][]string, error) {
+	keys, err := bucketKeys(ctx, kv)
+	if err != nil {
+		return nil, err
+	}
+	indexed := make(map[string][]string)
+	for _, key := range keys {
+		id, stamp, ok := splitAutomatedBackupKey(key)
+		if !ok {
+			continue
+		}
+		indexed[id] = append(indexed[id], stamp)
+	}
+	return indexed, nil
+}
+
+// One instance's automated-backup stamps, for the callers that already know
+// which instance they are acting on.
+func ListAutomatedBackupStamps(ctx context.Context, kv jetstream.KeyValue, dbInstanceIdentifier string) ([]string, error) {
+	return listNames(ctx, kv, AutomatedBackupsPrefix(dbInstanceIdentifier))
+}
+
+// The DB instance and timestamp a backups/ key names. The instance identifier
+// cannot contain a slash, so anything shaped otherwise belongs to a key space
+// this does not own.
+func splitAutomatedBackupKey(key string) (string, string, bool) {
+	rest, ok := strings.CutPrefix(key, AutomatedBackupsRootPrefix())
+	if !ok {
+		return "", "", false
+	}
+	id, rest, ok := strings.Cut(rest, "/")
+	if !ok || id == "" {
+		return "", "", false
+	}
+	stamp, ok := strings.CutPrefix(rest, "automated/")
+	if !ok || stamp == "" || strings.Contains(stamp, "/") {
+		return "", "", false
+	}
+	return id, stamp, true
+}
+
+func ListRetainedVolumeIDs(ctx context.Context, kv jetstream.KeyValue) ([]string, error) {
+	return listNames(ctx, kv, RetainedVolumesPrefix())
 }
 
 // The leaf names directly under prefix. A nested key belongs to a sub-space and

--- a/spinifex/handlers/rds/subjects.go
+++ b/spinifex/handlers/rds/subjects.go
@@ -39,6 +39,10 @@ const (
 	SubjectDeleteDBSnapshot                = "rds.DeleteDBSnapshot"
 	SubjectRestoreDBInstanceFromDBSnapshot = "rds.RestoreDBInstanceFromDBSnapshot"
 
+	// The automated-backup set, which is a KV read: the snapshots themselves are
+	// listed through DescribeDBSnapshots.
+	SubjectDescribeDBInstanceAutomatedBackups = "rds.DescribeDBInstanceAutomatedBackups"
+
 	// Configuration resources. Plain KV CRUD, so unlike the instance actions
 	// none of them drives a VM and all take the default budget.
 	SubjectCreateDBSubnetGroup    = "rds.CreateDBSubnetGroup"

--- a/spinifex/handlers/rds/validate.go
+++ b/spinifex/handlers/rds/validate.go
@@ -48,12 +48,18 @@ type validatedCreate struct {
 	DBSubnetGroupName    string
 	DBParameterGroupName string
 	DeletionProtection   bool
-	Tags                 map[string]string
+	// Automated backups as they will be in force: the retention defaulted when the
+	// request names none, and both windows in canonical text — assigned from the
+	// instance identifier when unnamed, never left empty (rds-9).
+	BackupRetentionPeriod      int64
+	PreferredBackupWindow      string
+	PreferredMaintenanceWindow string
+	Tags                       map[string]string
 }
 
 // Everything that can be decided from the request alone. Network resolution
 // runs afterwards, so a malformed request never reaches the VPC.
-func validateCreateRequest(input *rds.CreateDBInstanceInput) (*validatedCreate, error) {
+func (s *Service) validateCreateRequest(input *rds.CreateDBInstanceInput) (*validatedCreate, error) {
 	if input == nil {
 		return nil, awserrors.Errorf(awserrors.ErrorInvalidParameterValue, "empty request")
 	}
@@ -122,6 +128,21 @@ func validateCreateRequest(input *rds.CreateDBInstanceInput) (*validatedCreate, 
 		paramGroup = engine.DefaultParameterGroupName()
 	}
 
+	// Automated backups are on by default at the full retention cap, matching the
+	// console's own default. A request naming 0 explicitly still turns them off.
+	retention := s.defaultRetentionDays()
+	if input.BackupRetentionPeriod != nil {
+		retention = aws.Int64Value(input.BackupRetentionPeriod)
+		if err := s.validateRetentionPeriod(retention); err != nil {
+			return nil, err
+		}
+	}
+	backupWindow, maintenanceWindow, err := s.validateWindows(identifier,
+		aws.StringValue(input.PreferredBackupWindow), aws.StringValue(input.PreferredMaintenanceWindow))
+	if err != nil {
+		return nil, err
+	}
+
 	// Rejected before the identifier is reserved, so a create with bad tags
 	// leaves no partial record behind.
 	tags, err := validateTags(input.Tags)
@@ -145,7 +166,12 @@ func validateCreateRequest(input *rds.CreateDBInstanceInput) (*validatedCreate, 
 		DBSubnetGroupName:    aws.StringValue(input.DBSubnetGroupName),
 		DBParameterGroupName: paramGroup,
 		DeletionProtection:   aws.BoolValue(input.DeletionProtection),
-		Tags:                 tags,
+
+		BackupRetentionPeriod:      retention,
+		PreferredBackupWindow:      backupWindow,
+		PreferredMaintenanceWindow: maintenanceWindow,
+
+		Tags: tags,
 	}, nil
 }
 
@@ -192,15 +218,6 @@ func rejectUnimplemented(input *rds.CreateDBInstanceInput) error {
 	// not offered, and omitting it entirely still yields encrypted storage.
 	if input.StorageEncrypted != nil && !aws.BoolValue(input.StorageEncrypted) {
 		return unimplemented("StorageEncrypted=false", "unencrypted storage is not offered")
-	}
-	if aws.Int64Value(input.BackupRetentionPeriod) > 0 {
-		return unimplemented("BackupRetentionPeriod", "automated backups are not implemented yet")
-	}
-	if aws.StringValue(input.PreferredBackupWindow) != "" {
-		return unimplemented("PreferredBackupWindow", "automated backups are not implemented yet")
-	}
-	if aws.StringValue(input.PreferredMaintenanceWindow) != "" {
-		return unimplemented("PreferredMaintenanceWindow", "maintenance windows are not implemented yet")
 	}
 	if aws.BoolValue(input.EnableIAMDatabaseAuthentication) {
 		return unimplemented("EnableIAMDatabaseAuthentication", "IAM database authentication is not implemented")

--- a/spinifex/handlers/rds/window.go
+++ b/spinifex/handlers/rds/window.go
@@ -281,22 +281,68 @@ func formatWeekdayClock(offset time.Duration) string {
 // a hash over the configured block is stable for the life of the instance and
 // still spreads the fleet's quiesce load across it.
 func assignDailyWindow(block dailyWindow, identifier string) dailyWindow {
+	return assignDailySlot(block, identifier, 0)
+}
+
+// The assignment stepped on by whole slots through the block, wrapping at its
+// end. Stepping is what lets an assigned window move off one the customer named
+// rather than colliding with it.
+func assignDailySlot(block dailyWindow, identifier string, shift int64) dailyWindow {
 	slots := int64(block.length() / windowSlot)
 	if slots < 1 {
 		return block
 	}
 	slot := int64(windowHash(identifier) % uint64(slots)) //nolint:gosec // the modulus bounds it to the slot count
-	start := (block.start + time.Duration(slot)*windowSlot) % oneDay
+	start := (block.start + time.Duration((slot+shift)%slots)*windowSlot) % oneDay
 	return dailyWindow{start: start, end: (start + windowSlot) % oneDay}
 }
 
 // The same assignment plus a day, seeded apart from the backup window's so an
 // instance does not land on correlated positions within the two blocks.
 func assignWeeklyWindow(block dailyWindow, identifier string) weeklyWindow {
-	daily := assignDailyWindow(block, identifier)
+	return assignWeeklySlot(block, identifier, 0)
+}
+
+func assignWeeklySlot(block dailyWindow, identifier string, shift int64) weeklyWindow {
+	daily := assignDailySlot(block, identifier, shift)
 	day := int64(windowHash(identifier+"/maintenance") % 7)
 	start := (time.Duration(day)*oneDay + daily.start) % oneWeek
 	return weeklyWindow{start: start, end: (start + windowSlot) % oneWeek}
+}
+
+// The assigned backup window stepped clear of the maintenance window in force.
+// A window the customer did not name must never be the reason their request is
+// rejected, so the assignment moves — which is what AWS does with the window it
+// assigned itself. A block every slot of which collides falls back to the slot
+// beginning where the other window ends, so the pair is still separable when the
+// operator's block sits inside it.
+func assignDailyWindowClearOf(block dailyWindow, identifier string, avoid weeklyWindow) dailyWindow {
+	for shift := range int64(block.length() / windowSlot) {
+		if window := assignDailySlot(block, identifier, shift); !window.overlaps(avoid) {
+			return window
+		}
+	}
+	return slotAfter(avoid.timeOfDay().end)
+}
+
+func assignWeeklyWindowClearOf(block dailyWindow, identifier string, avoid dailyWindow) weeklyWindow {
+	for shift := range int64(block.length() / windowSlot) {
+		if window := assignWeeklySlot(block, identifier, shift); !avoid.overlaps(window) {
+			return window
+		}
+	}
+	day := int64(windowHash(identifier+"/maintenance") % 7)
+	daily := slotAfter(avoid.end)
+	start := (time.Duration(day)*oneDay + daily.start) % oneWeek
+	return weeklyWindow{start: start, end: (start + windowSlot) % oneWeek}
+}
+
+// The one slot beginning at offset. Whether it is free is the caller's overlap
+// check to make: for a window covering all but half an hour of the day there is
+// no free slot to find, and that pair is reported rather than placed.
+func slotAfter(offset time.Duration) dailyWindow {
+	start := (offset%oneDay + oneDay) % oneDay
+	return dailyWindow{start: start, end: (start + windowSlot) % oneDay}
 }
 
 func windowHash(value string) uint64 {

--- a/spinifex/handlers/rds/window.go
+++ b/spinifex/handlers/rds/window.go
@@ -1,0 +1,308 @@
+package handlers_rds
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// The window machinery both scheduled passes share. A backup window is a UTC
+// time of day and a maintenance window is a UTC day and time of day, but
+// everything around them is the same: AWS's textual form, a minimum length, a
+// deterministic assignment when the customer names none, and the instant the
+// current window opened — which is what lets a pass fire exactly once per window
+// from a persisted stamp rather than from a timer's memory.
+
+const (
+	oneDay  = 24 * time.Hour
+	oneWeek = 7 * oneDay
+
+	// AWS's granularity and minimum length for both windows. An assigned window
+	// is exactly one slot, which is also the shortest one a customer may name.
+	windowSlot      = 30 * time.Minute
+	minWindowLength = 30 * time.Minute
+
+	// AWS's own abbreviations, lowercase as it returns them.
+	weekdayNames = "sun mon tue wed thu fri sat"
+)
+
+// A UTC time-of-day window in AWS's hh24:mi-hh24:mi form, held as offsets from
+// midnight. An end at or before the start wraps midnight, which AWS allows and a
+// deterministic assignment near the end of a block produces.
+type dailyWindow struct {
+	start, end time.Duration
+}
+
+// A UTC weekly window in AWS's ddd:hh24:mi-ddd:hh24:mi form, held as offsets
+// from Sunday midnight so a window spanning a day boundary needs no special
+// case. Maintenance is weekly, so the day is part of the window rather than
+// something the caller supplies alongside it.
+type weeklyWindow struct {
+	start, end time.Duration
+}
+
+func parseDailyWindow(field, value string) (dailyWindow, error) {
+	from, to, err := cutWindow(field, value)
+	if err != nil {
+		return dailyWindow{}, err
+	}
+	start, err := parseClock(field, from)
+	if err != nil {
+		return dailyWindow{}, err
+	}
+	end, err := parseClock(field, to)
+	if err != nil {
+		return dailyWindow{}, err
+	}
+	window := dailyWindow{start: start, end: end}
+	if window.length() < minWindowLength {
+		return dailyWindow{}, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"%s must be at least %s long", field, minWindowLength)
+	}
+	return window, nil
+}
+
+func parseWeeklyWindow(field, value string) (weeklyWindow, error) {
+	from, to, err := cutWindow(field, value)
+	if err != nil {
+		return weeklyWindow{}, err
+	}
+	start, err := parseWeekdayClock(field, from)
+	if err != nil {
+		return weeklyWindow{}, err
+	}
+	end, err := parseWeekdayClock(field, to)
+	if err != nil {
+		return weeklyWindow{}, err
+	}
+	window := weeklyWindow{start: start, end: end}
+	if window.length() < minWindowLength {
+		return weeklyWindow{}, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"%s must be at least %s long", field, minWindowLength)
+	}
+	return window, nil
+}
+
+// The two halves of a window, rejecting anything that is not exactly one
+// hyphen-separated pair — a value with none or several is malformed rather than
+// something to guess at.
+func cutWindow(field, value string) (string, string, error) {
+	parts := strings.Split(value, "-")
+	if len(parts) != 2 {
+		return "", "", awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"%s %q is malformed; the form is %s", field, value, windowForm(field))
+	}
+	return parts[0], parts[1], nil
+}
+
+// Offsets from midnight, from AWS's hh24:mi.
+func parseClock(field, value string) (time.Duration, error) {
+	hour, minute, ok := strings.Cut(value, ":")
+	if !ok || !fixedDigits(hour, 2) || !fixedDigits(minute, 2) {
+		return 0, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"%s %q is malformed; the form is %s", field, value, windowForm(field))
+	}
+	hours, _ := strconv.Atoi(hour)
+	minutes, _ := strconv.Atoi(minute)
+	if hours > 23 || minutes > 59 {
+		return 0, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"%s %q is not a UTC time of day", field, value)
+	}
+	return time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute, nil
+}
+
+// Offsets from Sunday midnight, from AWS's ddd:hh24:mi.
+func parseWeekdayClock(field, value string) (time.Duration, error) {
+	day, clock, ok := strings.Cut(value, ":")
+	if !ok {
+		return 0, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"%s %q is malformed; the form is %s", field, value, windowForm(field))
+	}
+	index := strings.Index(weekdayNames, strings.ToLower(day))
+	// Four characters per name, so a match that is not on a name boundary is a
+	// substring of one rather than a day.
+	if len(day) != 3 || index < 0 || index%4 != 0 {
+		return 0, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"%s day %q is not a weekday; use one of %s", field, day, strings.ReplaceAll(weekdayNames, " ", ", "))
+	}
+	offset, err := parseClock(field, clock)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(index/4)*oneDay + offset, nil
+}
+
+func fixedDigits(value string, want int) bool {
+	if len(value) != want {
+		return false
+	}
+	for _, r := range value {
+		if !isDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func windowForm(field string) string {
+	if strings.Contains(field, "Maintenance") {
+		return "ddd:hh24:mi-ddd:hh24:mi in UTC"
+	}
+	return "hh24:mi-hh24:mi in UTC"
+}
+
+// A window that wraps is measured forward through midnight, so an equal start
+// and end reads as zero rather than a whole day and fails the minimum length.
+func (w dailyWindow) length() time.Duration {
+	return (w.end - w.start + oneDay) % oneDay
+}
+
+func (w weeklyWindow) length() time.Duration {
+	return (w.end - w.start + oneWeek) % oneWeek
+}
+
+func (w dailyWindow) contains(t time.Time) bool {
+	return withinSegments(w.segments(), sinceMidnight(t))
+}
+
+func (w weeklyWindow) contains(t time.Time) bool {
+	return withinSegments(w.segments(), sinceSunday(t))
+}
+
+// The most recent instant this window opened at or before t. Only meaningful
+// while t is inside the window, which is the only place the passes call it: it is
+// what a persisted stamp is compared against to decide whether this window has
+// already fired.
+func (w dailyWindow) openedAt(t time.Time) time.Time {
+	opened := midnight(t).Add(w.start)
+	if opened.After(t) {
+		opened = opened.Add(-oneDay)
+	}
+	return opened
+}
+
+func (w weeklyWindow) openedAt(t time.Time) time.Time {
+	opened := midnight(t).Add(-time.Duration(t.UTC().Weekday()) * oneDay).Add(w.start)
+	if opened.After(t) {
+		opened = opened.Add(-oneWeek)
+	}
+	return opened
+}
+
+func (w dailyWindow) String() string {
+	return formatClock(w.start) + "-" + formatClock(w.end)
+}
+
+func (w weeklyWindow) String() string {
+	return formatWeekdayClock(w.start) + "-" + formatWeekdayClock(w.end)
+}
+
+// Whether the two windows share any time of day. The maintenance window is
+// projected onto a single day for the comparison, which is what AWS's own
+// non-overlap rule does: it rejects an overlapping pair whatever day the
+// maintenance window falls on, because the two would collide the week they meet.
+func (w dailyWindow) overlaps(other weeklyWindow) bool {
+	for _, a := range w.segments() {
+		for _, b := range other.timeOfDay().segments() {
+			if a[0] < b[1] && b[0] < a[1] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// The window's daily projection. A window a whole day or longer covers every
+// time of day, so it is reported as one that leaves no gap.
+func (w weeklyWindow) timeOfDay() dailyWindow {
+	if w.length() >= oneDay {
+		return dailyWindow{start: 0, end: oneDay}
+	}
+	return dailyWindow{start: w.start % oneDay, end: w.end % oneDay}
+}
+
+// A wrapping window as the two non-wrapping spans it covers, so an overlap or a
+// containment check is plain interval arithmetic rather than a case analysis.
+func (w dailyWindow) segments() [][2]time.Duration {
+	if w.start < w.end {
+		return [][2]time.Duration{{w.start, w.end}}
+	}
+	return [][2]time.Duration{{w.start, oneDay}, {0, w.end}}
+}
+
+func (w weeklyWindow) segments() [][2]time.Duration {
+	if w.start < w.end {
+		return [][2]time.Duration{{w.start, w.end}}
+	}
+	return [][2]time.Duration{{w.start, oneWeek}, {0, w.end}}
+}
+
+func withinSegments(segments [][2]time.Duration, offset time.Duration) bool {
+	for _, segment := range segments {
+		if offset >= segment[0] && offset < segment[1] {
+			return true
+		}
+	}
+	return false
+}
+
+func sinceMidnight(t time.Time) time.Duration {
+	t = t.UTC()
+	return time.Duration(t.Hour())*time.Hour + time.Duration(t.Minute())*time.Minute +
+		time.Duration(t.Second())*time.Second
+}
+
+func sinceSunday(t time.Time) time.Duration {
+	return time.Duration(t.UTC().Weekday())*oneDay + sinceMidnight(t)
+}
+
+func midnight(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func formatClock(offset time.Duration) string {
+	offset = (offset%oneDay + oneDay) % oneDay
+	return fmt.Sprintf("%02d:%02d", int(offset/time.Hour), int(offset/time.Minute)%60)
+}
+
+func formatWeekdayClock(offset time.Duration) string {
+	offset = (offset%oneWeek + oneWeek) % oneWeek
+	day := int(offset / oneDay)
+	return weekdayNames[day*4:day*4+3] + ":" + formatClock(offset%oneDay)
+}
+
+// A window derived from the DB instance identifier rather than chosen at random.
+// AWS assigns a random one, which here would move whenever a record is rewritten;
+// a hash over the configured block is stable for the life of the instance and
+// still spreads the fleet's quiesce load across it.
+func assignDailyWindow(block dailyWindow, identifier string) dailyWindow {
+	slots := int64(block.length() / windowSlot)
+	if slots < 1 {
+		return block
+	}
+	slot := int64(windowHash(identifier) % uint64(slots)) //nolint:gosec // the modulus bounds it to the slot count
+	start := (block.start + time.Duration(slot)*windowSlot) % oneDay
+	return dailyWindow{start: start, end: (start + windowSlot) % oneDay}
+}
+
+// The same assignment plus a day, seeded apart from the backup window's so an
+// instance does not land on correlated positions within the two blocks.
+func assignWeeklyWindow(block dailyWindow, identifier string) weeklyWindow {
+	daily := assignDailyWindow(block, identifier)
+	day := int64(windowHash(identifier+"/maintenance") % 7)
+	start := (time.Duration(day)*oneDay + daily.start) % oneWeek
+	return weeklyWindow{start: start, end: (start + windowSlot) % oneWeek}
+}
+
+func windowHash(value string) uint64 {
+	h := fnv.New64a()
+	// Hash.Write never returns an error, which is why the interface's error is
+	// documented as always nil.
+	_, _ = h.Write([]byte(value))
+	return h.Sum64()
+}

--- a/tests/e2e/rds/automated_backup_test.go
+++ b/tests/e2e/rds/automated_backup_test.go
@@ -1,0 +1,211 @@
+//go:build e2e
+
+package rds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The namespace automated snapshots own, as in AWS.
+const automatedSnapshotPrefix = "rds:"
+
+// TestAutomatedBackups drives what only a live cluster can prove about rds-9:
+// the leader's window pass actually fires against a real engine, the snapshot it
+// takes is a real quiesced copy of the data volume, it fires once and not once per
+// pass, and turning retention off sweeps the set through the cluster-wide reaper.
+//
+// A window is the only trigger — there is no "back up now" API — so the window is
+// moved onto the instance once it is available rather than at create: a bootstrap
+// slower than the window would otherwise miss it and there is no catch-up.
+func TestAutomatedBackups(t *testing.T) {
+	f := requireRDSFixture(t)
+	id := fmt.Sprintf("%s-backup-%d", dbInstancePfx, time.Now().Unix())
+
+	harness.Phase(t, "Creating DB instance %q with automated backups on", id)
+	_, err := f.AWS.RDS.CreateDBInstance(&rds.CreateDBInstanceInput{ //nolint:staticcheck // e2e:allow-create — the instance under test
+		DBInstanceIdentifier:  aws.String(id),
+		Engine:                aws.String(dbEngine),
+		DBInstanceClass:       aws.String(dbClass),
+		AllocatedStorage:      aws.Int64(dbStorageGiB),
+		DBName:                aws.String(dbName),
+		MasterUsername:        aws.String(dbMasterUser),
+		MasterUserPassword:    aws.String(dbMasterPassword),
+		BackupRetentionPeriod: aws.Int64(1),
+	})
+	require.NoError(t, err, "create-db-instance")
+	t.Cleanup(func() { deleteInstance(t, f, id) })
+
+	instance := harness.WaitForDBInstanceAvailable(t, f.AWS, id)
+	assert.Equal(t, int64(1), aws.Int64Value(instance.BackupRetentionPeriod))
+	// A create that names no window is assigned one, as AWS does, so a customer is
+	// never left believing nothing is scheduled.
+	assert.Regexp(t, `^\d\d:\d\d-\d\d:\d\d$`, aws.StringValue(instance.PreferredBackupWindow))
+	assert.Regexp(t, `^[a-z]{3}:\d\d:\d\d-[a-z]{3}:\d\d:\d\d$`,
+		aws.StringValue(instance.PreferredMaintenanceWindow))
+
+	opens := time.Now().UTC().Add(time.Minute)
+	backupWindow := dailyWindowAt(opens, 30*time.Minute)
+	// Well clear of the backup window: the API refuses an overlapping pair.
+	maintenanceWindow := weeklyWindowAt(opens.Add(4*time.Hour), 30*time.Minute)
+
+	harness.Phase(t, "Moving the backup window of %q to %s", id, backupWindow)
+	modified, err := f.AWS.RDS.ModifyDBInstance(&rds.ModifyDBInstanceInput{
+		DBInstanceIdentifier:       aws.String(id),
+		PreferredBackupWindow:      aws.String(backupWindow),
+		PreferredMaintenanceWindow: aws.String(maintenanceWindow),
+		ApplyImmediately:           aws.Bool(true),
+	})
+	require.NoError(t, err, "modify-db-instance")
+	require.NotNil(t, modified.DBInstance)
+	assert.Equal(t, backupWindow, aws.StringValue(modified.DBInstance.PreferredBackupWindow),
+		"the window is reported back in AWS's canonical form")
+	assert.Equal(t, maintenanceWindow, aws.StringValue(modified.DBInstance.PreferredMaintenanceWindow))
+
+	var snapshot string
+	t.Run("TakesASnapshotInsideTheWindow", func(t *testing.T) {
+		harness.Phase(t, "Waiting for the automated backup of %q", id)
+		// The window may still be ahead of us, and the reconciler's pass is on its
+		// own cadence once it opens.
+		harness.EventuallyErr(t, func() error {
+			snapshots, err := automatedSnapshots(f, id)
+			if err != nil {
+				return err
+			}
+			if len(snapshots) == 0 {
+				return fmt.Errorf("no automated snapshot of %s yet", id)
+			}
+			snapshot = aws.StringValue(snapshots[0].DBSnapshotIdentifier)
+			return nil
+		}, 8*time.Minute, 15*time.Second)
+
+		assert.True(t, strings.HasPrefix(snapshot, automatedSnapshotPrefix),
+			"an automated snapshot takes AWS's own name, got %q", snapshot)
+
+		described, err := f.AWS.RDS.DescribeDBSnapshots(&rds.DescribeDBSnapshotsInput{
+			DBSnapshotIdentifier: aws.String(snapshot),
+		})
+		require.NoError(t, err, "describe-db-snapshots")
+		require.Len(t, described.DBSnapshots, 1)
+		assert.Equal(t, "automated", aws.StringValue(described.DBSnapshots[0].SnapshotType))
+		assert.Equal(t, "available", aws.StringValue(described.DBSnapshots[0].Status))
+		assert.Equal(t, id, aws.StringValue(described.DBSnapshots[0].DBInstanceIdentifier))
+	})
+
+	t.Run("ReportsTheAutomatedBackupSet", func(t *testing.T) {
+		requireSnapshot(t, snapshot)
+		out, err := f.AWS.RDS.DescribeDBInstanceAutomatedBackups(&rds.DescribeDBInstanceAutomatedBackupsInput{
+			DBInstanceIdentifier: aws.String(id),
+		})
+		require.NoError(t, err, "describe-db-instance-automated-backups")
+		require.Len(t, out.DBInstanceAutomatedBackups, 1)
+
+		backup := out.DBInstanceAutomatedBackups[0]
+		assert.Equal(t, id, aws.StringValue(backup.DBInstanceIdentifier))
+		assert.Equal(t, "active", aws.StringValue(backup.Status))
+		assert.Equal(t, int64(1), aws.Int64Value(backup.BackupRetentionPeriod))
+		// This phase backs discrete daily snapshots, so there is no restore window
+		// to report; reporting one would promise point-in-time recovery.
+		assert.Nil(t, backup.RestoreWindow)
+	})
+
+	// The reconciler passes every few seconds while the window stays open, so a
+	// window that fired per pass rather than per window shows up here immediately.
+	t.Run("FiresOncePerWindow", func(t *testing.T) {
+		requireSnapshot(t, snapshot)
+		harness.Phase(t, "Watching %q for a duplicate backup in the same window", id)
+		for range 8 {
+			time.Sleep(20 * time.Second)
+			snapshots, err := automatedSnapshots(f, id)
+			require.NoError(t, err)
+			require.Len(t, snapshots, 1, "the window has already fired; a second backup means it fired per pass")
+		}
+	})
+
+	// Turning retention off is what makes the data volume GC-eligible again, so it
+	// has to remove the set rather than leave it to expire.
+	t.Run("RetentionZeroSweepsTheSet", func(t *testing.T) {
+		requireSnapshot(t, snapshot)
+		_, err := f.AWS.RDS.ModifyDBInstance(&rds.ModifyDBInstanceInput{
+			DBInstanceIdentifier:  aws.String(id),
+			BackupRetentionPeriod: aws.Int64(0),
+			ApplyImmediately:      aws.Bool(true),
+		})
+		require.NoError(t, err, "modify-db-instance")
+
+		harness.Phase(t, "Waiting for the automated backups of %q to be swept", id)
+		harness.EventuallyErr(t, func() error {
+			snapshots, err := automatedSnapshots(f, id)
+			if err != nil {
+				return err
+			}
+			if len(snapshots) > 0 {
+				return fmt.Errorf("%s still has %d automated snapshots", id, len(snapshots))
+			}
+			return nil
+		}, 6*time.Minute, 15*time.Second)
+
+		out, err := f.AWS.RDS.DescribeDBInstanceAutomatedBackups(&rds.DescribeDBInstanceAutomatedBackupsInput{
+			DBInstanceIdentifier: aws.String(id),
+		})
+		require.NoError(t, err, "describe-db-instance-automated-backups")
+		assert.Empty(t, out.DBInstanceAutomatedBackups,
+			"an instance with backups off has no automated backup set")
+	})
+}
+
+// The automated snapshots of one instance, newest first, which is what the
+// snapshot-type filter has to answer without listing the manual ones.
+func automatedSnapshots(f *Fixture, id string) ([]*rds.DBSnapshot, error) {
+	out, err := f.AWS.RDS.DescribeDBSnapshots(&rds.DescribeDBSnapshotsInput{
+		DBInstanceIdentifier: aws.String(id),
+		SnapshotType:         aws.String("automated"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe-db-snapshots %s: %w", id, err)
+	}
+	return out.DBSnapshots, nil
+}
+
+func requireSnapshot(t *testing.T, snapshot string) {
+	t.Helper()
+	if snapshot == "" {
+		t.Skip("no automated snapshot was taken (TakesASnapshotInsideTheWindow failed)")
+	}
+}
+
+// AWS's hh24:mi-hh24:mi in UTC.
+func dailyWindowAt(start time.Time, length time.Duration) string {
+	return start.UTC().Format("15:04") + "-" + start.UTC().Add(length).Format("15:04")
+}
+
+// AWS's ddd:hh24:mi-ddd:hh24:mi in UTC.
+func weeklyWindowAt(start time.Time, length time.Duration) string {
+	return weekdayClock(start) + "-" + weekdayClock(start.Add(length))
+}
+
+func weekdayClock(at time.Time) string {
+	at = at.UTC()
+	return strings.ToLower(at.Format("Mon")) + ":" + at.Format("15:04")
+}
+
+func deleteInstance(t *testing.T, f *Fixture, id string) {
+	t.Helper()
+	_, err := f.AWS.RDS.DeleteDBInstance(&rds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String(id),
+		SkipFinalSnapshot:    aws.Bool(true),
+	})
+	if err != nil {
+		t.Logf("delete-db-instance %s: %v (left behind for manual teardown)", id, err)
+		return
+	}
+	harness.WaitForDBInstanceGone(t, f.AWS, id)
+}


### PR DESCRIPTION
## What lands

Automated backups for RDS DB instances: a backup window that cuts a snapshot once per window, a maintenance window that stands by for it, `DescribeDBInstanceAutomatedBackups`, and a retention sweep that deletes what has aged out. Windows and retention are settable on `CreateDBInstance` and `ModifyDBInstance`.

### Windows

`window.go` holds the machinery both passes share: AWS's `hh24:mi-hh24:mi` and `ddd:hh24:mi-ddd:hh24:mi` forms, the 30-minute minimum, the non-overlap rule between the two, and the instant the current window opened. A pass fires exactly once per window by comparing a persisted stamp against that instant rather than trusting a timer's memory, so a restart mid-window does not double-cut and a daemon that was down through a window does not backfill it.

A customer who names no window gets one derived from the instance identifier rather than chosen at random — AWS randomises, which here would move the window every time a record is rewritten. The hash is stable for the life of the instance and still spreads the fleet's quiesce load across the configured block. The maintenance window is seeded apart from the backup window's so an instance does not land on correlated positions in the two blocks.

### The backup pass

The snapshot is taken through the same rds-8 path a manual one is, so it inherits the quiesce, the in-flight guard, and the crash-consistent fallback. The identifier is AWS's `rds:{db}-{YYYY-MM-DD-HH-MM}`. An instance that cannot be snapshotted right now — one already in `backing-up`, or not `available` — is deferred with an event rather than failed, and retried on a paced delay while its window is still open.

`rds:` is refused as a prefix on any identifier a customer mints, so the automated namespace cannot be forged. The reference validators are separate from the minting ones, so an automated backup can still be described and restored from by name while `DeleteDBSnapshot` refuses it, as AWS does.

### Retention

`BackupRetentionReaper` is the sweep, registered with the existing `vm.Reaper` GC. It is the first `ScopeClusterWide` reaper, so `WithLeaderElection` is now actually wired — `Daemon.clusterSweepLease` hands the collector the RDS reconciler's cluster lease, without which the reaper would have been a silent no-op.

The sweep is per account and bounded per pass, resuming where it left off. It keeps the newest available backup whatever retention says, so an instance is never left with nothing to restore from. Retention 0 sweeps the set entirely, including that last one — which is the only way a source volume's chunk GC gets un-latched, since a COW snapshot holds it off for the life of the volume.

`reclaimOrphanedVolumes` re-checks every retained volume record against the volume store rather than skipping the ones that name holders: those holders are a past reading, and a volume whose last snapshot went in a crashed delete still names it. A disagreement with the volume store's own index is recorded on the record and re-checked next pass instead of failing the caller.

### KV keys

A JetStream KV key admits no colon, so `db-snapshots/rds:{db}-{stamp}` and the automated snapshot's event ring were unwritable. The customer-facing identifier keeps AWS's `rds:` form and the key segment maps the colon to `.`, the separator other stores compose keys from and a character no RDS identifier may contain. A manual snapshot's key is unchanged.

## Testing

`backup_test.go` and `backup_sweep_test.go`: the window parse matrices against what AWS accepts and rejects, canonical text, stable assignment, the once-per-window and no-backfill properties, retry pacing, the derived windows, the identifier and stamp formats, `DescribeDBInstanceAutomatedBackups` including the filters that are not implemented, the reconciler and cluster-lease wiring, and the sweep's retention boundary, keep-newest-available rule, per-pass bound, resume, in-use skip and orphan reclaim.

`tests/e2e/rds/automated_backup_test.go` takes a real instance through an assigned window, moves the window a minute out, waits for the snapshot, asserts the backup set is `active`, watches for a duplicate, then sets retention 0 and waits for the sweep.

Three `create_test.go` rejection cases were removed rather than relaxed: the parameters they asserted were rejected are now implemented.
