### PR TITLE
fix(e2e): fail TestMultinodeIPSec when a cluster that requested IPsec has none

### DIFF
--- a/tests/e2e/multinode/ipsec_test.go
+++ b/tests/e2e/multinode/ipsec_test.go
@@ -14,7 +14,7 @@ import (
 
 // runIPSec verifies OVN native IPsec is live on every node: OVS DB carries cert/key/CA
 // pointers, xfrm shows AES-GCM SAs, and ESP traffic is observed (best-effort tcpdump).
-// Skips if the cluster was bootstrapped with --ipsec=false.
+// Skips only when the node config disables IPsec; a cluster that asked for it fails.
 func runIPSec(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Multinode — OVN Native IPsec")
 
@@ -31,7 +31,14 @@ func runIPSec(t *testing.T, fix *Fixture) {
 		t.Fatalf("probe ovs-vsctl on %s: %v", first.Name, err)
 	}
 	if !strings.Contains(string(out), "true") {
-		t.Skipf("IPsec not enabled on cluster (%s reports %q): skip", first.Name, strings.TrimSpace(string(out)))
+		// An empty ipsec_encapsulation alone cannot distinguish "deliberately
+		// disabled" from "enable failed", so cross-check the config's intent.
+		// Skipping on both let ubuntu-24.04 cells run plaintext and report green.
+		if ipsecRequested(t, ssh, first) {
+			t.Fatalf("%s requests network.ipsec_enabled but reports ipsec_encapsulation=%q — intra-AZ Geneve is plaintext; check openvswitch-ipsec.service",
+				first.Name, strings.TrimSpace(string(out)))
+		}
+		t.Skipf("IPsec disabled in node config on %s (network.ipsec_enabled=false): skip", first.Name)
 	}
 
 	harness.Step(t, "OVS DB carries cert pointers + ipsec_encapsulation=true on every node")
@@ -91,4 +98,28 @@ func runIPSec(t *testing.T, fix *Fixture) {
 			t.Logf("WARN: %s tcpdump saw no ESP traffic in 5s window (geneve may be idle):\n%s", n.Name, s)
 		}
 	}
+}
+
+// nodeConfigPath is the daemon config the cluster is provisioned with.
+const nodeConfigPath = "/etc/spinifex/spinifex.toml"
+
+// ipsecRequested reports whether the node was configured to run IPsec.
+// network.ipsec_enabled defaults to true, so an absent or unreadable key means
+// requested; only an explicit false opts out.
+func ipsecRequested(t *testing.T, ssh *harness.PeerSSH, n harness.Node) bool {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	raw, err := ssh.Run(ctx, n.Addr,
+		"sudo grep -E '^[[:space:]]*ipsec_enabled' "+nodeConfigPath+" 2>/dev/null || true",
+	)
+	if err != nil {
+		t.Logf("WARN: %s read ipsec_enabled from %s: %v — assuming requested (config default)", n.Name, nodeConfigPath, err)
+		return true
+	}
+
+	line := strings.TrimSpace(string(raw))
+	harness.Detail(t, "node", n.Name, "ipsec_enabled", line)
+	return !strings.Contains(line, "false")
 }

--- a/tests/e2e/multinode/ipsec_test.go
+++ b/tests/e2e/multinode/ipsec_test.go
@@ -119,7 +119,16 @@ func ipsecRequested(t *testing.T, ssh *harness.PeerSSH, n harness.Node) bool {
 		return true
 	}
 
-	line := strings.TrimSpace(string(raw))
-	harness.Detail(t, "node", n.Name, "ipsec_enabled", line)
-	return !strings.Contains(line, "false")
+	// Keep the first token after "=" so a trailing comment cannot be mistaken
+	// for the value. An absent key leaves this empty, which reads as requested.
+	value := strings.TrimSpace(string(raw))
+	if _, after, ok := strings.Cut(value, "="); ok {
+		value = strings.TrimSpace(after)
+	}
+	if fields := strings.Fields(value); len(fields) > 0 {
+		value = fields[0]
+	}
+
+	harness.Detail(t, "node", n.Name, "ipsec_enabled", value)
+	return value != "false"
 }


### PR DESCRIPTION
## Summary

`runIPSec` skipped whenever `ipsec_encapsulation` was not `true`. That reads "deliberately disabled" and "enable failed" as the same thing, so a cluster that asked for IPsec and did not get it ran intra-AZ Geneve in plaintext and reported green.

That is how the ubuntu-24.04 nightly cells passed for weeks with no OVN IPsec support at all: the gold image was baked before `openvswitch-ipsec` and `strongswan-charon` were added to the image builder, `EnableOVNIPSec` correctly refused to proceed, and this test silently skipped over it. "Nightly has passed before" is precisely what a silent skip produces.

Now the test cross-checks the node config: an explicit `network.ipsec_enabled = false` still skips, anything else fails with the observed `ipsec_encapsulation` value and a pointer at `openvswitch-ipsec.service`. The key defaults to true, so an absent or unreadable config reads as requested — the safe direction, since a missing config should not silently license plaintext.

## Testing

Verified live on env19, all three states exercised end to end:

- healthy cluster — PASS
- `ipsec_encapsulation` cleared to simulate a failed enable — FAIL, with the intended message
- `ipsec_enabled = false` in the node config — SKIP

The live run also caught a cosmetic bug that compiling could not: the raw grep line was being logged as the value, so output read `ipsec_enabled=ipsec_enabled = true`. Fixed in the second commit, which keeps only the first token after `=` so a trailing comment cannot be mistaken for the value.

env19 was restored to its original healthy state afterwards (`encap="true"`, `svc=active`, `aead=8` on all three nodes).

## Note

The branch is based on an earlier `dev` and can be brought forward with GitHub's Update branch button if you would rather not rebase.