### PR TITLE
fix: group-scope the OVS/OVN sockets and retire the vpcd sudoers grants

### DIFF
--- a/build/systemd/spinifex-daemon.service
+++ b/build/systemd/spinifex-daemon.service
@@ -25,7 +25,8 @@ Environment=SPINIFEX_WAL_DIR=/var/lib/spinifex/spinifex/
 # Pin to host tmpfs: QEMU pidfiles/QMP sockets must survive PrivateTmp namespace churn (DDIL)
 Environment=XDG_RUNTIME_DIR=/run/spinifex
 
-# RG-9: daemon tier — privileged by necessity (GPU vfio). NoNewPrivileges omitted (RG-10: sudo ip/ovs-vsctl/dhcpcd)
+# RG-9: daemon tier — privileged by necessity (GPU vfio). No CAP_NET_ADMIN here,
+# so unlike vpcd it still escalates ip/sysctl and NoNewPrivileges stays omitted.
 AmbientCapabilities=CAP_SYS_ADMIN CAP_DAC_OVERRIDE
 ProtectSystem=full
 PrivateDevices=no

--- a/build/systemd/spinifex-vpcd.service
+++ b/build/systemd/spinifex-vpcd.service
@@ -20,7 +20,11 @@ Environment=SPINIFEX_BASE_DIR=/var/lib/spinifex/vpcd/
 
 # RG-9: network tier. Per-tap IMDS removed the in-process setns, so vpcd no
 # longer enters a per-VPC netns: CAP_SYS_ADMIN is dropped and the filesystem
-# sandbox is restored. NoNewPrivileges stays off (RG-10: sudo ip/ovs-vsctl/dhcpcd).
+# sandbox is restored.
+#
+# RG-10: these are ambient so ip/iptables/sysctl/arping inherit them on exec and
+# vpcd holds no sudoers rules at all. NoNewPrivileges stays off pending the ADR
+# update that retires the last escalation path.
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
 NoNewPrivileges=no

--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -1005,6 +1005,17 @@ for s in /var/run/openvswitch/db.sock /var/run/openvswitch/*.ctl /var/run/ovn/*.
         chmod 0660 "$s" 2>/dev/null || true
     fi
 done
+
+# Group-WRITE on the pidfiles, not just read: `ovn-appctl -t <daemon>` resolves
+# the pid-named ctl socket through the pidfile, and OVS opens it O_RDWR to test
+# the fcntl liveness lock. Read-only fails the probe with EACCES. This also
+# tightens them from the 0644 they ship with.
+for p in /var/run/openvswitch/*.pid /var/run/ovn/*.pid; do
+    if [ -f "$p" ]; then
+        chgrp "$GROUP" "$p" 2>/dev/null || true
+        chmod 0660 "$p" 2>/dev/null || true
+    fi
+done
 HELPER
 sudo chmod 0755 "$PERMS_HELPER"
 sudo "$PERMS_HELPER"
@@ -1012,7 +1023,11 @@ echo "  OVS/OVN sockets: 0660 root:spinifex (group-scoped, no world access)"
 
 # Persist across restarts of both daemons. Rewritten unconditionally: an existing
 # file is the old 0666 override, and skipping would leave that exposure in place.
-for unit in openvswitch-switch:/var/run/openvswitch/db.sock "ovn-controller:/var/run/ovn/*.ctl"; do
+# openvswitch-ipsec is included because Step 10 restarts it after this sweep,
+# so its ctl socket would otherwise be the one file left at the shipped mode.
+for unit in openvswitch-switch:/var/run/openvswitch/db.sock \
+    "ovn-controller:/var/run/ovn/*.ctl" \
+    "openvswitch-ipsec:/var/run/openvswitch/ovs-monitor-ipsec.*.ctl"; do
     UNIT="${unit%%:*}"
     WAIT_GLOB="${unit#*:}"
     OVERRIDE_DIR="/etc/systemd/system/${UNIT}.service.d"

--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -999,7 +999,12 @@ if [ -d /var/run/ovn ]; then
     chmod 0750 /var/run/ovn 2>/dev/null || true
 fi
 
-for s in /var/run/openvswitch/db.sock /var/run/openvswitch/*.ctl /var/run/ovn/*.ctl; do
+# ovn??_db.sock are the NB/SB databases themselves, which ovn-nbctl and
+# ovn-sbctl connect to. Bridge <name>.mgmt sockets are deliberately NOT here:
+# ovs-vswitchd creates one whenever a bridge appears, including bridges spinifex
+# creates at runtime, so ovs-ofctl keeps its sudo grant.
+for s in /var/run/openvswitch/db.sock /var/run/openvswitch/*.ctl \
+    /var/run/ovn/*.ctl /var/run/ovn/ovnnb_db.sock /var/run/ovn/ovnsb_db.sock; do
     if [ -S "$s" ]; then
         chgrp "$GROUP" "$s" 2>/dev/null || true
         chmod 0660 "$s" 2>/dev/null || true

--- a/scripts/setup-ovn.sh
+++ b/scripts/setup-ovn.sh
@@ -941,40 +941,89 @@ else
     echo "  WARNING: geneve module not available (tunnels may not work)"
 fi
 
-# --- Step 8: Grant non-root access to OVS/OVN ---
+# --- Step 8: Grant the spinifex service users access to OVS/OVN ---
 echo ""
-echo "Step 8: Configuring non-root access..."
+echo "Step 8: Configuring service-user access..."
 
-# Open OVS DB socket so non-root processes can use ovs-vsctl
-OVS_SOCK="/var/run/openvswitch/db.sock"
-if [ -S "$OVS_SOCK" ]; then
-    sudo chmod 0666 "$OVS_SOCK"
-    echo "  OVS DB socket: opened ($OVS_SOCK)"
+# Group-scoped, never world. spinifex-daemon and spinifex-vpcd both run with
+# Group=spinifex, so 0660 root:spinifex is exactly the reach they need. A
+# world-writable db.sock hands the local datapath — bridges, ports, ovn-remote —
+# to any account on the box, and a world-writable ctl socket lets any account
+# run `ovn-appctl exit`.
+PERMS_HELPER="/usr/local/lib/spinifex/ovs-socket-perms.sh"
+sudo mkdir -p "$(dirname "$PERMS_HELPER")"
+sudo tee "$PERMS_HELPER" >/dev/null <<'HELPER'
+#!/bin/sh
+# Group-own the OVS/OVN control sockets to `spinifex` so the service users reach
+# them without sudo. Driven from ExecStartPost on both openvswitch-switch and
+# ovn-controller: each recreates its own sockets on start, and the ovn-controller
+# ctl socket name embeds the pid, so it is a new file every time.
+#
+# $1 is an optional glob for the caller's own socket, waited on before the sweep.
+set -eu
+GROUP=spinifex
+WAIT_FOR="${1:-}"
+
+if ! getent group "$GROUP" >/dev/null 2>&1; then
+    exit 0
 fi
 
-# Open OVN runtime directory and ctl sockets for ovs-appctl access
-if [ -d "/var/run/ovn" ]; then
-    sudo chmod 0755 /var/run/ovn
-    sudo chmod 0666 /var/run/ovn/*.ctl 2>/dev/null || true
-    echo "  OVN ctl sockets: opened (/var/run/ovn/)"
-fi
-if [ -d "/var/run/openvswitch" ]; then
-    sudo chmod 0666 /var/run/openvswitch/*.ctl 2>/dev/null || true
+# Unquoted so the caller's pattern globs. A caller passing nothing sweeps at once.
+wait_target_present() {
+    if [ -z "$WAIT_FOR" ]; then
+        return 0
+    fi
+    for s in $WAIT_FOR; do
+        if [ -S "$s" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ExecStartPost can outrun socket creation, so poll briefly rather than miss the
+# socket and leave the health probe unable to read connection-status.
+i=0
+while [ "$i" -lt 25 ]; do
+    if wait_target_present; then
+        break
+    fi
+    i=$((i + 1))
+    sleep 0.2
+done
+
+# The dir must be traversable by the group before the sockets inside it matter.
+# Only the group changes; the owner keeps full access whoever it is.
+if [ -d /var/run/ovn ]; then
+    chgrp "$GROUP" /var/run/ovn 2>/dev/null || true
+    chmod 0750 /var/run/ovn 2>/dev/null || true
 fi
 
-# Create persistent systemd override so permissions survive OVS restarts
-OVERRIDE_DIR="/etc/systemd/system/openvswitch-switch.service.d"
-if [ ! -f "$OVERRIDE_DIR/spinifex-perms.conf" ]; then
+for s in /var/run/openvswitch/db.sock /var/run/openvswitch/*.ctl /var/run/ovn/*.ctl; do
+    if [ -S "$s" ]; then
+        chgrp "$GROUP" "$s" 2>/dev/null || true
+        chmod 0660 "$s" 2>/dev/null || true
+    fi
+done
+HELPER
+sudo chmod 0755 "$PERMS_HELPER"
+sudo "$PERMS_HELPER"
+echo "  OVS/OVN sockets: 0660 root:spinifex (group-scoped, no world access)"
+
+# Persist across restarts of both daemons. Rewritten unconditionally: an existing
+# file is the old 0666 override, and skipping would leave that exposure in place.
+for unit in openvswitch-switch:/var/run/openvswitch/db.sock "ovn-controller:/var/run/ovn/*.ctl"; do
+    UNIT="${unit%%:*}"
+    WAIT_GLOB="${unit#*:}"
+    OVERRIDE_DIR="/etc/systemd/system/${UNIT}.service.d"
     sudo mkdir -p "$OVERRIDE_DIR"
-    sudo tee "$OVERRIDE_DIR/spinifex-perms.conf" >/dev/null <<'OVERRIDE'
+    sudo tee "$OVERRIDE_DIR/spinifex-perms.conf" >/dev/null <<OVERRIDE
 [Service]
-ExecStartPost=/bin/chmod 0666 /var/run/openvswitch/db.sock
+ExecStartPost=$PERMS_HELPER "$WAIT_GLOB"
 OVERRIDE
-    sudo systemctl daemon-reload
-    echo "  systemd override: created (db.sock permissions persist across restarts)"
-else
-    echo "  systemd override: already exists"
-fi
+    echo "  systemd override: ${UNIT}.service.d/spinifex-perms.conf"
+done
+sudo systemctl daemon-reload
 
 # Sudoers rules for spinifex-daemon and spinifex-vpcd are managed by setup.sh
 # (install_sudoers). Skip writing here to avoid conflicts.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -189,7 +189,7 @@ install_sudoers() {
 # their CapabilityBoundingSet omits CAP_SYS_RESOURCE, so pam_limits cannot apply
 # the limits.conf default and warns. It also means sudo children inherit the
 # unit's rlimits rather than the system defaults, which is the RG-9 intent.
-Defaults:spinifex-daemon,spinifex-vpcd !pam_session
+Defaults:spinifex-daemon !pam_session
 
 # The OVS/OVN client tools are deliberately absent. They do all their work over
 # control sockets that setup-ovn.sh group-owns to `spinifex`, so they run as the
@@ -201,26 +201,22 @@ Defaults:spinifex-daemon,spinifex-vpcd !pam_session
 # <bridge>.mgmt socket created by ovs-vswitchd when the bridge appears, including
 # bridges spinifex creates at runtime, so it cannot be group-owned up front.
 
-# Spinifex daemon: tap devices, OpenFlow rules, and DHCP for external IPs.
-# ovs-ofctl installs the per-tap IMDS datapath flows on br-imds; sysctl sets the
-# per-endpoint rp_filter/accept_local the asymmetric reply path needs.
+# spinifex-vpcd has no rules at all. Its ip/iptables/sysctl/arping work is done
+# under the CAP_NET_ADMIN and CAP_NET_RAW its unit grants ambiently, which the
+# kernel passes to each child on exec. Those grants were also root-equivalent:
+# `sudo ip netns exec <ns> /bin/sh` is a root shell.
+
+# Spinifex daemon: tap devices and OpenFlow rules. Its unit holds no
+# CAP_NET_ADMIN, so unlike vpcd it cannot drop these. ovs-ofctl installs the
+# per-tap IMDS datapath flows on br-imds; sysctl sets the per-endpoint
+# rp_filter/accept_local the asymmetric reply path needs.
 spinifex-daemon ALL=(root) NOPASSWD: /sbin/ip, /usr/sbin/ip
 spinifex-daemon ALL=(root) NOPASSWD: /usr/bin/ovs-ofctl
 spinifex-daemon ALL=(root) NOPASSWD: /usr/sbin/sysctl -qw net.ipv4.conf.*
-spinifex-daemon ALL=(root) NOPASSWD: /usr/sbin/dhcpcd
-
-# Spinifex VPC daemon: link and firewall management, and DHCP for external IPs
-spinifex-vpcd ALL=(root) NOPASSWD: /usr/sbin/dhcpcd
-spinifex-vpcd ALL=(root) NOPASSWD: /sbin/ip, /usr/sbin/ip
-# Routed-NAT mode: transit masquerade + per-EIP FORWARD accepts, proxy-ARP
-# delay tune, and gratuitous ARP announcements for host-delivered EIPs.
-spinifex-vpcd ALL=(root) NOPASSWD: /usr/sbin/iptables, /sbin/iptables
-spinifex-vpcd ALL=(root) NOPASSWD: /usr/sbin/sysctl -w net.ipv4.neigh.*
-spinifex-vpcd ALL=(root) NOPASSWD: /usr/sbin/arping, /usr/bin/arping
 SUDOERS
     $SUDO chmod 0440 /etc/sudoers.d/spinifex-network
     $SUDO visudo -cf /etc/sudoers.d/spinifex-network || fatal "Invalid sudoers syntax in spinifex-network"
-    info "Scoped sudoers rules installed for spinifex-daemon and spinifex-vpcd"
+    info "Scoped sudoers rules installed for spinifex-daemon (spinifex-vpcd needs none)"
 }
 
 # --- Install apt dependencies ---

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -191,21 +191,26 @@ install_sudoers() {
 # unit's rlimits rather than the system defaults, which is the RG-9 intent.
 Defaults:spinifex-daemon,spinifex-vpcd !pam_session
 
-# Spinifex daemon: tap devices, OVS bridge management, and DHCP for external IPs
+# The OVS/OVN client tools are deliberately absent. They do all their work over
+# control sockets that setup-ovn.sh group-owns to `spinifex`, so they run as the
+# service user. Granting them would be worse than pointless: a NOPASSWD rule for
+# them takes unrestricted args, and ovs-vsctl/ovn-nbctl/ovn-appctl all accept
+# --log-file=PATH, which writes a root-owned file wherever the caller points it.
+#
+# ovs-ofctl is the exception that keeps its grant: it talks to a per-bridge
+# <bridge>.mgmt socket created by ovs-vswitchd when the bridge appears, including
+# bridges spinifex creates at runtime, so it cannot be group-owned up front.
+
+# Spinifex daemon: tap devices, OpenFlow rules, and DHCP for external IPs.
 # ovs-ofctl installs the per-tap IMDS datapath flows on br-imds; sysctl sets the
 # per-endpoint rp_filter/accept_local the asymmetric reply path needs.
 spinifex-daemon ALL=(root) NOPASSWD: /sbin/ip, /usr/sbin/ip
-spinifex-daemon ALL=(root) NOPASSWD: /usr/bin/ovs-vsctl, /usr/bin/ovs-appctl, /usr/bin/ovs-ofctl
+spinifex-daemon ALL=(root) NOPASSWD: /usr/bin/ovs-ofctl
 spinifex-daemon ALL=(root) NOPASSWD: /usr/sbin/sysctl -qw net.ipv4.conf.*
 spinifex-daemon ALL=(root) NOPASSWD: /usr/sbin/dhcpcd
-spinifex-daemon ALL=(root) NOPASSWD: /usr/bin/systemctl is-active openvswitch-ipsec.service
-spinifex-daemon ALL=(root) NOPASSWD: /usr/bin/ovn-nbctl set NB_Global . ipsec=true
 
-# Spinifex VPC daemon: OVN and OVS read/write, OVN controller status check and DHCP
+# Spinifex VPC daemon: link and firewall management, and DHCP for external IPs
 spinifex-vpcd ALL=(root) NOPASSWD: /usr/sbin/dhcpcd
-spinifex-vpcd ALL=(root) NOPASSWD: /usr/bin/ovs-vsctl, /usr/bin/ovs-appctl
-spinifex-vpcd ALL=(root) NOPASSWD: /usr/bin/ovn-nbctl, /usr/bin/ovn-sbctl, /usr/bin/ovn-appctl
-spinifex-vpcd ALL=(root) NOPASSWD: /usr/bin/systemctl is-active --quiet ovn-controller
 spinifex-vpcd ALL=(root) NOPASSWD: /sbin/ip, /usr/sbin/ip
 # Routed-NAT mode: transit masquerade + per-EIP FORWARD accepts, proxy-ARP
 # delay tune, and gratuitous ARP announcements for host-delivered EIPs.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -184,6 +184,13 @@ create_service_users() {
 install_sudoers() {
     stage "installing scoped sudoers rules"
     $SUDO tee /etc/sudoers.d/spinifex-network > /dev/null << 'SUDOERS'
+# No PAM session for the service users. Every sudo call otherwise logs
+# "pam_limits: Could not set limit for 'core'": the units set LimitCORE=0 and
+# their CapabilityBoundingSet omits CAP_SYS_RESOURCE, so pam_limits cannot apply
+# the limits.conf default and warns. It also means sudo children inherit the
+# unit's rlimits rather than the system defaults, which is the RG-9 intent.
+Defaults:spinifex-daemon,spinifex-vpcd !pam_session
+
 # Spinifex daemon: tap devices, OVS bridge management, and DHCP for external IPs
 # ovs-ofctl installs the per-tap IMDS datapath flows on br-imds; sysctl sets the
 # per-endpoint rp_filter/accept_local the asymmetric reply path needs.

--- a/spinifex/network/host/health.go
+++ b/spinifex/network/host/health.go
@@ -16,13 +16,14 @@ type OVNHealth struct {
 
 // HealthStatus probes local OVS/OVN state to determine network readiness.
 func HealthStatus() OVNHealth {
-	return healthStatus(context.Background(), NewDirectRunner())
+	return healthStatus(context.Background(), NewExecRunner())
 }
 
 // healthStatus is HealthStatus over an injected Runner. Every probe here is
-// read-only and runs unprivileged: db.sock and the ovn-controller ctl socket are
-// group-owned by `spinifex`, so probing needs no sudo. Escalating instead would
-// mean granting the daemon a root-equivalent ovn-appctl rule to read a status.
+// read-only and runs unprivileged: ovs-vsctl and ovn-appctl are socket clients
+// (utils.NeedsPrivilege), and db.sock plus the ovn-controller ctl socket are
+// group-owned by `spinifex`. Escalating instead would mean granting the daemon a
+// root-equivalent ovn-appctl rule to read a status.
 func healthStatus(ctx context.Context, r Runner) OVNHealth {
 	status := OVNHealth{}
 

--- a/spinifex/network/host/health.go
+++ b/spinifex/network/host/health.go
@@ -1,9 +1,8 @@
 package host
 
 import (
+	"context"
 	"strings"
-
-	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
 // OVNHealth reports the readiness of OVN networking on this compute node.
@@ -17,9 +16,17 @@ type OVNHealth struct {
 
 // HealthStatus probes local OVS/OVN state to determine network readiness.
 func HealthStatus() OVNHealth {
+	return healthStatus(context.Background(), NewDirectRunner())
+}
+
+// healthStatus is HealthStatus over an injected Runner. Every probe here is
+// read-only and runs unprivileged: db.sock and the ovn-controller ctl socket are
+// group-owned by `spinifex`, so probing needs no sudo. Escalating instead would
+// mean granting the daemon a root-equivalent ovn-appctl rule to read a status.
+func healthStatus(ctx context.Context, r Runner) OVNHealth {
 	status := OVNHealth{}
 
-	if err := utils.SudoCommand("ovs-vsctl", "br-exists", "br-int").Run(); err == nil {
+	if _, err := r.Run(ctx, "ovs-vsctl", "br-exists", "br-int"); err == nil {
 		status.BrIntExists = true
 	}
 
@@ -33,19 +40,24 @@ func HealthStatus() OVNHealth {
 	// true only when the process is up AND synced with the SB RAFT cluster, so a
 	// stale-SB wedge correctly surfaces as not_running instead of hiding behind a
 	// process-alive check.
-	if out, err := utils.SudoCommand("ovn-appctl", "-t", "ovn-controller", "connection-status").Output(); err == nil {
+	if out, err := r.Run(ctx, "ovn-appctl", "-t", "ovn-controller", "connection-status"); err == nil {
 		status.OVNControllerUp = strings.TrimSpace(string(out)) == "connected"
 	}
 
-	if out, err := utils.SudoCommand("ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:system-id").CombinedOutput(); err == nil {
-		status.ChassisID = strings.Trim(strings.TrimSpace(string(out)), "\"")
-	}
-	if out, err := utils.SudoCommand("ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:ovn-encap-ip").CombinedOutput(); err == nil {
-		status.EncapIP = strings.Trim(strings.TrimSpace(string(out)), "\"")
-	}
-	if out, err := utils.SudoCommand("ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:ovn-remote").CombinedOutput(); err == nil {
-		status.OVNRemote = strings.Trim(strings.TrimSpace(string(out)), "\"")
-	}
+	status.ChassisID = ovsGlobalExternalID(ctx, r, "system-id")
+	status.EncapIP = ovsGlobalExternalID(ctx, r, "ovn-encap-ip")
+	status.OVNRemote = ovsGlobalExternalID(ctx, r, "ovn-remote")
 
 	return status
+}
+
+// ovsGlobalExternalID reads one Open_vSwitch external_ids key, returning "" when
+// it is unset or unreadable — the field is omitted from the report rather than
+// carrying an error string into it.
+func ovsGlobalExternalID(ctx context.Context, r Runner, key string) string {
+	out, err := r.Run(ctx, "ovs-vsctl", "get", "Open_vSwitch", ".", "external_ids:"+key)
+	if err != nil {
+		return ""
+	}
+	return strings.Trim(strings.TrimSpace(string(out)), "\"")
 }

--- a/spinifex/network/host/health_test.go
+++ b/spinifex/network/host/health_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
 const (
@@ -99,14 +101,18 @@ func TestHealthStatus_FailedProbesReportUnset(t *testing.T) {
 	}
 }
 
-// directRunner must invoke the binary itself. Its whole purpose is to reach the
-// group-owned OVS/OVN sockets without a privilege transition.
-func TestDirectRunner_RunsWithoutSudo(t *testing.T) {
-	out, err := NewDirectRunner().Run(context.Background(), "/bin/echo", "spinifex")
-	if err != nil {
-		t.Fatalf("directRunner.Run: %v", err)
-	}
-	if strings.TrimSpace(string(out)) != "spinifex" {
-		t.Errorf("output = %q, want %q", strings.TrimSpace(string(out)), "spinifex")
+// Every tool healthStatus probes must be one the escalation policy classifies as
+// unprivileged, or the probe would need a sudoers grant to read a status.
+func TestHealthStatus_ProbesAreSocketClients(t *testing.T) {
+	s := newStubRunner()
+	stubHealthyOVN(s)
+
+	healthStatus(context.Background(), s)
+
+	for _, c := range s.calls {
+		tool := strings.Fields(c)[0]
+		if utils.NeedsPrivilege(tool) {
+			t.Errorf("probe tool %q is classified as needing privilege; health must only use socket clients", tool)
+		}
 	}
 }

--- a/spinifex/network/host/health_test.go
+++ b/spinifex/network/host/health_test.go
@@ -1,0 +1,112 @@
+package host
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+const (
+	brExistsCmd     = "ovs-vsctl br-exists br-int"
+	connStatusCmd   = "ovn-appctl -t ovn-controller connection-status"
+	systemIDCmd     = "ovs-vsctl get Open_vSwitch . external_ids:system-id"
+	encapIPCmd      = "ovs-vsctl get Open_vSwitch . external_ids:ovn-encap-ip"
+	ovnRemoteCmd    = "ovs-vsctl get Open_vSwitch . external_ids:ovn-remote"
+	healthyChassis  = "hydrogen"
+	healthyEncapIP  = "192.168.1.13"
+	healthyOVNRemte = "tcp:192.168.1.13:6642"
+)
+
+// stubHealthyOVN primes every probe with the output of a node where OVN is up.
+func stubHealthyOVN(s *stubRunner) {
+	s.expect(brExistsCmd, nil, nil)
+	s.expect(connStatusCmd, []byte("connected\n"), nil)
+	s.expect(systemIDCmd, []byte("\""+healthyChassis+"\"\n"), nil)
+	s.expect(encapIPCmd, []byte("\""+healthyEncapIP+"\"\n"), nil)
+	s.expect(ovnRemoteCmd, []byte("\""+healthyOVNRemte+"\"\n"), nil)
+}
+
+func TestHealthStatus_HealthyNode(t *testing.T) {
+	s := newStubRunner()
+	stubHealthyOVN(s)
+
+	got := healthStatus(context.Background(), s)
+
+	if !got.BrIntExists {
+		t.Error("BrIntExists = false, want true")
+	}
+	if !got.OVNControllerUp {
+		t.Error("OVNControllerUp = false, want true")
+	}
+	if got.ChassisID != healthyChassis {
+		t.Errorf("ChassisID = %q, want %q", got.ChassisID, healthyChassis)
+	}
+	if got.EncapIP != healthyEncapIP {
+		t.Errorf("EncapIP = %q, want %q", got.EncapIP, healthyEncapIP)
+	}
+	if got.OVNRemote != healthyOVNRemte {
+		t.Errorf("OVNRemote = %q, want %q", got.OVNRemote, healthyOVNRemte)
+	}
+}
+
+// No probe may escalate. The false-negative this replaced came from probing
+// ovn-appctl through sudo as spinifex-daemon, which holds no ovn-appctl grant:
+// sudo demanded a password, the error was swallowed, and a healthy node reported
+// ovn-controller as not_running. The sockets are group-owned instead, so a sudo
+// prefix reappearing here would resurrect that bug.
+func TestHealthStatus_ProbesDoNotEscalate(t *testing.T) {
+	s := newStubRunner()
+	stubHealthyOVN(s)
+
+	healthStatus(context.Background(), s)
+
+	if len(s.calls) == 0 {
+		t.Fatal("healthStatus issued no probes")
+	}
+	for _, c := range s.calls {
+		if strings.HasPrefix(c, "sudo ") {
+			t.Errorf("probe %q escalates; OVS/OVN read probes must run unprivileged", c)
+		}
+	}
+}
+
+// ovn-controller up but not synced with the SB cluster is not readiness: a
+// stale-SB wedge must surface as down rather than hide behind process liveness.
+func TestHealthStatus_UnsyncedControllerIsDown(t *testing.T) {
+	s := newStubRunner()
+	stubHealthyOVN(s)
+	s.expect(connStatusCmd, []byte("not connected\n"), nil)
+
+	if healthStatus(context.Background(), s).OVNControllerUp {
+		t.Error("OVNControllerUp = true for a controller that is not connected to the SB cluster")
+	}
+}
+
+// A probe that cannot run reports its field as unset, never as healthy.
+func TestHealthStatus_FailedProbesReportUnset(t *testing.T) {
+	s := newStubRunner()
+	s.expect(brExistsCmd, nil, errors.New("no such bridge"))
+	s.expect(connStatusCmd, nil, errors.New("no ovn-controller socket"))
+	s.expect(systemIDCmd, nil, errors.New("ovsdb unreachable"))
+	s.expect(encapIPCmd, nil, errors.New("ovsdb unreachable"))
+	s.expect(ovnRemoteCmd, nil, errors.New("ovsdb unreachable"))
+
+	got := healthStatus(context.Background(), s)
+
+	if got != (OVNHealth{}) {
+		t.Errorf("healthStatus = %+v on a node where every probe failed, want the zero value", got)
+	}
+}
+
+// directRunner must invoke the binary itself. Its whole purpose is to reach the
+// group-owned OVS/OVN sockets without a privilege transition.
+func TestDirectRunner_RunsWithoutSudo(t *testing.T) {
+	out, err := NewDirectRunner().Run(context.Background(), "/bin/echo", "spinifex")
+	if err != nil {
+		t.Fatalf("directRunner.Run: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "spinifex" {
+		t.Errorf("output = %q, want %q", strings.TrimSpace(string(out)), "spinifex")
+	}
+}

--- a/spinifex/network/host/imds_reconcile.go
+++ b/spinifex/network/host/imds_reconcile.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -21,45 +22,120 @@ type IMDSTapEndpoint struct {
 
 // ListIMDSTaps enumerates the local primary-ENI IMDS datapaths from live OVS state,
 // the source vpcd reconciles its responders against. The br-int patch ports ("imi-*")
-// carry the OVN iface-id, the only place the full ENI survives on the chassis. A
-// malformed iface-id is skipped; an unreadable one aborts the pass so a transient
-// read error can't drop a live tap and make reconcile stop its healthy responder.
+// carry the OVN iface-id, the only place the full ENI survives on the chassis.
+//
+// One query serves the whole pass: this runs on vpcd's 15s tick, and a per-port
+// query was 1+N sudo invocations every tick. The imi- prefix is unambiguous (the
+// br-imds patch end is "imp-", the endpoint "ime-"), so filtering every Interface
+// on the prefix is equivalent to enumerating br-int and filtering. A failed query
+// aborts the pass so a transient OVS error can't drop a live tap and make reconcile
+// stop its healthy responder.
 func ListIMDSTaps(ctx context.Context, r Runner) ([]IMDSTapEndpoint, error) {
-	out, err := r.Run(ctx, "ovs-vsctl", "list-ports", "br-int")
+	out, err := r.Run(ctx, "ovs-vsctl", "--format=json", "--columns=name,external_ids", "list", "Interface")
 	if err != nil {
-		return nil, fmt.Errorf("list br-int ports: %w", err)
+		return nil, fmt.Errorf("list OVS interfaces: %w", err)
+	}
+	rows, err := parseOVSInterfaceRows(out)
+	if err != nil {
+		return nil, err
 	}
 	var taps []IMDSTapEndpoint
-	for port := range strings.FieldsSeq(string(out)) {
-		if !strings.HasPrefix(port, imdsIntPatchPrefix) {
+	for _, row := range rows {
+		if !strings.HasPrefix(row.name, imdsIntPatchPrefix) {
 			continue
 		}
-		eniID, err := imdsPatchENI(ctx, r, port)
-		if err != nil {
-			// Abort rather than drop a live tap: a transient read error would make
-			// reconcile treat its healthy responder as stale and stop it.
-			return nil, fmt.Errorf("read iface-id for %s: %w", port, err)
-		}
-		if eniID == "" {
-			slog.Warn("IMDS: skipping IMDS patch port with unexpected iface-id", "port", port)
+		// Skip rather than abort: the iface-id is the only record of the full ENI, so
+		// a port missing it can never be a member of the live set either way, and one
+		// structurally broken port must not stall every reconcile pass.
+		ifaceID, ok := row.externalIDs["iface-id"]
+		if !ok || !strings.HasPrefix(ifaceID, ovsIfaceIDPrefix) {
+			slog.Warn("IMDS: skipping IMDS patch port with unexpected iface-id", "port", row.name, "iface_id", ifaceID)
 			continue
 		}
+		eniID := strings.TrimPrefix(ifaceID, ovsIfaceIDPrefix)
 		taps = append(taps, IMDSTapEndpoint{ENIID: eniID, Endpoint: IMDSEndpointName(eniID)})
 	}
 	return taps, nil
 }
 
-// imdsPatchENI reads a br-int IMDS patch port's iface-id and recovers the full
-// ENI. Returns "" (not an error) when the iface-id is missing the expected
-// "port-" prefix, so the caller skips rather than aborts.
-func imdsPatchENI(ctx context.Context, r Runner, port string) (string, error) {
-	out, err := r.Run(ctx, "ovs-vsctl", "get", "Interface", port, "external_ids:iface-id")
-	if err != nil {
-		return "", err
+// ovsInterfaceRow is one interface's name and external_ids from an ovs-vsctl list.
+type ovsInterfaceRow struct {
+	name        string
+	externalIDs map[string]string
+}
+
+// ovsListResult is the `ovs-vsctl --format=json list` envelope. Cells stay raw
+// because a column's shape follows its schema type: a scalar is a bare JSON
+// value, a map is the two-element array ["map", [[k, v], ...]].
+type ovsListResult struct {
+	Headings []string            `json:"headings"`
+	Data     [][]json.RawMessage `json:"data"`
+}
+
+// parseOVSInterfaceRows decodes `ovs-vsctl --format=json --columns=name,external_ids
+// list Interface`. Column positions come from the headings rather than being
+// assumed to follow the --columns order.
+func parseOVSInterfaceRows(out []byte) ([]ovsInterfaceRow, error) {
+	var result ovsListResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("parse ovs-vsctl JSON: %w", err)
 	}
-	ifaceID := strings.Trim(strings.TrimSpace(string(out)), `"`)
-	if !strings.HasPrefix(ifaceID, ovsIfaceIDPrefix) {
-		return "", nil
+	nameCol, extCol := -1, -1
+	for i, h := range result.Headings {
+		switch h {
+		case "name":
+			nameCol = i
+		case "external_ids":
+			extCol = i
+		}
 	}
-	return strings.TrimPrefix(ifaceID, ovsIfaceIDPrefix), nil
+	if nameCol < 0 || extCol < 0 {
+		return nil, fmt.Errorf("ovs-vsctl JSON missing name/external_ids columns, got %v", result.Headings)
+	}
+	rows := make([]ovsInterfaceRow, 0, len(result.Data))
+	for _, cells := range result.Data {
+		if nameCol >= len(cells) || extCol >= len(cells) {
+			return nil, fmt.Errorf("ovs-vsctl JSON row has %d cells, want at least %d", len(cells), max(nameCol, extCol)+1)
+		}
+		var name string
+		if err := json.Unmarshal(cells[nameCol], &name); err != nil {
+			return nil, fmt.Errorf("parse interface name: %w", err)
+		}
+		ids, err := parseOVSMap(cells[extCol])
+		if err != nil {
+			return nil, fmt.Errorf("parse external_ids for %s: %w", name, err)
+		}
+		rows = append(rows, ovsInterfaceRow{name: name, externalIDs: ids})
+	}
+	return rows, nil
+}
+
+// parseOVSMap decodes an OVSDB map cell, serialised as ["map", [[key, value], ...]].
+func parseOVSMap(cell json.RawMessage) (map[string]string, error) {
+	var wrapper []json.RawMessage
+	if err := json.Unmarshal(cell, &wrapper); err != nil {
+		return nil, err
+	}
+	if len(wrapper) != 2 {
+		return nil, fmt.Errorf("expected a 2-element map cell, got %d elements", len(wrapper))
+	}
+	var kind string
+	if err := json.Unmarshal(wrapper[0], &kind); err != nil {
+		return nil, err
+	}
+	if kind != "map" {
+		return nil, fmt.Errorf("expected a map cell, got %q", kind)
+	}
+	var pairs [][]string
+	if err := json.Unmarshal(wrapper[1], &pairs); err != nil {
+		return nil, err
+	}
+	ids := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		if len(p) != 2 {
+			return nil, fmt.Errorf("expected a key/value pair, got %d elements", len(p))
+		}
+		ids[p[0]] = p[1]
+	}
+	return ids, nil
 }

--- a/spinifex/network/host/imds_reconcile_test.go
+++ b/spinifex/network/host/imds_reconcile_test.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -9,24 +10,58 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/vm"
 )
 
-// ListIMDSTaps must enumerate only the IMDS patch ports (imi-*) on br-int,
-// recover the *full* ENI from each port's iface-id ("port-<eniID>"), and pair it
-// with the br-imds endpoint name — ignoring guest taps and the br-imds-end patch.
+// listInterfacesCmd is the single query ListIMDSTaps issues per pass.
+const listInterfacesCmd = "ovs-vsctl --format=json --columns=name,external_ids list Interface"
+
+// ovsListJSON renders the `ovs-vsctl --format=json list` envelope for a set of
+// interfaces, so the tests exercise the real decode path rather than a hand-typed
+// blob. A nil external_ids renders as OVSDB's empty map.
+func ovsListJSON(t *testing.T, ifaces []struct {
+	name string
+	ids  map[string]string
+},
+) []byte {
+	t.Helper()
+	data := make([]any, 0, len(ifaces))
+	for _, iface := range ifaces {
+		pairs := make([][]string, 0, len(iface.ids))
+		for k, v := range iface.ids {
+			pairs = append(pairs, []string{k, v})
+		}
+		data = append(data, []any{iface.name, []any{"map", pairs}})
+	}
+	out, err := json.Marshal(map[string]any{
+		"headings": []string{"name", "external_ids"},
+		"data":     data,
+	})
+	if err != nil {
+		t.Fatalf("marshal ovs-vsctl JSON: %v", err)
+	}
+	return out
+}
+
+// ListIMDSTaps must enumerate only the IMDS patch ports (imi-*), recover the
+// *full* ENI from each port's iface-id ("port-<eniID>"), and pair it with the
+// br-imds endpoint name — ignoring guest taps, the br-imds-end patch and the
+// endpoint port, all of which are in the same unfiltered interface list.
 func TestListIMDSTaps_RecoversENIFromPatchIfaceID(t *testing.T) {
 	const (
 		eniA = "eni-0aaa1111deadbeef"
 		eniB = "eni-0bbb2222cafef00d"
 	)
 	s := newStubRunner()
-	// br-int carries the two IMDS patch ports plus a guest tap and the br-imds-end
-	// patch name (which lives on br-imds, not br-int, but guards the imi- filter).
-	s.expect("ovs-vsctl list-ports br-int",
-		[]byte(IMDSIntPatchPort(eniA)+"\ntap0deadbeef\n"+IMDSIntPatchPort(eniB)+"\n"+IMDSPatchPort(eniA)+"\n"), nil)
-	// ovs-vsctl quotes the iface-id value and appends a newline.
-	s.expect("ovs-vsctl get Interface "+IMDSIntPatchPort(eniA)+" external_ids:iface-id",
-		[]byte("\""+vm.OVSIfaceID(eniA)+"\"\n"), nil)
-	s.expect("ovs-vsctl get Interface "+IMDSIntPatchPort(eniB)+" external_ids:iface-id",
-		[]byte("\""+vm.OVSIfaceID(eniB)+"\"\n"), nil)
+	s.expect(listInterfacesCmd, ovsListJSON(t, []struct {
+		name string
+		ids  map[string]string
+	}{
+		{name: IMDSIntPatchPort(eniA), ids: map[string]string{"iface-id": vm.OVSIfaceID(eniA), "attached-mac": "52:54:00:aa:bb:cc"}},
+		{name: "tap0deadbeef"},
+		{name: IMDSIntPatchPort(eniB), ids: map[string]string{"iface-id": vm.OVSIfaceID(eniB)}},
+		// The br-imds patch end and the endpoint carry neighbouring prefixes; both
+		// must fall outside the imi- filter.
+		{name: IMDSPatchPort(eniA)},
+		{name: IMDSEndpointName(eniA)},
+	}), nil)
 
 	taps, err := ListIMDSTaps(context.Background(), s)
 	if err != nil {
@@ -49,30 +84,56 @@ func TestListIMDSTaps_RecoversENIFromPatchIfaceID(t *testing.T) {
 			t.Errorf("endpoint for %s = %q, want %q", eni, got[eni], ep)
 		}
 	}
-	// The guest tap and the br-imds-end patch must never be queried.
-	if s.called("ovs-vsctl get Interface tap0deadbeef") {
-		t.Error("guest tap must not be queried for an iface-id")
+}
+
+// The pass costs exactly one OVS invocation however many taps are live. It runs
+// on vpcd's 15s tick, and the per-port query it replaced was 1+N sudo calls a
+// tick — the bulk of the service journal.
+func TestListIMDSTaps_IssuesOneQueryPerPass(t *testing.T) {
+	ifaces := make([]struct {
+		name string
+		ids  map[string]string
+	}, 0, 4)
+	for _, eni := range []string{"eni-01", "eni-02", "eni-03", "eni-04"} {
+		ifaces = append(ifaces, struct {
+			name string
+			ids  map[string]string
+		}{name: IMDSIntPatchPort(eni), ids: map[string]string{"iface-id": vm.OVSIfaceID(eni)}})
 	}
-	if s.called("ovs-vsctl get Interface " + IMDSPatchPort(eniA)) {
-		t.Error("br-imds-end patch must not be queried for an iface-id")
+	s := newStubRunner()
+	s.expect(listInterfacesCmd, ovsListJSON(t, ifaces), nil)
+
+	taps, err := ListIMDSTaps(context.Background(), s)
+	if err != nil {
+		t.Fatalf("ListIMDSTaps: %v", err)
+	}
+	if len(taps) != 4 {
+		t.Fatalf("ListIMDSTaps returned %d taps, want 4", len(taps))
+	}
+	if n := len(s.calls); n != 1 {
+		t.Fatalf("ListIMDSTaps issued %d commands, want exactly 1: %v", n, s.calls)
 	}
 }
 
-// A patch port whose iface-id is unexpected (missing the "port-" prefix) is
-// skipped, not fatal: one malformed port must not stall serving for the rest.
+// A patch port whose iface-id is unexpected — malformed (missing the "port-"
+// prefix) or absent entirely — is skipped, not fatal. The iface-id is the only
+// record of the full ENI, so such a port cannot join the live set either way, and
+// aborting would stall every pass for the healthy ports behind it.
 func TestListIMDSTaps_SkipsUnexpectedIfaceID(t *testing.T) {
 	const (
-		eniOK    = "eni-0aaa1111deadbeef"
-		eniWrong = "eni-0ccc3333beeff00d"
+		eniOK      = "eni-0aaa1111deadbeef"
+		eniWrong   = "eni-0ccc3333beeff00d"
+		eniMissing = "eni-0ddd4444f00dcafe"
 	)
 	s := newStubRunner()
-	s.expect("ovs-vsctl list-ports br-int",
-		[]byte(IMDSIntPatchPort(eniOK)+"\n"+IMDSIntPatchPort(eniWrong)+"\n"), nil)
-	s.expect("ovs-vsctl get Interface "+IMDSIntPatchPort(eniOK)+" external_ids:iface-id",
-		[]byte("\""+vm.OVSIfaceID(eniOK)+"\"\n"), nil)
-	// Missing the "port-" prefix — recovered ENI would be wrong, so it is dropped.
-	s.expect("ovs-vsctl get Interface "+IMDSIntPatchPort(eniWrong)+" external_ids:iface-id",
-		[]byte("\"bogus\"\n"), nil)
+	s.expect(listInterfacesCmd, ovsListJSON(t, []struct {
+		name string
+		ids  map[string]string
+	}{
+		{name: IMDSIntPatchPort(eniOK), ids: map[string]string{"iface-id": vm.OVSIfaceID(eniOK)}},
+		{name: IMDSIntPatchPort(eniWrong), ids: map[string]string{"iface-id": "bogus"}},
+		{name: IMDSIntPatchPort(eniMissing), ids: map[string]string{"attached-mac": "52:54:00:aa:bb:cc"}},
+	}), nil)
 
 	taps, err := ListIMDSTaps(context.Background(), s)
 	if err != nil {
@@ -80,28 +141,6 @@ func TestListIMDSTaps_SkipsUnexpectedIfaceID(t *testing.T) {
 	}
 	if len(taps) != 1 || taps[0].ENIID != eniOK {
 		t.Fatalf("ListIMDSTaps = %v, want only %s", taps, eniOK)
-	}
-}
-
-// A patch port whose iface-id cannot be READ aborts the reconcile pass rather
-// than silently dropping the tap. Dropping it would leave the ENI out of the live
-// set, so reconcile would treat the guest's healthy responder as stale and stop
-// it — flapping IMDS on a transient OVS read error. The caller retries next tick.
-func TestListIMDSTaps_UnreadableIfaceIDAbortsPass(t *testing.T) {
-	const (
-		eniOK  = "eni-0aaa1111deadbeef"
-		eniErr = "eni-0bbb2222cafef00d"
-	)
-	s := newStubRunner()
-	s.expect("ovs-vsctl list-ports br-int",
-		[]byte(IMDSIntPatchPort(eniOK)+"\n"+IMDSIntPatchPort(eniErr)+"\n"), nil)
-	s.expect("ovs-vsctl get Interface "+IMDSIntPatchPort(eniOK)+" external_ids:iface-id",
-		[]byte("\""+vm.OVSIfaceID(eniOK)+"\"\n"), nil)
-	s.expect("ovs-vsctl get Interface "+IMDSIntPatchPort(eniErr)+" external_ids:iface-id",
-		nil, errors.New("ovs-vsctl: connection refused"))
-
-	if _, err := ListIMDSTaps(context.Background(), s); err == nil {
-		t.Fatal("expected error when a patch port's iface-id cannot be read; a silent drop would stop the tap's healthy responder")
 	}
 }
 
@@ -118,12 +157,42 @@ func TestOVSIfaceIDPrefixMatchesVM(t *testing.T) {
 	}
 }
 
-// A failure listing br-int ports is fatal to one reconcile pass (the caller
-// retries on the next tick), not silently empty.
-func TestListIMDSTaps_ListPortsErrorPropagates(t *testing.T) {
+// A failed query is fatal to one reconcile pass (the caller retries on the next
+// tick), never silently empty. Returning no taps would make reconcile treat every
+// guest's healthy responder as stale and stop it on a transient OVS error.
+func TestListIMDSTaps_QueryErrorPropagates(t *testing.T) {
 	s := newStubRunner()
-	s.expect("ovs-vsctl list-ports br-int", nil, errors.New("ovs down"))
+	s.expect(listInterfacesCmd, nil, errors.New("ovs down"))
 	if _, err := ListIMDSTaps(context.Background(), s); err == nil {
-		t.Fatal("expected error when list-ports fails")
+		t.Fatal("expected error when the interface query fails; a silent empty result would stop every healthy responder")
+	}
+}
+
+// Unparseable output is an error too, for the same reason: it must not decode to
+// an empty live set.
+func TestListIMDSTaps_MalformedJSONPropagates(t *testing.T) {
+	s := newStubRunner()
+	s.expect(listInterfacesCmd, []byte("not json"), nil)
+	if _, err := ListIMDSTaps(context.Background(), s); err == nil {
+		t.Fatal("expected error on unparseable ovs-vsctl output")
+	}
+}
+
+// Column positions are read from the headings, not assumed to follow the
+// --columns order, so a reordering by ovs-vsctl cannot silently swap the fields.
+func TestParseOVSInterfaceRows_HonoursHeadingOrder(t *testing.T) {
+	out := []byte(`{"headings":["external_ids","name"],"data":[[["map",[["iface-id","port-eni-1"]]],"imi-abc"]]}`)
+	rows, err := parseOVSInterfaceRows(out)
+	if err != nil {
+		t.Fatalf("parseOVSInterfaceRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].name != "imi-abc" {
+		t.Errorf("name = %q, want imi-abc", rows[0].name)
+	}
+	if rows[0].externalIDs["iface-id"] != "port-eni-1" {
+		t.Errorf("iface-id = %q, want port-eni-1", rows[0].externalIDs["iface-id"])
 	}
 }

--- a/spinifex/network/host/run.go
+++ b/spinifex/network/host/run.go
@@ -16,7 +16,7 @@ import (
 
 // execRunner escalates only the commands that need it — see utils.NeedsPrivilege.
 // The OVS/OVN socket clients reach their daemons over the group-owned control
-// sockets and run as the service user; ip/iptables/dhcpcd still go via sudo.
+// sockets, and ip/iptables/arping run under the unit's ambient capabilities.
 type execRunner struct{}
 
 var _ Runner = execRunner{}
@@ -26,7 +26,7 @@ func NewExecRunner() Runner { return execRunner{} }
 
 func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
 	var cmd *exec.Cmd
-	if utils.NeedsPrivilege(name) {
+	if utils.NeedsPrivilege(name, args...) {
 		cmd = exec.CommandContext(ctx, "sudo", append([]string{name}, args...)...)
 	} else {
 		cmd = exec.CommandContext(ctx, name, args...)

--- a/spinifex/network/host/run.go
+++ b/spinifex/network/host/run.go
@@ -10,9 +10,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
-// execRunner runs the command directly when uid 0, otherwise via sudo.
+// execRunner escalates only the commands that need it — see utils.NeedsPrivilege.
+// The OVS/OVN socket clients reach their daemons over the group-owned control
+// sockets and run as the service user; ip/iptables/dhcpcd still go via sudo.
 type execRunner struct{}
 
 var _ Runner = execRunner{}
@@ -22,10 +26,10 @@ func NewExecRunner() Runner { return execRunner{} }
 
 func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
 	var cmd *exec.Cmd
-	if os.Getuid() == 0 {
-		cmd = exec.CommandContext(ctx, name, args...)
-	} else {
+	if utils.NeedsPrivilege(name) {
 		cmd = exec.CommandContext(ctx, "sudo", append([]string{name}, args...)...)
+	} else {
+		cmd = exec.CommandContext(ctx, name, args...)
 	}
 	// Capture stdout and stderr separately so stderr is not folded into parsed
 	// output: under a restrictive CapabilityBoundingSet (no CAP_AUDIT_WRITE) sudo
@@ -36,29 +40,6 @@ func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte,
 	if err := cmd.Run(); err != nil {
 		// On failure hand back stdout+stderr so callers matching diagnostics on the
 		// error path (e.g. "File exists" idempotency) still see them.
-		out := append(stdout.Bytes(), stderr.Bytes()...)
-		return out, fmt.Errorf("%s %s: %s: %w", name, strings.Join(args, " "), strings.TrimSpace(string(out)), err)
-	}
-	return stdout.Bytes(), nil
-}
-
-// directRunner runs the command as the calling user, never via sudo. It serves
-// the read-only OVS/OVN probes: setup-ovn.sh group-owns db.sock and the ctl
-// sockets to `spinifex`, so the service users reach them without a privilege
-// transition. Mutating call sites keep execRunner.
-type directRunner struct{}
-
-var _ Runner = directRunner{}
-
-// NewDirectRunner returns a Runner that never escalates.
-func NewDirectRunner() Runner { return directRunner{} }
-
-func (directRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
 		out := append(stdout.Bytes(), stderr.Bytes()...)
 		return out, fmt.Errorf("%s %s: %s: %w", name, strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}

--- a/spinifex/network/host/run.go
+++ b/spinifex/network/host/run.go
@@ -42,6 +42,29 @@ func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte,
 	return stdout.Bytes(), nil
 }
 
+// directRunner runs the command as the calling user, never via sudo. It serves
+// the read-only OVS/OVN probes: setup-ovn.sh group-owns db.sock and the ctl
+// sockets to `spinifex`, so the service users reach them without a privilege
+// transition. Mutating call sites keep execRunner.
+type directRunner struct{}
+
+var _ Runner = directRunner{}
+
+// NewDirectRunner returns a Runner that never escalates.
+func NewDirectRunner() Runner { return directRunner{} }
+
+func (directRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		out := append(stdout.Bytes(), stderr.Bytes()...)
+		return out, fmt.Errorf("%s %s: %s: %w", name, strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return stdout.Bytes(), nil
+}
+
 // kernelReader satisfies InterfaceReader via the live kernel.
 type kernelReader struct{}
 

--- a/spinifex/services/spinifexui/frontend/src/routeTree.gen.ts
+++ b/spinifex/services/spinifexui/frontend/src/routeTree.gen.ts
@@ -9,101 +9,101 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as AuthRouteRouteImport } from './routes/_auth/route'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as AuthRouteRouteImport } from './routes/_auth/route'
 import { Route as AuthIndexRouteImport } from './routes/_auth/index'
 import { Route as AuthNodesRouteImport } from './routes/_auth/nodes'
 import { Route as AuthS3ServiceMetricsRouteImport } from './routes/_auth/s3/service-metrics'
-import { Route as AuthEc2elasticIpsAllocateAddressRouteImport } from './routes/_auth/ec2/(elastic-ips)/allocate-address'
-import { Route as AuthEc2instancesRunInstancesRouteImport } from './routes/_auth/ec2/(instances)/run-instances'
-import { Route as AuthEc2internetGatewaysCreateInternetGatewayRouteImport } from './routes/_auth/ec2/(internet-gateways)/create-internet-gateway'
-import { Route as AuthEc2keyCreateKeyPairRouteImport } from './routes/_auth/ec2/(key)/create-key-pair'
-import { Route as AuthEc2keyImportKeyPairRouteImport } from './routes/_auth/ec2/(key)/import-key-pair'
-import { Route as AuthEc2launchTemplatesCreateLaunchTemplateRouteImport } from './routes/_auth/ec2/(launch-templates)/create-launch-template'
-import { Route as AuthEc2loadBalancersCreateLoadBalancerRouteImport } from './routes/_auth/ec2/(load-balancers)/create-load-balancer'
-import { Route as AuthEc2natGatewaysCreateNatGatewayRouteImport } from './routes/_auth/ec2/(nat-gateways)/create-nat-gateway'
-import { Route as AuthEc2placementGroupsCreatePlacementGroupRouteImport } from './routes/_auth/ec2/(placement-groups)/create-placement-group'
-import { Route as AuthEc2routeTablesCreateRouteTableRouteImport } from './routes/_auth/ec2/(route-tables)/create-route-table'
-import { Route as AuthEc2securityGroupsCreateSecurityGroupRouteImport } from './routes/_auth/ec2/(security-groups)/create-security-group'
-import { Route as AuthEc2snapshotsCreateSnapshotRouteImport } from './routes/_auth/ec2/(snapshots)/create-snapshot'
-import { Route as AuthEc2subnetCreateSubnetRouteImport } from './routes/_auth/ec2/(subnet)/create-subnet'
-import { Route as AuthEc2targetGroupsCreateTargetGroupRouteImport } from './routes/_auth/ec2/(target-groups)/create-target-group'
-import { Route as AuthEc2volumesCreateVolumeRouteImport } from './routes/_auth/ec2/(volumes)/create-volume'
-import { Route as AuthEc2vpcCreateVpcRouteImport } from './routes/_auth/ec2/(vpc)/create-vpc'
-import { Route as AuthEcsclustersCreateServiceRouteImport } from './routes/_auth/ecs/(clusters)/create-service'
-import { Route as AuthEcsclustersRegisterTaskDefinitionRouteImport } from './routes/_auth/ecs/(clusters)/register-task-definition'
-import { Route as AuthEcsclustersRunTaskRouteImport } from './routes/_auth/ecs/(clusters)/run-task'
-import { Route as AuthEcsclustersTaskDefinitionsRouteImport } from './routes/_auth/ecs/(clusters)/task-definitions'
-import { Route as AuthEksclustersCreateClusterRouteImport } from './routes/_auth/eks/(clusters)/create-cluster'
-import { Route as AuthIamgroupsCreateGroupRouteImport } from './routes/_auth/iam/(groups)/create-group'
-import { Route as AuthIaminstanceProfilesCreateInstanceProfileRouteImport } from './routes/_auth/iam/(instance-profiles)/create-instance-profile'
-import { Route as AuthIampoliciesCreatePolicyRouteImport } from './routes/_auth/iam/(policies)/create-policy'
-import { Route as AuthIamrolesCreateRoleRouteImport } from './routes/_auth/iam/(roles)/create-role'
-import { Route as AuthIamusersCreateUserRouteImport } from './routes/_auth/iam/(users)/create-user'
-import { Route as AuthS3bucketsCreateBucketRouteImport } from './routes/_auth/s3/(buckets)/create-bucket'
 import { Route as AuthS3LsIndexRouteImport } from './routes/_auth/s3/ls/index'
+import { Route as AuthS3bucketsCreateBucketRouteImport } from './routes/_auth/s3/(buckets)/create-bucket'
+import { Route as AuthIamusersCreateUserRouteImport } from './routes/_auth/iam/(users)/create-user'
+import { Route as AuthIamrolesCreateRoleRouteImport } from './routes/_auth/iam/(roles)/create-role'
+import { Route as AuthIampoliciesCreatePolicyRouteImport } from './routes/_auth/iam/(policies)/create-policy'
+import { Route as AuthIaminstanceProfilesCreateInstanceProfileRouteImport } from './routes/_auth/iam/(instance-profiles)/create-instance-profile'
+import { Route as AuthIamgroupsCreateGroupRouteImport } from './routes/_auth/iam/(groups)/create-group'
+import { Route as AuthEksclustersCreateClusterRouteImport } from './routes/_auth/eks/(clusters)/create-cluster'
+import { Route as AuthEcsclustersTaskDefinitionsRouteImport } from './routes/_auth/ecs/(clusters)/task-definitions'
+import { Route as AuthEcsclustersRunTaskRouteImport } from './routes/_auth/ecs/(clusters)/run-task'
+import { Route as AuthEcsclustersRegisterTaskDefinitionRouteImport } from './routes/_auth/ecs/(clusters)/register-task-definition'
+import { Route as AuthEcsclustersCreateServiceRouteImport } from './routes/_auth/ecs/(clusters)/create-service'
+import { Route as AuthEc2vpcCreateVpcRouteImport } from './routes/_auth/ec2/(vpc)/create-vpc'
+import { Route as AuthEc2volumesCreateVolumeRouteImport } from './routes/_auth/ec2/(volumes)/create-volume'
+import { Route as AuthEc2targetGroupsCreateTargetGroupRouteImport } from './routes/_auth/ec2/(target-groups)/create-target-group'
+import { Route as AuthEc2subnetCreateSubnetRouteImport } from './routes/_auth/ec2/(subnet)/create-subnet'
+import { Route as AuthEc2snapshotsCreateSnapshotRouteImport } from './routes/_auth/ec2/(snapshots)/create-snapshot'
+import { Route as AuthEc2securityGroupsCreateSecurityGroupRouteImport } from './routes/_auth/ec2/(security-groups)/create-security-group'
+import { Route as AuthEc2routeTablesCreateRouteTableRouteImport } from './routes/_auth/ec2/(route-tables)/create-route-table'
+import { Route as AuthEc2placementGroupsCreatePlacementGroupRouteImport } from './routes/_auth/ec2/(placement-groups)/create-placement-group'
+import { Route as AuthEc2natGatewaysCreateNatGatewayRouteImport } from './routes/_auth/ec2/(nat-gateways)/create-nat-gateway'
+import { Route as AuthEc2loadBalancersCreateLoadBalancerRouteImport } from './routes/_auth/ec2/(load-balancers)/create-load-balancer'
+import { Route as AuthEc2launchTemplatesCreateLaunchTemplateRouteImport } from './routes/_auth/ec2/(launch-templates)/create-launch-template'
+import { Route as AuthEc2keyImportKeyPairRouteImport } from './routes/_auth/ec2/(key)/import-key-pair'
+import { Route as AuthEc2keyCreateKeyPairRouteImport } from './routes/_auth/ec2/(key)/create-key-pair'
+import { Route as AuthEc2internetGatewaysCreateInternetGatewayRouteImport } from './routes/_auth/ec2/(internet-gateways)/create-internet-gateway'
+import { Route as AuthEc2instancesRunInstancesRouteImport } from './routes/_auth/ec2/(instances)/run-instances'
+import { Route as AuthEc2elasticIpsAllocateAddressRouteImport } from './routes/_auth/ec2/(elastic-ips)/allocate-address'
 import { Route as AuthS3LsBucketRouteRouteImport } from './routes/_auth/s3/ls/$bucket/route'
-import { Route as AuthEc2elasticIpsDescribeAddressesIndexRouteImport } from './routes/_auth/ec2/(elastic-ips)/describe-addresses/index'
-import { Route as AuthEc2elasticIpsDescribeAddressesIdRouteImport } from './routes/_auth/ec2/(elastic-ips)/describe-addresses/$id'
-import { Route as AuthEc2imagesDescribeImagesIndexRouteImport } from './routes/_auth/ec2/(images)/describe-images/index'
-import { Route as AuthEc2imagesDescribeImagesIdRouteImport } from './routes/_auth/ec2/(images)/describe-images/$id'
-import { Route as AuthEc2instancesDescribeInstancesIndexRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/index'
-import { Route as AuthEc2instancesDescribeInstancesIdRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/$id'
-import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/index'
-import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
-import { Route as AuthEc2keyDescribeKeyPairsIndexRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/index'
-import { Route as AuthEc2keyDescribeKeyPairsIdRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/$id'
-import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/index'
-import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
-import { Route as AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/index'
-import { Route as AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
-import { Route as AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/index'
-import { Route as AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
-import { Route as AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/index'
-import { Route as AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
-import { Route as AuthEc2routeTablesDescribeRouteTablesIndexRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/index'
-import { Route as AuthEc2routeTablesDescribeRouteTablesIdRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/$id'
-import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/index'
-import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/$id'
-import { Route as AuthEc2snapshotsDescribeSnapshotsIndexRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/index'
-import { Route as AuthEc2snapshotsDescribeSnapshotsIdRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/$id'
-import { Route as AuthEc2subnetDescribeSubnetsIndexRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/index'
-import { Route as AuthEc2subnetDescribeSubnetsIdRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/$id'
-import { Route as AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/index'
-import { Route as AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/$id'
-import { Route as AuthEc2volumesDescribeVolumesIndexRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/index'
-import { Route as AuthEc2volumesDescribeVolumesIdRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/$id'
-import { Route as AuthEc2volumesModifyVolumeIdRouteImport } from './routes/_auth/ec2/(volumes)/modify-volume/$id'
-import { Route as AuthEc2vpcDescribeVpcsIndexRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/index'
-import { Route as AuthEc2vpcDescribeVpcsIdRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/$id'
-import { Route as AuthEcrrepositoriesListRepositoriesIndexRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/index'
-import { Route as AuthEcrrepositoriesListRepositoriesIdRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/$id'
-import { Route as AuthEcsclustersListClustersIndexRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/index'
-import { Route as AuthEcsclustersListClustersClusterNameRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName'
-import { Route as AuthEksclustersListClustersIndexRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/index'
-import { Route as AuthEksclustersListClustersClusterNameRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/$clusterName'
-import { Route as AuthIamgroupsListGroupsIndexRouteImport } from './routes/_auth/iam/(groups)/list-groups/index'
-import { Route as AuthIamgroupsListGroupsGroupNameRouteImport } from './routes/_auth/iam/(groups)/list-groups/$groupName'
-import { Route as AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/index'
-import { Route as AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
-import { Route as AuthIampoliciesListPoliciesIndexRouteImport } from './routes/_auth/iam/(policies)/list-policies/index'
-import { Route as AuthIampoliciesListPoliciesPolicyArnRouteImport } from './routes/_auth/iam/(policies)/list-policies/$policyArn'
-import { Route as AuthIamrolesListRolesIndexRouteImport } from './routes/_auth/iam/(roles)/list-roles/index'
-import { Route as AuthIamrolesListRolesRoleNameRouteImport } from './routes/_auth/iam/(roles)/list-roles/$roleName'
-import { Route as AuthIamusersListUsersIndexRouteImport } from './routes/_auth/iam/(users)/list-users/index'
-import { Route as AuthIamusersListUsersUserNameRouteImport } from './routes/_auth/iam/(users)/list-users/$userName'
 import { Route as AuthS3LsBucketIndexRouteImport } from './routes/_auth/s3/ls/$bucket/index'
+import { Route as AuthIamusersListUsersIndexRouteImport } from './routes/_auth/iam/(users)/list-users/index'
+import { Route as AuthIamrolesListRolesIndexRouteImport } from './routes/_auth/iam/(roles)/list-roles/index'
+import { Route as AuthIampoliciesListPoliciesIndexRouteImport } from './routes/_auth/iam/(policies)/list-policies/index'
+import { Route as AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/index'
+import { Route as AuthIamgroupsListGroupsIndexRouteImport } from './routes/_auth/iam/(groups)/list-groups/index'
+import { Route as AuthEksclustersListClustersIndexRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/index'
+import { Route as AuthEcsclustersListClustersIndexRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/index'
+import { Route as AuthEcrrepositoriesListRepositoriesIndexRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/index'
+import { Route as AuthEc2vpcDescribeVpcsIndexRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/index'
+import { Route as AuthEc2volumesDescribeVolumesIndexRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/index'
+import { Route as AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/index'
+import { Route as AuthEc2subnetDescribeSubnetsIndexRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/index'
+import { Route as AuthEc2snapshotsDescribeSnapshotsIndexRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/index'
+import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/index'
+import { Route as AuthEc2routeTablesDescribeRouteTablesIndexRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/index'
+import { Route as AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/index'
+import { Route as AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/index'
+import { Route as AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/index'
+import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/index'
+import { Route as AuthEc2keyDescribeKeyPairsIndexRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/index'
+import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/index'
+import { Route as AuthEc2instancesDescribeInstancesIndexRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/index'
+import { Route as AuthEc2imagesDescribeImagesIndexRouteImport } from './routes/_auth/ec2/(images)/describe-images/index'
+import { Route as AuthEc2elasticIpsDescribeAddressesIndexRouteImport } from './routes/_auth/ec2/(elastic-ips)/describe-addresses/index'
 import { Route as AuthS3LsBucketSplatRouteImport } from './routes/_auth/s3/ls/$bucket/$'
-import { Route as AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName'
+import { Route as AuthIamusersListUsersUserNameRouteImport } from './routes/_auth/iam/(users)/list-users/$userName'
+import { Route as AuthIamrolesListRolesRoleNameRouteImport } from './routes/_auth/iam/(roles)/list-roles/$roleName'
+import { Route as AuthIampoliciesListPoliciesPolicyArnRouteImport } from './routes/_auth/iam/(policies)/list-policies/$policyArn'
+import { Route as AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
+import { Route as AuthIamgroupsListGroupsGroupNameRouteImport } from './routes/_auth/iam/(groups)/list-groups/$groupName'
+import { Route as AuthEksclustersListClustersClusterNameRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/$clusterName'
+import { Route as AuthEcsclustersListClustersClusterNameRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName'
+import { Route as AuthEcrrepositoriesListRepositoriesIdRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/$id'
+import { Route as AuthEc2vpcDescribeVpcsIdRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/$id'
+import { Route as AuthEc2volumesModifyVolumeIdRouteImport } from './routes/_auth/ec2/(volumes)/modify-volume/$id'
+import { Route as AuthEc2volumesDescribeVolumesIdRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/$id'
+import { Route as AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/$id'
+import { Route as AuthEc2subnetDescribeSubnetsIdRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/$id'
+import { Route as AuthEc2snapshotsDescribeSnapshotsIdRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/$id'
+import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/$id'
+import { Route as AuthEc2routeTablesDescribeRouteTablesIdRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/$id'
+import { Route as AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
+import { Route as AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
+import { Route as AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
+import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
+import { Route as AuthEc2keyDescribeKeyPairsIdRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/$id'
+import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
+import { Route as AuthEc2instancesDescribeInstancesIdRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/$id'
+import { Route as AuthEc2imagesDescribeImagesIdRouteImport } from './routes/_auth/ec2/(images)/describe-images/$id'
+import { Route as AuthEc2elasticIpsDescribeAddressesIdRouteImport } from './routes/_auth/ec2/(elastic-ips)/describe-addresses/$id'
 import { Route as AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId'
+import { Route as AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName'
 
-const AuthRouteRoute = AuthRouteRouteImport.update({
-  id: '/_auth',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthRouteRoute = AuthRouteRouteImport.update({
+  id: '/_auth',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthIndexRoute = AuthIndexRouteImport.update({
@@ -121,154 +121,9 @@ const AuthS3ServiceMetricsRoute = AuthS3ServiceMetricsRouteImport.update({
   path: '/s3/service-metrics',
   getParentRoute: () => AuthRouteRoute,
 } as any)
-const AuthEc2elasticIpsAllocateAddressRoute =
-  AuthEc2elasticIpsAllocateAddressRouteImport.update({
-    id: '/ec2/(elastic-ips)/allocate-address',
-    path: '/ec2/allocate-address',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2instancesRunInstancesRoute =
-  AuthEc2instancesRunInstancesRouteImport.update({
-    id: '/ec2/(instances)/run-instances',
-    path: '/ec2/run-instances',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2internetGatewaysCreateInternetGatewayRoute =
-  AuthEc2internetGatewaysCreateInternetGatewayRouteImport.update({
-    id: '/ec2/(internet-gateways)/create-internet-gateway',
-    path: '/ec2/create-internet-gateway',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2keyCreateKeyPairRoute = AuthEc2keyCreateKeyPairRouteImport.update({
-  id: '/ec2/(key)/create-key-pair',
-  path: '/ec2/create-key-pair',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEc2keyImportKeyPairRoute = AuthEc2keyImportKeyPairRouteImport.update({
-  id: '/ec2/(key)/import-key-pair',
-  path: '/ec2/import-key-pair',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEc2launchTemplatesCreateLaunchTemplateRoute =
-  AuthEc2launchTemplatesCreateLaunchTemplateRouteImport.update({
-    id: '/ec2/(launch-templates)/create-launch-template',
-    path: '/ec2/create-launch-template',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2loadBalancersCreateLoadBalancerRoute =
-  AuthEc2loadBalancersCreateLoadBalancerRouteImport.update({
-    id: '/ec2/(load-balancers)/create-load-balancer',
-    path: '/ec2/create-load-balancer',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2natGatewaysCreateNatGatewayRoute =
-  AuthEc2natGatewaysCreateNatGatewayRouteImport.update({
-    id: '/ec2/(nat-gateways)/create-nat-gateway',
-    path: '/ec2/create-nat-gateway',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2placementGroupsCreatePlacementGroupRoute =
-  AuthEc2placementGroupsCreatePlacementGroupRouteImport.update({
-    id: '/ec2/(placement-groups)/create-placement-group',
-    path: '/ec2/create-placement-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2routeTablesCreateRouteTableRoute =
-  AuthEc2routeTablesCreateRouteTableRouteImport.update({
-    id: '/ec2/(route-tables)/create-route-table',
-    path: '/ec2/create-route-table',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2securityGroupsCreateSecurityGroupRoute =
-  AuthEc2securityGroupsCreateSecurityGroupRouteImport.update({
-    id: '/ec2/(security-groups)/create-security-group',
-    path: '/ec2/create-security-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2snapshotsCreateSnapshotRoute =
-  AuthEc2snapshotsCreateSnapshotRouteImport.update({
-    id: '/ec2/(snapshots)/create-snapshot',
-    path: '/ec2/create-snapshot',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2subnetCreateSubnetRoute =
-  AuthEc2subnetCreateSubnetRouteImport.update({
-    id: '/ec2/(subnet)/create-subnet',
-    path: '/ec2/create-subnet',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2targetGroupsCreateTargetGroupRoute =
-  AuthEc2targetGroupsCreateTargetGroupRouteImport.update({
-    id: '/ec2/(target-groups)/create-target-group',
-    path: '/ec2/create-target-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2volumesCreateVolumeRoute =
-  AuthEc2volumesCreateVolumeRouteImport.update({
-    id: '/ec2/(volumes)/create-volume',
-    path: '/ec2/create-volume',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2vpcCreateVpcRoute = AuthEc2vpcCreateVpcRouteImport.update({
-  id: '/ec2/(vpc)/create-vpc',
-  path: '/ec2/create-vpc',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEcsclustersCreateServiceRoute =
-  AuthEcsclustersCreateServiceRouteImport.update({
-    id: '/ecs/(clusters)/create-service',
-    path: '/ecs/create-service',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersRegisterTaskDefinitionRoute =
-  AuthEcsclustersRegisterTaskDefinitionRouteImport.update({
-    id: '/ecs/(clusters)/register-task-definition',
-    path: '/ecs/register-task-definition',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersRunTaskRoute = AuthEcsclustersRunTaskRouteImport.update({
-  id: '/ecs/(clusters)/run-task',
-  path: '/ecs/run-task',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEcsclustersTaskDefinitionsRoute =
-  AuthEcsclustersTaskDefinitionsRouteImport.update({
-    id: '/ecs/(clusters)/task-definitions',
-    path: '/ecs/task-definitions',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEksclustersCreateClusterRoute =
-  AuthEksclustersCreateClusterRouteImport.update({
-    id: '/eks/(clusters)/create-cluster',
-    path: '/eks/create-cluster',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIamgroupsCreateGroupRoute =
-  AuthIamgroupsCreateGroupRouteImport.update({
-    id: '/iam/(groups)/create-group',
-    path: '/iam/create-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIaminstanceProfilesCreateInstanceProfileRoute =
-  AuthIaminstanceProfilesCreateInstanceProfileRouteImport.update({
-    id: '/iam/(instance-profiles)/create-instance-profile',
-    path: '/iam/create-instance-profile',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIampoliciesCreatePolicyRoute =
-  AuthIampoliciesCreatePolicyRouteImport.update({
-    id: '/iam/(policies)/create-policy',
-    path: '/iam/create-policy',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIamrolesCreateRoleRoute = AuthIamrolesCreateRoleRouteImport.update({
-  id: '/iam/(roles)/create-role',
-  path: '/iam/create-role',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthIamusersCreateUserRoute = AuthIamusersCreateUserRouteImport.update({
-  id: '/iam/(users)/create-user',
-  path: '/iam/create-user',
+const AuthS3LsIndexRoute = AuthS3LsIndexRouteImport.update({
+  id: '/s3/ls/',
+  path: '/s3/ls/',
   getParentRoute: () => AuthRouteRoute,
 } as any)
 const AuthS3bucketsCreateBucketRoute =
@@ -277,248 +132,188 @@ const AuthS3bucketsCreateBucketRoute =
     path: '/s3/create-bucket',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthS3LsIndexRoute = AuthS3LsIndexRouteImport.update({
-  id: '/s3/ls/',
-  path: '/s3/ls/',
+const AuthIamusersCreateUserRoute = AuthIamusersCreateUserRouteImport.update({
+  id: '/iam/(users)/create-user',
+  path: '/iam/create-user',
   getParentRoute: () => AuthRouteRoute,
 } as any)
+const AuthIamrolesCreateRoleRoute = AuthIamrolesCreateRoleRouteImport.update({
+  id: '/iam/(roles)/create-role',
+  path: '/iam/create-role',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthIampoliciesCreatePolicyRoute =
+  AuthIampoliciesCreatePolicyRouteImport.update({
+    id: '/iam/(policies)/create-policy',
+    path: '/iam/create-policy',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIaminstanceProfilesCreateInstanceProfileRoute =
+  AuthIaminstanceProfilesCreateInstanceProfileRouteImport.update({
+    id: '/iam/(instance-profiles)/create-instance-profile',
+    path: '/iam/create-instance-profile',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIamgroupsCreateGroupRoute =
+  AuthIamgroupsCreateGroupRouteImport.update({
+    id: '/iam/(groups)/create-group',
+    path: '/iam/create-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEksclustersCreateClusterRoute =
+  AuthEksclustersCreateClusterRouteImport.update({
+    id: '/eks/(clusters)/create-cluster',
+    path: '/eks/create-cluster',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersTaskDefinitionsRoute =
+  AuthEcsclustersTaskDefinitionsRouteImport.update({
+    id: '/ecs/(clusters)/task-definitions',
+    path: '/ecs/task-definitions',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersRunTaskRoute = AuthEcsclustersRunTaskRouteImport.update({
+  id: '/ecs/(clusters)/run-task',
+  path: '/ecs/run-task',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEcsclustersRegisterTaskDefinitionRoute =
+  AuthEcsclustersRegisterTaskDefinitionRouteImport.update({
+    id: '/ecs/(clusters)/register-task-definition',
+    path: '/ecs/register-task-definition',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersCreateServiceRoute =
+  AuthEcsclustersCreateServiceRouteImport.update({
+    id: '/ecs/(clusters)/create-service',
+    path: '/ecs/create-service',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2vpcCreateVpcRoute = AuthEc2vpcCreateVpcRouteImport.update({
+  id: '/ec2/(vpc)/create-vpc',
+  path: '/ec2/create-vpc',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEc2volumesCreateVolumeRoute =
+  AuthEc2volumesCreateVolumeRouteImport.update({
+    id: '/ec2/(volumes)/create-volume',
+    path: '/ec2/create-volume',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2targetGroupsCreateTargetGroupRoute =
+  AuthEc2targetGroupsCreateTargetGroupRouteImport.update({
+    id: '/ec2/(target-groups)/create-target-group',
+    path: '/ec2/create-target-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2subnetCreateSubnetRoute =
+  AuthEc2subnetCreateSubnetRouteImport.update({
+    id: '/ec2/(subnet)/create-subnet',
+    path: '/ec2/create-subnet',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2snapshotsCreateSnapshotRoute =
+  AuthEc2snapshotsCreateSnapshotRouteImport.update({
+    id: '/ec2/(snapshots)/create-snapshot',
+    path: '/ec2/create-snapshot',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2securityGroupsCreateSecurityGroupRoute =
+  AuthEc2securityGroupsCreateSecurityGroupRouteImport.update({
+    id: '/ec2/(security-groups)/create-security-group',
+    path: '/ec2/create-security-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2routeTablesCreateRouteTableRoute =
+  AuthEc2routeTablesCreateRouteTableRouteImport.update({
+    id: '/ec2/(route-tables)/create-route-table',
+    path: '/ec2/create-route-table',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2placementGroupsCreatePlacementGroupRoute =
+  AuthEc2placementGroupsCreatePlacementGroupRouteImport.update({
+    id: '/ec2/(placement-groups)/create-placement-group',
+    path: '/ec2/create-placement-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2natGatewaysCreateNatGatewayRoute =
+  AuthEc2natGatewaysCreateNatGatewayRouteImport.update({
+    id: '/ec2/(nat-gateways)/create-nat-gateway',
+    path: '/ec2/create-nat-gateway',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2loadBalancersCreateLoadBalancerRoute =
+  AuthEc2loadBalancersCreateLoadBalancerRouteImport.update({
+    id: '/ec2/(load-balancers)/create-load-balancer',
+    path: '/ec2/create-load-balancer',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2launchTemplatesCreateLaunchTemplateRoute =
+  AuthEc2launchTemplatesCreateLaunchTemplateRouteImport.update({
+    id: '/ec2/(launch-templates)/create-launch-template',
+    path: '/ec2/create-launch-template',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2keyImportKeyPairRoute = AuthEc2keyImportKeyPairRouteImport.update({
+  id: '/ec2/(key)/import-key-pair',
+  path: '/ec2/import-key-pair',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEc2keyCreateKeyPairRoute = AuthEc2keyCreateKeyPairRouteImport.update({
+  id: '/ec2/(key)/create-key-pair',
+  path: '/ec2/create-key-pair',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEc2internetGatewaysCreateInternetGatewayRoute =
+  AuthEc2internetGatewaysCreateInternetGatewayRouteImport.update({
+    id: '/ec2/(internet-gateways)/create-internet-gateway',
+    path: '/ec2/create-internet-gateway',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2instancesRunInstancesRoute =
+  AuthEc2instancesRunInstancesRouteImport.update({
+    id: '/ec2/(instances)/run-instances',
+    path: '/ec2/run-instances',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2elasticIpsAllocateAddressRoute =
+  AuthEc2elasticIpsAllocateAddressRouteImport.update({
+    id: '/ec2/(elastic-ips)/allocate-address',
+    path: '/ec2/allocate-address',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
 const AuthS3LsBucketRouteRoute = AuthS3LsBucketRouteRouteImport.update({
   id: '/s3/ls/$bucket',
   path: '/s3/ls/$bucket',
   getParentRoute: () => AuthRouteRoute,
 } as any)
-const AuthEc2elasticIpsDescribeAddressesIndexRoute =
-  AuthEc2elasticIpsDescribeAddressesIndexRouteImport.update({
-    id: '/ec2/(elastic-ips)/describe-addresses/',
-    path: '/ec2/describe-addresses/',
+const AuthS3LsBucketIndexRoute = AuthS3LsBucketIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthS3LsBucketRouteRoute,
+} as any)
+const AuthIamusersListUsersIndexRoute =
+  AuthIamusersListUsersIndexRouteImport.update({
+    id: '/iam/(users)/list-users/',
+    path: '/iam/list-users/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2elasticIpsDescribeAddressesIdRoute =
-  AuthEc2elasticIpsDescribeAddressesIdRouteImport.update({
-    id: '/ec2/(elastic-ips)/describe-addresses/$id',
-    path: '/ec2/describe-addresses/$id',
+const AuthIamrolesListRolesIndexRoute =
+  AuthIamrolesListRolesIndexRouteImport.update({
+    id: '/iam/(roles)/list-roles/',
+    path: '/iam/list-roles/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2imagesDescribeImagesIndexRoute =
-  AuthEc2imagesDescribeImagesIndexRouteImport.update({
-    id: '/ec2/(images)/describe-images/',
-    path: '/ec2/describe-images/',
+const AuthIampoliciesListPoliciesIndexRoute =
+  AuthIampoliciesListPoliciesIndexRouteImport.update({
+    id: '/iam/(policies)/list-policies/',
+    path: '/iam/list-policies/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2imagesDescribeImagesIdRoute =
-  AuthEc2imagesDescribeImagesIdRouteImport.update({
-    id: '/ec2/(images)/describe-images/$id',
-    path: '/ec2/describe-images/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2instancesDescribeInstancesIndexRoute =
-  AuthEc2instancesDescribeInstancesIndexRouteImport.update({
-    id: '/ec2/(instances)/describe-instances/',
-    path: '/ec2/describe-instances/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2instancesDescribeInstancesIdRoute =
-  AuthEc2instancesDescribeInstancesIdRouteImport.update({
-    id: '/ec2/(instances)/describe-instances/$id',
-    path: '/ec2/describe-instances/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2internetGatewaysDescribeInternetGatewaysIndexRoute =
-  AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport.update({
-    id: '/ec2/(internet-gateways)/describe-internet-gateways/',
-    path: '/ec2/describe-internet-gateways/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2internetGatewaysDescribeInternetGatewaysIdRoute =
-  AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport.update({
-    id: '/ec2/(internet-gateways)/describe-internet-gateways/$id',
-    path: '/ec2/describe-internet-gateways/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2keyDescribeKeyPairsIndexRoute =
-  AuthEc2keyDescribeKeyPairsIndexRouteImport.update({
-    id: '/ec2/(key)/describe-key-pairs/',
-    path: '/ec2/describe-key-pairs/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2keyDescribeKeyPairsIdRoute =
-  AuthEc2keyDescribeKeyPairsIdRouteImport.update({
-    id: '/ec2/(key)/describe-key-pairs/$id',
-    path: '/ec2/describe-key-pairs/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRoute =
-  AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport.update({
-    id: '/ec2/(launch-templates)/describe-launch-templates/',
-    path: '/ec2/describe-launch-templates/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2launchTemplatesDescribeLaunchTemplatesIdRoute =
-  AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport.update({
-    id: '/ec2/(launch-templates)/describe-launch-templates/$id',
-    path: '/ec2/describe-launch-templates/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2loadBalancersDescribeLoadBalancersIndexRoute =
-  AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport.update({
-    id: '/ec2/(load-balancers)/describe-load-balancers/',
-    path: '/ec2/describe-load-balancers/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2loadBalancersDescribeLoadBalancersIdRoute =
-  AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport.update({
-    id: '/ec2/(load-balancers)/describe-load-balancers/$id',
-    path: '/ec2/describe-load-balancers/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2natGatewaysDescribeNatGatewaysIndexRoute =
-  AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport.update({
-    id: '/ec2/(nat-gateways)/describe-nat-gateways/',
-    path: '/ec2/describe-nat-gateways/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2natGatewaysDescribeNatGatewaysIdRoute =
-  AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport.update({
-    id: '/ec2/(nat-gateways)/describe-nat-gateways/$id',
-    path: '/ec2/describe-nat-gateways/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2placementGroupsDescribePlacementGroupsIndexRoute =
-  AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport.update({
-    id: '/ec2/(placement-groups)/describe-placement-groups/',
-    path: '/ec2/describe-placement-groups/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2placementGroupsDescribePlacementGroupsIdRoute =
-  AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport.update({
-    id: '/ec2/(placement-groups)/describe-placement-groups/$id',
-    path: '/ec2/describe-placement-groups/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2routeTablesDescribeRouteTablesIndexRoute =
-  AuthEc2routeTablesDescribeRouteTablesIndexRouteImport.update({
-    id: '/ec2/(route-tables)/describe-route-tables/',
-    path: '/ec2/describe-route-tables/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2routeTablesDescribeRouteTablesIdRoute =
-  AuthEc2routeTablesDescribeRouteTablesIdRouteImport.update({
-    id: '/ec2/(route-tables)/describe-route-tables/$id',
-    path: '/ec2/describe-route-tables/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2securityGroupsDescribeSecurityGroupsIndexRoute =
-  AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport.update({
-    id: '/ec2/(security-groups)/describe-security-groups/',
-    path: '/ec2/describe-security-groups/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2securityGroupsDescribeSecurityGroupsIdRoute =
-  AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport.update({
-    id: '/ec2/(security-groups)/describe-security-groups/$id',
-    path: '/ec2/describe-security-groups/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2snapshotsDescribeSnapshotsIndexRoute =
-  AuthEc2snapshotsDescribeSnapshotsIndexRouteImport.update({
-    id: '/ec2/(snapshots)/describe-snapshots/',
-    path: '/ec2/describe-snapshots/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2snapshotsDescribeSnapshotsIdRoute =
-  AuthEc2snapshotsDescribeSnapshotsIdRouteImport.update({
-    id: '/ec2/(snapshots)/describe-snapshots/$id',
-    path: '/ec2/describe-snapshots/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2subnetDescribeSubnetsIndexRoute =
-  AuthEc2subnetDescribeSubnetsIndexRouteImport.update({
-    id: '/ec2/(subnet)/describe-subnets/',
-    path: '/ec2/describe-subnets/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2subnetDescribeSubnetsIdRoute =
-  AuthEc2subnetDescribeSubnetsIdRouteImport.update({
-    id: '/ec2/(subnet)/describe-subnets/$id',
-    path: '/ec2/describe-subnets/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2targetGroupsDescribeTargetGroupsIndexRoute =
-  AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport.update({
-    id: '/ec2/(target-groups)/describe-target-groups/',
-    path: '/ec2/describe-target-groups/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2targetGroupsDescribeTargetGroupsIdRoute =
-  AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport.update({
-    id: '/ec2/(target-groups)/describe-target-groups/$id',
-    path: '/ec2/describe-target-groups/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2volumesDescribeVolumesIndexRoute =
-  AuthEc2volumesDescribeVolumesIndexRouteImport.update({
-    id: '/ec2/(volumes)/describe-volumes/',
-    path: '/ec2/describe-volumes/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2volumesDescribeVolumesIdRoute =
-  AuthEc2volumesDescribeVolumesIdRouteImport.update({
-    id: '/ec2/(volumes)/describe-volumes/$id',
-    path: '/ec2/describe-volumes/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2volumesModifyVolumeIdRoute =
-  AuthEc2volumesModifyVolumeIdRouteImport.update({
-    id: '/ec2/(volumes)/modify-volume/$id',
-    path: '/ec2/modify-volume/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2vpcDescribeVpcsIndexRoute =
-  AuthEc2vpcDescribeVpcsIndexRouteImport.update({
-    id: '/ec2/(vpc)/describe-vpcs/',
-    path: '/ec2/describe-vpcs/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2vpcDescribeVpcsIdRoute =
-  AuthEc2vpcDescribeVpcsIdRouteImport.update({
-    id: '/ec2/(vpc)/describe-vpcs/$id',
-    path: '/ec2/describe-vpcs/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcrrepositoriesListRepositoriesIndexRoute =
-  AuthEcrrepositoriesListRepositoriesIndexRouteImport.update({
-    id: '/ecr/(repositories)/list-repositories/',
-    path: '/ecr/list-repositories/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcrrepositoriesListRepositoriesIdRoute =
-  AuthEcrrepositoriesListRepositoriesIdRouteImport.update({
-    id: '/ecr/(repositories)/list-repositories/$id',
-    path: '/ecr/list-repositories/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersListClustersIndexRoute =
-  AuthEcsclustersListClustersIndexRouteImport.update({
-    id: '/ecs/(clusters)/list-clusters/',
-    path: '/ecs/list-clusters/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersListClustersClusterNameRoute =
-  AuthEcsclustersListClustersClusterNameRouteImport.update({
-    id: '/ecs/(clusters)/list-clusters/$clusterName',
-    path: '/ecs/list-clusters/$clusterName',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEksclustersListClustersIndexRoute =
-  AuthEksclustersListClustersIndexRouteImport.update({
-    id: '/eks/(clusters)/list-clusters/',
-    path: '/eks/list-clusters/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEksclustersListClustersClusterNameRoute =
-  AuthEksclustersListClustersClusterNameRouteImport.update({
-    id: '/eks/(clusters)/list-clusters/$clusterName',
-    path: '/eks/list-clusters/$clusterName',
+const AuthIaminstanceProfilesListInstanceProfilesIndexRoute =
+  AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport.update({
+    id: '/iam/(instance-profiles)/list-instance-profiles/',
+    path: '/iam/list-instance-profiles/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 const AuthIamgroupsListGroupsIndexRoute =
@@ -527,16 +322,141 @@ const AuthIamgroupsListGroupsIndexRoute =
     path: '/iam/list-groups/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIamgroupsListGroupsGroupNameRoute =
-  AuthIamgroupsListGroupsGroupNameRouteImport.update({
-    id: '/iam/(groups)/list-groups/$groupName',
-    path: '/iam/list-groups/$groupName',
+const AuthEksclustersListClustersIndexRoute =
+  AuthEksclustersListClustersIndexRouteImport.update({
+    id: '/eks/(clusters)/list-clusters/',
+    path: '/eks/list-clusters/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIaminstanceProfilesListInstanceProfilesIndexRoute =
-  AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport.update({
-    id: '/iam/(instance-profiles)/list-instance-profiles/',
-    path: '/iam/list-instance-profiles/',
+const AuthEcsclustersListClustersIndexRoute =
+  AuthEcsclustersListClustersIndexRouteImport.update({
+    id: '/ecs/(clusters)/list-clusters/',
+    path: '/ecs/list-clusters/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcrrepositoriesListRepositoriesIndexRoute =
+  AuthEcrrepositoriesListRepositoriesIndexRouteImport.update({
+    id: '/ecr/(repositories)/list-repositories/',
+    path: '/ecr/list-repositories/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2vpcDescribeVpcsIndexRoute =
+  AuthEc2vpcDescribeVpcsIndexRouteImport.update({
+    id: '/ec2/(vpc)/describe-vpcs/',
+    path: '/ec2/describe-vpcs/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2volumesDescribeVolumesIndexRoute =
+  AuthEc2volumesDescribeVolumesIndexRouteImport.update({
+    id: '/ec2/(volumes)/describe-volumes/',
+    path: '/ec2/describe-volumes/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2targetGroupsDescribeTargetGroupsIndexRoute =
+  AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport.update({
+    id: '/ec2/(target-groups)/describe-target-groups/',
+    path: '/ec2/describe-target-groups/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2subnetDescribeSubnetsIndexRoute =
+  AuthEc2subnetDescribeSubnetsIndexRouteImport.update({
+    id: '/ec2/(subnet)/describe-subnets/',
+    path: '/ec2/describe-subnets/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2snapshotsDescribeSnapshotsIndexRoute =
+  AuthEc2snapshotsDescribeSnapshotsIndexRouteImport.update({
+    id: '/ec2/(snapshots)/describe-snapshots/',
+    path: '/ec2/describe-snapshots/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2securityGroupsDescribeSecurityGroupsIndexRoute =
+  AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport.update({
+    id: '/ec2/(security-groups)/describe-security-groups/',
+    path: '/ec2/describe-security-groups/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2routeTablesDescribeRouteTablesIndexRoute =
+  AuthEc2routeTablesDescribeRouteTablesIndexRouteImport.update({
+    id: '/ec2/(route-tables)/describe-route-tables/',
+    path: '/ec2/describe-route-tables/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2placementGroupsDescribePlacementGroupsIndexRoute =
+  AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport.update({
+    id: '/ec2/(placement-groups)/describe-placement-groups/',
+    path: '/ec2/describe-placement-groups/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2natGatewaysDescribeNatGatewaysIndexRoute =
+  AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport.update({
+    id: '/ec2/(nat-gateways)/describe-nat-gateways/',
+    path: '/ec2/describe-nat-gateways/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2loadBalancersDescribeLoadBalancersIndexRoute =
+  AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport.update({
+    id: '/ec2/(load-balancers)/describe-load-balancers/',
+    path: '/ec2/describe-load-balancers/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRoute =
+  AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport.update({
+    id: '/ec2/(launch-templates)/describe-launch-templates/',
+    path: '/ec2/describe-launch-templates/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2keyDescribeKeyPairsIndexRoute =
+  AuthEc2keyDescribeKeyPairsIndexRouteImport.update({
+    id: '/ec2/(key)/describe-key-pairs/',
+    path: '/ec2/describe-key-pairs/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2internetGatewaysDescribeInternetGatewaysIndexRoute =
+  AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport.update({
+    id: '/ec2/(internet-gateways)/describe-internet-gateways/',
+    path: '/ec2/describe-internet-gateways/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2instancesDescribeInstancesIndexRoute =
+  AuthEc2instancesDescribeInstancesIndexRouteImport.update({
+    id: '/ec2/(instances)/describe-instances/',
+    path: '/ec2/describe-instances/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2imagesDescribeImagesIndexRoute =
+  AuthEc2imagesDescribeImagesIndexRouteImport.update({
+    id: '/ec2/(images)/describe-images/',
+    path: '/ec2/describe-images/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2elasticIpsDescribeAddressesIndexRoute =
+  AuthEc2elasticIpsDescribeAddressesIndexRouteImport.update({
+    id: '/ec2/(elastic-ips)/describe-addresses/',
+    path: '/ec2/describe-addresses/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthS3LsBucketSplatRoute = AuthS3LsBucketSplatRouteImport.update({
+  id: '/$',
+  path: '/$',
+  getParentRoute: () => AuthS3LsBucketRouteRoute,
+} as any)
+const AuthIamusersListUsersUserNameRoute =
+  AuthIamusersListUsersUserNameRouteImport.update({
+    id: '/iam/(users)/list-users/$userName',
+    path: '/iam/list-users/$userName',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIamrolesListRolesRoleNameRoute =
+  AuthIamrolesListRolesRoleNameRouteImport.update({
+    id: '/iam/(roles)/list-roles/$roleName',
+    path: '/iam/list-roles/$roleName',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIampoliciesListPoliciesPolicyArnRoute =
+  AuthIampoliciesListPoliciesPolicyArnRouteImport.update({
+    id: '/iam/(policies)/list-policies/$policyArn',
+    path: '/iam/list-policies/$policyArn',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 const AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRoute =
@@ -547,62 +467,142 @@ const AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRoute =
       getParentRoute: () => AuthRouteRoute,
     } as any,
   )
-const AuthIampoliciesListPoliciesIndexRoute =
-  AuthIampoliciesListPoliciesIndexRouteImport.update({
-    id: '/iam/(policies)/list-policies/',
-    path: '/iam/list-policies/',
+const AuthIamgroupsListGroupsGroupNameRoute =
+  AuthIamgroupsListGroupsGroupNameRouteImport.update({
+    id: '/iam/(groups)/list-groups/$groupName',
+    path: '/iam/list-groups/$groupName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIampoliciesListPoliciesPolicyArnRoute =
-  AuthIampoliciesListPoliciesPolicyArnRouteImport.update({
-    id: '/iam/(policies)/list-policies/$policyArn',
-    path: '/iam/list-policies/$policyArn',
+const AuthEksclustersListClustersClusterNameRoute =
+  AuthEksclustersListClustersClusterNameRouteImport.update({
+    id: '/eks/(clusters)/list-clusters/$clusterName',
+    path: '/eks/list-clusters/$clusterName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIamrolesListRolesIndexRoute =
-  AuthIamrolesListRolesIndexRouteImport.update({
-    id: '/iam/(roles)/list-roles/',
-    path: '/iam/list-roles/',
+const AuthEcsclustersListClustersClusterNameRoute =
+  AuthEcsclustersListClustersClusterNameRouteImport.update({
+    id: '/ecs/(clusters)/list-clusters/$clusterName',
+    path: '/ecs/list-clusters/$clusterName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIamrolesListRolesRoleNameRoute =
-  AuthIamrolesListRolesRoleNameRouteImport.update({
-    id: '/iam/(roles)/list-roles/$roleName',
-    path: '/iam/list-roles/$roleName',
+const AuthEcrrepositoriesListRepositoriesIdRoute =
+  AuthEcrrepositoriesListRepositoriesIdRouteImport.update({
+    id: '/ecr/(repositories)/list-repositories/$id',
+    path: '/ecr/list-repositories/$id',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIamusersListUsersIndexRoute =
-  AuthIamusersListUsersIndexRouteImport.update({
-    id: '/iam/(users)/list-users/',
-    path: '/iam/list-users/',
+const AuthEc2vpcDescribeVpcsIdRoute =
+  AuthEc2vpcDescribeVpcsIdRouteImport.update({
+    id: '/ec2/(vpc)/describe-vpcs/$id',
+    path: '/ec2/describe-vpcs/$id',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIamusersListUsersUserNameRoute =
-  AuthIamusersListUsersUserNameRouteImport.update({
-    id: '/iam/(users)/list-users/$userName',
-    path: '/iam/list-users/$userName',
+const AuthEc2volumesModifyVolumeIdRoute =
+  AuthEc2volumesModifyVolumeIdRouteImport.update({
+    id: '/ec2/(volumes)/modify-volume/$id',
+    path: '/ec2/modify-volume/$id',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthS3LsBucketIndexRoute = AuthS3LsBucketIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AuthS3LsBucketRouteRoute,
-} as any)
-const AuthS3LsBucketSplatRoute = AuthS3LsBucketSplatRouteImport.update({
-  id: '/$',
-  path: '/$',
-  getParentRoute: () => AuthS3LsBucketRouteRoute,
-} as any)
-const AuthEcsclustersListClustersClusterNameServicesServiceNameRoute =
-  AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport.update({
-    id: '/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName',
-    path: '/ecs/list-clusters/$clusterName/services/$serviceName',
+const AuthEc2volumesDescribeVolumesIdRoute =
+  AuthEc2volumesDescribeVolumesIdRouteImport.update({
+    id: '/ec2/(volumes)/describe-volumes/$id',
+    path: '/ec2/describe-volumes/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2targetGroupsDescribeTargetGroupsIdRoute =
+  AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport.update({
+    id: '/ec2/(target-groups)/describe-target-groups/$id',
+    path: '/ec2/describe-target-groups/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2subnetDescribeSubnetsIdRoute =
+  AuthEc2subnetDescribeSubnetsIdRouteImport.update({
+    id: '/ec2/(subnet)/describe-subnets/$id',
+    path: '/ec2/describe-subnets/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2snapshotsDescribeSnapshotsIdRoute =
+  AuthEc2snapshotsDescribeSnapshotsIdRouteImport.update({
+    id: '/ec2/(snapshots)/describe-snapshots/$id',
+    path: '/ec2/describe-snapshots/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2securityGroupsDescribeSecurityGroupsIdRoute =
+  AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport.update({
+    id: '/ec2/(security-groups)/describe-security-groups/$id',
+    path: '/ec2/describe-security-groups/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2routeTablesDescribeRouteTablesIdRoute =
+  AuthEc2routeTablesDescribeRouteTablesIdRouteImport.update({
+    id: '/ec2/(route-tables)/describe-route-tables/$id',
+    path: '/ec2/describe-route-tables/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2placementGroupsDescribePlacementGroupsIdRoute =
+  AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport.update({
+    id: '/ec2/(placement-groups)/describe-placement-groups/$id',
+    path: '/ec2/describe-placement-groups/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2natGatewaysDescribeNatGatewaysIdRoute =
+  AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport.update({
+    id: '/ec2/(nat-gateways)/describe-nat-gateways/$id',
+    path: '/ec2/describe-nat-gateways/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2loadBalancersDescribeLoadBalancersIdRoute =
+  AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport.update({
+    id: '/ec2/(load-balancers)/describe-load-balancers/$id',
+    path: '/ec2/describe-load-balancers/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2launchTemplatesDescribeLaunchTemplatesIdRoute =
+  AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport.update({
+    id: '/ec2/(launch-templates)/describe-launch-templates/$id',
+    path: '/ec2/describe-launch-templates/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2keyDescribeKeyPairsIdRoute =
+  AuthEc2keyDescribeKeyPairsIdRouteImport.update({
+    id: '/ec2/(key)/describe-key-pairs/$id',
+    path: '/ec2/describe-key-pairs/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2internetGatewaysDescribeInternetGatewaysIdRoute =
+  AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport.update({
+    id: '/ec2/(internet-gateways)/describe-internet-gateways/$id',
+    path: '/ec2/describe-internet-gateways/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2instancesDescribeInstancesIdRoute =
+  AuthEc2instancesDescribeInstancesIdRouteImport.update({
+    id: '/ec2/(instances)/describe-instances/$id',
+    path: '/ec2/describe-instances/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2imagesDescribeImagesIdRoute =
+  AuthEc2imagesDescribeImagesIdRouteImport.update({
+    id: '/ec2/(images)/describe-images/$id',
+    path: '/ec2/describe-images/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2elasticIpsDescribeAddressesIdRoute =
+  AuthEc2elasticIpsDescribeAddressesIdRouteImport.update({
+    id: '/ec2/(elastic-ips)/describe-addresses/$id',
+    path: '/ec2/describe-addresses/$id',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 const AuthEcsclustersListClustersClusterNameTasksTaskIdRoute =
   AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport.update({
     id: '/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId',
     path: '/ecs/list-clusters/$clusterName/tasks/$taskId',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersListClustersClusterNameServicesServiceNameRoute =
+  AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport.update({
+    id: '/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName',
+    path: '/ecs/list-clusters/$clusterName/services/$serviceName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 
@@ -1145,18 +1145,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/_auth': {
-      id: '/_auth'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof AuthRouteRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/login': {
       id: '/login'
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_auth': {
+      id: '/_auth'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_auth/': {
@@ -1180,186 +1180,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthS3ServiceMetricsRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/ec2/(elastic-ips)/allocate-address': {
-      id: '/_auth/ec2/(elastic-ips)/allocate-address'
-      path: '/ec2/allocate-address'
-      fullPath: '/ec2/allocate-address'
-      preLoaderRoute: typeof AuthEc2elasticIpsAllocateAddressRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(instances)/run-instances': {
-      id: '/_auth/ec2/(instances)/run-instances'
-      path: '/ec2/run-instances'
-      fullPath: '/ec2/run-instances'
-      preLoaderRoute: typeof AuthEc2instancesRunInstancesRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(internet-gateways)/create-internet-gateway': {
-      id: '/_auth/ec2/(internet-gateways)/create-internet-gateway'
-      path: '/ec2/create-internet-gateway'
-      fullPath: '/ec2/create-internet-gateway'
-      preLoaderRoute: typeof AuthEc2internetGatewaysCreateInternetGatewayRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/create-key-pair': {
-      id: '/_auth/ec2/(key)/create-key-pair'
-      path: '/ec2/create-key-pair'
-      fullPath: '/ec2/create-key-pair'
-      preLoaderRoute: typeof AuthEc2keyCreateKeyPairRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/import-key-pair': {
-      id: '/_auth/ec2/(key)/import-key-pair'
-      path: '/ec2/import-key-pair'
-      fullPath: '/ec2/import-key-pair'
-      preLoaderRoute: typeof AuthEc2keyImportKeyPairRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(launch-templates)/create-launch-template': {
-      id: '/_auth/ec2/(launch-templates)/create-launch-template'
-      path: '/ec2/create-launch-template'
-      fullPath: '/ec2/create-launch-template'
-      preLoaderRoute: typeof AuthEc2launchTemplatesCreateLaunchTemplateRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(load-balancers)/create-load-balancer': {
-      id: '/_auth/ec2/(load-balancers)/create-load-balancer'
-      path: '/ec2/create-load-balancer'
-      fullPath: '/ec2/create-load-balancer'
-      preLoaderRoute: typeof AuthEc2loadBalancersCreateLoadBalancerRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(nat-gateways)/create-nat-gateway': {
-      id: '/_auth/ec2/(nat-gateways)/create-nat-gateway'
-      path: '/ec2/create-nat-gateway'
-      fullPath: '/ec2/create-nat-gateway'
-      preLoaderRoute: typeof AuthEc2natGatewaysCreateNatGatewayRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(placement-groups)/create-placement-group': {
-      id: '/_auth/ec2/(placement-groups)/create-placement-group'
-      path: '/ec2/create-placement-group'
-      fullPath: '/ec2/create-placement-group'
-      preLoaderRoute: typeof AuthEc2placementGroupsCreatePlacementGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(route-tables)/create-route-table': {
-      id: '/_auth/ec2/(route-tables)/create-route-table'
-      path: '/ec2/create-route-table'
-      fullPath: '/ec2/create-route-table'
-      preLoaderRoute: typeof AuthEc2routeTablesCreateRouteTableRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(security-groups)/create-security-group': {
-      id: '/_auth/ec2/(security-groups)/create-security-group'
-      path: '/ec2/create-security-group'
-      fullPath: '/ec2/create-security-group'
-      preLoaderRoute: typeof AuthEc2securityGroupsCreateSecurityGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(snapshots)/create-snapshot': {
-      id: '/_auth/ec2/(snapshots)/create-snapshot'
-      path: '/ec2/create-snapshot'
-      fullPath: '/ec2/create-snapshot'
-      preLoaderRoute: typeof AuthEc2snapshotsCreateSnapshotRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(subnet)/create-subnet': {
-      id: '/_auth/ec2/(subnet)/create-subnet'
-      path: '/ec2/create-subnet'
-      fullPath: '/ec2/create-subnet'
-      preLoaderRoute: typeof AuthEc2subnetCreateSubnetRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(target-groups)/create-target-group': {
-      id: '/_auth/ec2/(target-groups)/create-target-group'
-      path: '/ec2/create-target-group'
-      fullPath: '/ec2/create-target-group'
-      preLoaderRoute: typeof AuthEc2targetGroupsCreateTargetGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/create-volume': {
-      id: '/_auth/ec2/(volumes)/create-volume'
-      path: '/ec2/create-volume'
-      fullPath: '/ec2/create-volume'
-      preLoaderRoute: typeof AuthEc2volumesCreateVolumeRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(vpc)/create-vpc': {
-      id: '/_auth/ec2/(vpc)/create-vpc'
-      path: '/ec2/create-vpc'
-      fullPath: '/ec2/create-vpc'
-      preLoaderRoute: typeof AuthEc2vpcCreateVpcRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/create-service': {
-      id: '/_auth/ecs/(clusters)/create-service'
-      path: '/ecs/create-service'
-      fullPath: '/ecs/create-service'
-      preLoaderRoute: typeof AuthEcsclustersCreateServiceRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/register-task-definition': {
-      id: '/_auth/ecs/(clusters)/register-task-definition'
-      path: '/ecs/register-task-definition'
-      fullPath: '/ecs/register-task-definition'
-      preLoaderRoute: typeof AuthEcsclustersRegisterTaskDefinitionRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/run-task': {
-      id: '/_auth/ecs/(clusters)/run-task'
-      path: '/ecs/run-task'
-      fullPath: '/ecs/run-task'
-      preLoaderRoute: typeof AuthEcsclustersRunTaskRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/task-definitions': {
-      id: '/_auth/ecs/(clusters)/task-definitions'
-      path: '/ecs/task-definitions'
-      fullPath: '/ecs/task-definitions'
-      preLoaderRoute: typeof AuthEcsclustersTaskDefinitionsRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/eks/(clusters)/create-cluster': {
-      id: '/_auth/eks/(clusters)/create-cluster'
-      path: '/eks/create-cluster'
-      fullPath: '/eks/create-cluster'
-      preLoaderRoute: typeof AuthEksclustersCreateClusterRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(groups)/create-group': {
-      id: '/_auth/iam/(groups)/create-group'
-      path: '/iam/create-group'
-      fullPath: '/iam/create-group'
-      preLoaderRoute: typeof AuthIamgroupsCreateGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(instance-profiles)/create-instance-profile': {
-      id: '/_auth/iam/(instance-profiles)/create-instance-profile'
-      path: '/iam/create-instance-profile'
-      fullPath: '/iam/create-instance-profile'
-      preLoaderRoute: typeof AuthIaminstanceProfilesCreateInstanceProfileRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(policies)/create-policy': {
-      id: '/_auth/iam/(policies)/create-policy'
-      path: '/iam/create-policy'
-      fullPath: '/iam/create-policy'
-      preLoaderRoute: typeof AuthIampoliciesCreatePolicyRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(roles)/create-role': {
-      id: '/_auth/iam/(roles)/create-role'
-      path: '/iam/create-role'
-      fullPath: '/iam/create-role'
-      preLoaderRoute: typeof AuthIamrolesCreateRoleRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(users)/create-user': {
-      id: '/_auth/iam/(users)/create-user'
-      path: '/iam/create-user'
-      fullPath: '/iam/create-user'
-      preLoaderRoute: typeof AuthIamusersCreateUserRouteImport
+    '/_auth/s3/ls/': {
+      id: '/_auth/s3/ls/'
+      path: '/s3/ls'
+      fullPath: '/s3/ls/'
+      preLoaderRoute: typeof AuthS3LsIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_auth/s3/(buckets)/create-bucket': {
@@ -1369,11 +1194,186 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthS3bucketsCreateBucketRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/s3/ls/': {
-      id: '/_auth/s3/ls/'
-      path: '/s3/ls'
-      fullPath: '/s3/ls/'
-      preLoaderRoute: typeof AuthS3LsIndexRouteImport
+    '/_auth/iam/(users)/create-user': {
+      id: '/_auth/iam/(users)/create-user'
+      path: '/iam/create-user'
+      fullPath: '/iam/create-user'
+      preLoaderRoute: typeof AuthIamusersCreateUserRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(roles)/create-role': {
+      id: '/_auth/iam/(roles)/create-role'
+      path: '/iam/create-role'
+      fullPath: '/iam/create-role'
+      preLoaderRoute: typeof AuthIamrolesCreateRoleRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(policies)/create-policy': {
+      id: '/_auth/iam/(policies)/create-policy'
+      path: '/iam/create-policy'
+      fullPath: '/iam/create-policy'
+      preLoaderRoute: typeof AuthIampoliciesCreatePolicyRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(instance-profiles)/create-instance-profile': {
+      id: '/_auth/iam/(instance-profiles)/create-instance-profile'
+      path: '/iam/create-instance-profile'
+      fullPath: '/iam/create-instance-profile'
+      preLoaderRoute: typeof AuthIaminstanceProfilesCreateInstanceProfileRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(groups)/create-group': {
+      id: '/_auth/iam/(groups)/create-group'
+      path: '/iam/create-group'
+      fullPath: '/iam/create-group'
+      preLoaderRoute: typeof AuthIamgroupsCreateGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/eks/(clusters)/create-cluster': {
+      id: '/_auth/eks/(clusters)/create-cluster'
+      path: '/eks/create-cluster'
+      fullPath: '/eks/create-cluster'
+      preLoaderRoute: typeof AuthEksclustersCreateClusterRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/task-definitions': {
+      id: '/_auth/ecs/(clusters)/task-definitions'
+      path: '/ecs/task-definitions'
+      fullPath: '/ecs/task-definitions'
+      preLoaderRoute: typeof AuthEcsclustersTaskDefinitionsRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/run-task': {
+      id: '/_auth/ecs/(clusters)/run-task'
+      path: '/ecs/run-task'
+      fullPath: '/ecs/run-task'
+      preLoaderRoute: typeof AuthEcsclustersRunTaskRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/register-task-definition': {
+      id: '/_auth/ecs/(clusters)/register-task-definition'
+      path: '/ecs/register-task-definition'
+      fullPath: '/ecs/register-task-definition'
+      preLoaderRoute: typeof AuthEcsclustersRegisterTaskDefinitionRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/create-service': {
+      id: '/_auth/ecs/(clusters)/create-service'
+      path: '/ecs/create-service'
+      fullPath: '/ecs/create-service'
+      preLoaderRoute: typeof AuthEcsclustersCreateServiceRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(vpc)/create-vpc': {
+      id: '/_auth/ec2/(vpc)/create-vpc'
+      path: '/ec2/create-vpc'
+      fullPath: '/ec2/create-vpc'
+      preLoaderRoute: typeof AuthEc2vpcCreateVpcRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/create-volume': {
+      id: '/_auth/ec2/(volumes)/create-volume'
+      path: '/ec2/create-volume'
+      fullPath: '/ec2/create-volume'
+      preLoaderRoute: typeof AuthEc2volumesCreateVolumeRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(target-groups)/create-target-group': {
+      id: '/_auth/ec2/(target-groups)/create-target-group'
+      path: '/ec2/create-target-group'
+      fullPath: '/ec2/create-target-group'
+      preLoaderRoute: typeof AuthEc2targetGroupsCreateTargetGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(subnet)/create-subnet': {
+      id: '/_auth/ec2/(subnet)/create-subnet'
+      path: '/ec2/create-subnet'
+      fullPath: '/ec2/create-subnet'
+      preLoaderRoute: typeof AuthEc2subnetCreateSubnetRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(snapshots)/create-snapshot': {
+      id: '/_auth/ec2/(snapshots)/create-snapshot'
+      path: '/ec2/create-snapshot'
+      fullPath: '/ec2/create-snapshot'
+      preLoaderRoute: typeof AuthEc2snapshotsCreateSnapshotRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(security-groups)/create-security-group': {
+      id: '/_auth/ec2/(security-groups)/create-security-group'
+      path: '/ec2/create-security-group'
+      fullPath: '/ec2/create-security-group'
+      preLoaderRoute: typeof AuthEc2securityGroupsCreateSecurityGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(route-tables)/create-route-table': {
+      id: '/_auth/ec2/(route-tables)/create-route-table'
+      path: '/ec2/create-route-table'
+      fullPath: '/ec2/create-route-table'
+      preLoaderRoute: typeof AuthEc2routeTablesCreateRouteTableRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(placement-groups)/create-placement-group': {
+      id: '/_auth/ec2/(placement-groups)/create-placement-group'
+      path: '/ec2/create-placement-group'
+      fullPath: '/ec2/create-placement-group'
+      preLoaderRoute: typeof AuthEc2placementGroupsCreatePlacementGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(nat-gateways)/create-nat-gateway': {
+      id: '/_auth/ec2/(nat-gateways)/create-nat-gateway'
+      path: '/ec2/create-nat-gateway'
+      fullPath: '/ec2/create-nat-gateway'
+      preLoaderRoute: typeof AuthEc2natGatewaysCreateNatGatewayRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(load-balancers)/create-load-balancer': {
+      id: '/_auth/ec2/(load-balancers)/create-load-balancer'
+      path: '/ec2/create-load-balancer'
+      fullPath: '/ec2/create-load-balancer'
+      preLoaderRoute: typeof AuthEc2loadBalancersCreateLoadBalancerRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(launch-templates)/create-launch-template': {
+      id: '/_auth/ec2/(launch-templates)/create-launch-template'
+      path: '/ec2/create-launch-template'
+      fullPath: '/ec2/create-launch-template'
+      preLoaderRoute: typeof AuthEc2launchTemplatesCreateLaunchTemplateRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/import-key-pair': {
+      id: '/_auth/ec2/(key)/import-key-pair'
+      path: '/ec2/import-key-pair'
+      fullPath: '/ec2/import-key-pair'
+      preLoaderRoute: typeof AuthEc2keyImportKeyPairRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/create-key-pair': {
+      id: '/_auth/ec2/(key)/create-key-pair'
+      path: '/ec2/create-key-pair'
+      fullPath: '/ec2/create-key-pair'
+      preLoaderRoute: typeof AuthEc2keyCreateKeyPairRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(internet-gateways)/create-internet-gateway': {
+      id: '/_auth/ec2/(internet-gateways)/create-internet-gateway'
+      path: '/ec2/create-internet-gateway'
+      fullPath: '/ec2/create-internet-gateway'
+      preLoaderRoute: typeof AuthEc2internetGatewaysCreateInternetGatewayRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(instances)/run-instances': {
+      id: '/_auth/ec2/(instances)/run-instances'
+      path: '/ec2/run-instances'
+      fullPath: '/ec2/run-instances'
+      preLoaderRoute: typeof AuthEc2instancesRunInstancesRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(elastic-ips)/allocate-address': {
+      id: '/_auth/ec2/(elastic-ips)/allocate-address'
+      path: '/ec2/allocate-address'
+      fullPath: '/ec2/allocate-address'
+      preLoaderRoute: typeof AuthEc2elasticIpsAllocateAddressRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_auth/s3/ls/$bucket': {
@@ -1383,319 +1383,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthS3LsBucketRouteRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/ec2/(elastic-ips)/describe-addresses/': {
-      id: '/_auth/ec2/(elastic-ips)/describe-addresses/'
-      path: '/ec2/describe-addresses'
-      fullPath: '/ec2/describe-addresses/'
-      preLoaderRoute: typeof AuthEc2elasticIpsDescribeAddressesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
+    '/_auth/s3/ls/$bucket/': {
+      id: '/_auth/s3/ls/$bucket/'
+      path: '/'
+      fullPath: '/s3/ls/$bucket/'
+      preLoaderRoute: typeof AuthS3LsBucketIndexRouteImport
+      parentRoute: typeof AuthS3LsBucketRouteRoute
     }
-    '/_auth/ec2/(elastic-ips)/describe-addresses/$id': {
-      id: '/_auth/ec2/(elastic-ips)/describe-addresses/$id'
-      path: '/ec2/describe-addresses/$id'
-      fullPath: '/ec2/describe-addresses/$id'
-      preLoaderRoute: typeof AuthEc2elasticIpsDescribeAddressesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(images)/describe-images/': {
-      id: '/_auth/ec2/(images)/describe-images/'
-      path: '/ec2/describe-images'
-      fullPath: '/ec2/describe-images/'
-      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(images)/describe-images/$id': {
-      id: '/_auth/ec2/(images)/describe-images/$id'
-      path: '/ec2/describe-images/$id'
-      fullPath: '/ec2/describe-images/$id'
-      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(instances)/describe-instances/': {
-      id: '/_auth/ec2/(instances)/describe-instances/'
-      path: '/ec2/describe-instances'
-      fullPath: '/ec2/describe-instances/'
-      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(instances)/describe-instances/$id': {
-      id: '/_auth/ec2/(instances)/describe-instances/$id'
-      path: '/ec2/describe-instances/$id'
-      fullPath: '/ec2/describe-instances/$id'
-      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/': {
-      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/'
-      path: '/ec2/describe-internet-gateways'
-      fullPath: '/ec2/describe-internet-gateways/'
-      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id': {
-      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
-      path: '/ec2/describe-internet-gateways/$id'
-      fullPath: '/ec2/describe-internet-gateways/$id'
-      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/describe-key-pairs/': {
-      id: '/_auth/ec2/(key)/describe-key-pairs/'
-      path: '/ec2/describe-key-pairs'
-      fullPath: '/ec2/describe-key-pairs/'
-      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/describe-key-pairs/$id': {
-      id: '/_auth/ec2/(key)/describe-key-pairs/$id'
-      path: '/ec2/describe-key-pairs/$id'
-      fullPath: '/ec2/describe-key-pairs/$id'
-      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(launch-templates)/describe-launch-templates/': {
-      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/'
-      path: '/ec2/describe-launch-templates'
-      fullPath: '/ec2/describe-launch-templates/'
-      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(launch-templates)/describe-launch-templates/$id': {
-      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
-      path: '/ec2/describe-launch-templates/$id'
-      fullPath: '/ec2/describe-launch-templates/$id'
-      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(load-balancers)/describe-load-balancers/': {
-      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/'
-      path: '/ec2/describe-load-balancers'
-      fullPath: '/ec2/describe-load-balancers/'
-      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(load-balancers)/describe-load-balancers/$id': {
-      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
-      path: '/ec2/describe-load-balancers/$id'
-      fullPath: '/ec2/describe-load-balancers/$id'
-      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/': {
-      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/'
-      path: '/ec2/describe-nat-gateways'
-      fullPath: '/ec2/describe-nat-gateways/'
-      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id': {
-      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
-      path: '/ec2/describe-nat-gateways/$id'
-      fullPath: '/ec2/describe-nat-gateways/$id'
-      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(placement-groups)/describe-placement-groups/': {
-      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/'
-      path: '/ec2/describe-placement-groups'
-      fullPath: '/ec2/describe-placement-groups/'
-      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(placement-groups)/describe-placement-groups/$id': {
-      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
-      path: '/ec2/describe-placement-groups/$id'
-      fullPath: '/ec2/describe-placement-groups/$id'
-      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(route-tables)/describe-route-tables/': {
-      id: '/_auth/ec2/(route-tables)/describe-route-tables/'
-      path: '/ec2/describe-route-tables'
-      fullPath: '/ec2/describe-route-tables/'
-      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(route-tables)/describe-route-tables/$id': {
-      id: '/_auth/ec2/(route-tables)/describe-route-tables/$id'
-      path: '/ec2/describe-route-tables/$id'
-      fullPath: '/ec2/describe-route-tables/$id'
-      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(security-groups)/describe-security-groups/': {
-      id: '/_auth/ec2/(security-groups)/describe-security-groups/'
-      path: '/ec2/describe-security-groups'
-      fullPath: '/ec2/describe-security-groups/'
-      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(security-groups)/describe-security-groups/$id': {
-      id: '/_auth/ec2/(security-groups)/describe-security-groups/$id'
-      path: '/ec2/describe-security-groups/$id'
-      fullPath: '/ec2/describe-security-groups/$id'
-      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(snapshots)/describe-snapshots/': {
-      id: '/_auth/ec2/(snapshots)/describe-snapshots/'
-      path: '/ec2/describe-snapshots'
-      fullPath: '/ec2/describe-snapshots/'
-      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(snapshots)/describe-snapshots/$id': {
-      id: '/_auth/ec2/(snapshots)/describe-snapshots/$id'
-      path: '/ec2/describe-snapshots/$id'
-      fullPath: '/ec2/describe-snapshots/$id'
-      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(subnet)/describe-subnets/': {
-      id: '/_auth/ec2/(subnet)/describe-subnets/'
-      path: '/ec2/describe-subnets'
-      fullPath: '/ec2/describe-subnets/'
-      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(subnet)/describe-subnets/$id': {
-      id: '/_auth/ec2/(subnet)/describe-subnets/$id'
-      path: '/ec2/describe-subnets/$id'
-      fullPath: '/ec2/describe-subnets/$id'
-      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(target-groups)/describe-target-groups/': {
-      id: '/_auth/ec2/(target-groups)/describe-target-groups/'
-      path: '/ec2/describe-target-groups'
-      fullPath: '/ec2/describe-target-groups/'
-      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(target-groups)/describe-target-groups/$id': {
-      id: '/_auth/ec2/(target-groups)/describe-target-groups/$id'
-      path: '/ec2/describe-target-groups/$id'
-      fullPath: '/ec2/describe-target-groups/$id'
-      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/describe-volumes/': {
-      id: '/_auth/ec2/(volumes)/describe-volumes/'
-      path: '/ec2/describe-volumes'
-      fullPath: '/ec2/describe-volumes/'
-      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/describe-volumes/$id': {
-      id: '/_auth/ec2/(volumes)/describe-volumes/$id'
-      path: '/ec2/describe-volumes/$id'
-      fullPath: '/ec2/describe-volumes/$id'
-      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/modify-volume/$id': {
-      id: '/_auth/ec2/(volumes)/modify-volume/$id'
-      path: '/ec2/modify-volume/$id'
-      fullPath: '/ec2/modify-volume/$id'
-      preLoaderRoute: typeof AuthEc2volumesModifyVolumeIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(vpc)/describe-vpcs/': {
-      id: '/_auth/ec2/(vpc)/describe-vpcs/'
-      path: '/ec2/describe-vpcs'
-      fullPath: '/ec2/describe-vpcs/'
-      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(vpc)/describe-vpcs/$id': {
-      id: '/_auth/ec2/(vpc)/describe-vpcs/$id'
-      path: '/ec2/describe-vpcs/$id'
-      fullPath: '/ec2/describe-vpcs/$id'
-      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecr/(repositories)/list-repositories/': {
-      id: '/_auth/ecr/(repositories)/list-repositories/'
-      path: '/ecr/list-repositories'
-      fullPath: '/ecr/list-repositories/'
-      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecr/(repositories)/list-repositories/$id': {
-      id: '/_auth/ecr/(repositories)/list-repositories/$id'
-      path: '/ecr/list-repositories/$id'
-      fullPath: '/ecr/list-repositories/$id'
-      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/list-clusters/': {
-      id: '/_auth/ecs/(clusters)/list-clusters/'
-      path: '/ecs/list-clusters'
-      fullPath: '/ecs/list-clusters/'
-      preLoaderRoute: typeof AuthEcsclustersListClustersIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/list-clusters/$clusterName': {
-      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName'
-      path: '/ecs/list-clusters/$clusterName'
-      fullPath: '/ecs/list-clusters/$clusterName'
-      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/eks/(clusters)/list-clusters/': {
-      id: '/_auth/eks/(clusters)/list-clusters/'
-      path: '/eks/list-clusters'
-      fullPath: '/eks/list-clusters/'
-      preLoaderRoute: typeof AuthEksclustersListClustersIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/eks/(clusters)/list-clusters/$clusterName': {
-      id: '/_auth/eks/(clusters)/list-clusters/$clusterName'
-      path: '/eks/list-clusters/$clusterName'
-      fullPath: '/eks/list-clusters/$clusterName'
-      preLoaderRoute: typeof AuthEksclustersListClustersClusterNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(groups)/list-groups/': {
-      id: '/_auth/iam/(groups)/list-groups/'
-      path: '/iam/list-groups'
-      fullPath: '/iam/list-groups/'
-      preLoaderRoute: typeof AuthIamgroupsListGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(groups)/list-groups/$groupName': {
-      id: '/_auth/iam/(groups)/list-groups/$groupName'
-      path: '/iam/list-groups/$groupName'
-      fullPath: '/iam/list-groups/$groupName'
-      preLoaderRoute: typeof AuthIamgroupsListGroupsGroupNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(instance-profiles)/list-instance-profiles/': {
-      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/'
-      path: '/iam/list-instance-profiles'
-      fullPath: '/iam/list-instance-profiles/'
-      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName': {
-      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
-      path: '/iam/list-instance-profiles/$instanceProfileName'
-      fullPath: '/iam/list-instance-profiles/$instanceProfileName'
-      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(policies)/list-policies/': {
-      id: '/_auth/iam/(policies)/list-policies/'
-      path: '/iam/list-policies'
-      fullPath: '/iam/list-policies/'
-      preLoaderRoute: typeof AuthIampoliciesListPoliciesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(policies)/list-policies/$policyArn': {
-      id: '/_auth/iam/(policies)/list-policies/$policyArn'
-      path: '/iam/list-policies/$policyArn'
-      fullPath: '/iam/list-policies/$policyArn'
-      preLoaderRoute: typeof AuthIampoliciesListPoliciesPolicyArnRouteImport
+    '/_auth/iam/(users)/list-users/': {
+      id: '/_auth/iam/(users)/list-users/'
+      path: '/iam/list-users'
+      fullPath: '/iam/list-users/'
+      preLoaderRoute: typeof AuthIamusersListUsersIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_auth/iam/(roles)/list-roles/': {
@@ -1705,33 +1404,159 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthIamrolesListRolesIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/iam/(roles)/list-roles/$roleName': {
-      id: '/_auth/iam/(roles)/list-roles/$roleName'
-      path: '/iam/list-roles/$roleName'
-      fullPath: '/iam/list-roles/$roleName'
-      preLoaderRoute: typeof AuthIamrolesListRolesRoleNameRouteImport
+    '/_auth/iam/(policies)/list-policies/': {
+      id: '/_auth/iam/(policies)/list-policies/'
+      path: '/iam/list-policies'
+      fullPath: '/iam/list-policies/'
+      preLoaderRoute: typeof AuthIampoliciesListPoliciesIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/iam/(users)/list-users/': {
-      id: '/_auth/iam/(users)/list-users/'
-      path: '/iam/list-users'
-      fullPath: '/iam/list-users/'
-      preLoaderRoute: typeof AuthIamusersListUsersIndexRouteImport
+    '/_auth/iam/(instance-profiles)/list-instance-profiles/': {
+      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/'
+      path: '/iam/list-instance-profiles'
+      fullPath: '/iam/list-instance-profiles/'
+      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/iam/(users)/list-users/$userName': {
-      id: '/_auth/iam/(users)/list-users/$userName'
-      path: '/iam/list-users/$userName'
-      fullPath: '/iam/list-users/$userName'
-      preLoaderRoute: typeof AuthIamusersListUsersUserNameRouteImport
+    '/_auth/iam/(groups)/list-groups/': {
+      id: '/_auth/iam/(groups)/list-groups/'
+      path: '/iam/list-groups'
+      fullPath: '/iam/list-groups/'
+      preLoaderRoute: typeof AuthIamgroupsListGroupsIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/s3/ls/$bucket/': {
-      id: '/_auth/s3/ls/$bucket/'
-      path: '/'
-      fullPath: '/s3/ls/$bucket/'
-      preLoaderRoute: typeof AuthS3LsBucketIndexRouteImport
-      parentRoute: typeof AuthS3LsBucketRouteRoute
+    '/_auth/eks/(clusters)/list-clusters/': {
+      id: '/_auth/eks/(clusters)/list-clusters/'
+      path: '/eks/list-clusters'
+      fullPath: '/eks/list-clusters/'
+      preLoaderRoute: typeof AuthEksclustersListClustersIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/list-clusters/': {
+      id: '/_auth/ecs/(clusters)/list-clusters/'
+      path: '/ecs/list-clusters'
+      fullPath: '/ecs/list-clusters/'
+      preLoaderRoute: typeof AuthEcsclustersListClustersIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecr/(repositories)/list-repositories/': {
+      id: '/_auth/ecr/(repositories)/list-repositories/'
+      path: '/ecr/list-repositories'
+      fullPath: '/ecr/list-repositories/'
+      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(vpc)/describe-vpcs/': {
+      id: '/_auth/ec2/(vpc)/describe-vpcs/'
+      path: '/ec2/describe-vpcs'
+      fullPath: '/ec2/describe-vpcs/'
+      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/describe-volumes/': {
+      id: '/_auth/ec2/(volumes)/describe-volumes/'
+      path: '/ec2/describe-volumes'
+      fullPath: '/ec2/describe-volumes/'
+      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(target-groups)/describe-target-groups/': {
+      id: '/_auth/ec2/(target-groups)/describe-target-groups/'
+      path: '/ec2/describe-target-groups'
+      fullPath: '/ec2/describe-target-groups/'
+      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(subnet)/describe-subnets/': {
+      id: '/_auth/ec2/(subnet)/describe-subnets/'
+      path: '/ec2/describe-subnets'
+      fullPath: '/ec2/describe-subnets/'
+      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(snapshots)/describe-snapshots/': {
+      id: '/_auth/ec2/(snapshots)/describe-snapshots/'
+      path: '/ec2/describe-snapshots'
+      fullPath: '/ec2/describe-snapshots/'
+      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(security-groups)/describe-security-groups/': {
+      id: '/_auth/ec2/(security-groups)/describe-security-groups/'
+      path: '/ec2/describe-security-groups'
+      fullPath: '/ec2/describe-security-groups/'
+      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(route-tables)/describe-route-tables/': {
+      id: '/_auth/ec2/(route-tables)/describe-route-tables/'
+      path: '/ec2/describe-route-tables'
+      fullPath: '/ec2/describe-route-tables/'
+      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(placement-groups)/describe-placement-groups/': {
+      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/'
+      path: '/ec2/describe-placement-groups'
+      fullPath: '/ec2/describe-placement-groups/'
+      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/': {
+      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/'
+      path: '/ec2/describe-nat-gateways'
+      fullPath: '/ec2/describe-nat-gateways/'
+      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(load-balancers)/describe-load-balancers/': {
+      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/'
+      path: '/ec2/describe-load-balancers'
+      fullPath: '/ec2/describe-load-balancers/'
+      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(launch-templates)/describe-launch-templates/': {
+      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/'
+      path: '/ec2/describe-launch-templates'
+      fullPath: '/ec2/describe-launch-templates/'
+      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/describe-key-pairs/': {
+      id: '/_auth/ec2/(key)/describe-key-pairs/'
+      path: '/ec2/describe-key-pairs'
+      fullPath: '/ec2/describe-key-pairs/'
+      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/': {
+      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/'
+      path: '/ec2/describe-internet-gateways'
+      fullPath: '/ec2/describe-internet-gateways/'
+      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(instances)/describe-instances/': {
+      id: '/_auth/ec2/(instances)/describe-instances/'
+      path: '/ec2/describe-instances'
+      fullPath: '/ec2/describe-instances/'
+      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(images)/describe-images/': {
+      id: '/_auth/ec2/(images)/describe-images/'
+      path: '/ec2/describe-images'
+      fullPath: '/ec2/describe-images/'
+      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(elastic-ips)/describe-addresses/': {
+      id: '/_auth/ec2/(elastic-ips)/describe-addresses/'
+      path: '/ec2/describe-addresses'
+      fullPath: '/ec2/describe-addresses/'
+      preLoaderRoute: typeof AuthEc2elasticIpsDescribeAddressesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
     }
     '/_auth/s3/ls/$bucket/$': {
       id: '/_auth/s3/ls/$bucket/$'
@@ -1740,11 +1565,179 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthS3LsBucketSplatRouteImport
       parentRoute: typeof AuthS3LsBucketRouteRoute
     }
-    '/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName': {
-      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName'
-      path: '/ecs/list-clusters/$clusterName/services/$serviceName'
-      fullPath: '/ecs/list-clusters/$clusterName/services/$serviceName'
-      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport
+    '/_auth/iam/(users)/list-users/$userName': {
+      id: '/_auth/iam/(users)/list-users/$userName'
+      path: '/iam/list-users/$userName'
+      fullPath: '/iam/list-users/$userName'
+      preLoaderRoute: typeof AuthIamusersListUsersUserNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(roles)/list-roles/$roleName': {
+      id: '/_auth/iam/(roles)/list-roles/$roleName'
+      path: '/iam/list-roles/$roleName'
+      fullPath: '/iam/list-roles/$roleName'
+      preLoaderRoute: typeof AuthIamrolesListRolesRoleNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(policies)/list-policies/$policyArn': {
+      id: '/_auth/iam/(policies)/list-policies/$policyArn'
+      path: '/iam/list-policies/$policyArn'
+      fullPath: '/iam/list-policies/$policyArn'
+      preLoaderRoute: typeof AuthIampoliciesListPoliciesPolicyArnRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName': {
+      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
+      path: '/iam/list-instance-profiles/$instanceProfileName'
+      fullPath: '/iam/list-instance-profiles/$instanceProfileName'
+      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(groups)/list-groups/$groupName': {
+      id: '/_auth/iam/(groups)/list-groups/$groupName'
+      path: '/iam/list-groups/$groupName'
+      fullPath: '/iam/list-groups/$groupName'
+      preLoaderRoute: typeof AuthIamgroupsListGroupsGroupNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/eks/(clusters)/list-clusters/$clusterName': {
+      id: '/_auth/eks/(clusters)/list-clusters/$clusterName'
+      path: '/eks/list-clusters/$clusterName'
+      fullPath: '/eks/list-clusters/$clusterName'
+      preLoaderRoute: typeof AuthEksclustersListClustersClusterNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/list-clusters/$clusterName': {
+      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName'
+      path: '/ecs/list-clusters/$clusterName'
+      fullPath: '/ecs/list-clusters/$clusterName'
+      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecr/(repositories)/list-repositories/$id': {
+      id: '/_auth/ecr/(repositories)/list-repositories/$id'
+      path: '/ecr/list-repositories/$id'
+      fullPath: '/ecr/list-repositories/$id'
+      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(vpc)/describe-vpcs/$id': {
+      id: '/_auth/ec2/(vpc)/describe-vpcs/$id'
+      path: '/ec2/describe-vpcs/$id'
+      fullPath: '/ec2/describe-vpcs/$id'
+      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/modify-volume/$id': {
+      id: '/_auth/ec2/(volumes)/modify-volume/$id'
+      path: '/ec2/modify-volume/$id'
+      fullPath: '/ec2/modify-volume/$id'
+      preLoaderRoute: typeof AuthEc2volumesModifyVolumeIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/describe-volumes/$id': {
+      id: '/_auth/ec2/(volumes)/describe-volumes/$id'
+      path: '/ec2/describe-volumes/$id'
+      fullPath: '/ec2/describe-volumes/$id'
+      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(target-groups)/describe-target-groups/$id': {
+      id: '/_auth/ec2/(target-groups)/describe-target-groups/$id'
+      path: '/ec2/describe-target-groups/$id'
+      fullPath: '/ec2/describe-target-groups/$id'
+      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(subnet)/describe-subnets/$id': {
+      id: '/_auth/ec2/(subnet)/describe-subnets/$id'
+      path: '/ec2/describe-subnets/$id'
+      fullPath: '/ec2/describe-subnets/$id'
+      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(snapshots)/describe-snapshots/$id': {
+      id: '/_auth/ec2/(snapshots)/describe-snapshots/$id'
+      path: '/ec2/describe-snapshots/$id'
+      fullPath: '/ec2/describe-snapshots/$id'
+      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(security-groups)/describe-security-groups/$id': {
+      id: '/_auth/ec2/(security-groups)/describe-security-groups/$id'
+      path: '/ec2/describe-security-groups/$id'
+      fullPath: '/ec2/describe-security-groups/$id'
+      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(route-tables)/describe-route-tables/$id': {
+      id: '/_auth/ec2/(route-tables)/describe-route-tables/$id'
+      path: '/ec2/describe-route-tables/$id'
+      fullPath: '/ec2/describe-route-tables/$id'
+      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(placement-groups)/describe-placement-groups/$id': {
+      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
+      path: '/ec2/describe-placement-groups/$id'
+      fullPath: '/ec2/describe-placement-groups/$id'
+      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id': {
+      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
+      path: '/ec2/describe-nat-gateways/$id'
+      fullPath: '/ec2/describe-nat-gateways/$id'
+      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(load-balancers)/describe-load-balancers/$id': {
+      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
+      path: '/ec2/describe-load-balancers/$id'
+      fullPath: '/ec2/describe-load-balancers/$id'
+      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(launch-templates)/describe-launch-templates/$id': {
+      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
+      path: '/ec2/describe-launch-templates/$id'
+      fullPath: '/ec2/describe-launch-templates/$id'
+      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/describe-key-pairs/$id': {
+      id: '/_auth/ec2/(key)/describe-key-pairs/$id'
+      path: '/ec2/describe-key-pairs/$id'
+      fullPath: '/ec2/describe-key-pairs/$id'
+      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id': {
+      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
+      path: '/ec2/describe-internet-gateways/$id'
+      fullPath: '/ec2/describe-internet-gateways/$id'
+      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(instances)/describe-instances/$id': {
+      id: '/_auth/ec2/(instances)/describe-instances/$id'
+      path: '/ec2/describe-instances/$id'
+      fullPath: '/ec2/describe-instances/$id'
+      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(images)/describe-images/$id': {
+      id: '/_auth/ec2/(images)/describe-images/$id'
+      path: '/ec2/describe-images/$id'
+      fullPath: '/ec2/describe-images/$id'
+      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(elastic-ips)/describe-addresses/$id': {
+      id: '/_auth/ec2/(elastic-ips)/describe-addresses/$id'
+      path: '/ec2/describe-addresses/$id'
+      fullPath: '/ec2/describe-addresses/$id'
+      preLoaderRoute: typeof AuthEc2elasticIpsDescribeAddressesIdRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId': {
@@ -1752,6 +1745,13 @@ declare module '@tanstack/react-router' {
       path: '/ecs/list-clusters/$clusterName/tasks/$taskId'
       fullPath: '/ecs/list-clusters/$clusterName/tasks/$taskId'
       preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName': {
+      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName'
+      path: '/ecs/list-clusters/$clusterName/services/$serviceName'
+      fullPath: '/ecs/list-clusters/$clusterName/services/$serviceName'
+      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport
       parentRoute: typeof AuthRouteRoute
     }
   }

--- a/spinifex/services/spinifexui/frontend/src/routeTree.gen.ts
+++ b/spinifex/services/spinifexui/frontend/src/routeTree.gen.ts
@@ -9,101 +9,101 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthRouteRouteImport } from './routes/_auth/route'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthIndexRouteImport } from './routes/_auth/index'
 import { Route as AuthNodesRouteImport } from './routes/_auth/nodes'
 import { Route as AuthS3ServiceMetricsRouteImport } from './routes/_auth/s3/service-metrics'
-import { Route as AuthS3LsIndexRouteImport } from './routes/_auth/s3/ls/index'
-import { Route as AuthS3bucketsCreateBucketRouteImport } from './routes/_auth/s3/(buckets)/create-bucket'
-import { Route as AuthIamusersCreateUserRouteImport } from './routes/_auth/iam/(users)/create-user'
-import { Route as AuthIamrolesCreateRoleRouteImport } from './routes/_auth/iam/(roles)/create-role'
-import { Route as AuthIampoliciesCreatePolicyRouteImport } from './routes/_auth/iam/(policies)/create-policy'
-import { Route as AuthIaminstanceProfilesCreateInstanceProfileRouteImport } from './routes/_auth/iam/(instance-profiles)/create-instance-profile'
-import { Route as AuthIamgroupsCreateGroupRouteImport } from './routes/_auth/iam/(groups)/create-group'
-import { Route as AuthEksclustersCreateClusterRouteImport } from './routes/_auth/eks/(clusters)/create-cluster'
-import { Route as AuthEcsclustersTaskDefinitionsRouteImport } from './routes/_auth/ecs/(clusters)/task-definitions'
-import { Route as AuthEcsclustersRunTaskRouteImport } from './routes/_auth/ecs/(clusters)/run-task'
-import { Route as AuthEcsclustersRegisterTaskDefinitionRouteImport } from './routes/_auth/ecs/(clusters)/register-task-definition'
-import { Route as AuthEcsclustersCreateServiceRouteImport } from './routes/_auth/ecs/(clusters)/create-service'
-import { Route as AuthEc2vpcCreateVpcRouteImport } from './routes/_auth/ec2/(vpc)/create-vpc'
-import { Route as AuthEc2volumesCreateVolumeRouteImport } from './routes/_auth/ec2/(volumes)/create-volume'
-import { Route as AuthEc2targetGroupsCreateTargetGroupRouteImport } from './routes/_auth/ec2/(target-groups)/create-target-group'
-import { Route as AuthEc2subnetCreateSubnetRouteImport } from './routes/_auth/ec2/(subnet)/create-subnet'
-import { Route as AuthEc2snapshotsCreateSnapshotRouteImport } from './routes/_auth/ec2/(snapshots)/create-snapshot'
-import { Route as AuthEc2securityGroupsCreateSecurityGroupRouteImport } from './routes/_auth/ec2/(security-groups)/create-security-group'
-import { Route as AuthEc2routeTablesCreateRouteTableRouteImport } from './routes/_auth/ec2/(route-tables)/create-route-table'
-import { Route as AuthEc2placementGroupsCreatePlacementGroupRouteImport } from './routes/_auth/ec2/(placement-groups)/create-placement-group'
-import { Route as AuthEc2natGatewaysCreateNatGatewayRouteImport } from './routes/_auth/ec2/(nat-gateways)/create-nat-gateway'
-import { Route as AuthEc2loadBalancersCreateLoadBalancerRouteImport } from './routes/_auth/ec2/(load-balancers)/create-load-balancer'
-import { Route as AuthEc2launchTemplatesCreateLaunchTemplateRouteImport } from './routes/_auth/ec2/(launch-templates)/create-launch-template'
-import { Route as AuthEc2keyImportKeyPairRouteImport } from './routes/_auth/ec2/(key)/import-key-pair'
-import { Route as AuthEc2keyCreateKeyPairRouteImport } from './routes/_auth/ec2/(key)/create-key-pair'
-import { Route as AuthEc2internetGatewaysCreateInternetGatewayRouteImport } from './routes/_auth/ec2/(internet-gateways)/create-internet-gateway'
-import { Route as AuthEc2instancesRunInstancesRouteImport } from './routes/_auth/ec2/(instances)/run-instances'
 import { Route as AuthEc2elasticIpsAllocateAddressRouteImport } from './routes/_auth/ec2/(elastic-ips)/allocate-address'
+import { Route as AuthEc2instancesRunInstancesRouteImport } from './routes/_auth/ec2/(instances)/run-instances'
+import { Route as AuthEc2internetGatewaysCreateInternetGatewayRouteImport } from './routes/_auth/ec2/(internet-gateways)/create-internet-gateway'
+import { Route as AuthEc2keyCreateKeyPairRouteImport } from './routes/_auth/ec2/(key)/create-key-pair'
+import { Route as AuthEc2keyImportKeyPairRouteImport } from './routes/_auth/ec2/(key)/import-key-pair'
+import { Route as AuthEc2launchTemplatesCreateLaunchTemplateRouteImport } from './routes/_auth/ec2/(launch-templates)/create-launch-template'
+import { Route as AuthEc2loadBalancersCreateLoadBalancerRouteImport } from './routes/_auth/ec2/(load-balancers)/create-load-balancer'
+import { Route as AuthEc2natGatewaysCreateNatGatewayRouteImport } from './routes/_auth/ec2/(nat-gateways)/create-nat-gateway'
+import { Route as AuthEc2placementGroupsCreatePlacementGroupRouteImport } from './routes/_auth/ec2/(placement-groups)/create-placement-group'
+import { Route as AuthEc2routeTablesCreateRouteTableRouteImport } from './routes/_auth/ec2/(route-tables)/create-route-table'
+import { Route as AuthEc2securityGroupsCreateSecurityGroupRouteImport } from './routes/_auth/ec2/(security-groups)/create-security-group'
+import { Route as AuthEc2snapshotsCreateSnapshotRouteImport } from './routes/_auth/ec2/(snapshots)/create-snapshot'
+import { Route as AuthEc2subnetCreateSubnetRouteImport } from './routes/_auth/ec2/(subnet)/create-subnet'
+import { Route as AuthEc2targetGroupsCreateTargetGroupRouteImport } from './routes/_auth/ec2/(target-groups)/create-target-group'
+import { Route as AuthEc2volumesCreateVolumeRouteImport } from './routes/_auth/ec2/(volumes)/create-volume'
+import { Route as AuthEc2vpcCreateVpcRouteImport } from './routes/_auth/ec2/(vpc)/create-vpc'
+import { Route as AuthEcsclustersCreateServiceRouteImport } from './routes/_auth/ecs/(clusters)/create-service'
+import { Route as AuthEcsclustersRegisterTaskDefinitionRouteImport } from './routes/_auth/ecs/(clusters)/register-task-definition'
+import { Route as AuthEcsclustersRunTaskRouteImport } from './routes/_auth/ecs/(clusters)/run-task'
+import { Route as AuthEcsclustersTaskDefinitionsRouteImport } from './routes/_auth/ecs/(clusters)/task-definitions'
+import { Route as AuthEksclustersCreateClusterRouteImport } from './routes/_auth/eks/(clusters)/create-cluster'
+import { Route as AuthIamgroupsCreateGroupRouteImport } from './routes/_auth/iam/(groups)/create-group'
+import { Route as AuthIaminstanceProfilesCreateInstanceProfileRouteImport } from './routes/_auth/iam/(instance-profiles)/create-instance-profile'
+import { Route as AuthIampoliciesCreatePolicyRouteImport } from './routes/_auth/iam/(policies)/create-policy'
+import { Route as AuthIamrolesCreateRoleRouteImport } from './routes/_auth/iam/(roles)/create-role'
+import { Route as AuthIamusersCreateUserRouteImport } from './routes/_auth/iam/(users)/create-user'
+import { Route as AuthS3bucketsCreateBucketRouteImport } from './routes/_auth/s3/(buckets)/create-bucket'
+import { Route as AuthS3LsIndexRouteImport } from './routes/_auth/s3/ls/index'
 import { Route as AuthS3LsBucketRouteRouteImport } from './routes/_auth/s3/ls/$bucket/route'
-import { Route as AuthS3LsBucketIndexRouteImport } from './routes/_auth/s3/ls/$bucket/index'
-import { Route as AuthIamusersListUsersIndexRouteImport } from './routes/_auth/iam/(users)/list-users/index'
-import { Route as AuthIamrolesListRolesIndexRouteImport } from './routes/_auth/iam/(roles)/list-roles/index'
-import { Route as AuthIampoliciesListPoliciesIndexRouteImport } from './routes/_auth/iam/(policies)/list-policies/index'
-import { Route as AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/index'
-import { Route as AuthIamgroupsListGroupsIndexRouteImport } from './routes/_auth/iam/(groups)/list-groups/index'
-import { Route as AuthEksclustersListClustersIndexRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/index'
-import { Route as AuthEcsclustersListClustersIndexRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/index'
-import { Route as AuthEcrrepositoriesListRepositoriesIndexRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/index'
-import { Route as AuthEc2vpcDescribeVpcsIndexRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/index'
-import { Route as AuthEc2volumesDescribeVolumesIndexRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/index'
-import { Route as AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/index'
-import { Route as AuthEc2subnetDescribeSubnetsIndexRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/index'
-import { Route as AuthEc2snapshotsDescribeSnapshotsIndexRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/index'
-import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/index'
-import { Route as AuthEc2routeTablesDescribeRouteTablesIndexRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/index'
-import { Route as AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/index'
-import { Route as AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/index'
-import { Route as AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/index'
-import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/index'
-import { Route as AuthEc2keyDescribeKeyPairsIndexRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/index'
-import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/index'
-import { Route as AuthEc2instancesDescribeInstancesIndexRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/index'
-import { Route as AuthEc2imagesDescribeImagesIndexRouteImport } from './routes/_auth/ec2/(images)/describe-images/index'
 import { Route as AuthEc2elasticIpsDescribeAddressesIndexRouteImport } from './routes/_auth/ec2/(elastic-ips)/describe-addresses/index'
-import { Route as AuthS3LsBucketSplatRouteImport } from './routes/_auth/s3/ls/$bucket/$'
-import { Route as AuthIamusersListUsersUserNameRouteImport } from './routes/_auth/iam/(users)/list-users/$userName'
-import { Route as AuthIamrolesListRolesRoleNameRouteImport } from './routes/_auth/iam/(roles)/list-roles/$roleName'
-import { Route as AuthIampoliciesListPoliciesPolicyArnRouteImport } from './routes/_auth/iam/(policies)/list-policies/$policyArn'
-import { Route as AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
-import { Route as AuthIamgroupsListGroupsGroupNameRouteImport } from './routes/_auth/iam/(groups)/list-groups/$groupName'
-import { Route as AuthEksclustersListClustersClusterNameRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/$clusterName'
-import { Route as AuthEcsclustersListClustersClusterNameRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName'
-import { Route as AuthEcrrepositoriesListRepositoriesIdRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/$id'
-import { Route as AuthEc2vpcDescribeVpcsIdRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/$id'
-import { Route as AuthEc2volumesModifyVolumeIdRouteImport } from './routes/_auth/ec2/(volumes)/modify-volume/$id'
-import { Route as AuthEc2volumesDescribeVolumesIdRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/$id'
-import { Route as AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/$id'
-import { Route as AuthEc2subnetDescribeSubnetsIdRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/$id'
-import { Route as AuthEc2snapshotsDescribeSnapshotsIdRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/$id'
-import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/$id'
-import { Route as AuthEc2routeTablesDescribeRouteTablesIdRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/$id'
-import { Route as AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
-import { Route as AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
-import { Route as AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
-import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
-import { Route as AuthEc2keyDescribeKeyPairsIdRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/$id'
-import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
-import { Route as AuthEc2instancesDescribeInstancesIdRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/$id'
-import { Route as AuthEc2imagesDescribeImagesIdRouteImport } from './routes/_auth/ec2/(images)/describe-images/$id'
 import { Route as AuthEc2elasticIpsDescribeAddressesIdRouteImport } from './routes/_auth/ec2/(elastic-ips)/describe-addresses/$id'
-import { Route as AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId'
+import { Route as AuthEc2imagesDescribeImagesIndexRouteImport } from './routes/_auth/ec2/(images)/describe-images/index'
+import { Route as AuthEc2imagesDescribeImagesIdRouteImport } from './routes/_auth/ec2/(images)/describe-images/$id'
+import { Route as AuthEc2instancesDescribeInstancesIndexRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/index'
+import { Route as AuthEc2instancesDescribeInstancesIdRouteImport } from './routes/_auth/ec2/(instances)/describe-instances/$id'
+import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/index'
+import { Route as AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport } from './routes/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
+import { Route as AuthEc2keyDescribeKeyPairsIndexRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/index'
+import { Route as AuthEc2keyDescribeKeyPairsIdRouteImport } from './routes/_auth/ec2/(key)/describe-key-pairs/$id'
+import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/index'
+import { Route as AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport } from './routes/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
+import { Route as AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/index'
+import { Route as AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport } from './routes/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
+import { Route as AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/index'
+import { Route as AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport } from './routes/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
+import { Route as AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/index'
+import { Route as AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport } from './routes/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
+import { Route as AuthEc2routeTablesDescribeRouteTablesIndexRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/index'
+import { Route as AuthEc2routeTablesDescribeRouteTablesIdRouteImport } from './routes/_auth/ec2/(route-tables)/describe-route-tables/$id'
+import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/index'
+import { Route as AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport } from './routes/_auth/ec2/(security-groups)/describe-security-groups/$id'
+import { Route as AuthEc2snapshotsDescribeSnapshotsIndexRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/index'
+import { Route as AuthEc2snapshotsDescribeSnapshotsIdRouteImport } from './routes/_auth/ec2/(snapshots)/describe-snapshots/$id'
+import { Route as AuthEc2subnetDescribeSubnetsIndexRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/index'
+import { Route as AuthEc2subnetDescribeSubnetsIdRouteImport } from './routes/_auth/ec2/(subnet)/describe-subnets/$id'
+import { Route as AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/index'
+import { Route as AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport } from './routes/_auth/ec2/(target-groups)/describe-target-groups/$id'
+import { Route as AuthEc2volumesDescribeVolumesIndexRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/index'
+import { Route as AuthEc2volumesDescribeVolumesIdRouteImport } from './routes/_auth/ec2/(volumes)/describe-volumes/$id'
+import { Route as AuthEc2volumesModifyVolumeIdRouteImport } from './routes/_auth/ec2/(volumes)/modify-volume/$id'
+import { Route as AuthEc2vpcDescribeVpcsIndexRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/index'
+import { Route as AuthEc2vpcDescribeVpcsIdRouteImport } from './routes/_auth/ec2/(vpc)/describe-vpcs/$id'
+import { Route as AuthEcrrepositoriesListRepositoriesIndexRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/index'
+import { Route as AuthEcrrepositoriesListRepositoriesIdRouteImport } from './routes/_auth/ecr/(repositories)/list-repositories/$id'
+import { Route as AuthEcsclustersListClustersIndexRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/index'
+import { Route as AuthEcsclustersListClustersClusterNameRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName'
+import { Route as AuthEksclustersListClustersIndexRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/index'
+import { Route as AuthEksclustersListClustersClusterNameRouteImport } from './routes/_auth/eks/(clusters)/list-clusters/$clusterName'
+import { Route as AuthIamgroupsListGroupsIndexRouteImport } from './routes/_auth/iam/(groups)/list-groups/index'
+import { Route as AuthIamgroupsListGroupsGroupNameRouteImport } from './routes/_auth/iam/(groups)/list-groups/$groupName'
+import { Route as AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/index'
+import { Route as AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport } from './routes/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
+import { Route as AuthIampoliciesListPoliciesIndexRouteImport } from './routes/_auth/iam/(policies)/list-policies/index'
+import { Route as AuthIampoliciesListPoliciesPolicyArnRouteImport } from './routes/_auth/iam/(policies)/list-policies/$policyArn'
+import { Route as AuthIamrolesListRolesIndexRouteImport } from './routes/_auth/iam/(roles)/list-roles/index'
+import { Route as AuthIamrolesListRolesRoleNameRouteImport } from './routes/_auth/iam/(roles)/list-roles/$roleName'
+import { Route as AuthIamusersListUsersIndexRouteImport } from './routes/_auth/iam/(users)/list-users/index'
+import { Route as AuthIamusersListUsersUserNameRouteImport } from './routes/_auth/iam/(users)/list-users/$userName'
+import { Route as AuthS3LsBucketIndexRouteImport } from './routes/_auth/s3/ls/$bucket/index'
+import { Route as AuthS3LsBucketSplatRouteImport } from './routes/_auth/s3/ls/$bucket/$'
 import { Route as AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName'
+import { Route as AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport } from './routes/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId'
 
+const AuthRouteRoute = AuthRouteRouteImport.update({
+  id: '/_auth',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AuthRouteRoute = AuthRouteRouteImport.update({
-  id: '/_auth',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthIndexRoute = AuthIndexRouteImport.update({
@@ -121,153 +121,10 @@ const AuthS3ServiceMetricsRoute = AuthS3ServiceMetricsRouteImport.update({
   path: '/s3/service-metrics',
   getParentRoute: () => AuthRouteRoute,
 } as any)
-const AuthS3LsIndexRoute = AuthS3LsIndexRouteImport.update({
-  id: '/s3/ls/',
-  path: '/s3/ls/',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthS3bucketsCreateBucketRoute =
-  AuthS3bucketsCreateBucketRouteImport.update({
-    id: '/s3/(buckets)/create-bucket',
-    path: '/s3/create-bucket',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIamusersCreateUserRoute = AuthIamusersCreateUserRouteImport.update({
-  id: '/iam/(users)/create-user',
-  path: '/iam/create-user',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthIamrolesCreateRoleRoute = AuthIamrolesCreateRoleRouteImport.update({
-  id: '/iam/(roles)/create-role',
-  path: '/iam/create-role',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthIampoliciesCreatePolicyRoute =
-  AuthIampoliciesCreatePolicyRouteImport.update({
-    id: '/iam/(policies)/create-policy',
-    path: '/iam/create-policy',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIaminstanceProfilesCreateInstanceProfileRoute =
-  AuthIaminstanceProfilesCreateInstanceProfileRouteImport.update({
-    id: '/iam/(instance-profiles)/create-instance-profile',
-    path: '/iam/create-instance-profile',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIamgroupsCreateGroupRoute =
-  AuthIamgroupsCreateGroupRouteImport.update({
-    id: '/iam/(groups)/create-group',
-    path: '/iam/create-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEksclustersCreateClusterRoute =
-  AuthEksclustersCreateClusterRouteImport.update({
-    id: '/eks/(clusters)/create-cluster',
-    path: '/eks/create-cluster',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersTaskDefinitionsRoute =
-  AuthEcsclustersTaskDefinitionsRouteImport.update({
-    id: '/ecs/(clusters)/task-definitions',
-    path: '/ecs/task-definitions',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersRunTaskRoute = AuthEcsclustersRunTaskRouteImport.update({
-  id: '/ecs/(clusters)/run-task',
-  path: '/ecs/run-task',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEcsclustersRegisterTaskDefinitionRoute =
-  AuthEcsclustersRegisterTaskDefinitionRouteImport.update({
-    id: '/ecs/(clusters)/register-task-definition',
-    path: '/ecs/register-task-definition',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersCreateServiceRoute =
-  AuthEcsclustersCreateServiceRouteImport.update({
-    id: '/ecs/(clusters)/create-service',
-    path: '/ecs/create-service',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2vpcCreateVpcRoute = AuthEc2vpcCreateVpcRouteImport.update({
-  id: '/ec2/(vpc)/create-vpc',
-  path: '/ec2/create-vpc',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEc2volumesCreateVolumeRoute =
-  AuthEc2volumesCreateVolumeRouteImport.update({
-    id: '/ec2/(volumes)/create-volume',
-    path: '/ec2/create-volume',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2targetGroupsCreateTargetGroupRoute =
-  AuthEc2targetGroupsCreateTargetGroupRouteImport.update({
-    id: '/ec2/(target-groups)/create-target-group',
-    path: '/ec2/create-target-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2subnetCreateSubnetRoute =
-  AuthEc2subnetCreateSubnetRouteImport.update({
-    id: '/ec2/(subnet)/create-subnet',
-    path: '/ec2/create-subnet',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2snapshotsCreateSnapshotRoute =
-  AuthEc2snapshotsCreateSnapshotRouteImport.update({
-    id: '/ec2/(snapshots)/create-snapshot',
-    path: '/ec2/create-snapshot',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2securityGroupsCreateSecurityGroupRoute =
-  AuthEc2securityGroupsCreateSecurityGroupRouteImport.update({
-    id: '/ec2/(security-groups)/create-security-group',
-    path: '/ec2/create-security-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2routeTablesCreateRouteTableRoute =
-  AuthEc2routeTablesCreateRouteTableRouteImport.update({
-    id: '/ec2/(route-tables)/create-route-table',
-    path: '/ec2/create-route-table',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2placementGroupsCreatePlacementGroupRoute =
-  AuthEc2placementGroupsCreatePlacementGroupRouteImport.update({
-    id: '/ec2/(placement-groups)/create-placement-group',
-    path: '/ec2/create-placement-group',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2natGatewaysCreateNatGatewayRoute =
-  AuthEc2natGatewaysCreateNatGatewayRouteImport.update({
-    id: '/ec2/(nat-gateways)/create-nat-gateway',
-    path: '/ec2/create-nat-gateway',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2loadBalancersCreateLoadBalancerRoute =
-  AuthEc2loadBalancersCreateLoadBalancerRouteImport.update({
-    id: '/ec2/(load-balancers)/create-load-balancer',
-    path: '/ec2/create-load-balancer',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2launchTemplatesCreateLaunchTemplateRoute =
-  AuthEc2launchTemplatesCreateLaunchTemplateRouteImport.update({
-    id: '/ec2/(launch-templates)/create-launch-template',
-    path: '/ec2/create-launch-template',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2keyImportKeyPairRoute = AuthEc2keyImportKeyPairRouteImport.update({
-  id: '/ec2/(key)/import-key-pair',
-  path: '/ec2/import-key-pair',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEc2keyCreateKeyPairRoute = AuthEc2keyCreateKeyPairRouteImport.update({
-  id: '/ec2/(key)/create-key-pair',
-  path: '/ec2/create-key-pair',
-  getParentRoute: () => AuthRouteRoute,
-} as any)
-const AuthEc2internetGatewaysCreateInternetGatewayRoute =
-  AuthEc2internetGatewaysCreateInternetGatewayRouteImport.update({
-    id: '/ec2/(internet-gateways)/create-internet-gateway',
-    path: '/ec2/create-internet-gateway',
+const AuthEc2elasticIpsAllocateAddressRoute =
+  AuthEc2elasticIpsAllocateAddressRouteImport.update({
+    id: '/ec2/(elastic-ips)/allocate-address',
+    path: '/ec2/allocate-address',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 const AuthEc2instancesRunInstancesRoute =
@@ -276,152 +133,170 @@ const AuthEc2instancesRunInstancesRoute =
     path: '/ec2/run-instances',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2elasticIpsAllocateAddressRoute =
-  AuthEc2elasticIpsAllocateAddressRouteImport.update({
-    id: '/ec2/(elastic-ips)/allocate-address',
-    path: '/ec2/allocate-address',
+const AuthEc2internetGatewaysCreateInternetGatewayRoute =
+  AuthEc2internetGatewaysCreateInternetGatewayRouteImport.update({
+    id: '/ec2/(internet-gateways)/create-internet-gateway',
+    path: '/ec2/create-internet-gateway',
     getParentRoute: () => AuthRouteRoute,
   } as any)
+const AuthEc2keyCreateKeyPairRoute = AuthEc2keyCreateKeyPairRouteImport.update({
+  id: '/ec2/(key)/create-key-pair',
+  path: '/ec2/create-key-pair',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEc2keyImportKeyPairRoute = AuthEc2keyImportKeyPairRouteImport.update({
+  id: '/ec2/(key)/import-key-pair',
+  path: '/ec2/import-key-pair',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEc2launchTemplatesCreateLaunchTemplateRoute =
+  AuthEc2launchTemplatesCreateLaunchTemplateRouteImport.update({
+    id: '/ec2/(launch-templates)/create-launch-template',
+    path: '/ec2/create-launch-template',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2loadBalancersCreateLoadBalancerRoute =
+  AuthEc2loadBalancersCreateLoadBalancerRouteImport.update({
+    id: '/ec2/(load-balancers)/create-load-balancer',
+    path: '/ec2/create-load-balancer',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2natGatewaysCreateNatGatewayRoute =
+  AuthEc2natGatewaysCreateNatGatewayRouteImport.update({
+    id: '/ec2/(nat-gateways)/create-nat-gateway',
+    path: '/ec2/create-nat-gateway',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2placementGroupsCreatePlacementGroupRoute =
+  AuthEc2placementGroupsCreatePlacementGroupRouteImport.update({
+    id: '/ec2/(placement-groups)/create-placement-group',
+    path: '/ec2/create-placement-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2routeTablesCreateRouteTableRoute =
+  AuthEc2routeTablesCreateRouteTableRouteImport.update({
+    id: '/ec2/(route-tables)/create-route-table',
+    path: '/ec2/create-route-table',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2securityGroupsCreateSecurityGroupRoute =
+  AuthEc2securityGroupsCreateSecurityGroupRouteImport.update({
+    id: '/ec2/(security-groups)/create-security-group',
+    path: '/ec2/create-security-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2snapshotsCreateSnapshotRoute =
+  AuthEc2snapshotsCreateSnapshotRouteImport.update({
+    id: '/ec2/(snapshots)/create-snapshot',
+    path: '/ec2/create-snapshot',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2subnetCreateSubnetRoute =
+  AuthEc2subnetCreateSubnetRouteImport.update({
+    id: '/ec2/(subnet)/create-subnet',
+    path: '/ec2/create-subnet',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2targetGroupsCreateTargetGroupRoute =
+  AuthEc2targetGroupsCreateTargetGroupRouteImport.update({
+    id: '/ec2/(target-groups)/create-target-group',
+    path: '/ec2/create-target-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2volumesCreateVolumeRoute =
+  AuthEc2volumesCreateVolumeRouteImport.update({
+    id: '/ec2/(volumes)/create-volume',
+    path: '/ec2/create-volume',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2vpcCreateVpcRoute = AuthEc2vpcCreateVpcRouteImport.update({
+  id: '/ec2/(vpc)/create-vpc',
+  path: '/ec2/create-vpc',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEcsclustersCreateServiceRoute =
+  AuthEcsclustersCreateServiceRouteImport.update({
+    id: '/ecs/(clusters)/create-service',
+    path: '/ecs/create-service',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersRegisterTaskDefinitionRoute =
+  AuthEcsclustersRegisterTaskDefinitionRouteImport.update({
+    id: '/ecs/(clusters)/register-task-definition',
+    path: '/ecs/register-task-definition',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersRunTaskRoute = AuthEcsclustersRunTaskRouteImport.update({
+  id: '/ecs/(clusters)/run-task',
+  path: '/ecs/run-task',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthEcsclustersTaskDefinitionsRoute =
+  AuthEcsclustersTaskDefinitionsRouteImport.update({
+    id: '/ecs/(clusters)/task-definitions',
+    path: '/ecs/task-definitions',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEksclustersCreateClusterRoute =
+  AuthEksclustersCreateClusterRouteImport.update({
+    id: '/eks/(clusters)/create-cluster',
+    path: '/eks/create-cluster',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIamgroupsCreateGroupRoute =
+  AuthIamgroupsCreateGroupRouteImport.update({
+    id: '/iam/(groups)/create-group',
+    path: '/iam/create-group',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIaminstanceProfilesCreateInstanceProfileRoute =
+  AuthIaminstanceProfilesCreateInstanceProfileRouteImport.update({
+    id: '/iam/(instance-profiles)/create-instance-profile',
+    path: '/iam/create-instance-profile',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIampoliciesCreatePolicyRoute =
+  AuthIampoliciesCreatePolicyRouteImport.update({
+    id: '/iam/(policies)/create-policy',
+    path: '/iam/create-policy',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIamrolesCreateRoleRoute = AuthIamrolesCreateRoleRouteImport.update({
+  id: '/iam/(roles)/create-role',
+  path: '/iam/create-role',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthIamusersCreateUserRoute = AuthIamusersCreateUserRouteImport.update({
+  id: '/iam/(users)/create-user',
+  path: '/iam/create-user',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthS3bucketsCreateBucketRoute =
+  AuthS3bucketsCreateBucketRouteImport.update({
+    id: '/s3/(buckets)/create-bucket',
+    path: '/s3/create-bucket',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthS3LsIndexRoute = AuthS3LsIndexRouteImport.update({
+  id: '/s3/ls/',
+  path: '/s3/ls/',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
 const AuthS3LsBucketRouteRoute = AuthS3LsBucketRouteRouteImport.update({
   id: '/s3/ls/$bucket',
   path: '/s3/ls/$bucket',
   getParentRoute: () => AuthRouteRoute,
 } as any)
-const AuthS3LsBucketIndexRoute = AuthS3LsBucketIndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => AuthS3LsBucketRouteRoute,
-} as any)
-const AuthIamusersListUsersIndexRoute =
-  AuthIamusersListUsersIndexRouteImport.update({
-    id: '/iam/(users)/list-users/',
-    path: '/iam/list-users/',
+const AuthEc2elasticIpsDescribeAddressesIndexRoute =
+  AuthEc2elasticIpsDescribeAddressesIndexRouteImport.update({
+    id: '/ec2/(elastic-ips)/describe-addresses/',
+    path: '/ec2/describe-addresses/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIamrolesListRolesIndexRoute =
-  AuthIamrolesListRolesIndexRouteImport.update({
-    id: '/iam/(roles)/list-roles/',
-    path: '/iam/list-roles/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIampoliciesListPoliciesIndexRoute =
-  AuthIampoliciesListPoliciesIndexRouteImport.update({
-    id: '/iam/(policies)/list-policies/',
-    path: '/iam/list-policies/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIaminstanceProfilesListInstanceProfilesIndexRoute =
-  AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport.update({
-    id: '/iam/(instance-profiles)/list-instance-profiles/',
-    path: '/iam/list-instance-profiles/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthIamgroupsListGroupsIndexRoute =
-  AuthIamgroupsListGroupsIndexRouteImport.update({
-    id: '/iam/(groups)/list-groups/',
-    path: '/iam/list-groups/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEksclustersListClustersIndexRoute =
-  AuthEksclustersListClustersIndexRouteImport.update({
-    id: '/eks/(clusters)/list-clusters/',
-    path: '/eks/list-clusters/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersListClustersIndexRoute =
-  AuthEcsclustersListClustersIndexRouteImport.update({
-    id: '/ecs/(clusters)/list-clusters/',
-    path: '/ecs/list-clusters/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcrrepositoriesListRepositoriesIndexRoute =
-  AuthEcrrepositoriesListRepositoriesIndexRouteImport.update({
-    id: '/ecr/(repositories)/list-repositories/',
-    path: '/ecr/list-repositories/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2vpcDescribeVpcsIndexRoute =
-  AuthEc2vpcDescribeVpcsIndexRouteImport.update({
-    id: '/ec2/(vpc)/describe-vpcs/',
-    path: '/ec2/describe-vpcs/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2volumesDescribeVolumesIndexRoute =
-  AuthEc2volumesDescribeVolumesIndexRouteImport.update({
-    id: '/ec2/(volumes)/describe-volumes/',
-    path: '/ec2/describe-volumes/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2targetGroupsDescribeTargetGroupsIndexRoute =
-  AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport.update({
-    id: '/ec2/(target-groups)/describe-target-groups/',
-    path: '/ec2/describe-target-groups/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2subnetDescribeSubnetsIndexRoute =
-  AuthEc2subnetDescribeSubnetsIndexRouteImport.update({
-    id: '/ec2/(subnet)/describe-subnets/',
-    path: '/ec2/describe-subnets/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2snapshotsDescribeSnapshotsIndexRoute =
-  AuthEc2snapshotsDescribeSnapshotsIndexRouteImport.update({
-    id: '/ec2/(snapshots)/describe-snapshots/',
-    path: '/ec2/describe-snapshots/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2securityGroupsDescribeSecurityGroupsIndexRoute =
-  AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport.update({
-    id: '/ec2/(security-groups)/describe-security-groups/',
-    path: '/ec2/describe-security-groups/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2routeTablesDescribeRouteTablesIndexRoute =
-  AuthEc2routeTablesDescribeRouteTablesIndexRouteImport.update({
-    id: '/ec2/(route-tables)/describe-route-tables/',
-    path: '/ec2/describe-route-tables/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2placementGroupsDescribePlacementGroupsIndexRoute =
-  AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport.update({
-    id: '/ec2/(placement-groups)/describe-placement-groups/',
-    path: '/ec2/describe-placement-groups/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2natGatewaysDescribeNatGatewaysIndexRoute =
-  AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport.update({
-    id: '/ec2/(nat-gateways)/describe-nat-gateways/',
-    path: '/ec2/describe-nat-gateways/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2loadBalancersDescribeLoadBalancersIndexRoute =
-  AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport.update({
-    id: '/ec2/(load-balancers)/describe-load-balancers/',
-    path: '/ec2/describe-load-balancers/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRoute =
-  AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport.update({
-    id: '/ec2/(launch-templates)/describe-launch-templates/',
-    path: '/ec2/describe-launch-templates/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2keyDescribeKeyPairsIndexRoute =
-  AuthEc2keyDescribeKeyPairsIndexRouteImport.update({
-    id: '/ec2/(key)/describe-key-pairs/',
-    path: '/ec2/describe-key-pairs/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2internetGatewaysDescribeInternetGatewaysIndexRoute =
-  AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport.update({
-    id: '/ec2/(internet-gateways)/describe-internet-gateways/',
-    path: '/ec2/describe-internet-gateways/',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2instancesDescribeInstancesIndexRoute =
-  AuthEc2instancesDescribeInstancesIndexRouteImport.update({
-    id: '/ec2/(instances)/describe-instances/',
-    path: '/ec2/describe-instances/',
+const AuthEc2elasticIpsDescribeAddressesIdRoute =
+  AuthEc2elasticIpsDescribeAddressesIdRouteImport.update({
+    id: '/ec2/(elastic-ips)/describe-addresses/$id',
+    path: '/ec2/describe-addresses/$id',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 const AuthEc2imagesDescribeImagesIndexRoute =
@@ -430,33 +305,238 @@ const AuthEc2imagesDescribeImagesIndexRoute =
     path: '/ec2/describe-images/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2elasticIpsDescribeAddressesIndexRoute =
-  AuthEc2elasticIpsDescribeAddressesIndexRouteImport.update({
-    id: '/ec2/(elastic-ips)/describe-addresses/',
-    path: '/ec2/describe-addresses/',
+const AuthEc2imagesDescribeImagesIdRoute =
+  AuthEc2imagesDescribeImagesIdRouteImport.update({
+    id: '/ec2/(images)/describe-images/$id',
+    path: '/ec2/describe-images/$id',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthS3LsBucketSplatRoute = AuthS3LsBucketSplatRouteImport.update({
-  id: '/$',
-  path: '/$',
-  getParentRoute: () => AuthS3LsBucketRouteRoute,
-} as any)
-const AuthIamusersListUsersUserNameRoute =
-  AuthIamusersListUsersUserNameRouteImport.update({
-    id: '/iam/(users)/list-users/$userName',
-    path: '/iam/list-users/$userName',
+const AuthEc2instancesDescribeInstancesIndexRoute =
+  AuthEc2instancesDescribeInstancesIndexRouteImport.update({
+    id: '/ec2/(instances)/describe-instances/',
+    path: '/ec2/describe-instances/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIamrolesListRolesRoleNameRoute =
-  AuthIamrolesListRolesRoleNameRouteImport.update({
-    id: '/iam/(roles)/list-roles/$roleName',
-    path: '/iam/list-roles/$roleName',
+const AuthEc2instancesDescribeInstancesIdRoute =
+  AuthEc2instancesDescribeInstancesIdRouteImport.update({
+    id: '/ec2/(instances)/describe-instances/$id',
+    path: '/ec2/describe-instances/$id',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthIampoliciesListPoliciesPolicyArnRoute =
-  AuthIampoliciesListPoliciesPolicyArnRouteImport.update({
-    id: '/iam/(policies)/list-policies/$policyArn',
-    path: '/iam/list-policies/$policyArn',
+const AuthEc2internetGatewaysDescribeInternetGatewaysIndexRoute =
+  AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport.update({
+    id: '/ec2/(internet-gateways)/describe-internet-gateways/',
+    path: '/ec2/describe-internet-gateways/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2internetGatewaysDescribeInternetGatewaysIdRoute =
+  AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport.update({
+    id: '/ec2/(internet-gateways)/describe-internet-gateways/$id',
+    path: '/ec2/describe-internet-gateways/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2keyDescribeKeyPairsIndexRoute =
+  AuthEc2keyDescribeKeyPairsIndexRouteImport.update({
+    id: '/ec2/(key)/describe-key-pairs/',
+    path: '/ec2/describe-key-pairs/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2keyDescribeKeyPairsIdRoute =
+  AuthEc2keyDescribeKeyPairsIdRouteImport.update({
+    id: '/ec2/(key)/describe-key-pairs/$id',
+    path: '/ec2/describe-key-pairs/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRoute =
+  AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport.update({
+    id: '/ec2/(launch-templates)/describe-launch-templates/',
+    path: '/ec2/describe-launch-templates/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2launchTemplatesDescribeLaunchTemplatesIdRoute =
+  AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport.update({
+    id: '/ec2/(launch-templates)/describe-launch-templates/$id',
+    path: '/ec2/describe-launch-templates/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2loadBalancersDescribeLoadBalancersIndexRoute =
+  AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport.update({
+    id: '/ec2/(load-balancers)/describe-load-balancers/',
+    path: '/ec2/describe-load-balancers/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2loadBalancersDescribeLoadBalancersIdRoute =
+  AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport.update({
+    id: '/ec2/(load-balancers)/describe-load-balancers/$id',
+    path: '/ec2/describe-load-balancers/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2natGatewaysDescribeNatGatewaysIndexRoute =
+  AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport.update({
+    id: '/ec2/(nat-gateways)/describe-nat-gateways/',
+    path: '/ec2/describe-nat-gateways/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2natGatewaysDescribeNatGatewaysIdRoute =
+  AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport.update({
+    id: '/ec2/(nat-gateways)/describe-nat-gateways/$id',
+    path: '/ec2/describe-nat-gateways/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2placementGroupsDescribePlacementGroupsIndexRoute =
+  AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport.update({
+    id: '/ec2/(placement-groups)/describe-placement-groups/',
+    path: '/ec2/describe-placement-groups/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2placementGroupsDescribePlacementGroupsIdRoute =
+  AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport.update({
+    id: '/ec2/(placement-groups)/describe-placement-groups/$id',
+    path: '/ec2/describe-placement-groups/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2routeTablesDescribeRouteTablesIndexRoute =
+  AuthEc2routeTablesDescribeRouteTablesIndexRouteImport.update({
+    id: '/ec2/(route-tables)/describe-route-tables/',
+    path: '/ec2/describe-route-tables/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2routeTablesDescribeRouteTablesIdRoute =
+  AuthEc2routeTablesDescribeRouteTablesIdRouteImport.update({
+    id: '/ec2/(route-tables)/describe-route-tables/$id',
+    path: '/ec2/describe-route-tables/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2securityGroupsDescribeSecurityGroupsIndexRoute =
+  AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport.update({
+    id: '/ec2/(security-groups)/describe-security-groups/',
+    path: '/ec2/describe-security-groups/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2securityGroupsDescribeSecurityGroupsIdRoute =
+  AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport.update({
+    id: '/ec2/(security-groups)/describe-security-groups/$id',
+    path: '/ec2/describe-security-groups/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2snapshotsDescribeSnapshotsIndexRoute =
+  AuthEc2snapshotsDescribeSnapshotsIndexRouteImport.update({
+    id: '/ec2/(snapshots)/describe-snapshots/',
+    path: '/ec2/describe-snapshots/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2snapshotsDescribeSnapshotsIdRoute =
+  AuthEc2snapshotsDescribeSnapshotsIdRouteImport.update({
+    id: '/ec2/(snapshots)/describe-snapshots/$id',
+    path: '/ec2/describe-snapshots/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2subnetDescribeSubnetsIndexRoute =
+  AuthEc2subnetDescribeSubnetsIndexRouteImport.update({
+    id: '/ec2/(subnet)/describe-subnets/',
+    path: '/ec2/describe-subnets/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2subnetDescribeSubnetsIdRoute =
+  AuthEc2subnetDescribeSubnetsIdRouteImport.update({
+    id: '/ec2/(subnet)/describe-subnets/$id',
+    path: '/ec2/describe-subnets/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2targetGroupsDescribeTargetGroupsIndexRoute =
+  AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport.update({
+    id: '/ec2/(target-groups)/describe-target-groups/',
+    path: '/ec2/describe-target-groups/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2targetGroupsDescribeTargetGroupsIdRoute =
+  AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport.update({
+    id: '/ec2/(target-groups)/describe-target-groups/$id',
+    path: '/ec2/describe-target-groups/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2volumesDescribeVolumesIndexRoute =
+  AuthEc2volumesDescribeVolumesIndexRouteImport.update({
+    id: '/ec2/(volumes)/describe-volumes/',
+    path: '/ec2/describe-volumes/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2volumesDescribeVolumesIdRoute =
+  AuthEc2volumesDescribeVolumesIdRouteImport.update({
+    id: '/ec2/(volumes)/describe-volumes/$id',
+    path: '/ec2/describe-volumes/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2volumesModifyVolumeIdRoute =
+  AuthEc2volumesModifyVolumeIdRouteImport.update({
+    id: '/ec2/(volumes)/modify-volume/$id',
+    path: '/ec2/modify-volume/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2vpcDescribeVpcsIndexRoute =
+  AuthEc2vpcDescribeVpcsIndexRouteImport.update({
+    id: '/ec2/(vpc)/describe-vpcs/',
+    path: '/ec2/describe-vpcs/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEc2vpcDescribeVpcsIdRoute =
+  AuthEc2vpcDescribeVpcsIdRouteImport.update({
+    id: '/ec2/(vpc)/describe-vpcs/$id',
+    path: '/ec2/describe-vpcs/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcrrepositoriesListRepositoriesIndexRoute =
+  AuthEcrrepositoriesListRepositoriesIndexRouteImport.update({
+    id: '/ecr/(repositories)/list-repositories/',
+    path: '/ecr/list-repositories/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcrrepositoriesListRepositoriesIdRoute =
+  AuthEcrrepositoriesListRepositoriesIdRouteImport.update({
+    id: '/ecr/(repositories)/list-repositories/$id',
+    path: '/ecr/list-repositories/$id',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersListClustersIndexRoute =
+  AuthEcsclustersListClustersIndexRouteImport.update({
+    id: '/ecs/(clusters)/list-clusters/',
+    path: '/ecs/list-clusters/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEcsclustersListClustersClusterNameRoute =
+  AuthEcsclustersListClustersClusterNameRouteImport.update({
+    id: '/ecs/(clusters)/list-clusters/$clusterName',
+    path: '/ecs/list-clusters/$clusterName',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEksclustersListClustersIndexRoute =
+  AuthEksclustersListClustersIndexRouteImport.update({
+    id: '/eks/(clusters)/list-clusters/',
+    path: '/eks/list-clusters/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthEksclustersListClustersClusterNameRoute =
+  AuthEksclustersListClustersClusterNameRouteImport.update({
+    id: '/eks/(clusters)/list-clusters/$clusterName',
+    path: '/eks/list-clusters/$clusterName',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIamgroupsListGroupsIndexRoute =
+  AuthIamgroupsListGroupsIndexRouteImport.update({
+    id: '/iam/(groups)/list-groups/',
+    path: '/iam/list-groups/',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIamgroupsListGroupsGroupNameRoute =
+  AuthIamgroupsListGroupsGroupNameRouteImport.update({
+    id: '/iam/(groups)/list-groups/$groupName',
+    path: '/iam/list-groups/$groupName',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
+const AuthIaminstanceProfilesListInstanceProfilesIndexRoute =
+  AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport.update({
+    id: '/iam/(instance-profiles)/list-instance-profiles/',
+    path: '/iam/list-instance-profiles/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 const AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRoute =
@@ -467,142 +547,62 @@ const AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRoute =
       getParentRoute: () => AuthRouteRoute,
     } as any,
   )
-const AuthIamgroupsListGroupsGroupNameRoute =
-  AuthIamgroupsListGroupsGroupNameRouteImport.update({
-    id: '/iam/(groups)/list-groups/$groupName',
-    path: '/iam/list-groups/$groupName',
+const AuthIampoliciesListPoliciesIndexRoute =
+  AuthIampoliciesListPoliciesIndexRouteImport.update({
+    id: '/iam/(policies)/list-policies/',
+    path: '/iam/list-policies/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEksclustersListClustersClusterNameRoute =
-  AuthEksclustersListClustersClusterNameRouteImport.update({
-    id: '/eks/(clusters)/list-clusters/$clusterName',
-    path: '/eks/list-clusters/$clusterName',
+const AuthIampoliciesListPoliciesPolicyArnRoute =
+  AuthIampoliciesListPoliciesPolicyArnRouteImport.update({
+    id: '/iam/(policies)/list-policies/$policyArn',
+    path: '/iam/list-policies/$policyArn',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEcsclustersListClustersClusterNameRoute =
-  AuthEcsclustersListClustersClusterNameRouteImport.update({
-    id: '/ecs/(clusters)/list-clusters/$clusterName',
-    path: '/ecs/list-clusters/$clusterName',
+const AuthIamrolesListRolesIndexRoute =
+  AuthIamrolesListRolesIndexRouteImport.update({
+    id: '/iam/(roles)/list-roles/',
+    path: '/iam/list-roles/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEcrrepositoriesListRepositoriesIdRoute =
-  AuthEcrrepositoriesListRepositoriesIdRouteImport.update({
-    id: '/ecr/(repositories)/list-repositories/$id',
-    path: '/ecr/list-repositories/$id',
+const AuthIamrolesListRolesRoleNameRoute =
+  AuthIamrolesListRolesRoleNameRouteImport.update({
+    id: '/iam/(roles)/list-roles/$roleName',
+    path: '/iam/list-roles/$roleName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2vpcDescribeVpcsIdRoute =
-  AuthEc2vpcDescribeVpcsIdRouteImport.update({
-    id: '/ec2/(vpc)/describe-vpcs/$id',
-    path: '/ec2/describe-vpcs/$id',
+const AuthIamusersListUsersIndexRoute =
+  AuthIamusersListUsersIndexRouteImport.update({
+    id: '/iam/(users)/list-users/',
+    path: '/iam/list-users/',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2volumesModifyVolumeIdRoute =
-  AuthEc2volumesModifyVolumeIdRouteImport.update({
-    id: '/ec2/(volumes)/modify-volume/$id',
-    path: '/ec2/modify-volume/$id',
+const AuthIamusersListUsersUserNameRoute =
+  AuthIamusersListUsersUserNameRouteImport.update({
+    id: '/iam/(users)/list-users/$userName',
+    path: '/iam/list-users/$userName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
-const AuthEc2volumesDescribeVolumesIdRoute =
-  AuthEc2volumesDescribeVolumesIdRouteImport.update({
-    id: '/ec2/(volumes)/describe-volumes/$id',
-    path: '/ec2/describe-volumes/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2targetGroupsDescribeTargetGroupsIdRoute =
-  AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport.update({
-    id: '/ec2/(target-groups)/describe-target-groups/$id',
-    path: '/ec2/describe-target-groups/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2subnetDescribeSubnetsIdRoute =
-  AuthEc2subnetDescribeSubnetsIdRouteImport.update({
-    id: '/ec2/(subnet)/describe-subnets/$id',
-    path: '/ec2/describe-subnets/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2snapshotsDescribeSnapshotsIdRoute =
-  AuthEc2snapshotsDescribeSnapshotsIdRouteImport.update({
-    id: '/ec2/(snapshots)/describe-snapshots/$id',
-    path: '/ec2/describe-snapshots/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2securityGroupsDescribeSecurityGroupsIdRoute =
-  AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport.update({
-    id: '/ec2/(security-groups)/describe-security-groups/$id',
-    path: '/ec2/describe-security-groups/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2routeTablesDescribeRouteTablesIdRoute =
-  AuthEc2routeTablesDescribeRouteTablesIdRouteImport.update({
-    id: '/ec2/(route-tables)/describe-route-tables/$id',
-    path: '/ec2/describe-route-tables/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2placementGroupsDescribePlacementGroupsIdRoute =
-  AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport.update({
-    id: '/ec2/(placement-groups)/describe-placement-groups/$id',
-    path: '/ec2/describe-placement-groups/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2natGatewaysDescribeNatGatewaysIdRoute =
-  AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport.update({
-    id: '/ec2/(nat-gateways)/describe-nat-gateways/$id',
-    path: '/ec2/describe-nat-gateways/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2loadBalancersDescribeLoadBalancersIdRoute =
-  AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport.update({
-    id: '/ec2/(load-balancers)/describe-load-balancers/$id',
-    path: '/ec2/describe-load-balancers/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2launchTemplatesDescribeLaunchTemplatesIdRoute =
-  AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport.update({
-    id: '/ec2/(launch-templates)/describe-launch-templates/$id',
-    path: '/ec2/describe-launch-templates/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2keyDescribeKeyPairsIdRoute =
-  AuthEc2keyDescribeKeyPairsIdRouteImport.update({
-    id: '/ec2/(key)/describe-key-pairs/$id',
-    path: '/ec2/describe-key-pairs/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2internetGatewaysDescribeInternetGatewaysIdRoute =
-  AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport.update({
-    id: '/ec2/(internet-gateways)/describe-internet-gateways/$id',
-    path: '/ec2/describe-internet-gateways/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2instancesDescribeInstancesIdRoute =
-  AuthEc2instancesDescribeInstancesIdRouteImport.update({
-    id: '/ec2/(instances)/describe-instances/$id',
-    path: '/ec2/describe-instances/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2imagesDescribeImagesIdRoute =
-  AuthEc2imagesDescribeImagesIdRouteImport.update({
-    id: '/ec2/(images)/describe-images/$id',
-    path: '/ec2/describe-images/$id',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEc2elasticIpsDescribeAddressesIdRoute =
-  AuthEc2elasticIpsDescribeAddressesIdRouteImport.update({
-    id: '/ec2/(elastic-ips)/describe-addresses/$id',
-    path: '/ec2/describe-addresses/$id',
+const AuthS3LsBucketIndexRoute = AuthS3LsBucketIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthS3LsBucketRouteRoute,
+} as any)
+const AuthS3LsBucketSplatRoute = AuthS3LsBucketSplatRouteImport.update({
+  id: '/$',
+  path: '/$',
+  getParentRoute: () => AuthS3LsBucketRouteRoute,
+} as any)
+const AuthEcsclustersListClustersClusterNameServicesServiceNameRoute =
+  AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport.update({
+    id: '/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName',
+    path: '/ecs/list-clusters/$clusterName/services/$serviceName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 const AuthEcsclustersListClustersClusterNameTasksTaskIdRoute =
   AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport.update({
     id: '/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId',
     path: '/ecs/list-clusters/$clusterName/tasks/$taskId',
-    getParentRoute: () => AuthRouteRoute,
-  } as any)
-const AuthEcsclustersListClustersClusterNameServicesServiceNameRoute =
-  AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport.update({
-    id: '/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName',
-    path: '/ecs/list-clusters/$clusterName/services/$serviceName',
     getParentRoute: () => AuthRouteRoute,
   } as any)
 
@@ -1145,18 +1145,18 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/_auth': {
       id: '/_auth'
       path: ''
       fullPath: '/'
       preLoaderRoute: typeof AuthRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_auth/': {
@@ -1180,186 +1180,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthS3ServiceMetricsRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/s3/ls/': {
-      id: '/_auth/s3/ls/'
-      path: '/s3/ls'
-      fullPath: '/s3/ls/'
-      preLoaderRoute: typeof AuthS3LsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/s3/(buckets)/create-bucket': {
-      id: '/_auth/s3/(buckets)/create-bucket'
-      path: '/s3/create-bucket'
-      fullPath: '/s3/create-bucket'
-      preLoaderRoute: typeof AuthS3bucketsCreateBucketRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(users)/create-user': {
-      id: '/_auth/iam/(users)/create-user'
-      path: '/iam/create-user'
-      fullPath: '/iam/create-user'
-      preLoaderRoute: typeof AuthIamusersCreateUserRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(roles)/create-role': {
-      id: '/_auth/iam/(roles)/create-role'
-      path: '/iam/create-role'
-      fullPath: '/iam/create-role'
-      preLoaderRoute: typeof AuthIamrolesCreateRoleRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(policies)/create-policy': {
-      id: '/_auth/iam/(policies)/create-policy'
-      path: '/iam/create-policy'
-      fullPath: '/iam/create-policy'
-      preLoaderRoute: typeof AuthIampoliciesCreatePolicyRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(instance-profiles)/create-instance-profile': {
-      id: '/_auth/iam/(instance-profiles)/create-instance-profile'
-      path: '/iam/create-instance-profile'
-      fullPath: '/iam/create-instance-profile'
-      preLoaderRoute: typeof AuthIaminstanceProfilesCreateInstanceProfileRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(groups)/create-group': {
-      id: '/_auth/iam/(groups)/create-group'
-      path: '/iam/create-group'
-      fullPath: '/iam/create-group'
-      preLoaderRoute: typeof AuthIamgroupsCreateGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/eks/(clusters)/create-cluster': {
-      id: '/_auth/eks/(clusters)/create-cluster'
-      path: '/eks/create-cluster'
-      fullPath: '/eks/create-cluster'
-      preLoaderRoute: typeof AuthEksclustersCreateClusterRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/task-definitions': {
-      id: '/_auth/ecs/(clusters)/task-definitions'
-      path: '/ecs/task-definitions'
-      fullPath: '/ecs/task-definitions'
-      preLoaderRoute: typeof AuthEcsclustersTaskDefinitionsRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/run-task': {
-      id: '/_auth/ecs/(clusters)/run-task'
-      path: '/ecs/run-task'
-      fullPath: '/ecs/run-task'
-      preLoaderRoute: typeof AuthEcsclustersRunTaskRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/register-task-definition': {
-      id: '/_auth/ecs/(clusters)/register-task-definition'
-      path: '/ecs/register-task-definition'
-      fullPath: '/ecs/register-task-definition'
-      preLoaderRoute: typeof AuthEcsclustersRegisterTaskDefinitionRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/create-service': {
-      id: '/_auth/ecs/(clusters)/create-service'
-      path: '/ecs/create-service'
-      fullPath: '/ecs/create-service'
-      preLoaderRoute: typeof AuthEcsclustersCreateServiceRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(vpc)/create-vpc': {
-      id: '/_auth/ec2/(vpc)/create-vpc'
-      path: '/ec2/create-vpc'
-      fullPath: '/ec2/create-vpc'
-      preLoaderRoute: typeof AuthEc2vpcCreateVpcRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/create-volume': {
-      id: '/_auth/ec2/(volumes)/create-volume'
-      path: '/ec2/create-volume'
-      fullPath: '/ec2/create-volume'
-      preLoaderRoute: typeof AuthEc2volumesCreateVolumeRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(target-groups)/create-target-group': {
-      id: '/_auth/ec2/(target-groups)/create-target-group'
-      path: '/ec2/create-target-group'
-      fullPath: '/ec2/create-target-group'
-      preLoaderRoute: typeof AuthEc2targetGroupsCreateTargetGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(subnet)/create-subnet': {
-      id: '/_auth/ec2/(subnet)/create-subnet'
-      path: '/ec2/create-subnet'
-      fullPath: '/ec2/create-subnet'
-      preLoaderRoute: typeof AuthEc2subnetCreateSubnetRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(snapshots)/create-snapshot': {
-      id: '/_auth/ec2/(snapshots)/create-snapshot'
-      path: '/ec2/create-snapshot'
-      fullPath: '/ec2/create-snapshot'
-      preLoaderRoute: typeof AuthEc2snapshotsCreateSnapshotRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(security-groups)/create-security-group': {
-      id: '/_auth/ec2/(security-groups)/create-security-group'
-      path: '/ec2/create-security-group'
-      fullPath: '/ec2/create-security-group'
-      preLoaderRoute: typeof AuthEc2securityGroupsCreateSecurityGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(route-tables)/create-route-table': {
-      id: '/_auth/ec2/(route-tables)/create-route-table'
-      path: '/ec2/create-route-table'
-      fullPath: '/ec2/create-route-table'
-      preLoaderRoute: typeof AuthEc2routeTablesCreateRouteTableRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(placement-groups)/create-placement-group': {
-      id: '/_auth/ec2/(placement-groups)/create-placement-group'
-      path: '/ec2/create-placement-group'
-      fullPath: '/ec2/create-placement-group'
-      preLoaderRoute: typeof AuthEc2placementGroupsCreatePlacementGroupRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(nat-gateways)/create-nat-gateway': {
-      id: '/_auth/ec2/(nat-gateways)/create-nat-gateway'
-      path: '/ec2/create-nat-gateway'
-      fullPath: '/ec2/create-nat-gateway'
-      preLoaderRoute: typeof AuthEc2natGatewaysCreateNatGatewayRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(load-balancers)/create-load-balancer': {
-      id: '/_auth/ec2/(load-balancers)/create-load-balancer'
-      path: '/ec2/create-load-balancer'
-      fullPath: '/ec2/create-load-balancer'
-      preLoaderRoute: typeof AuthEc2loadBalancersCreateLoadBalancerRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(launch-templates)/create-launch-template': {
-      id: '/_auth/ec2/(launch-templates)/create-launch-template'
-      path: '/ec2/create-launch-template'
-      fullPath: '/ec2/create-launch-template'
-      preLoaderRoute: typeof AuthEc2launchTemplatesCreateLaunchTemplateRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/import-key-pair': {
-      id: '/_auth/ec2/(key)/import-key-pair'
-      path: '/ec2/import-key-pair'
-      fullPath: '/ec2/import-key-pair'
-      preLoaderRoute: typeof AuthEc2keyImportKeyPairRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/create-key-pair': {
-      id: '/_auth/ec2/(key)/create-key-pair'
-      path: '/ec2/create-key-pair'
-      fullPath: '/ec2/create-key-pair'
-      preLoaderRoute: typeof AuthEc2keyCreateKeyPairRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(internet-gateways)/create-internet-gateway': {
-      id: '/_auth/ec2/(internet-gateways)/create-internet-gateway'
-      path: '/ec2/create-internet-gateway'
-      fullPath: '/ec2/create-internet-gateway'
-      preLoaderRoute: typeof AuthEc2internetGatewaysCreateInternetGatewayRouteImport
+    '/_auth/ec2/(elastic-ips)/allocate-address': {
+      id: '/_auth/ec2/(elastic-ips)/allocate-address'
+      path: '/ec2/allocate-address'
+      fullPath: '/ec2/allocate-address'
+      preLoaderRoute: typeof AuthEc2elasticIpsAllocateAddressRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_auth/ec2/(instances)/run-instances': {
@@ -1369,11 +1194,186 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthEc2instancesRunInstancesRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/ec2/(elastic-ips)/allocate-address': {
-      id: '/_auth/ec2/(elastic-ips)/allocate-address'
-      path: '/ec2/allocate-address'
-      fullPath: '/ec2/allocate-address'
-      preLoaderRoute: typeof AuthEc2elasticIpsAllocateAddressRouteImport
+    '/_auth/ec2/(internet-gateways)/create-internet-gateway': {
+      id: '/_auth/ec2/(internet-gateways)/create-internet-gateway'
+      path: '/ec2/create-internet-gateway'
+      fullPath: '/ec2/create-internet-gateway'
+      preLoaderRoute: typeof AuthEc2internetGatewaysCreateInternetGatewayRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/create-key-pair': {
+      id: '/_auth/ec2/(key)/create-key-pair'
+      path: '/ec2/create-key-pair'
+      fullPath: '/ec2/create-key-pair'
+      preLoaderRoute: typeof AuthEc2keyCreateKeyPairRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/import-key-pair': {
+      id: '/_auth/ec2/(key)/import-key-pair'
+      path: '/ec2/import-key-pair'
+      fullPath: '/ec2/import-key-pair'
+      preLoaderRoute: typeof AuthEc2keyImportKeyPairRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(launch-templates)/create-launch-template': {
+      id: '/_auth/ec2/(launch-templates)/create-launch-template'
+      path: '/ec2/create-launch-template'
+      fullPath: '/ec2/create-launch-template'
+      preLoaderRoute: typeof AuthEc2launchTemplatesCreateLaunchTemplateRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(load-balancers)/create-load-balancer': {
+      id: '/_auth/ec2/(load-balancers)/create-load-balancer'
+      path: '/ec2/create-load-balancer'
+      fullPath: '/ec2/create-load-balancer'
+      preLoaderRoute: typeof AuthEc2loadBalancersCreateLoadBalancerRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(nat-gateways)/create-nat-gateway': {
+      id: '/_auth/ec2/(nat-gateways)/create-nat-gateway'
+      path: '/ec2/create-nat-gateway'
+      fullPath: '/ec2/create-nat-gateway'
+      preLoaderRoute: typeof AuthEc2natGatewaysCreateNatGatewayRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(placement-groups)/create-placement-group': {
+      id: '/_auth/ec2/(placement-groups)/create-placement-group'
+      path: '/ec2/create-placement-group'
+      fullPath: '/ec2/create-placement-group'
+      preLoaderRoute: typeof AuthEc2placementGroupsCreatePlacementGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(route-tables)/create-route-table': {
+      id: '/_auth/ec2/(route-tables)/create-route-table'
+      path: '/ec2/create-route-table'
+      fullPath: '/ec2/create-route-table'
+      preLoaderRoute: typeof AuthEc2routeTablesCreateRouteTableRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(security-groups)/create-security-group': {
+      id: '/_auth/ec2/(security-groups)/create-security-group'
+      path: '/ec2/create-security-group'
+      fullPath: '/ec2/create-security-group'
+      preLoaderRoute: typeof AuthEc2securityGroupsCreateSecurityGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(snapshots)/create-snapshot': {
+      id: '/_auth/ec2/(snapshots)/create-snapshot'
+      path: '/ec2/create-snapshot'
+      fullPath: '/ec2/create-snapshot'
+      preLoaderRoute: typeof AuthEc2snapshotsCreateSnapshotRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(subnet)/create-subnet': {
+      id: '/_auth/ec2/(subnet)/create-subnet'
+      path: '/ec2/create-subnet'
+      fullPath: '/ec2/create-subnet'
+      preLoaderRoute: typeof AuthEc2subnetCreateSubnetRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(target-groups)/create-target-group': {
+      id: '/_auth/ec2/(target-groups)/create-target-group'
+      path: '/ec2/create-target-group'
+      fullPath: '/ec2/create-target-group'
+      preLoaderRoute: typeof AuthEc2targetGroupsCreateTargetGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/create-volume': {
+      id: '/_auth/ec2/(volumes)/create-volume'
+      path: '/ec2/create-volume'
+      fullPath: '/ec2/create-volume'
+      preLoaderRoute: typeof AuthEc2volumesCreateVolumeRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(vpc)/create-vpc': {
+      id: '/_auth/ec2/(vpc)/create-vpc'
+      path: '/ec2/create-vpc'
+      fullPath: '/ec2/create-vpc'
+      preLoaderRoute: typeof AuthEc2vpcCreateVpcRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/create-service': {
+      id: '/_auth/ecs/(clusters)/create-service'
+      path: '/ecs/create-service'
+      fullPath: '/ecs/create-service'
+      preLoaderRoute: typeof AuthEcsclustersCreateServiceRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/register-task-definition': {
+      id: '/_auth/ecs/(clusters)/register-task-definition'
+      path: '/ecs/register-task-definition'
+      fullPath: '/ecs/register-task-definition'
+      preLoaderRoute: typeof AuthEcsclustersRegisterTaskDefinitionRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/run-task': {
+      id: '/_auth/ecs/(clusters)/run-task'
+      path: '/ecs/run-task'
+      fullPath: '/ecs/run-task'
+      preLoaderRoute: typeof AuthEcsclustersRunTaskRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/task-definitions': {
+      id: '/_auth/ecs/(clusters)/task-definitions'
+      path: '/ecs/task-definitions'
+      fullPath: '/ecs/task-definitions'
+      preLoaderRoute: typeof AuthEcsclustersTaskDefinitionsRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/eks/(clusters)/create-cluster': {
+      id: '/_auth/eks/(clusters)/create-cluster'
+      path: '/eks/create-cluster'
+      fullPath: '/eks/create-cluster'
+      preLoaderRoute: typeof AuthEksclustersCreateClusterRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(groups)/create-group': {
+      id: '/_auth/iam/(groups)/create-group'
+      path: '/iam/create-group'
+      fullPath: '/iam/create-group'
+      preLoaderRoute: typeof AuthIamgroupsCreateGroupRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(instance-profiles)/create-instance-profile': {
+      id: '/_auth/iam/(instance-profiles)/create-instance-profile'
+      path: '/iam/create-instance-profile'
+      fullPath: '/iam/create-instance-profile'
+      preLoaderRoute: typeof AuthIaminstanceProfilesCreateInstanceProfileRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(policies)/create-policy': {
+      id: '/_auth/iam/(policies)/create-policy'
+      path: '/iam/create-policy'
+      fullPath: '/iam/create-policy'
+      preLoaderRoute: typeof AuthIampoliciesCreatePolicyRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(roles)/create-role': {
+      id: '/_auth/iam/(roles)/create-role'
+      path: '/iam/create-role'
+      fullPath: '/iam/create-role'
+      preLoaderRoute: typeof AuthIamrolesCreateRoleRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(users)/create-user': {
+      id: '/_auth/iam/(users)/create-user'
+      path: '/iam/create-user'
+      fullPath: '/iam/create-user'
+      preLoaderRoute: typeof AuthIamusersCreateUserRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/s3/(buckets)/create-bucket': {
+      id: '/_auth/s3/(buckets)/create-bucket'
+      path: '/s3/create-bucket'
+      fullPath: '/s3/create-bucket'
+      preLoaderRoute: typeof AuthS3bucketsCreateBucketRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/s3/ls/': {
+      id: '/_auth/s3/ls/'
+      path: '/s3/ls'
+      fullPath: '/s3/ls/'
+      preLoaderRoute: typeof AuthS3LsIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_auth/s3/ls/$bucket': {
@@ -1383,354 +1383,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthS3LsBucketRouteRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/s3/ls/$bucket/': {
-      id: '/_auth/s3/ls/$bucket/'
-      path: '/'
-      fullPath: '/s3/ls/$bucket/'
-      preLoaderRoute: typeof AuthS3LsBucketIndexRouteImport
-      parentRoute: typeof AuthS3LsBucketRouteRoute
-    }
-    '/_auth/iam/(users)/list-users/': {
-      id: '/_auth/iam/(users)/list-users/'
-      path: '/iam/list-users'
-      fullPath: '/iam/list-users/'
-      preLoaderRoute: typeof AuthIamusersListUsersIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(roles)/list-roles/': {
-      id: '/_auth/iam/(roles)/list-roles/'
-      path: '/iam/list-roles'
-      fullPath: '/iam/list-roles/'
-      preLoaderRoute: typeof AuthIamrolesListRolesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(policies)/list-policies/': {
-      id: '/_auth/iam/(policies)/list-policies/'
-      path: '/iam/list-policies'
-      fullPath: '/iam/list-policies/'
-      preLoaderRoute: typeof AuthIampoliciesListPoliciesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(instance-profiles)/list-instance-profiles/': {
-      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/'
-      path: '/iam/list-instance-profiles'
-      fullPath: '/iam/list-instance-profiles/'
-      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(groups)/list-groups/': {
-      id: '/_auth/iam/(groups)/list-groups/'
-      path: '/iam/list-groups'
-      fullPath: '/iam/list-groups/'
-      preLoaderRoute: typeof AuthIamgroupsListGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/eks/(clusters)/list-clusters/': {
-      id: '/_auth/eks/(clusters)/list-clusters/'
-      path: '/eks/list-clusters'
-      fullPath: '/eks/list-clusters/'
-      preLoaderRoute: typeof AuthEksclustersListClustersIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/list-clusters/': {
-      id: '/_auth/ecs/(clusters)/list-clusters/'
-      path: '/ecs/list-clusters'
-      fullPath: '/ecs/list-clusters/'
-      preLoaderRoute: typeof AuthEcsclustersListClustersIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecr/(repositories)/list-repositories/': {
-      id: '/_auth/ecr/(repositories)/list-repositories/'
-      path: '/ecr/list-repositories'
-      fullPath: '/ecr/list-repositories/'
-      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(vpc)/describe-vpcs/': {
-      id: '/_auth/ec2/(vpc)/describe-vpcs/'
-      path: '/ec2/describe-vpcs'
-      fullPath: '/ec2/describe-vpcs/'
-      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/describe-volumes/': {
-      id: '/_auth/ec2/(volumes)/describe-volumes/'
-      path: '/ec2/describe-volumes'
-      fullPath: '/ec2/describe-volumes/'
-      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(target-groups)/describe-target-groups/': {
-      id: '/_auth/ec2/(target-groups)/describe-target-groups/'
-      path: '/ec2/describe-target-groups'
-      fullPath: '/ec2/describe-target-groups/'
-      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(subnet)/describe-subnets/': {
-      id: '/_auth/ec2/(subnet)/describe-subnets/'
-      path: '/ec2/describe-subnets'
-      fullPath: '/ec2/describe-subnets/'
-      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(snapshots)/describe-snapshots/': {
-      id: '/_auth/ec2/(snapshots)/describe-snapshots/'
-      path: '/ec2/describe-snapshots'
-      fullPath: '/ec2/describe-snapshots/'
-      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(security-groups)/describe-security-groups/': {
-      id: '/_auth/ec2/(security-groups)/describe-security-groups/'
-      path: '/ec2/describe-security-groups'
-      fullPath: '/ec2/describe-security-groups/'
-      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(route-tables)/describe-route-tables/': {
-      id: '/_auth/ec2/(route-tables)/describe-route-tables/'
-      path: '/ec2/describe-route-tables'
-      fullPath: '/ec2/describe-route-tables/'
-      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(placement-groups)/describe-placement-groups/': {
-      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/'
-      path: '/ec2/describe-placement-groups'
-      fullPath: '/ec2/describe-placement-groups/'
-      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/': {
-      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/'
-      path: '/ec2/describe-nat-gateways'
-      fullPath: '/ec2/describe-nat-gateways/'
-      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(load-balancers)/describe-load-balancers/': {
-      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/'
-      path: '/ec2/describe-load-balancers'
-      fullPath: '/ec2/describe-load-balancers/'
-      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(launch-templates)/describe-launch-templates/': {
-      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/'
-      path: '/ec2/describe-launch-templates'
-      fullPath: '/ec2/describe-launch-templates/'
-      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/describe-key-pairs/': {
-      id: '/_auth/ec2/(key)/describe-key-pairs/'
-      path: '/ec2/describe-key-pairs'
-      fullPath: '/ec2/describe-key-pairs/'
-      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/': {
-      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/'
-      path: '/ec2/describe-internet-gateways'
-      fullPath: '/ec2/describe-internet-gateways/'
-      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(instances)/describe-instances/': {
-      id: '/_auth/ec2/(instances)/describe-instances/'
-      path: '/ec2/describe-instances'
-      fullPath: '/ec2/describe-instances/'
-      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(images)/describe-images/': {
-      id: '/_auth/ec2/(images)/describe-images/'
-      path: '/ec2/describe-images'
-      fullPath: '/ec2/describe-images/'
-      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
     '/_auth/ec2/(elastic-ips)/describe-addresses/': {
       id: '/_auth/ec2/(elastic-ips)/describe-addresses/'
       path: '/ec2/describe-addresses'
       fullPath: '/ec2/describe-addresses/'
       preLoaderRoute: typeof AuthEc2elasticIpsDescribeAddressesIndexRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/s3/ls/$bucket/$': {
-      id: '/_auth/s3/ls/$bucket/$'
-      path: '/$'
-      fullPath: '/s3/ls/$bucket/$'
-      preLoaderRoute: typeof AuthS3LsBucketSplatRouteImport
-      parentRoute: typeof AuthS3LsBucketRouteRoute
-    }
-    '/_auth/iam/(users)/list-users/$userName': {
-      id: '/_auth/iam/(users)/list-users/$userName'
-      path: '/iam/list-users/$userName'
-      fullPath: '/iam/list-users/$userName'
-      preLoaderRoute: typeof AuthIamusersListUsersUserNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(roles)/list-roles/$roleName': {
-      id: '/_auth/iam/(roles)/list-roles/$roleName'
-      path: '/iam/list-roles/$roleName'
-      fullPath: '/iam/list-roles/$roleName'
-      preLoaderRoute: typeof AuthIamrolesListRolesRoleNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(policies)/list-policies/$policyArn': {
-      id: '/_auth/iam/(policies)/list-policies/$policyArn'
-      path: '/iam/list-policies/$policyArn'
-      fullPath: '/iam/list-policies/$policyArn'
-      preLoaderRoute: typeof AuthIampoliciesListPoliciesPolicyArnRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName': {
-      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
-      path: '/iam/list-instance-profiles/$instanceProfileName'
-      fullPath: '/iam/list-instance-profiles/$instanceProfileName'
-      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/iam/(groups)/list-groups/$groupName': {
-      id: '/_auth/iam/(groups)/list-groups/$groupName'
-      path: '/iam/list-groups/$groupName'
-      fullPath: '/iam/list-groups/$groupName'
-      preLoaderRoute: typeof AuthIamgroupsListGroupsGroupNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/eks/(clusters)/list-clusters/$clusterName': {
-      id: '/_auth/eks/(clusters)/list-clusters/$clusterName'
-      path: '/eks/list-clusters/$clusterName'
-      fullPath: '/eks/list-clusters/$clusterName'
-      preLoaderRoute: typeof AuthEksclustersListClustersClusterNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecs/(clusters)/list-clusters/$clusterName': {
-      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName'
-      path: '/ecs/list-clusters/$clusterName'
-      fullPath: '/ecs/list-clusters/$clusterName'
-      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ecr/(repositories)/list-repositories/$id': {
-      id: '/_auth/ecr/(repositories)/list-repositories/$id'
-      path: '/ecr/list-repositories/$id'
-      fullPath: '/ecr/list-repositories/$id'
-      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(vpc)/describe-vpcs/$id': {
-      id: '/_auth/ec2/(vpc)/describe-vpcs/$id'
-      path: '/ec2/describe-vpcs/$id'
-      fullPath: '/ec2/describe-vpcs/$id'
-      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/modify-volume/$id': {
-      id: '/_auth/ec2/(volumes)/modify-volume/$id'
-      path: '/ec2/modify-volume/$id'
-      fullPath: '/ec2/modify-volume/$id'
-      preLoaderRoute: typeof AuthEc2volumesModifyVolumeIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(volumes)/describe-volumes/$id': {
-      id: '/_auth/ec2/(volumes)/describe-volumes/$id'
-      path: '/ec2/describe-volumes/$id'
-      fullPath: '/ec2/describe-volumes/$id'
-      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(target-groups)/describe-target-groups/$id': {
-      id: '/_auth/ec2/(target-groups)/describe-target-groups/$id'
-      path: '/ec2/describe-target-groups/$id'
-      fullPath: '/ec2/describe-target-groups/$id'
-      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(subnet)/describe-subnets/$id': {
-      id: '/_auth/ec2/(subnet)/describe-subnets/$id'
-      path: '/ec2/describe-subnets/$id'
-      fullPath: '/ec2/describe-subnets/$id'
-      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(snapshots)/describe-snapshots/$id': {
-      id: '/_auth/ec2/(snapshots)/describe-snapshots/$id'
-      path: '/ec2/describe-snapshots/$id'
-      fullPath: '/ec2/describe-snapshots/$id'
-      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(security-groups)/describe-security-groups/$id': {
-      id: '/_auth/ec2/(security-groups)/describe-security-groups/$id'
-      path: '/ec2/describe-security-groups/$id'
-      fullPath: '/ec2/describe-security-groups/$id'
-      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(route-tables)/describe-route-tables/$id': {
-      id: '/_auth/ec2/(route-tables)/describe-route-tables/$id'
-      path: '/ec2/describe-route-tables/$id'
-      fullPath: '/ec2/describe-route-tables/$id'
-      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(placement-groups)/describe-placement-groups/$id': {
-      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
-      path: '/ec2/describe-placement-groups/$id'
-      fullPath: '/ec2/describe-placement-groups/$id'
-      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id': {
-      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
-      path: '/ec2/describe-nat-gateways/$id'
-      fullPath: '/ec2/describe-nat-gateways/$id'
-      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(load-balancers)/describe-load-balancers/$id': {
-      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
-      path: '/ec2/describe-load-balancers/$id'
-      fullPath: '/ec2/describe-load-balancers/$id'
-      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(launch-templates)/describe-launch-templates/$id': {
-      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
-      path: '/ec2/describe-launch-templates/$id'
-      fullPath: '/ec2/describe-launch-templates/$id'
-      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(key)/describe-key-pairs/$id': {
-      id: '/_auth/ec2/(key)/describe-key-pairs/$id'
-      path: '/ec2/describe-key-pairs/$id'
-      fullPath: '/ec2/describe-key-pairs/$id'
-      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id': {
-      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
-      path: '/ec2/describe-internet-gateways/$id'
-      fullPath: '/ec2/describe-internet-gateways/$id'
-      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(instances)/describe-instances/$id': {
-      id: '/_auth/ec2/(instances)/describe-instances/$id'
-      path: '/ec2/describe-instances/$id'
-      fullPath: '/ec2/describe-instances/$id'
-      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIdRouteImport
-      parentRoute: typeof AuthRouteRoute
-    }
-    '/_auth/ec2/(images)/describe-images/$id': {
-      id: '/_auth/ec2/(images)/describe-images/$id'
-      path: '/ec2/describe-images/$id'
-      fullPath: '/ec2/describe-images/$id'
-      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIdRouteImport
       parentRoute: typeof AuthRouteRoute
     }
     '/_auth/ec2/(elastic-ips)/describe-addresses/$id': {
@@ -1740,18 +1397,361 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthEc2elasticIpsDescribeAddressesIdRouteImport
       parentRoute: typeof AuthRouteRoute
     }
-    '/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId': {
-      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId'
-      path: '/ecs/list-clusters/$clusterName/tasks/$taskId'
-      fullPath: '/ecs/list-clusters/$clusterName/tasks/$taskId'
-      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport
+    '/_auth/ec2/(images)/describe-images/': {
+      id: '/_auth/ec2/(images)/describe-images/'
+      path: '/ec2/describe-images'
+      fullPath: '/ec2/describe-images/'
+      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIndexRouteImport
       parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(images)/describe-images/$id': {
+      id: '/_auth/ec2/(images)/describe-images/$id'
+      path: '/ec2/describe-images/$id'
+      fullPath: '/ec2/describe-images/$id'
+      preLoaderRoute: typeof AuthEc2imagesDescribeImagesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(instances)/describe-instances/': {
+      id: '/_auth/ec2/(instances)/describe-instances/'
+      path: '/ec2/describe-instances'
+      fullPath: '/ec2/describe-instances/'
+      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(instances)/describe-instances/$id': {
+      id: '/_auth/ec2/(instances)/describe-instances/$id'
+      path: '/ec2/describe-instances/$id'
+      fullPath: '/ec2/describe-instances/$id'
+      preLoaderRoute: typeof AuthEc2instancesDescribeInstancesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/': {
+      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/'
+      path: '/ec2/describe-internet-gateways'
+      fullPath: '/ec2/describe-internet-gateways/'
+      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id': {
+      id: '/_auth/ec2/(internet-gateways)/describe-internet-gateways/$id'
+      path: '/ec2/describe-internet-gateways/$id'
+      fullPath: '/ec2/describe-internet-gateways/$id'
+      preLoaderRoute: typeof AuthEc2internetGatewaysDescribeInternetGatewaysIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/describe-key-pairs/': {
+      id: '/_auth/ec2/(key)/describe-key-pairs/'
+      path: '/ec2/describe-key-pairs'
+      fullPath: '/ec2/describe-key-pairs/'
+      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(key)/describe-key-pairs/$id': {
+      id: '/_auth/ec2/(key)/describe-key-pairs/$id'
+      path: '/ec2/describe-key-pairs/$id'
+      fullPath: '/ec2/describe-key-pairs/$id'
+      preLoaderRoute: typeof AuthEc2keyDescribeKeyPairsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(launch-templates)/describe-launch-templates/': {
+      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/'
+      path: '/ec2/describe-launch-templates'
+      fullPath: '/ec2/describe-launch-templates/'
+      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(launch-templates)/describe-launch-templates/$id': {
+      id: '/_auth/ec2/(launch-templates)/describe-launch-templates/$id'
+      path: '/ec2/describe-launch-templates/$id'
+      fullPath: '/ec2/describe-launch-templates/$id'
+      preLoaderRoute: typeof AuthEc2launchTemplatesDescribeLaunchTemplatesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(load-balancers)/describe-load-balancers/': {
+      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/'
+      path: '/ec2/describe-load-balancers'
+      fullPath: '/ec2/describe-load-balancers/'
+      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(load-balancers)/describe-load-balancers/$id': {
+      id: '/_auth/ec2/(load-balancers)/describe-load-balancers/$id'
+      path: '/ec2/describe-load-balancers/$id'
+      fullPath: '/ec2/describe-load-balancers/$id'
+      preLoaderRoute: typeof AuthEc2loadBalancersDescribeLoadBalancersIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/': {
+      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/'
+      path: '/ec2/describe-nat-gateways'
+      fullPath: '/ec2/describe-nat-gateways/'
+      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id': {
+      id: '/_auth/ec2/(nat-gateways)/describe-nat-gateways/$id'
+      path: '/ec2/describe-nat-gateways/$id'
+      fullPath: '/ec2/describe-nat-gateways/$id'
+      preLoaderRoute: typeof AuthEc2natGatewaysDescribeNatGatewaysIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(placement-groups)/describe-placement-groups/': {
+      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/'
+      path: '/ec2/describe-placement-groups'
+      fullPath: '/ec2/describe-placement-groups/'
+      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(placement-groups)/describe-placement-groups/$id': {
+      id: '/_auth/ec2/(placement-groups)/describe-placement-groups/$id'
+      path: '/ec2/describe-placement-groups/$id'
+      fullPath: '/ec2/describe-placement-groups/$id'
+      preLoaderRoute: typeof AuthEc2placementGroupsDescribePlacementGroupsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(route-tables)/describe-route-tables/': {
+      id: '/_auth/ec2/(route-tables)/describe-route-tables/'
+      path: '/ec2/describe-route-tables'
+      fullPath: '/ec2/describe-route-tables/'
+      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(route-tables)/describe-route-tables/$id': {
+      id: '/_auth/ec2/(route-tables)/describe-route-tables/$id'
+      path: '/ec2/describe-route-tables/$id'
+      fullPath: '/ec2/describe-route-tables/$id'
+      preLoaderRoute: typeof AuthEc2routeTablesDescribeRouteTablesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(security-groups)/describe-security-groups/': {
+      id: '/_auth/ec2/(security-groups)/describe-security-groups/'
+      path: '/ec2/describe-security-groups'
+      fullPath: '/ec2/describe-security-groups/'
+      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(security-groups)/describe-security-groups/$id': {
+      id: '/_auth/ec2/(security-groups)/describe-security-groups/$id'
+      path: '/ec2/describe-security-groups/$id'
+      fullPath: '/ec2/describe-security-groups/$id'
+      preLoaderRoute: typeof AuthEc2securityGroupsDescribeSecurityGroupsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(snapshots)/describe-snapshots/': {
+      id: '/_auth/ec2/(snapshots)/describe-snapshots/'
+      path: '/ec2/describe-snapshots'
+      fullPath: '/ec2/describe-snapshots/'
+      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(snapshots)/describe-snapshots/$id': {
+      id: '/_auth/ec2/(snapshots)/describe-snapshots/$id'
+      path: '/ec2/describe-snapshots/$id'
+      fullPath: '/ec2/describe-snapshots/$id'
+      preLoaderRoute: typeof AuthEc2snapshotsDescribeSnapshotsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(subnet)/describe-subnets/': {
+      id: '/_auth/ec2/(subnet)/describe-subnets/'
+      path: '/ec2/describe-subnets'
+      fullPath: '/ec2/describe-subnets/'
+      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(subnet)/describe-subnets/$id': {
+      id: '/_auth/ec2/(subnet)/describe-subnets/$id'
+      path: '/ec2/describe-subnets/$id'
+      fullPath: '/ec2/describe-subnets/$id'
+      preLoaderRoute: typeof AuthEc2subnetDescribeSubnetsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(target-groups)/describe-target-groups/': {
+      id: '/_auth/ec2/(target-groups)/describe-target-groups/'
+      path: '/ec2/describe-target-groups'
+      fullPath: '/ec2/describe-target-groups/'
+      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(target-groups)/describe-target-groups/$id': {
+      id: '/_auth/ec2/(target-groups)/describe-target-groups/$id'
+      path: '/ec2/describe-target-groups/$id'
+      fullPath: '/ec2/describe-target-groups/$id'
+      preLoaderRoute: typeof AuthEc2targetGroupsDescribeTargetGroupsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/describe-volumes/': {
+      id: '/_auth/ec2/(volumes)/describe-volumes/'
+      path: '/ec2/describe-volumes'
+      fullPath: '/ec2/describe-volumes/'
+      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/describe-volumes/$id': {
+      id: '/_auth/ec2/(volumes)/describe-volumes/$id'
+      path: '/ec2/describe-volumes/$id'
+      fullPath: '/ec2/describe-volumes/$id'
+      preLoaderRoute: typeof AuthEc2volumesDescribeVolumesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(volumes)/modify-volume/$id': {
+      id: '/_auth/ec2/(volumes)/modify-volume/$id'
+      path: '/ec2/modify-volume/$id'
+      fullPath: '/ec2/modify-volume/$id'
+      preLoaderRoute: typeof AuthEc2volumesModifyVolumeIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(vpc)/describe-vpcs/': {
+      id: '/_auth/ec2/(vpc)/describe-vpcs/'
+      path: '/ec2/describe-vpcs'
+      fullPath: '/ec2/describe-vpcs/'
+      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ec2/(vpc)/describe-vpcs/$id': {
+      id: '/_auth/ec2/(vpc)/describe-vpcs/$id'
+      path: '/ec2/describe-vpcs/$id'
+      fullPath: '/ec2/describe-vpcs/$id'
+      preLoaderRoute: typeof AuthEc2vpcDescribeVpcsIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecr/(repositories)/list-repositories/': {
+      id: '/_auth/ecr/(repositories)/list-repositories/'
+      path: '/ecr/list-repositories'
+      fullPath: '/ecr/list-repositories/'
+      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecr/(repositories)/list-repositories/$id': {
+      id: '/_auth/ecr/(repositories)/list-repositories/$id'
+      path: '/ecr/list-repositories/$id'
+      fullPath: '/ecr/list-repositories/$id'
+      preLoaderRoute: typeof AuthEcrrepositoriesListRepositoriesIdRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/list-clusters/': {
+      id: '/_auth/ecs/(clusters)/list-clusters/'
+      path: '/ecs/list-clusters'
+      fullPath: '/ecs/list-clusters/'
+      preLoaderRoute: typeof AuthEcsclustersListClustersIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/list-clusters/$clusterName': {
+      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName'
+      path: '/ecs/list-clusters/$clusterName'
+      fullPath: '/ecs/list-clusters/$clusterName'
+      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/eks/(clusters)/list-clusters/': {
+      id: '/_auth/eks/(clusters)/list-clusters/'
+      path: '/eks/list-clusters'
+      fullPath: '/eks/list-clusters/'
+      preLoaderRoute: typeof AuthEksclustersListClustersIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/eks/(clusters)/list-clusters/$clusterName': {
+      id: '/_auth/eks/(clusters)/list-clusters/$clusterName'
+      path: '/eks/list-clusters/$clusterName'
+      fullPath: '/eks/list-clusters/$clusterName'
+      preLoaderRoute: typeof AuthEksclustersListClustersClusterNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(groups)/list-groups/': {
+      id: '/_auth/iam/(groups)/list-groups/'
+      path: '/iam/list-groups'
+      fullPath: '/iam/list-groups/'
+      preLoaderRoute: typeof AuthIamgroupsListGroupsIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(groups)/list-groups/$groupName': {
+      id: '/_auth/iam/(groups)/list-groups/$groupName'
+      path: '/iam/list-groups/$groupName'
+      fullPath: '/iam/list-groups/$groupName'
+      preLoaderRoute: typeof AuthIamgroupsListGroupsGroupNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(instance-profiles)/list-instance-profiles/': {
+      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/'
+      path: '/iam/list-instance-profiles'
+      fullPath: '/iam/list-instance-profiles/'
+      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName': {
+      id: '/_auth/iam/(instance-profiles)/list-instance-profiles/$instanceProfileName'
+      path: '/iam/list-instance-profiles/$instanceProfileName'
+      fullPath: '/iam/list-instance-profiles/$instanceProfileName'
+      preLoaderRoute: typeof AuthIaminstanceProfilesListInstanceProfilesInstanceProfileNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(policies)/list-policies/': {
+      id: '/_auth/iam/(policies)/list-policies/'
+      path: '/iam/list-policies'
+      fullPath: '/iam/list-policies/'
+      preLoaderRoute: typeof AuthIampoliciesListPoliciesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(policies)/list-policies/$policyArn': {
+      id: '/_auth/iam/(policies)/list-policies/$policyArn'
+      path: '/iam/list-policies/$policyArn'
+      fullPath: '/iam/list-policies/$policyArn'
+      preLoaderRoute: typeof AuthIampoliciesListPoliciesPolicyArnRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(roles)/list-roles/': {
+      id: '/_auth/iam/(roles)/list-roles/'
+      path: '/iam/list-roles'
+      fullPath: '/iam/list-roles/'
+      preLoaderRoute: typeof AuthIamrolesListRolesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(roles)/list-roles/$roleName': {
+      id: '/_auth/iam/(roles)/list-roles/$roleName'
+      path: '/iam/list-roles/$roleName'
+      fullPath: '/iam/list-roles/$roleName'
+      preLoaderRoute: typeof AuthIamrolesListRolesRoleNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(users)/list-users/': {
+      id: '/_auth/iam/(users)/list-users/'
+      path: '/iam/list-users'
+      fullPath: '/iam/list-users/'
+      preLoaderRoute: typeof AuthIamusersListUsersIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/iam/(users)/list-users/$userName': {
+      id: '/_auth/iam/(users)/list-users/$userName'
+      path: '/iam/list-users/$userName'
+      fullPath: '/iam/list-users/$userName'
+      preLoaderRoute: typeof AuthIamusersListUsersUserNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/s3/ls/$bucket/': {
+      id: '/_auth/s3/ls/$bucket/'
+      path: '/'
+      fullPath: '/s3/ls/$bucket/'
+      preLoaderRoute: typeof AuthS3LsBucketIndexRouteImport
+      parentRoute: typeof AuthS3LsBucketRouteRoute
+    }
+    '/_auth/s3/ls/$bucket/$': {
+      id: '/_auth/s3/ls/$bucket/$'
+      path: '/$'
+      fullPath: '/s3/ls/$bucket/$'
+      preLoaderRoute: typeof AuthS3LsBucketSplatRouteImport
+      parentRoute: typeof AuthS3LsBucketRouteRoute
     }
     '/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName': {
       id: '/_auth/ecs/(clusters)/list-clusters/$clusterName_/services/$serviceName'
       path: '/ecs/list-clusters/$clusterName/services/$serviceName'
       fullPath: '/ecs/list-clusters/$clusterName/services/$serviceName'
       preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameServicesServiceNameRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId': {
+      id: '/_auth/ecs/(clusters)/list-clusters/$clusterName_/tasks/$taskId'
+      path: '/ecs/list-clusters/$clusterName/tasks/$taskId'
+      fullPath: '/ecs/list-clusters/$clusterName/tasks/$taskId'
+      preLoaderRoute: typeof AuthEcsclustersListClustersClusterNameTasksTaskIdRouteImport
       parentRoute: typeof AuthRouteRoute
     }
   }

--- a/spinifex/utils/sudo.go
+++ b/spinifex/utils/sudo.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 // socketClients are the OVS/OVN client tools that do all their work over a
@@ -30,25 +33,90 @@ var socketClients = map[string]bool{
 	"systemctl": true,
 }
 
+// Capability bit numbers from linux/capability.h.
+const (
+	capNetAdmin = 12
+	capNetRaw   = 13
+)
+
+// capForTool returns the capability that lets this invocation run unescalated.
+// The bool is false when no capability substitutes for root, in which case the
+// caller must go through sudo.
+func capForTool(name string, args []string) (uint, bool) {
+	switch name {
+	case "ip", "iptables", "ip6tables":
+		return capNetAdmin, true
+	case "arping":
+		return capNetRaw, true
+	case "sysctl":
+		// Only the net.* trees are governed by CAP_NET_ADMIN in the caller's
+		// network namespace; every other key is a root-only write.
+		for _, a := range args {
+			if strings.HasPrefix(a, "-") {
+				continue
+			}
+			return capNetAdmin, strings.HasPrefix(a, "net.")
+		}
+	}
+	return 0, false
+}
+
+// ambientCaps reports the process's ambient capability set, read once. Tests
+// override it.
+var ambientCaps = sync.OnceValue(readAmbientCaps)
+
+// readAmbientCaps parses CapAmb from /proc/self/status. The ambient set — not
+// the effective one — is what an exec'd child inherits, so it is what decides
+// whether `ip` will hold CAP_NET_ADMIN when we run it as ourselves.
+func readAmbientCaps() uint64 {
+	body, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0
+	}
+	for line := range strings.SplitSeq(string(body), "\n") {
+		hex, ok := strings.CutPrefix(line, "CapAmb:")
+		if !ok {
+			continue
+		}
+		caps, err := strconv.ParseUint(strings.TrimSpace(hex), 16, 64)
+		if err != nil {
+			return 0
+		}
+		return caps
+	}
+	return 0
+}
+
 // NeedsPrivilege reports whether a command has to be escalated. False for the
-// OVS/OVN socket clients and for anything already running as root.
-func NeedsPrivilege(name string) bool {
+// OVS/OVN socket clients, for anything already running as root, and for tools
+// covered by a capability this process holds ambiently.
+func NeedsPrivilege(name string, args ...string) bool {
 	if os.Getuid() == 0 {
 		return false
 	}
-	return !socketClients[name]
+	if socketClients[name] {
+		return false
+	}
+	// spx is one binary shared by units with different ambient sets: vpcd holds
+	// CAP_NET_ADMIN/CAP_NET_RAW and runs these directly, the daemon does not and
+	// still needs its sudoers grant. So this is decided at runtime, not by tool.
+	if bit, ok := capForTool(name, args); ok && ambientCaps()&(1<<bit) != 0 {
+		return false
+	}
+	return true
 }
 
 // sudoCommand is the private runtime implementation; use SetSudoCommandForTest in tests.
 var sudoCommand = func(name string, args ...string) *exec.Cmd {
-	if !NeedsPrivilege(name) {
+	if !NeedsPrivilege(name, args...) {
 		return exec.Command(name, args...)
 	}
 	return exec.Command("sudo", append([]string{name}, args...)...)
 }
 
 // SudoCommand wraps exec.Command with sudo when the command genuinely needs it.
-// ip/iptables/dhcpcd and friends still do; the OVS/OVN socket clients do not.
+// The OVS/OVN socket clients never do, and neither does a tool whose capability
+// this process already holds.
 func SudoCommand(name string, args ...string) *exec.Cmd {
 	return sudoCommand(name, args...)
 }
@@ -56,7 +124,7 @@ func SudoCommand(name string, args ...string) *exec.Cmd {
 // SudoCommandContext is SudoCommand bound to a context so a wedged subprocess is
 // killed when the context is cancelled or its deadline elapses.
 func SudoCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	if !NeedsPrivilege(name) {
+	if !NeedsPrivilege(name, args...) {
 		return exec.CommandContext(ctx, name, args...)
 	}
 	return exec.CommandContext(ctx, "sudo", append([]string{name}, args...)...)

--- a/spinifex/utils/sudo.go
+++ b/spinifex/utils/sudo.go
@@ -6,17 +6,49 @@ import (
 	"os/exec"
 )
 
+// socketClients are the OVS/OVN client tools that do all their work over a
+// control socket, not through privileged syscalls. setup-ovn.sh group-owns
+// those sockets to `spinifex` (0660), so the service users reach them as
+// themselves and escalating buys nothing.
+//
+// Escalating actively costs: a sudoers rule for these takes unrestricted args,
+// and every one of them accepts --log-file=PATH, which writes a root-owned file
+// wherever the caller points it. A NOPASSWD grant for any of them is therefore a
+// root-equivalent grant handed out to read a status.
+//
+// ovs-ofctl is deliberately absent: it talks to a per-bridge
+// /var/run/openvswitch/<bridge>.mgmt socket created by ovs-vswitchd when the
+// bridge appears — including bridges spinifex creates at runtime, long after
+// the provisioning sweep — so those sockets cannot be group-owned up front.
+var socketClients = map[string]bool{
+	"ovs-vsctl":  true,
+	"ovs-appctl": true,
+	"ovn-nbctl":  true,
+	"ovn-sbctl":  true,
+	"ovn-appctl": true,
+	// systemctl is-active is a read of the system bus, allowed unprivileged.
+	"systemctl": true,
+}
+
+// NeedsPrivilege reports whether a command has to be escalated. False for the
+// OVS/OVN socket clients and for anything already running as root.
+func NeedsPrivilege(name string) bool {
+	if os.Getuid() == 0 {
+		return false
+	}
+	return !socketClients[name]
+}
+
 // sudoCommand is the private runtime implementation; use SetSudoCommandForTest in tests.
 var sudoCommand = func(name string, args ...string) *exec.Cmd {
-	if os.Getuid() == 0 {
+	if !NeedsPrivilege(name) {
 		return exec.Command(name, args...)
 	}
 	return exec.Command("sudo", append([]string{name}, args...)...)
 }
 
-// SudoCommand wraps exec.Command with sudo when running as non-root.
-// OVS/OVN/ip require CAP_NET_ADMIN; production daemons run as root, but
-// dev environments may not.
+// SudoCommand wraps exec.Command with sudo when the command genuinely needs it.
+// ip/iptables/dhcpcd and friends still do; the OVS/OVN socket clients do not.
 func SudoCommand(name string, args ...string) *exec.Cmd {
 	return sudoCommand(name, args...)
 }
@@ -24,7 +56,7 @@ func SudoCommand(name string, args ...string) *exec.Cmd {
 // SudoCommandContext is SudoCommand bound to a context so a wedged subprocess is
 // killed when the context is cancelled or its deadline elapses.
 func SudoCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	if os.Getuid() == 0 {
+	if !NeedsPrivilege(name) {
 		return exec.CommandContext(ctx, name, args...)
 	}
 	return exec.CommandContext(ctx, "sudo", append([]string{name}, args...)...)

--- a/spinifex/utils/sudo_invariants_test.go
+++ b/spinifex/utils/sudo_invariants_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// policyOwners are the only files allowed to build a sudo invocation. Everything
+// else must route through utils.SudoCommand / host.NewExecRunner so the
+// escalation policy in NeedsPrivilege applies.
+var policyOwners = map[string]bool{
+	filepath.Join("spinifex", "utils", "sudo.go"):          true,
+	filepath.Join("spinifex", "network", "host", "run.go"): true,
+}
+
+// repoRoot walks up from this test file to the directory holding go.mod.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(self)
+	for range 8 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatalf("go.mod not found above %s", self)
+	return ""
+}
+
+// TestRG10_SudoOnlyThroughThePolicy fails when a package builds its own sudo
+// invocation. vpcd carried such a copy: every OVS/OVN call it made was escalated
+// unconditionally, so it kept working only because the sudoers grants existed,
+// and it broke the OVN flows-ready barrier the moment they were removed. A local
+// copy also silently re-widens the sudoers surface a reviewer thinks is gone.
+func TestRG10_SudoOnlyThroughThePolicy(t *testing.T) {
+	root := repoRoot(t)
+	var offenders []string
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules", "testdata":
+				return filepath.SkipDir
+			// The e2e harness is not a daemon: it runs as the developer or CI
+			// user, who holds full sudo, and shells out to inspect a live node.
+			// The policy governs what the service users escalate.
+			case "tests":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if policyOwners[rel] {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			if strings.Contains(line, `exec.Command(`) && strings.Contains(line, `"sudo"`) {
+				offenders = append(offenders, rel+":"+strconv.Itoa(i+1))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("RG-10: these build sudo invocations directly, bypassing utils.NeedsPrivilege:\n  %s\n"+
+			"Use utils.SudoCommand or host.NewExecRunner so the OVS/OVN socket clients stay unescalated.",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/spinifex/utils/sudo_invariants_test.go
+++ b/spinifex/utils/sudo_invariants_test.go
@@ -91,3 +91,45 @@ func TestRG10_SudoOnlyThroughThePolicy(t *testing.T) {
 			strings.Join(offenders, "\n  "))
 	}
 }
+
+// TestRG10_VPCDHoldsNoSudoersGrant pins the two halves that have to move
+// together: vpcd's unit grants CAP_NET_ADMIN and CAP_NET_RAW ambiently, and in
+// exchange it gets no sudoers rules. Re-adding a rule reopens the hole the caps
+// closed — every candidate takes unrestricted args, and `sudo ip netns exec
+// <ns> /bin/sh` is a root shell.
+func TestRG10_VPCDHoldsNoSudoersGrant(t *testing.T) {
+	root := repoRoot(t)
+
+	unit, err := os.ReadFile(filepath.Join(root, "build", "systemd", "spinifex-vpcd.service"))
+	if err != nil {
+		t.Fatalf("read vpcd unit: %v", err)
+	}
+	ambient := ambientLine(string(unit))
+	for _, capability := range []string{"CAP_NET_ADMIN", "CAP_NET_RAW"} {
+		if !strings.Contains(ambient, capability) {
+			t.Fatalf("RG-10: spinifex-vpcd.service must grant %s ambiently; without it "+
+				"ip/iptables/arping fail as the service user and the sudoers rules cannot stay removed", capability)
+		}
+	}
+
+	setup, err := os.ReadFile(filepath.Join(root, "scripts", "setup.sh"))
+	if err != nil {
+		t.Fatalf("read setup.sh: %v", err)
+	}
+	for i, line := range strings.Split(string(setup), "\n") {
+		if strings.HasPrefix(line, "spinifex-vpcd ALL=") {
+			t.Fatalf("RG-10: scripts/setup.sh:%d grants spinifex-vpcd a sudoers rule:\n  %s\n"+
+				"vpcd runs these under its ambient capabilities; add the capability to the unit instead.", i+1, line)
+		}
+	}
+}
+
+// ambientLine returns the unit's AmbientCapabilities= value, or "".
+func ambientLine(unit string) string {
+	for line := range strings.SplitSeq(unit, "\n") {
+		if v, ok := strings.CutPrefix(line, "AmbientCapabilities="); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/spinifex/utils/sudo_test.go
+++ b/spinifex/utils/sudo_test.go
@@ -5,23 +5,61 @@ import (
 	"testing"
 )
 
-func TestSudoCommand_NonRoot(t *testing.T) {
-	cmd := SudoCommand("ovs-vsctl", "br-exists", "br-int")
+// A tool that needs real privilege is wrapped in sudo when we are not root, and
+// invoked directly when we are.
+func TestSudoCommand_PrivilegedTool(t *testing.T) {
+	cmd := SudoCommand("ip", "link", "show")
 	args := cmd.Args
 
 	if os.Getuid() == 0 {
-		if args[0] != "ovs-vsctl" {
-			t.Errorf("as root, expected args[0]='ovs-vsctl', got %q", args[0])
+		if args[0] != "ip" {
+			t.Errorf("as root, expected args[0]='ip', got %q", args[0])
 		}
 		return
 	}
 	if args[0] != "sudo" {
 		t.Errorf("as non-root, expected args[0]='sudo', got %q", args[0])
 	}
-	if args[1] != "ovs-vsctl" {
-		t.Errorf("as non-root, expected args[1]='ovs-vsctl', got %q", args[1])
+	if args[1] != "ip" {
+		t.Errorf("as non-root, expected args[1]='ip', got %q", args[1])
 	}
 	if len(args) != 4 {
-		t.Errorf("expected 4 args [sudo ovs-vsctl br-exists br-int], got %d: %v", len(args), args)
+		t.Errorf("expected 4 args [sudo ip link show], got %d: %v", len(args), args)
+	}
+}
+
+// The OVS/OVN socket clients must never be escalated. Each accepts
+// --log-file=PATH, so a NOPASSWD sudoers rule for one — which necessarily takes
+// unrestricted args — writes a root-owned file wherever the caller points it.
+// They reach their daemons over the group-owned control sockets instead.
+func TestSocketClientsAreNotEscalated(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: nothing is escalated, so the policy is not exercised")
+	}
+	for _, tool := range []string{"ovs-vsctl", "ovs-appctl", "ovn-nbctl", "ovn-sbctl", "ovn-appctl", "systemctl"} {
+		if NeedsPrivilege(tool) {
+			t.Errorf("%s is escalated; it talks to a group-owned socket, and a sudoers grant for it would be root-equivalent", tool)
+		}
+		if args := SudoCommand(tool, "--version").Args; len(args) > 0 && args[0] == "sudo" {
+			t.Errorf("SudoCommand(%s) built a sudo invocation: %v", tool, args)
+		}
+	}
+}
+
+// The tools that genuinely need privilege keep it. ovs-ofctl is in this list on
+// purpose: it talks to a per-bridge <bridge>.mgmt socket that ovs-vswitchd
+// creates when the bridge appears — including bridges spinifex creates at
+// runtime — so those cannot be group-owned by the provisioning sweep.
+func TestPrivilegedToolsStillEscalate(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: nothing is escalated, so the policy is not exercised")
+	}
+	for _, tool := range []string{"ip", "iptables", "dhcpcd", "sysctl", "arping", "ovs-ofctl"} {
+		if !NeedsPrivilege(tool) {
+			t.Errorf("%s is not escalated, but it needs root or an ambient capability", tool)
+		}
+		if args := SudoCommand(tool, "--version").Args; len(args) == 0 || args[0] != "sudo" {
+			t.Errorf("SudoCommand(%s) did not build a sudo invocation: %v", tool, args)
+		}
 	}
 }

--- a/spinifex/utils/sudo_test.go
+++ b/spinifex/utils/sudo_test.go
@@ -5,9 +5,19 @@ import (
 	"testing"
 )
 
+// withAmbientCaps pins the ambient capability set for one test, so the result
+// does not depend on how the test binary itself was launched.
+func withAmbientCaps(t *testing.T, caps uint64) {
+	t.Helper()
+	orig := ambientCaps
+	ambientCaps = func() uint64 { return caps }
+	t.Cleanup(func() { ambientCaps = orig })
+}
+
 // A tool that needs real privilege is wrapped in sudo when we are not root, and
 // invoked directly when we are.
 func TestSudoCommand_PrivilegedTool(t *testing.T) {
+	withAmbientCaps(t, 0)
 	cmd := SudoCommand("ip", "link", "show")
 	args := cmd.Args
 
@@ -54,12 +64,69 @@ func TestPrivilegedToolsStillEscalate(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("running as root: nothing is escalated, so the policy is not exercised")
 	}
+	withAmbientCaps(t, 0)
 	for _, tool := range []string{"ip", "iptables", "dhcpcd", "sysctl", "arping", "ovs-ofctl"} {
-		if !NeedsPrivilege(tool) {
+		if !NeedsPrivilege(tool, "net.ipv4.neigh.x=1") {
 			t.Errorf("%s is not escalated, but it needs root or an ambient capability", tool)
 		}
 		if args := SudoCommand(tool, "--version").Args; len(args) == 0 || args[0] != "sudo" {
 			t.Errorf("SudoCommand(%s) did not build a sudo invocation: %v", tool, args)
+		}
+	}
+}
+
+// vpcd holds CAP_NET_ADMIN and CAP_NET_RAW ambiently, so the kernel hands them
+// to each child on exec and these tools work as the service user. This is what
+// lets spinifex-vpcd carry no sudoers rules at all.
+func TestAmbientCapabilitiesReplaceSudo(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: nothing is escalated, so the policy is not exercised")
+	}
+	withAmbientCaps(t, 1<<capNetAdmin|1<<capNetRaw)
+
+	unescalated := [][]string{
+		{"ip", "addr", "replace", "10.0.0.1/24", "dev", "eth0"},
+		{"iptables", "-A", "FORWARD", "-j", "ACCEPT"},
+		{"arping", "-U", "-c", "2", "-I", "br-wan", "10.0.0.1"},
+		{"sysctl", "-w", "net.ipv4.neigh.br-wan.proxy_delay=0"},
+	}
+	for _, argv := range unescalated {
+		if NeedsPrivilege(argv[0], argv[1:]...) {
+			t.Errorf("%v is escalated despite the ambient capability", argv)
+		}
+	}
+
+	// The capability is per-tool, and for sysctl per-key: CAP_NET_ADMIN governs
+	// the net.* trees only, and nothing makes ovs-ofctl's root-owned
+	// <bridge>.mgmt socket readable.
+	escalated := [][]string{
+		{"sysctl", "-w", "vm.swappiness=10"},
+		{"ovs-ofctl", "dump-flows", "br-int"},
+		{"dhcpcd", "-q", "br-wan"},
+	}
+	for _, argv := range escalated {
+		if !NeedsPrivilege(argv[0], argv[1:]...) {
+			t.Errorf("%v is not escalated, but CAP_NET_ADMIN/CAP_NET_RAW do not cover it", argv)
+		}
+	}
+}
+
+// The daemon runs the same spx binary as vpcd but its unit grants no
+// CAP_NET_ADMIN, so the decision has to be made from the live capability set
+// rather than from the tool name.
+func TestDaemonAmbientSetStillEscalatesIP(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: nothing is escalated, so the policy is not exercised")
+	}
+	const capSysAdmin, capDACOverride = 21, 1
+	withAmbientCaps(t, 1<<capSysAdmin|1<<capDACOverride)
+
+	for _, argv := range [][]string{
+		{"ip", "tuntap", "add", "tap0", "mode", "tap"},
+		{"sysctl", "-qw", "net.ipv4.conf.tap0.rp_filter=0"},
+	} {
+		if !NeedsPrivilege(argv[0], argv[1:]...) {
+			t.Errorf("%v is not escalated, but the daemon holds no CAP_NET_ADMIN", argv)
 		}
 	}
 }

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -65,13 +65,11 @@ var waitForFlowsHV = func() error {
 	return nil
 }
 
-// sudoCommand wraps exec.Command with sudo when not root; OVS/OVN commands require elevated privileges.
-func sudoCommand(name string, args ...string) *exec.Cmd {
-	if os.Getuid() == 0 {
-		return exec.Command(name, args...)
-	}
-	return exec.Command("sudo", append([]string{name}, args...)...)
-}
+// sudoCommand is utils.SudoCommand, which escalates only what genuinely needs
+// it. Every caller here is an OVS/OVN socket client, so none of them escalate;
+// a local copy that always sudoed silently bypassed that policy and broke the
+// flows-ready barrier once the grants were removed.
+var sudoCommand = utils.SudoCommand
 
 var serviceName = "vpcd"
 

--- a/spinifex/vpcd/vpcd.go
+++ b/spinifex/vpcd/vpcd.go
@@ -201,9 +201,11 @@ var checkBrInt = func() error {
 	return nil
 }
 
-// checkOVNController verifies ovn-controller is running. Tries legacy socket path, then OVN 22.03+ path, then systemctl.
+// checkOVNController verifies ovn-controller is running. ovn-appctl resolves a
+// bare target against /var/run/ovn where the socket and pidfile live; ovs-appctl
+// looks in /var/run/openvswitch and only ever logged a missing pidfile.
 var checkOVNController = func() error {
-	if sudoCommand("ovs-appctl", "-t", "ovn-controller", "version").Run() == nil {
+	if sudoCommand("ovn-appctl", "-t", "ovn-controller", "version").Run() == nil {
 		return nil
 	}
 	if matches, _ := filepath.Glob("/var/run/ovn/ovn-controller.*.ctl"); len(matches) > 0 {


### PR DESCRIPTION
Three related passes over the OVS/OVN privilege surface, prompted by `sudo` audit noise from `spinifex-vpcd` on `hydrogen`.

## What was wrong

**The control sockets were world-writable.** `setup-ovn.sh` chmod'd `db.sock` and the `*.ctl` sockets to `0666`, with a persistent `ExecStartPost` override to keep them that way. Any local user could drive OVSDB and the OVN daemons.

**Every OVS/OVN call was escalated.** The sudoers drop-in granted `ovs-vsctl`, `ovs-appctl`, `ovn-nbctl`, `ovn-sbctl`, `ovn-appctl` and `systemctl`. Those grants necessarily take unrestricted arguments, and every one of those tools accepts `--log-file=PATH` — so each was a root-equivalent grant handed out to read a status.

**vpcd's `ip` grant was a root shell.** `NOPASSWD: /sbin/ip` cannot constrain arguments, so `sudo ip netns exec <ns> /bin/sh` was available to the service account.

**Health reported OVN down on a healthy node.** `health.go` probed `sudo ovn-appctl -t ovn-controller connection-status`, which the daemon has no grant for. The error was swallowed and `OVNControllerUp` silently stayed false. (`mulga-9p0it`)

**The IMDS reconcile tick was `1+N` execs.** One `ovs-vsctl list-ports` plus one `ovs-vsctl get Interface … external_ids:iface-id` per port, every 15s — the source of the original audit noise.

## What changed

**Sockets are group-owned, not world-writable.** `setup-ovn.sh` installs a helper that sets `db.sock`, `*.ctl`, `ovn??_db.sock` and the `*.pid` files to `0660 root:spinifex`, and `/var/run/ovn` to `0750`. Pidfiles need group *write*: OVS opens them `O_RDWR` for an fcntl liveness lock, so group-owning the socket alone is not enough. Overrides are installed for `openvswitch-switch`, `ovn-controller` and `openvswitch-ipsec` — the last restarts after the sweep and would otherwise keep its shipped mode.

The per-bridge `<bridge>.mgmt` sockets are deliberately excluded: `ovs-vswitchd` creates them when a bridge appears, including bridges spinifex creates at runtime, so a provisioning-time sweep cannot cover them.

**`spinifex-vpcd` now holds no sudoers rules at all.** Its `ip`/`iptables`/`sysctl`/`arping` work runs under the `CAP_NET_ADMIN` and `CAP_NET_RAW` its unit already granted ambiently — the kernel passes an ambient set to each child on exec.

**`utils.NeedsPrivilege` is capability-aware.** `spx` is one binary shared by both units, and the daemon holds `CAP_SYS_ADMIN`/`CAP_DAC_OVERRIDE` but deliberately no `CAP_NET_ADMIN`, so a static tool list cannot express "vpcd runs `ip` directly, the daemon escalates it". It reads `CapAmb` from `/proc/self/status` once and matches per invocation. `sysctl` resolves per key, since `CAP_NET_ADMIN` governs the `net.*` trees and nothing else.

**Nine grants removed in total.** The six OVS/OVN clients, plus vpcd's `ip`/`iptables`/`sysctl`/`arping`, plus both `dhcpcd` grants — neither daemon invokes `dhcpcd`, only `setup-ovn.sh` (provisioning user) and the in-guest `ecs-agent`.

**Reconcile is one query per tick.** A single `ovs-vsctl --format=json --columns=name,external_ids list Interface`, parsed with `encoding/json`. Behaviour change: a port with an absent `iface-id` now warns and skips rather than aborting the pass.

**Two liveness probes fixed.** `health.go` no longer escalates. `checkOVNController` passed a bare `-t ovn-controller` to `ovs-appctl`, which resolves against `/var/run/openvswitch` — but ovn-controller lives in `/var/run/ovn`, so that probe could never succeed. Now `ovn-appctl`.

## Invariants added

- `TestRG10_SudoOnlyThroughThePolicy` — no package may build its own `sudo` invocation. vpcd carried a private `sudoCommand` copy that escalated unconditionally; it worked only because the grants existed, and broke the OVN flows-ready barrier the moment they were removed.
- `TestRG10_VPCDHoldsNoSudoersGrant` — pins the unit's ambient capabilities and vpcd's empty sudoers together, so a grant cannot be re-added without explaining why the capability stopped working.

## Verification

Live on two nodes: the local single-node dev box, and a clean-slate remote bootstrap of `env12` (`bottlebrush`).

On `env12`, post-bootstrap:

| | |
|---|---|
| `spinifex-vpcd` sudo calls | **0** |
| `spinifex-daemon` sudo calls | 20 — `ip` x12, `ovs-ofctl` x6, `sysctl` x2 |
| `pam_limits(sudo)` warnings | **0** |
| vpcd permission denials | **0** |
| world-writable files under `/var/run/{ovn,openvswitch}` | **none** |

`sudo -u spinifex-vpcd ovn-appctl -t ovn-controller connection-status` returns `connected` with no escalation. vpcd's `CapAmb` is `0x34c0` — exactly the five capabilities its unit grants. An instance launch, EIP associate, disassociate and terminate all completed with vpcd at zero sudo calls.

Each `ip` subcommand vpcd issues, plus `iptables` reads and writes, `sysctl -w` on `net.ipv4.neigh`, and `arping`, were also exercised directly under vpcd's exact ambient set via `systemd-run`.

`make preflight` green.

## Rollout note

**`cluster-deploy` does not deliver this fix.** The deploy role explicitly skips `setup.sh` (`ansible/roles/deploy/tasks/main.yml:4`), so the sudoers rewrite and the socket-permission sweep only land via `cluster-bootstrap`/`cluster-reset`, or a targeted re-run of `setup.sh` + `setup-ovn.sh`.

Mixed state is safe in the meantime: the `AmbientCapabilities=` line is unchanged, so a node running the new binary against old units and old sudoers still works — `CapAmb` already carries `CAP_NET_ADMIN`, so `ip` runs directly and the stale grants sit unused.

## Not covered

- Multi-node OVN encap. Both verified nodes were single-node.
- `spinifex-daemon` keeps `ip`, `ovs-ofctl` and `sysctl -qw net.ipv4.conf.*`. `ovs-ofctl` is the hard one — `<bridge>.mgmt` is `0700 root` and created dynamically per bridge. Tracked on `mulga-siv-262`.
- `NoNewPrivileges=yes` is now achievable for vpcd but not set: `systemd/units_invariants_test.go` asserts `NoNewPrivileges=no`, and changing an invariant needs its own ADR update and commit.