### PR TITLE
feat: enforce rds:* authorization by principal class and resource

### DIFF
--- a/spinifex/gateway/rds.go
+++ b/spinifex/gateway/rds.go
@@ -30,18 +30,28 @@ func (gw *GatewayConfig) RDS_Request(w http.ResponseWriter, r *http.Request) err
 		return errors.New(awserrors.ErrorInvalidAction)
 	}
 
-	if err := gw.checkPolicy(r, "rds", action); err != nil {
+	caller, err := rdsCaller(r)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "RDS_Request: no account ID in auth context")
+		return err
+	}
+
+	// Before the policy check, so no customer grant is ever evaluated against an
+	// internal agent action. See AuthorizeCaller.
+	if err := gateway_rds.AuthorizeCaller(r.Context(), action, caller); err != nil {
+		return err
+	}
+
+	resource, err := gateway_rds.ResourceARN(action, gw.Region, caller.AccountID, queryArgs)
+	if err != nil {
+		return err
+	}
+	if err := gw.checkPolicyResource(r, "rds", action, resource); err != nil {
 		return err
 	}
 
 	if gw.NATSConn == nil {
 		return errors.New(awserrors.ErrorServerInternal)
-	}
-
-	caller, err := rdsCaller(r)
-	if err != nil {
-		slog.ErrorContext(r.Context(), "RDS_Request: no account ID in auth context")
-		return err
 	}
 
 	xmlOutput, err := gateway_rds.Dispatch(r.Context(), action, queryArgs, gw.NATSConn, caller)

--- a/spinifex/gateway/rds/agent.go
+++ b/spinifex/gateway/rds/agent.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
-	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -35,13 +34,10 @@ type agentIdentity struct {
 // the authoritative identifier comes from the index, so an agent cannot act on
 // another instance by asking to.
 func authorizeAgent(ctx context.Context, nc *nats.Conn, caller Caller, requestedID string) (*agentIdentity, error) {
-	if caller.PrincipalType != principalTypeAssumedRole ||
-		caller.AccountID != utils.GlobalAccountID ||
-		caller.RoleName != handlers_rds.InstanceRoleName ||
-		caller.SessionName == "" {
-		slog.DebugContext(ctx, "RDS: internal action rejected for non-agent caller",
-			"principalType", caller.PrincipalType, "accountID", caller.AccountID, "roleName", caller.RoleName)
-		return nil, errors.New(awserrors.ErrorAccessDenied)
+	// Re-run at the handler even though the gateway gate already ran it: this is
+	// the check that must hold, and it must not depend on a caller remembering.
+	if err := requireAgentPrincipal(ctx, caller); err != nil {
+		return nil, err
 	}
 
 	// IMDS instance-role credentials set RoleSessionName to the internal EC2

--- a/spinifex/gateway/rds/authz.go
+++ b/spinifex/gateway/rds/authz.go
@@ -1,0 +1,94 @@
+package gateway_rds
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+)
+
+// The resource a policy check evaluates against when the request names nothing
+// in particular: every create, and the describes that filter rather than
+// address.
+const anyResource = "*"
+
+// Which query parameter names the single resource an action acts on, and the ARN
+// type it resolves to. An action naming no resource, or more than one, carries no
+// scope at all.
+type resourceScope struct {
+	param string
+	// Empty when param already carries a full ARN — the tag actions — which is
+	// validated rather than built.
+	kind handlers_rds.ResourceKind
+}
+
+var (
+	dbInstanceScope       = &resourceScope{param: "DBInstanceIdentifier", kind: handlers_rds.ResourceKindDBInstance}
+	dbSnapshotScope       = &resourceScope{param: "DBSnapshotIdentifier", kind: handlers_rds.ResourceKindDBSnapshot}
+	dbSubnetGroupScope    = &resourceScope{param: "DBSubnetGroupName", kind: handlers_rds.ResourceKindDBSubnetGroup}
+	dbParameterGroupScope = &resourceScope{param: "DBParameterGroupName", kind: handlers_rds.ResourceKindDBParameterGroup}
+	taggedResourceScope   = &resourceScope{param: "ResourceName"}
+)
+
+// AuthorizeCaller is the principal-class gate, run before the policy check.
+// Internal actions are agent-only, and no customer grant can reach them: rds:* is
+// a legitimate admin grant, and GetDBBootstrapConfig returns a master password.
+func AuthorizeCaller(ctx context.Context, action string, caller Caller) error {
+	def, ok := actions[action]
+	if !ok {
+		return errors.New(awserrors.ErrorInvalidAction)
+	}
+	if !def.internal {
+		return nil
+	}
+	return requireAgentPrincipal(ctx, caller)
+}
+
+// The class check on its own: a session assumed from the DB VM's instance role
+// in the system account. It says the caller is an RDS VM, not which one — the
+// binding to a specific DB instance is authorizeAgent's, and needs NATS.
+func requireAgentPrincipal(ctx context.Context, caller Caller) error {
+	if caller.PrincipalType != principalTypeAssumedRole ||
+		caller.AccountID != utils.GlobalAccountID ||
+		caller.RoleName != handlers_rds.InstanceRoleName ||
+		caller.SessionName == "" {
+		slog.DebugContext(ctx, "RDS: internal action rejected for non-agent caller",
+			"principalType", caller.PrincipalType, "accountID", caller.AccountID, "roleName", caller.RoleName)
+		return errors.New(awserrors.ErrorAccessDenied)
+	}
+	return nil
+}
+
+// ResourceARN builds the resource the action's policy check evaluates against. A
+// policy written for arn:aws:rds:*:*:db:prod-* but checked against "*" would
+// permit every instance in the account, which is worse than no policy at all.
+func ResourceARN(action, region, accountID string, q map[string]string) (string, error) {
+	def, ok := actions[action]
+	// Rejected here too, not just by the dispatcher: a caller that skipped the
+	// action check must not get a resource back for rds:<garbage>.
+	if !ok {
+		return "", errors.New(awserrors.ErrorInvalidAction)
+	}
+	if def.scope == nil {
+		return anyResource, nil
+	}
+	identifier := q[def.scope.param]
+	// An absent identifier is a validation fault the handler reports precisely;
+	// answering it with a denial here would hide the real reason.
+	if identifier == "" {
+		return anyResource, nil
+	}
+	if def.scope.kind == "" {
+		// Parsed rather than passed through, so a foreign account or region is an
+		// InvalidParameterValue before the evaluator sees it: cross-account sharing
+		// is out of v1, and a permissive parser is how it arrives anyway.
+		if _, err := handlers_rds.ParseARN(identifier, region, accountID); err != nil {
+			return "", err
+		}
+		return identifier, nil
+	}
+	return handlers_rds.FormatARN(def.scope.kind, region, accountID, identifier), nil
+}

--- a/spinifex/gateway/rds/authz_test.go
+++ b/spinifex/gateway/rds/authz_test.go
@@ -1,0 +1,212 @@
+package gateway_rds
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testRegion = "ap-southeast-2"
+
+// The set the gate refuses to customers must be the set the instance role
+// grants. Deriving one from the other would let both drift together.
+func TestActions_InternalSetMatchesTheInstanceRoleGrant(t *testing.T) {
+	var internal []string
+	for action, def := range actions {
+		if def.internal {
+			internal = append(internal, action)
+		}
+	}
+	slices.Sort(internal)
+	want := slices.Clone(handlers_rds.InternalAgentActions)
+	slices.Sort(want)
+	assert.Equal(t, want, internal)
+}
+
+func TestAuthorizeCaller_DeniesInternalActionsToCustomers(t *testing.T) {
+	callers := []struct {
+		name   string
+		caller Caller
+	}{
+		{"customer user", testCaller},
+		{"customer role session", Caller{
+			AccountID: testAccountID, PrincipalType: principalTypeAssumedRole,
+			RoleName: "admin", SessionName: "alice",
+		}},
+		// The one an rds:* admin grant would otherwise carry all the way in.
+		{"customer session named like an instance", Caller{
+			AccountID: testAccountID, PrincipalType: principalTypeAssumedRole,
+			RoleName: handlers_rds.InstanceRoleName, SessionName: testInstanceID,
+		}},
+		{"system user rather than a session", Caller{
+			AccountID: utils.GlobalAccountID, PrincipalType: "user",
+			RoleName: handlers_rds.InstanceRoleName, SessionName: testInstanceID,
+		}},
+		{"system session under another role", Caller{
+			AccountID: utils.GlobalAccountID, PrincipalType: principalTypeAssumedRole,
+			RoleName: "ecsInstanceRole", SessionName: testInstanceID,
+		}},
+	}
+	for _, action := range handlers_rds.InternalAgentActions {
+		for _, tt := range callers {
+			t.Run(action+"/"+tt.name, func(t *testing.T) {
+				err := AuthorizeCaller(t.Context(), action, tt.caller)
+				require.Error(t, err)
+				assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+			})
+		}
+	}
+}
+
+// The class gate says the caller is an RDS VM. Which instance it is stays
+// authorizeAgent's question, so no NATS lookup happens here.
+func TestAuthorizeCaller_AdmitsTheAgentPrincipalClass(t *testing.T) {
+	for _, action := range handlers_rds.InternalAgentActions {
+		t.Run(action, func(t *testing.T) {
+			require.NoError(t, AuthorizeCaller(t.Context(), action, agentCaller()))
+		})
+	}
+}
+
+// Customer actions carry no class requirement: the policy check decides, which
+// is what denies the instance role its account's fleet.
+func TestAuthorizeCaller_LeavesCustomerActionsToPolicy(t *testing.T) {
+	for _, action := range []string{"CreateDBInstance", "DescribeDBInstances", "DeleteDBInstance"} {
+		require.NoError(t, AuthorizeCaller(t.Context(), action, testCaller), "action %q", action)
+		require.NoError(t, AuthorizeCaller(t.Context(), action, agentCaller()), "action %q", action)
+	}
+}
+
+func TestAuthorizeCaller_UnknownAction(t *testing.T) {
+	err := AuthorizeCaller(t.Context(), "NotAnRDSAction", agentCaller())
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidAction, err.Error())
+}
+
+func TestResourceARN_ScopesSingleResourceActions(t *testing.T) {
+	tests := []struct {
+		action string
+		params map[string]string
+		want   string
+	}{
+		{"ModifyDBInstance", map[string]string{"DBInstanceIdentifier": "orders-db"},
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db"},
+		{"DeleteDBInstance", map[string]string{"DBInstanceIdentifier": "orders-db"},
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db"},
+		{"RebootDBInstance", map[string]string{"DBInstanceIdentifier": "orders-db"},
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db"},
+		{"StartDBInstance", map[string]string{"DBInstanceIdentifier": "orders-db"},
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db"},
+		{"StopDBInstance", map[string]string{"DBInstanceIdentifier": "orders-db"},
+			"arn:aws:rds:ap-southeast-2:123456789012:db:orders-db"},
+		{"DeleteDBSnapshot", map[string]string{"DBSnapshotIdentifier": "orders-db-pre-upgrade"},
+			"arn:aws:rds:ap-southeast-2:123456789012:snapshot:orders-db-pre-upgrade"},
+		{"DeleteDBSubnetGroup", map[string]string{"DBSubnetGroupName": "db-private"},
+			"arn:aws:rds:ap-southeast-2:123456789012:subgrp:db-private"},
+		{"ModifyDBParameterGroup", map[string]string{"DBParameterGroupName": "pg16-tuned"},
+			"arn:aws:rds:ap-southeast-2:123456789012:pg:pg16-tuned"},
+		{"DescribeDBParameters", map[string]string{"DBParameterGroupName": "pg16-tuned"},
+			"arn:aws:rds:ap-southeast-2:123456789012:pg:pg16-tuned"},
+		{"DeleteDBParameterGroup", map[string]string{"DBParameterGroupName": "pg16-tuned"},
+			"arn:aws:rds:ap-southeast-2:123456789012:pg:pg16-tuned"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			got, err := ResourceARN(tt.action, testRegion, testAccountID, tt.params)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// A create names no existing resource, and a plural describe filters rather than
+// addresses, so both are evaluated against "*".
+func TestResourceARN_UnscopedActions(t *testing.T) {
+	unscoped := []string{
+		"CreateDBInstance", "DescribeDBInstances", "CreateDBSnapshot", "DescribeDBSnapshots",
+		"RestoreDBInstanceFromDBSnapshot", "DescribeDBInstanceAutomatedBackups",
+		"CreateDBSubnetGroup", "DescribeDBSubnetGroups",
+		"CreateDBParameterGroup", "DescribeDBParameterGroups",
+		"DescribeEvents",
+		"RegisterDBInstance", "SubmitDBStateChange", "PollDBCommands", "GetDBBootstrapConfig",
+	}
+	for _, action := range unscoped {
+		t.Run(action, func(t *testing.T) {
+			// The identifiers a scoped action would consume are supplied on purpose:
+			// an unscoped action must ignore them rather than narrow itself.
+			got, err := ResourceARN(action, testRegion, testAccountID, map[string]string{
+				"DBInstanceIdentifier": "orders-db",
+				"DBSnapshotIdentifier": "orders-db-pre-upgrade",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, anyResource, got)
+		})
+	}
+}
+
+// The tag actions name their resource by ARN, so the scope validates the ARN it
+// was given rather than rebuilding it from an identifier.
+func TestResourceARN_TagActionsUseTheSuppliedARN(t *testing.T) {
+	arn := handlers_rds.DBSnapshotARN(testRegion, testAccountID, "orders-db-pre-upgrade")
+	for _, action := range []string{"AddTagsToResource", "RemoveTagsFromResource", "ListTagsForResource"} {
+		t.Run(action, func(t *testing.T) {
+			got, err := ResourceARN(action, testRegion, testAccountID, map[string]string{"ResourceName": arn})
+			require.NoError(t, err)
+			assert.Equal(t, arn, got)
+		})
+	}
+}
+
+func TestResourceARN_RejectsUnusableARNs(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceName string
+	}{
+		{"another account", handlers_rds.DBInstanceARN(testRegion, "999988887777", "orders-db")},
+		{"another region", handlers_rds.DBInstanceARN("us-east-1", testAccountID, "orders-db")},
+		{"another service", "arn:aws:ec2:" + testRegion + ":" + testAccountID + ":instance/i-0abc123"},
+		{"not an ARN", "orders-db"},
+		{"unknown resource type", "arn:aws:rds:" + testRegion + ":" + testAccountID + ":cluster:orders"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResourceARN("ListTagsForResource", testRegion, testAccountID,
+				map[string]string{"ResourceName": tt.resourceName})
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+		})
+	}
+}
+
+// A missing identifier is the handler's validation fault to report. Answering it
+// with a denial here would tell the caller the wrong thing about their policy.
+func TestResourceARN_MissingIdentifierFallsBackToAnyResource(t *testing.T) {
+	for _, action := range []string{"DeleteDBInstance", "DescribeDBParameters", "ListTagsForResource"} {
+		got, err := ResourceARN(action, testRegion, testAccountID, map[string]string{})
+		require.NoError(t, err, "action %q", action)
+		assert.Equal(t, anyResource, got, "action %q", action)
+	}
+}
+
+// An unknown action must not resolve to "*": a caller that reached here without
+// the dispatcher's action check would otherwise evaluate rds:<garbage> against
+// every resource in the account and be told it was fine.
+func TestResourceARN_UnknownAction(t *testing.T) {
+	_, err := ResourceARN("NotAnRDSAction", testRegion, testAccountID, nil)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidAction, err.Error())
+}
+
+// Every registered action must resolve a resource without error, so an action
+// added with a scope but no identifier in the request cannot fail the request.
+func TestResourceARN_EveryActionResolves(t *testing.T) {
+	for action := range actions {
+		_, err := ResourceARN(action, testRegion, testAccountID, map[string]string{"Action": action})
+		require.NoError(t, err, "action %q", action)
+	}
+}

--- a/spinifex/gateway/rds/handler.go
+++ b/spinifex/gateway/rds/handler.go
@@ -69,70 +69,86 @@ func rejectWith(code string) Handler {
 	}
 }
 
+// One entry per action: what serves it, whether it is agent-only, and which
+// resource its policy check evaluates against. Both authorization facts live on
+// the table so a new action cannot be added without deciding either.
+type actionDef struct {
+	handler Handler
+	// Agent-only: refused to every customer principal by class, before any
+	// policy is evaluated.
+	internal bool
+	// nil evaluates against "*", which is right for creates and for describes
+	// that filter rather than address one resource.
+	scope *resourceScope
+}
+
 // The whole namespace is registered from day one, so an action outside v1 stays
 // distinct from an unknown one.
-var actions = map[string]Handler{
+var actions = map[string]actionDef{
 	// Instance lifecycle.
-	"CreateDBInstance":    typed(CreateDBInstance),
-	"DescribeDBInstances": typed(DescribeDBInstances),
-	"ModifyDBInstance":    typed(ModifyDBInstance),
-	"DeleteDBInstance":    typed(DeleteDBInstance),
-	"RebootDBInstance":    typed(RebootDBInstance),
-	"StartDBInstance":     typed(StartDBInstance),
-	"StopDBInstance":      typed(StopDBInstance),
+	"CreateDBInstance":    {handler: typed(CreateDBInstance)},
+	"DescribeDBInstances": {handler: typed(DescribeDBInstances)},
+	"ModifyDBInstance":    {handler: typed(ModifyDBInstance), scope: dbInstanceScope},
+	"DeleteDBInstance":    {handler: typed(DeleteDBInstance), scope: dbInstanceScope},
+	"RebootDBInstance":    {handler: typed(RebootDBInstance), scope: dbInstanceScope},
+	"StartDBInstance":     {handler: typed(StartDBInstance), scope: dbInstanceScope},
+	"StopDBInstance":      {handler: typed(StopDBInstance), scope: dbInstanceScope},
 
-	// Snapshots.
-	"CreateDBSnapshot":                typed(CreateDBSnapshot),
-	"DescribeDBSnapshots":             typed(DescribeDBSnapshots),
-	"DeleteDBSnapshot":                typed(DeleteDBSnapshot),
-	"RestoreDBInstanceFromDBSnapshot": typed(RestoreDBInstanceFromDBSnapshot),
+	// Snapshots. A create names two resources — the source instance and the new
+	// snapshot — so it is not scoped to either.
+	"CreateDBSnapshot":                {handler: typed(CreateDBSnapshot)},
+	"DescribeDBSnapshots":             {handler: typed(DescribeDBSnapshots)},
+	"DeleteDBSnapshot":                {handler: typed(DeleteDBSnapshot), scope: dbSnapshotScope},
+	"RestoreDBInstanceFromDBSnapshot": {handler: typed(RestoreDBInstanceFromDBSnapshot)},
 
 	// Automated backups.
-	"DescribeDBInstanceAutomatedBackups": typed(DescribeDBInstanceAutomatedBackups),
+	"DescribeDBInstanceAutomatedBackups": {handler: typed(DescribeDBInstanceAutomatedBackups)},
 
 	// Subnet groups.
-	"CreateDBSubnetGroup":    typed(CreateDBSubnetGroup),
-	"DescribeDBSubnetGroups": typed(DescribeDBSubnetGroups),
-	"DeleteDBSubnetGroup":    typed(DeleteDBSubnetGroup),
+	"CreateDBSubnetGroup":    {handler: typed(CreateDBSubnetGroup)},
+	"DescribeDBSubnetGroups": {handler: typed(DescribeDBSubnetGroups)},
+	"DeleteDBSubnetGroup":    {handler: typed(DeleteDBSubnetGroup), scope: dbSubnetGroupScope},
 
-	// Parameter groups.
-	"CreateDBParameterGroup":    typed(CreateDBParameterGroup),
-	"DescribeDBParameterGroups": typed(DescribeDBParameterGroups),
-	"ModifyDBParameterGroup":    typed(ModifyDBParameterGroup),
-	"DescribeDBParameters":      typed(DescribeDBParameters),
-	"DeleteDBParameterGroup":    typed(DeleteDBParameterGroup),
+	// Parameter groups. DescribeDBParameters is scoped despite being a describe:
+	// its parameter group is required and singular, so it addresses one resource.
+	"CreateDBParameterGroup":    {handler: typed(CreateDBParameterGroup)},
+	"DescribeDBParameterGroups": {handler: typed(DescribeDBParameterGroups)},
+	"ModifyDBParameterGroup":    {handler: typed(ModifyDBParameterGroup), scope: dbParameterGroupScope},
+	"DescribeDBParameters":      {handler: typed(DescribeDBParameters), scope: dbParameterGroupScope},
+	"DeleteDBParameterGroup":    {handler: typed(DeleteDBParameterGroup), scope: dbParameterGroupScope},
 
-	// Tags.
-	"AddTagsToResource":      typed(AddTagsToResource),
-	"RemoveTagsFromResource": typed(RemoveTagsFromResource),
-	"ListTagsForResource":    typed(ListTagsForResource),
+	// Tags. The request names its resource by ARN, so the scope validates one
+	// rather than building it.
+	"AddTagsToResource":      {handler: typed(AddTagsToResource), scope: taggedResourceScope},
+	"RemoveTagsFromResource": {handler: typed(RemoveTagsFromResource), scope: taggedResourceScope},
+	"ListTagsForResource":    {handler: typed(ListTagsForResource), scope: taggedResourceScope},
 
-	// Events.
-	"DescribeEvents": typed(DescribeEvents),
+	// Events. The ring is per-account and a filter names no single resource.
+	"DescribeEvents": {handler: typed(DescribeEvents)},
 
 	// Internal agent actions, callable only by the in-guest agent's system role.
 	// They share the namespace because the agent reaches the control plane over
 	// SigV4-on-awsgw like every other in-guest agent.
-	"RegisterDBInstance":   typed(RegisterDBInstance),
-	"SubmitDBStateChange":  typed(SubmitDBStateChange),
-	"PollDBCommands":       typed(PollDBCommands),
-	"GetDBBootstrapConfig": typed(GetDBBootstrapConfig),
+	"RegisterDBInstance":   {handler: typed(RegisterDBInstance), internal: true},
+	"SubmitDBStateChange":  {handler: typed(SubmitDBStateChange), internal: true},
+	"PollDBCommands":       {handler: typed(PollDBCommands), internal: true},
+	"GetDBBootstrapConfig": {handler: typed(GetDBBootstrapConfig), internal: true},
 
 	// Recognised but out of scope. Read replicas, Aurora clusters and option
 	// groups are not offered at all; point-in-time restore waits on WAL
 	// archiving.
-	"CreateDBInstanceReadReplica":    unsupported(),
-	"PromoteReadReplica":             unsupported(),
-	"CreateDBCluster":                unsupported(),
-	"ModifyDBCluster":                unsupported(),
-	"DeleteDBCluster":                unsupported(),
-	"DescribeDBClusters":             unsupported(),
-	"FailoverDBCluster":              unsupported(),
-	"CreateOptionGroup":              unsupported(),
-	"ModifyOptionGroup":              unsupported(),
-	"DeleteOptionGroup":              unsupported(),
-	"DescribeOptionGroups":           unsupported(),
-	"RestoreDBInstanceToPointInTime": unsupported(),
+	"CreateDBInstanceReadReplica":    {handler: unsupported()},
+	"PromoteReadReplica":             {handler: unsupported()},
+	"CreateDBCluster":                {handler: unsupported()},
+	"ModifyDBCluster":                {handler: unsupported()},
+	"DeleteDBCluster":                {handler: unsupported()},
+	"DescribeDBClusters":             {handler: unsupported()},
+	"FailoverDBCluster":              {handler: unsupported()},
+	"CreateOptionGroup":              {handler: unsupported()},
+	"ModifyOptionGroup":              {handler: unsupported()},
+	"DeleteOptionGroup":              {handler: unsupported()},
+	"DescribeOptionGroups":           {handler: unsupported()},
+	"RestoreDBInstanceToPointInTime": {handler: unsupported()},
 }
 
 // Checked before the IAM policy check, so an unknown action is rejected as
@@ -142,12 +158,13 @@ func HasAction(action string) bool {
 	return ok
 }
 
-// Callers are expected to have authorized the action already; the
-// unknown-action check here is a backstop, not the enforcement point.
+// Callers are expected to have authorized the action already; the unknown-action
+// check here is a backstop, not the enforcement point. The internal actions
+// re-run their own gate, so skipping AuthorizeCaller still cannot reach one.
 func Dispatch(ctx context.Context, action string, q map[string]string, nc *nats.Conn, caller Caller) ([]byte, error) {
-	handler, ok := actions[action]
+	def, ok := actions[action]
 	if !ok {
 		return nil, errors.New(awserrors.ErrorInvalidAction)
 	}
-	return handler(ctx, action, q, nc, caller)
+	return def.handler(ctx, action, q, nc, caller)
 }

--- a/spinifex/gateway/rds_test.go
+++ b/spinifex/gateway/rds_test.go
@@ -9,15 +9,76 @@ import (
 	"testing"
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+const rdsTestAccountID = "123456789012"
+
 func setupRDSRequest(body string) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
 	ctx := context.WithValue(req.Context(), ctxService, "rds")
-	ctx = context.WithValue(ctx, ctxAccountID, "123456789012")
+	ctx = context.WithValue(ctx, ctxAccountID, rdsTestAccountID)
 	return req.WithContext(ctx)
+}
+
+// A signed customer request: an IAM user with a resolvable identity, which is
+// what turns the policy check from the pre-IAM bypass into a real evaluation.
+func setupRDSUserRequest(body, accountID string) *http.Request {
+	req := setupRDSRequest(body)
+	ctx := context.WithValue(req.Context(), ctxAccountID, accountID)
+	ctx = context.WithValue(ctx, ctxIdentity, "alice")
+	ctx = context.WithValue(ctx, ctxPrincipalType, principalTypeUser)
+	return req.WithContext(ctx)
+}
+
+// An in-guest agent's request: an assumed-role session under the system account
+// whose underlying role is the DB VM instance role.
+func setupRDSAgentRequest(body, sessionName string) *http.Request {
+	req := setupRDSRequest(body)
+	roleARN := "arn:aws:iam::" + utils.GlobalAccountID + ":role/" + handlers_rds.InstanceRoleName
+	ctx := context.WithValue(req.Context(), ctxAccountID, utils.GlobalAccountID)
+	ctx = context.WithValue(ctx, ctxIdentity, sessionName)
+	ctx = context.WithValue(ctx, ctxPrincipalType, principalTypeAssumedRole)
+	ctx = context.WithValue(ctx, ctxUnderlyingRoleARN, roleARN)
+	ctx = context.WithValue(ctx, ctxAssumedRoleARN,
+		"arn:aws:sts::"+utils.GlobalAccountID+":assumed-role/"+handlers_rds.InstanceRoleName+"/"+sessionName)
+	return req.WithContext(ctx)
+}
+
+// Counts policy resolutions, so a test can tell an authorized request from one
+// that failed some other guard before the evaluator was ever reached.
+type rdsPolicyProbe struct{ consulted int }
+
+// A gateway whose IAM service answers with policies, so the RDS dispatch path
+// runs a real evaluation for either principal branch.
+func newRDSPolicyGateway(policies []handlers_iam.PolicyDocument) (*GatewayConfig, *rdsPolicyProbe) {
+	return newRDSGatewayWithResolver(func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		return policies, nil
+	})
+}
+
+func newRDSGatewayWithResolver(
+	resolve func(accountID, name string) ([]handlers_iam.PolicyDocument, error),
+) (*GatewayConfig, *rdsPolicyProbe) {
+	probe := &rdsPolicyProbe{}
+	counted := func(accountID, name string) ([]handlers_iam.PolicyDocument, error) {
+		probe.consulted++
+		return resolve(accountID, name)
+	}
+	// Both branches are wired: an assumed-role principal resolves by role, and a
+	// test that only stubbed users would miss it entirely.
+	return &GatewayConfig{
+		DisableLogging: true,
+		Region:         "ap-southeast-2",
+		IAMService: &policyMockIAMService{
+			getUserPoliciesFn: counted,
+			getRolePoliciesFn: counted,
+		},
+	}, probe
 }
 
 func TestRDSRequest_MissingAction(t *testing.T) {
@@ -49,6 +110,99 @@ func TestRDSRequest_NoNATSConn(t *testing.T) {
 	err := gw.RDS_Request(httptest.NewRecorder(), setupRDSRequest("Action=DescribeDBInstances"))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+}
+
+// The headline of this surface: rds:* on * is the natural admin grant, and it
+// must not reach an internal agent action — GetDBBootstrapConfig returns the
+// database master password.
+func TestRDSRequest_InternalActionsDeniedToCustomerAdmin(t *testing.T) {
+	gw, _ := newRDSPolicyGateway(allowPolicy("rds:*"))
+	for _, action := range handlers_rds.InternalAgentActions {
+		t.Run(action, func(t *testing.T) {
+			err := gw.RDS_Request(httptest.NewRecorder(),
+				setupRDSUserRequest("Action="+action, rdsTestAccountID))
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+		})
+	}
+}
+
+// A DB VM's own session passes the class gate and is evaluated against the
+// four-action role policy, which admits it: the only thing left to fail on is the
+// control plane, absent here.
+func TestRDSRequest_InternalActionAdmitsTheAgentPrincipal(t *testing.T) {
+	gw, probe := newRDSPolicyGateway(allowPolicy("rds:GetDBBootstrapConfig"))
+	err := gw.RDS_Request(httptest.NewRecorder(),
+		setupRDSAgentRequest("Action=GetDBBootstrapConfig", "i-0abc123"))
+	require.Error(t, err)
+	assert.Equal(t, 1, probe.consulted, "the agent's role policy must be evaluated, not bypassed")
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error(),
+		"the agent must be authorized and fail only on the missing NATS connection")
+}
+
+// The instance role grants only the internal actions, so the same credentials
+// that register an instance cannot describe the account's fleet.
+func TestRDSRequest_AgentRoleCannotCallCustomerActions(t *testing.T) {
+	gw, _ := newRDSPolicyGateway(allowPolicy("rds:GetDBBootstrapConfig"))
+	err := gw.RDS_Request(httptest.NewRecorder(),
+		setupRDSAgentRequest("Action=DescribeDBInstances", "i-0abc123"))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+// A policy scoped to db:prod-* has to actually restrict: checked against "*" it
+// would read as a restriction and permit the whole account.
+func TestRDSRequest_ResourceScopedPolicyRestrictsByIdentifier(t *testing.T) {
+	gw, probe := newRDSPolicyGateway(allowPolicyResource("rds:*", "arn:aws:rds:*:*:db:prod-*"))
+
+	err := gw.RDS_Request(httptest.NewRecorder(),
+		setupRDSUserRequest("Action=DeleteDBInstance&DBInstanceIdentifier=prod-orders", rdsTestAccountID))
+	require.Error(t, err)
+	// The probe is what makes the pass meaningful: a guard that failed before the
+	// evaluator would leave the same error with no policy consulted at all.
+	assert.Equal(t, 1, probe.consulted)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error(),
+		"the in-scope instance must be authorized and fail only on the missing NATS connection")
+
+	err = gw.RDS_Request(httptest.NewRecorder(),
+		setupRDSUserRequest("Action=DeleteDBInstance&DBInstanceIdentifier=dev-orders", rdsTestAccountID))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+// Creates and plural describes name no one resource, so a policy scoped to a
+// single instance must not be read as permitting them.
+func TestRDSRequest_UnscopedActionsEvaluateAgainstAnyResource(t *testing.T) {
+	gw, _ := newRDSPolicyGateway(allowPolicyResource("rds:*", "arn:aws:rds:*:*:db:prod-orders"))
+	err := gw.RDS_Request(httptest.NewRecorder(),
+		setupRDSUserRequest("Action=CreateDBInstance&DBInstanceIdentifier=prod-orders", rdsTestAccountID))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorAccessDenied, err.Error())
+}
+
+// Cross-account references are refused at the ARN, not merely unauthorized:
+// snapshot sharing is out of v1, and an evaluator that sees a foreign account is
+// one policy away from allowing it.
+func TestRDSRequest_CrossAccountARNIsRejectedNotEvaluated(t *testing.T) {
+	gw, _ := newRDSGatewayWithResolver(func(_, _ string) ([]handlers_iam.PolicyDocument, error) {
+		t.Error("a cross-account ARN must never reach policy evaluation")
+		return nil, nil
+	})
+	foreign := handlers_rds.DBInstanceARN("ap-southeast-2", "999988887777", "orders-db")
+	err := gw.RDS_Request(httptest.NewRecorder(),
+		setupRDSUserRequest("Action=ListTagsForResource&ResourceName="+foreign, rdsTestAccountID))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+}
+
+// An authenticated request with no resolvable identity predates per-principal
+// enforcement and keeps its documented allow, rather than newly failing closed.
+func TestRDSRequest_NoIdentityKeepsPreIAMAllow(t *testing.T) {
+	gw, probe := newRDSPolicyGateway(nil) // no policies: an evaluated request would be denied
+	err := gw.RDS_Request(httptest.NewRecorder(), setupRDSRequest("Action=DescribeDBInstances"))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+	assert.Zero(t, probe.consulted, "a request with no identity must not be evaluated at all")
 }
 
 // RDS errors must use the IAM-style <ErrorResponse> envelope: the aws-sdk-go

--- a/spinifex/handlers/iam/managed_policies.go
+++ b/spinifex/handlers/iam/managed_policies.go
@@ -168,6 +168,94 @@ var awsManagedPolicyDocs = map[string]string{
 		]
 	}`,
 
+	// Verb prefixes rather than the rds:* AWS publishes: rds:* would also match
+	// the internal agent actions the gateway reserves for a DB VM's own role, and
+	// a document appearing to grant those would be a lie in GetPolicyVersion.
+	"arn:aws:iam::aws:policy/AmazonRDSFullAccess": `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": [
+					"rds:Add*",
+					"rds:Copy*",
+					"rds:Create*",
+					"rds:Delete*",
+					"rds:Describe*",
+					"rds:Download*",
+					"rds:Failover*",
+					"rds:List*",
+					"rds:Modify*",
+					"rds:Promote*",
+					"rds:Purchase*",
+					"rds:Reboot*",
+					"rds:Remove*",
+					"rds:Reset*",
+					"rds:Restore*",
+					"rds:Start*",
+					"rds:Stop*"
+				],
+				"Resource": "*"
+			},
+			{
+				"Effect": "Allow",
+				"Action": [
+					"ec2:DescribeAccountAttributes",
+					"ec2:DescribeAvailabilityZones",
+					"ec2:DescribeInternetGateways",
+					"ec2:DescribeSecurityGroups",
+					"ec2:DescribeSubnets",
+					"ec2:DescribeVpcAttribute",
+					"ec2:DescribeVpcs",
+					"cloudwatch:GetMetricStatistics",
+					"cloudwatch:ListMetrics",
+					"logs:DescribeLogStreams",
+					"logs:GetLogEvents",
+					"sns:ListSubscriptions",
+					"sns:ListTopics",
+					"sns:Publish"
+				],
+				"Resource": "*"
+			},
+			{
+				"Sid": "AllowServiceLinkedRole",
+				"Effect": "Allow",
+				"Action": "iam:CreateServiceLinkedRole",
+				"Resource": "*"
+			}
+		]
+	}`,
+
+	"arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess": `{
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": [
+					"rds:Describe*",
+					"rds:ListTagsForResource",
+					"rds:DownloadDBLogFilePortion"
+				],
+				"Resource": "*"
+			},
+			{
+				"Effect": "Allow",
+				"Action": [
+					"ec2:DescribeAccountAttributes",
+					"ec2:DescribeAvailabilityZones",
+					"ec2:DescribeSecurityGroups",
+					"ec2:DescribeSubnets",
+					"ec2:DescribeVpcs",
+					"cloudwatch:GetMetricStatistics",
+					"cloudwatch:ListMetrics",
+					"logs:DescribeLogStreams",
+					"logs:GetLogEvents"
+				],
+				"Resource": "*"
+			}
+		]
+	}`,
+
 	"arn:aws:iam::aws:policy/AmazonEKSServicePolicy": `{
 		"Version": "2012-10-17",
 		"Statement": [

--- a/spinifex/handlers/iam/managed_policies_test.go
+++ b/spinifex/handlers/iam/managed_policies_test.go
@@ -1,0 +1,106 @@
+package handlers_iam
+
+import (
+	"testing"
+
+	"github.com/mulgadc/predastore/pkg/iampolicy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	rdsFullAccessARN     = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+	rdsReadOnlyAccessARN = "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess"
+)
+
+// The four internal RDS agent actions. Written out rather than imported from
+// handlers_rds, which imports this package.
+var rdsInternalActions = []string{
+	"rds:RegisterDBInstance",
+	"rds:SubmitDBStateChange",
+	"rds:PollDBCommands",
+	"rds:GetDBBootstrapConfig",
+}
+
+// A role whose permissions come entirely from an attached AWS-managed ARN has to
+// resolve to a grant, the way the stock EKS roles already do, rather than fail
+// closed on a document Spinifex never stores.
+func TestResolveAttachedPolicy_RDSManagedShimsResolve(t *testing.T) {
+	s := &IAMServiceImpl{}
+	for _, arn := range []string{rdsFullAccessARN, rdsReadOnlyAccessARN} {
+		doc, include, err := s.resolveAttachedPolicy(t.Context(), "123456789012", arn)
+		require.NoError(t, err, "arn %q", arn)
+		require.True(t, include, "arn %q must resolve to a grant", arn)
+		assert.NotEmpty(t, doc.Statement, "arn %q must carry statements", arn)
+	}
+}
+
+// AmazonRDSFullAccess is what a stock admin role carries, and it must not read as
+// a path to the master password. The gateway refuses the internal actions by
+// principal class regardless, but GetPolicyVersion must not claim otherwise.
+func TestRDSManagedShims_GrantNoInternalAction(t *testing.T) {
+	for _, arn := range []string{rdsFullAccessARN, rdsReadOnlyAccessARN} {
+		doc, ok := builtinManagedPolicyDoc(arn)
+		require.True(t, ok, "arn %q", arn)
+		for _, action := range rdsInternalActions {
+			assert.Equal(t, iampolicy.Deny, iampolicy.Evaluate(action, "*", []PolicyDocument{doc}),
+				"%s must not grant %s", arn, action)
+		}
+	}
+}
+
+func TestRDSFullAccessShim_GrantsTheCustomerSurface(t *testing.T) {
+	doc, ok := builtinManagedPolicyDoc(rdsFullAccessARN)
+	require.True(t, ok)
+
+	granted := []string{
+		"rds:CreateDBInstance", "rds:DescribeDBInstances", "rds:ModifyDBInstance",
+		"rds:DeleteDBInstance", "rds:RebootDBInstance", "rds:StartDBInstance", "rds:StopDBInstance",
+		"rds:CreateDBSnapshot", "rds:DeleteDBSnapshot", "rds:RestoreDBInstanceFromDBSnapshot",
+		"rds:DescribeDBInstanceAutomatedBackups",
+		"rds:CreateDBSubnetGroup", "rds:DeleteDBSubnetGroup",
+		"rds:CreateDBParameterGroup", "rds:ModifyDBParameterGroup", "rds:DescribeDBParameters",
+		"rds:DeleteDBParameterGroup",
+		"rds:AddTagsToResource", "rds:RemoveTagsFromResource", "rds:ListTagsForResource",
+		"rds:DescribeEvents",
+	}
+	for _, action := range granted {
+		assert.Equal(t, iampolicy.Allow, iampolicy.Evaluate(action, "*", []PolicyDocument{doc}),
+			"AmazonRDSFullAccess must grant %s", action)
+	}
+}
+
+// Read-only means read-only: the shim is the whole grant for a role that carries
+// nothing else, so a mutation reaching Allow here would be the only check missed.
+func TestRDSReadOnlyAccessShim_GrantsReadsOnly(t *testing.T) {
+	doc, ok := builtinManagedPolicyDoc(rdsReadOnlyAccessARN)
+	require.True(t, ok)
+
+	for _, action := range []string{"rds:DescribeDBInstances", "rds:DescribeDBSnapshots",
+		"rds:DescribeDBParameters", "rds:ListTagsForResource"} {
+		assert.Equal(t, iampolicy.Allow, iampolicy.Evaluate(action, "*", []PolicyDocument{doc}),
+			"AmazonRDSReadOnlyAccess must grant %s", action)
+	}
+	for _, action := range []string{"rds:CreateDBInstance", "rds:DeleteDBInstance",
+		"rds:ModifyDBInstance", "rds:StopDBInstance", "rds:AddTagsToResource",
+		"rds:RestoreDBInstanceFromDBSnapshot"} {
+		assert.Equal(t, iampolicy.Deny, iampolicy.Evaluate(action, "*", []PolicyDocument{doc}),
+			"AmazonRDSReadOnlyAccess must not grant %s", action)
+	}
+}
+
+// An RDS-looking managed ARN Spinifex does not model resolves to no grant rather
+// than an error, so a role carrying it is denied that grant and not broken.
+func TestResolveAttachedPolicy_UnmodeledRDSManagedARNGrantsNothing(t *testing.T) {
+	s := &IAMServiceImpl{}
+	for _, arn := range []string{
+		"arn:aws:iam::aws:policy/AmazonRDSDataFullAccess",
+		"arn:aws:iam::aws:policy/AmazonRDSFullAccess2",
+		"arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole",
+	} {
+		doc, include, err := s.resolveAttachedPolicy(t.Context(), "123456789012", arn)
+		require.NoError(t, err, "arn %q", arn)
+		assert.False(t, include, "arn %q must resolve to no grant", arn)
+		assert.Empty(t, doc.Statement)
+	}
+}

--- a/spinifex/handlers/rds/arn.go
+++ b/spinifex/handlers/rds/arn.go
@@ -12,20 +12,26 @@ import (
 // against the real service.
 
 func DBInstanceARN(region, accountID, dbInstanceIdentifier string) string {
-	return fmt.Sprintf("arn:aws:rds:%s:%s:db:%s", region, accountID, dbInstanceIdentifier)
+	return FormatARN(ResourceKindDBInstance, region, accountID, dbInstanceIdentifier)
 }
 
 // Manual and automated snapshots share the one resource type.
 func DBSnapshotARN(region, accountID, dbSnapshotIdentifier string) string {
-	return fmt.Sprintf("arn:aws:rds:%s:%s:snapshot:%s", region, accountID, dbSnapshotIdentifier)
+	return FormatARN(ResourceKindDBSnapshot, region, accountID, dbSnapshotIdentifier)
 }
 
 func DBSubnetGroupARN(region, accountID, name string) string {
-	return fmt.Sprintf("arn:aws:rds:%s:%s:subgrp:%s", region, accountID, name)
+	return FormatARN(ResourceKindDBSubnetGroup, region, accountID, name)
 }
 
 func DBParameterGroupARN(region, accountID, name string) string {
-	return fmt.Sprintf("arn:aws:rds:%s:%s:pg:%s", region, accountID, name)
+	return FormatARN(ResourceKindDBParameterGroup, region, accountID, name)
+}
+
+// The one place the ARN shape is written, for callers that already hold a kind
+// rather than a resource type of their own.
+func FormatARN(kind ResourceKind, region, accountID, identifier string) string {
+	return fmt.Sprintf("arn:aws:rds:%s:%s:%s:%s", region, accountID, kind, identifier)
 }
 
 // The resource-type segment of an RDS ARN, and the key the tag registry and

--- a/spinifex/handlers/rds/iam.go
+++ b/spinifex/handlers/rds/iam.go
@@ -1,6 +1,7 @@
 package handlers_rds
 
 import (
+	"encoding/json"
 	"log/slog"
 
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
@@ -13,11 +14,38 @@ const (
 	InstanceRoleName = "rdsInstanceRole"
 
 	instanceRoleInlinePolicyName = "spinifex-rds-instance-internal"
-
-	// Only the four internal agent actions. The customer-facing rds:* set is
-	// rds-10a's; granting it here would let a DB VM manage its account's fleet.
-	instanceRoleInlinePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["rds:RegisterDBInstance","rds:SubmitDBStateChange","rds:PollDBCommands","rds:GetDBBootstrapConfig"],"Resource":"*"}]}`
 )
+
+// The agent-only actions. The gateway's principal-class gate reserves exactly
+// this set, and the role below grants exactly it — one list, so adding a fifth
+// cannot leave the gate and the grant disagreeing.
+var InternalAgentActions = []string{
+	"RegisterDBInstance",
+	"SubmitDBStateChange",
+	"PollDBCommands",
+	"GetDBBootstrapConfig",
+}
+
+// Never rds:*: granting the customer surface here would let a Postgres RCE on
+// one DB VM manage its account's whole fleet.
+var instanceRoleInlinePolicy = func() string {
+	actions := make(handlers_iam.StringOrArr, 0, len(InternalAgentActions))
+	for _, action := range InternalAgentActions {
+		actions = append(actions, "rds:"+action)
+	}
+	doc, err := json.Marshal(handlers_iam.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []handlers_iam.Statement{{
+			Effect:   handlers_iam.PolicyEffectAllow,
+			Action:   actions,
+			Resource: handlers_iam.StringOrArr{"*"},
+		}},
+	})
+	if err != nil {
+		panic("rds: cannot marshal the instance-role policy: " + err.Error())
+	}
+	return string(doc)
+}()
 
 // Resolved per launch rather than held, mirroring EKS: the KV-backed IAM
 // service has no responders until JetStream is up, so an eager build races

--- a/spinifex/handlers/rds/iam_test.go
+++ b/spinifex/handlers/rds/iam_test.go
@@ -1,0 +1,145 @@
+package handlers_rds
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRDSEnsurer records every call so both the grant and its idempotency can be
+// asserted. The role and profile exist from the second call onward, which is the
+// state a re-launch finds.
+type fakeRDSEnsurer struct {
+	roleAcct     string
+	profileAcct  string
+	trust        string
+	policies     []iam.PutRolePolicyInput
+	roleCreates  int
+	roleExists   bool
+	profileNames []string
+}
+
+func (f *fakeRDSEnsurer) GetRole(_ string, _ *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	if !f.roleExists {
+		return nil, errors.New(awserrors.ErrorIAMNoSuchEntity)
+	}
+	return &iam.GetRoleOutput{Role: &iam.Role{RoleName: aws.String(InstanceRoleName)}}, nil
+}
+
+func (f *fakeRDSEnsurer) CreateRole(acct string, in *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
+	f.roleAcct = acct
+	f.roleCreates++
+	f.roleExists = true
+	f.trust = aws.StringValue(in.AssumeRolePolicyDocument)
+	name := aws.StringValue(in.RoleName)
+	return &iam.CreateRoleOutput{Role: &iam.Role{
+		RoleName: aws.String(name),
+		Arn:      aws.String("arn:aws:iam::" + acct + ":role/" + name),
+	}}, nil
+}
+
+func (f *fakeRDSEnsurer) PutRolePolicy(_ string, in *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	f.policies = append(f.policies, *in)
+	return &iam.PutRolePolicyOutput{}, nil
+}
+
+func (f *fakeRDSEnsurer) GetInstanceProfile(_ string, _ *iam.GetInstanceProfileInput) (*iam.GetInstanceProfileOutput, error) {
+	if len(f.profileNames) == 0 {
+		return nil, errors.New(awserrors.ErrorIAMNoSuchEntity)
+	}
+	return &iam.GetInstanceProfileOutput{InstanceProfile: &iam.InstanceProfile{
+		InstanceProfileName: aws.String(InstanceRoleName),
+		Arn:                 aws.String("arn:aws:iam::" + f.profileAcct + ":instance-profile/" + InstanceRoleName),
+		Roles:               []*iam.Role{{RoleName: aws.String(InstanceRoleName)}},
+	}}, nil
+}
+
+func (f *fakeRDSEnsurer) CreateInstanceProfile(acct string, in *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
+	f.profileAcct = acct
+	name := aws.StringValue(in.InstanceProfileName)
+	f.profileNames = append(f.profileNames, name)
+	return &iam.CreateInstanceProfileOutput{InstanceProfile: &iam.InstanceProfile{
+		InstanceProfileName: aws.String(name),
+		Arn:                 aws.String("arn:aws:iam::" + acct + ":instance-profile/" + name),
+	}}, nil
+}
+
+func (f *fakeRDSEnsurer) AddRoleToInstanceProfile(_ string, _ *iam.AddRoleToInstanceProfileInput) (*iam.AddRoleToInstanceProfileOutput, error) {
+	return &iam.AddRoleToInstanceProfileOutput{}, nil
+}
+
+var _ handlers_iam.SystemInstanceRoleEnsurer = (*fakeRDSEnsurer)(nil)
+
+// A Postgres RCE on a DB VM inherits this role, so the grant must be the four
+// internal actions and nothing wildcarded that could reach the customer surface.
+func TestInstanceRolePolicy_GrantsOnlyTheInternalActions(t *testing.T) {
+	var doc handlers_iam.PolicyDocument
+	require.NoError(t, json.Unmarshal([]byte(instanceRoleInlinePolicy), &doc))
+	require.Len(t, doc.Statement, 1)
+
+	stmt := doc.Statement[0]
+	assert.Equal(t, handlers_iam.PolicyEffectAllow, stmt.Effect)
+
+	want := make([]string, 0, len(InternalAgentActions))
+	for _, action := range InternalAgentActions {
+		want = append(want, "rds:"+action)
+	}
+	granted := slices.Clone([]string(stmt.Action))
+	slices.Sort(granted)
+	slices.Sort(want)
+	assert.Equal(t, want, granted)
+
+	for _, action := range granted {
+		assert.NotContains(t, action, "*", "the instance role must name its actions, never wildcard them")
+	}
+}
+
+// The role is created in the system account: IMDS resolves an instance profile
+// under the VM's own account, so a role in the customer account would be
+// invisible to the agent and it would get no credentials at all.
+func TestEnsureInstanceProfile_CreatesInSystemAccount(t *testing.T) {
+	f := &fakeRDSEnsurer{}
+	arn := ensureInstanceProfile(func() handlers_iam.SystemInstanceRoleEnsurer { return f }, utils.GlobalAccountID)
+
+	assert.Equal(t, "arn:aws:iam::"+utils.GlobalAccountID+":instance-profile/"+InstanceRoleName, arn)
+	assert.Equal(t, utils.GlobalAccountID, f.roleAcct)
+	assert.Equal(t, utils.GlobalAccountID, f.profileAcct)
+	assert.Equal(t, handlers_iam.EC2InstanceTrustPolicy, f.trust,
+		"AssumeRoleForInstance only mints credentials for the EC2 trust document")
+}
+
+// Every launch calls this, so a second call must converge on the existing role
+// rather than create a second one, and must re-assert the same grant.
+func TestEnsureInstanceProfile_IsIdempotent(t *testing.T) {
+	f := &fakeRDSEnsurer{}
+	provider := func() handlers_iam.SystemInstanceRoleEnsurer { return f }
+
+	first := ensureInstanceProfile(provider, utils.GlobalAccountID)
+	second := ensureInstanceProfile(provider, utils.GlobalAccountID)
+
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, f.roleCreates, "the second launch must find the role, not create it")
+	assert.Len(t, f.profileNames, 1, "the second launch must find the instance profile")
+	require.Len(t, f.policies, 2, "the grant is re-asserted on every launch")
+	for _, put := range f.policies {
+		assert.Equal(t, instanceRoleInlinePolicyName, aws.StringValue(put.PolicyName))
+		assert.Equal(t, instanceRoleInlinePolicy, aws.StringValue(put.PolicyDocument))
+	}
+}
+
+// Without IAM the agent has no gateway credentials at all, so the caller has to
+// see an empty ARN rather than a launch that looks provisioned.
+func TestEnsureInstanceProfile_UnwiredIAMYieldsNoProfile(t *testing.T) {
+	assert.Empty(t, ensureInstanceProfile(nil, utils.GlobalAccountID))
+	assert.Empty(t, ensureInstanceProfile(
+		func() handlers_iam.SystemInstanceRoleEnsurer { return nil }, utils.GlobalAccountID))
+}


### PR DESCRIPTION
Makes `rds:*` a real, enforced surface: every phase dispatched through `checkPolicy(r, "rds", action)`, but nothing had decided what a customer policy may say, what the DB VM's own role may do, or who may call the four internal agent actions.

## Internal actions are gated by principal class, before policy evaluation

`AuthorizeCaller` (`gateway/rds/authz.go`) refuses `RegisterDBInstance`, `SubmitDBStateChange`, `PollDBCommands` and `GetDBBootstrapConfig` to any caller that is not an assumed-role session for `rdsInstanceRole` under the system account. This runs before `checkPolicyResource`, so no customer grant is ever evaluated against them.

That ordering is the point. `{"Effect":"Allow","Action":"rds:*","Resource":"*"}` is the natural admin grant every Terraform admin role carries, and `GetDBBootstrapConfig` returns a database master password. No amount of documentation makes a wildcard stop matching, so the gate is deny-by-default and lives in the dispatch path rather than per-action. The class check is re-run inside `authorizeAgent` as well — the check that must hold cannot depend on a caller remembering to call it.

Internal actions keep their policy check behind the gate, which is what makes the instance role's four-action document meaningful and what denies those same credentials `rds:DescribeDBInstances`.

## Customer actions are resource-scoped

Actions naming exactly one resource now evaluate against their D17 ARN instead of `"*"`: the five single-instance lifecycle actions, `DeleteDBSnapshot`, `DeleteDBSubnetGroup`, and the parameter-group modify/describe/delete. Creates and plural describes stay on `"*"` — they name no resource, or more than one.

A policy scoped to `arn:aws:rds:*:*:db:prod-*` and checked against `"*"` would silently permit every instance in the account. A policy that reads as a restriction and enforces nothing is worse than no policy.

The tag actions take an ARN in the request, so their scope validates it through rds-4b's `ParseARN`. A foreign-account or foreign-region reference is `InvalidParameterValue` before the evaluator sees it: cross-account snapshot sharing is out of v1, and a permissive parser is how it arrives anyway.

Both facts — principal class and resource scope — live on the action table (`actionDef{handler, internal, scope}`), so an action cannot be registered without deciding either.

## Managed-policy shims

`AmazonRDSFullAccess` and `AmazonRDSReadOnlyAccess` join `awsManagedPolicyDocs`, so a role whose permissions come entirely from an attached AWS-managed ARN resolves to a grant rather than failing closed, as the EKS roles already do. Unknown managed ARNs still resolve to no grant.

`FullAccess` is written as verb prefixes (`rds:Create*`, `rds:Describe*`, `rds:Modify*`, …) rather than the `rds:*` AWS publishes, deliberately omitting the internal verbs Register/Submit/Poll/Get. `rds:*` would match the internal actions by wildcard; the class gate would refuse them anyway, but a document that appeared to grant them would be a lie in `GetPolicyVersion` output.

## Already landed before this phase

Two items the plan scoped arrived early with rds-2a and rds-3 and are unchanged here: the session-name to instance-ID binding against the `rds-system` reverse index, and `rdsInstanceRole` itself (in `handlers/rds/iam.go`, using the shared `EnsureSystemInstanceProfile` that ELBv2 and EKS use rather than copying `ensureECSInstanceProfile`). Its grant is now marshalled from `InternalAgentActions`, the one list the gate and the grant are both checked against, so adding a fifth internal action cannot leave them disagreeing.

## Interpretation worth a look

`DescribeDBParameters` is resource-scoped to its parameter-group ARN despite being a describe: its identifier is required and singular, so it addresses one resource rather than filtering a list. The plan's wording put describes on `"*"`; happy to flip it if reviewers disagree.

A missing identifier on a scoped action falls back to `"*"` rather than denying — the handler reports the absent parameter precisely, and answering it with `AccessDenied` would blame the policy. This cannot widen a narrow policy: `"*"` as the requested resource matches no pattern narrower than itself.

## Testing

- `gateway/rds/authz_test.go` — each internal action denied to a customer principal, including one whose session is named like an instance and one holding a role named `rdsInstanceRole` in its own account; admitted for the agent class; customer actions left to policy; the exact resource every action resolves to; cross-account, cross-region, wrong-service and unparsable ARNs rejected; unknown action rejected rather than resolved to `"*"`; and the table's internal set matching the role's grant.
- `gateway/rds_test.go` — end to end through `RDS_Request`: a customer holding `rds:*` on `*` denied every internal action; the agent principal admitted for `GetDBBootstrapConfig` and denied `DescribeDBInstances`; a `db:prod-*` policy allowing `prod-orders` and denying `dev-orders`; that policy not read as permitting an unscoped create; a cross-account ARN rejected without the policy resolver being consulted at all; a request with no resolvable identity keeping the documented pre-IAM allow.
- `handlers/rds/iam_test.go` — the grant is exactly the four internal actions with no wildcard, created in the system account under the EC2 trust document, idempotent across launches.
- `handlers/iam/managed_policies_test.go` — both shims resolve through `resolveAttachedPolicy`, neither grants an internal action, `FullAccess` covers the whole v1 customer surface, `ReadOnlyAccess` grants no mutation, an unmodeled RDS-looking managed ARN grants nothing.
- `make preflight` green; diff coverage 83.0%.

The in-VM half of the integration test (a real DB VM completing register to bootstrap to heartbeat on `rdsInstanceRole` credentials alone) rides rds-10b, along with the e2e policy-denial scenario that exercises this surface end to end.