### PR TITLE
ci(nightly): move ubuntu cells to the 26.04 gold image

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -20,7 +20,7 @@ permissions:
 # trigger must stay in sync on main for cron to fire.
 env:
   GIT_BRANCH: ${{ github.event_name == 'schedule' && 'dev' || github.ref_name }}
-  UBUNTU_GOLD_IMAGE: /mnt/disk1/gold-images/spinifex-image-builder-ubuntu-24.04.qcow2
+  UBUNTU_GOLD_IMAGE: /mnt/disk1/gold-images/spinifex-image-builder-ubuntu-26.04.qcow2
   # OTLP export to the central Elastic sink (wattle). Repo variable overrides;
   # empty string disables telemetry entirely.
   SPINIFEX_OTLP_ENDPOINT: ${{ vars.SPINIFEX_OTLP_ENDPOINT || 'http://192.168.1.13:8200' }}
@@ -36,11 +36,11 @@ jobs:
       matrix:
         include:
           - { cell: 1,  install: binary, topo: single,     net: dhcp,   host: debian-13,    arch: x86_64, runner: ci-single, extra: "" }
-          - { cell: 2,  install: binary, topo: single,     net: static, host: ubuntu-24.04, arch: x86_64, runner: ci-single, extra: "" }
-          - { cell: 3,  install: binary, topo: single,     net: dhcp,   host: ubuntu-24.04, arch: x86_64, runner: ci-single, extra: "" }
+          - { cell: 2,  install: binary, topo: single,     net: static, host: ubuntu-26.04, arch: x86_64, runner: ci-single, extra: "" }
+          - { cell: 3,  install: binary, topo: single,     net: dhcp,   host: ubuntu-26.04, arch: x86_64, runner: ci-single, extra: "" }
           - { cell: 8,  install: binary, topo: real-multi, net: dhcp,   host: debian-13,    arch: x86_64, runner: ci-multi,  extra: "" }
-          - { cell: 9,  install: binary, topo: real-multi, net: static, host: ubuntu-24.04, arch: x86_64, runner: ci-multi,  extra: "" }
-          - { cell: 10, install: binary, topo: real-multi, net: dhcp,   host: ubuntu-24.04, arch: x86_64, runner: ci-multi,  extra: "" }
+          - { cell: 9,  install: binary, topo: real-multi, net: static, host: ubuntu-26.04, arch: x86_64, runner: ci-multi,  extra: "" }
+          - { cell: 10, install: binary, topo: real-multi, net: dhcp,   host: ubuntu-26.04, arch: x86_64, runner: ci-multi,  extra: "" }
           - { cell: 17, install: binary, topo: single,     net: static, host: debian-13,    arch: x86_64, runner: ci-pseudo, extra: "tofu-examples" }
           - { cell: 18, install: binary, topo: single,     net: static, host: debian-13,    arch: x86_64, runner: ci-single, extra: "reboot-single" }
           - { cell: 19, install: binary, topo: single,     net: nat,    host: debian-13,    arch: x86_64, runner: ci-single, extra: "nat-single" }
@@ -128,10 +128,13 @@ jobs:
         run: |
           export TF_VAR_git_branch="${GIT_BRANCH}"
 
+          # Match the family, not a pinned version: an exact match silently stops
+          # overriding the image when the matrix bumps release, dropping the cell
+          # back onto the debian gold.
           TOFU_VAR_ARGS=""
-          if [ "$MATRIX_HOST" = "ubuntu-24.04" ]; then
-            TOFU_VAR_ARGS="-var=host_image_override=${UBUNTU_GOLD_IMAGE}"
-          fi
+          case "$MATRIX_HOST" in
+            ubuntu-*) TOFU_VAR_ARGS="-var=host_image_override=${UBUNTU_GOLD_IMAGE}" ;;
+          esac
 
           tofu init -input=false >> "$TOFU_LOG" 2>&1
           tofu workspace select -or-create "${SPINIFEX_CI_ENV}" >> "$TOFU_LOG" 2>&1
@@ -370,10 +373,12 @@ jobs:
         env:
           MATRIX_HOST: ${{ matrix.host }}
         run: |
+          # Must mirror the Provision step's override, or destroy runs against a
+          # different image path than apply did.
           TOFU_VAR_ARGS=""
-          if [ "$MATRIX_HOST" = "ubuntu-24.04" ]; then
-            TOFU_VAR_ARGS="-var=host_image_override=${UBUNTU_GOLD_IMAGE}"
-          fi
+          case "$MATRIX_HOST" in
+            ubuntu-*) TOFU_VAR_ARGS="-var=host_image_override=${UBUNTU_GOLD_IMAGE}" ;;
+          esac
           tofu workspace select -or-create "${SPINIFEX_CI_ENV}" >> "$TOFU_LOG" 2>&1
           timeout 120 ./flush-telemetry.sh "${SPINIFEX_CI_ENV}" >> "$TOFU_LOG" 2>&1 || true
           tofu destroy -var-file=envs/${SPINIFEX_CI_ENV}.tfvars ${TOFU_VAR_ARGS} -auto-approve -input=false >> "$TOFU_LOG" 2>&1


### PR DESCRIPTION
## Summary

Cells 2, 3, 9 and 10 ran on `spinifex-image-builder-ubuntu-24.04.qcow2`, built 2026-04-20 — five weeks before `openvswitch-ipsec` (a9b3a9cf) and `strongswan-charon` (116bb05f) were added to the image builder. Those cells had no OVN IPsec support and ran intra-AZ Geneve in plaintext. Every other workflow (`e2e.yml`, `e2e-suites.yml`, `e2e-baremetal.yml`, `gpu-e2e.yml`) is already on 26.04.

The root cause was that `scripts/tofu-cluster/image-builder/` only defined Debian variants, so ubuntu golds were baked by hand out-of-band and never picked up builder changes. That is fixed on mulga main (14dfa067, 4ab5f2d4), which adds an ubuntu variant.

## Image

`spinifex-image-builder-ubuntu-26.04.qcow2` is built and staged, sha256 `3e215930285c5b25f16457e54a9b711d896e848e07e64d06eb3c6b91e3d1dba3`, byte-identical on banksia, wattle, bottlebrush, ironbark and casuarina.

Verified in the image: Ubuntu 26.04 LTS, standalone qcow2 (no backing file), with `openvswitch-ipsec`, `strongswan-charon`, `ovn-host`, `openvswitch-switch`, `qemu-system-x86` and `nbdkit` all `install ok installed`.

## Also changed

The `host_image_override` guards now match `ubuntu-*` rather than a pinned version. An exact match is what let this drift go unnoticed — bumping the matrix release silently stops overriding the image and drops the cell back onto the debian gold. The teardown step's copy must stay in sync with the provision step's, or destroy runs against a different image path than apply did.

## Testing

Not yet smoke-tested on CI. Dispatching cell 2 on this branch would contend with tonight's scheduled nightly, so it is left for the merger to decide.

Note that with the IPsec masking fix (`fix/ipsec-masked-skip`), the ipsec suite now fails rather than skips when a cluster requests IPsec and does not get it — so these cells will report honestly either way.