### PR TITLE
fix(ci): report a cell that never ran a test as failed, not clean

### DIFF
--- a/.github/actions/e2e-analyze/analyze.go
+++ b/.github/actions/e2e-analyze/analyze.go
@@ -467,9 +467,19 @@ func Render(r Report) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## %s\n\n", r.Title)
 
-	totalFail := 0
+	totalFail, totalTests := 0, 0
 	for _, s := range r.Suites {
 		totalFail += s.FailCount
+		totalTests += s.Total
+	}
+
+	// A cell that dies before the suites run emits junit with no testcases at
+	// all. Reporting that as clean turns "nothing ran" into "nothing wrong", so
+	// name it and point above the suites.
+	if totalTests == 0 {
+		b.WriteString("⚠️ No tests ran — no testcases in any junit file. " +
+			"The failure is upstream of the suites (provisioning, bootstrap, or reimage); check the job log.\n")
+		return b.String()
 	}
 	if totalFail == 0 {
 		b.WriteString("✅ No failures across any suite.\n")

--- a/.github/actions/e2e-analyze/analyze_test.go
+++ b/.github/actions/e2e-analyze/analyze_test.go
@@ -189,3 +189,25 @@ func TestRender_NoFailuresIsClean(t *testing.T) {
 		t.Errorf("expected zero-failure banner, got:\n%s", out)
 	}
 }
+
+// A cell that fails in provisioning writes junit with no testcases. Rendering
+// the clean banner there reports "nothing ran" as "nothing wrong".
+func TestRender_NoTestsRanIsNotClean(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		suites []SuiteReport
+	}{
+		{"empty junit file", []SuiteReport{{File: "junit-baremetal.xml", Label: "baremetal", Total: 0, FailCount: 0}}},
+		{"no junit files at all", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := Render(Report{Title: "E2E failure analysis", Suites: tc.suites})
+			if strings.Contains(out, "No failures across any suite") {
+				t.Errorf("clean banner rendered when no test ran, got:\n%s", out)
+			}
+			if !strings.Contains(out, "No tests ran") {
+				t.Errorf("expected a no-tests-ran warning, got:\n%s", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`Render` summed `FailCount` across suites and printed `✅ No failures across any suite` whenever the total was zero — without asking whether any test had actually run.

A cell that dies during provisioning emits a junit file with no testcases at all, so it took the clean path. In nightly run 30467638631, cell 20 failed with `bm-reimage: [node1] FAIL: install callback never fired after 3 attempts; PXE never triggered install`, and its `analysis.md` read `✅ No failures across any suite`. The job conclusion was `failure`.

This is the same failure mode as the IPsec silent skip (#612): absence of evidence rendered as positive evidence.

## Change

Zero testcases across all junit files now renders a warning naming the layer above the suites, rather than the clean banner. A run that has tests and no failures is unchanged.

## Testing

`TestRender_NoTestsRanIsNotClean` covers both the empty-junit-file and no-junit-files-at-all cases.

Replayed all ten cells' real junit from run 30467638631 through the fixed analyzer. Nine render byte-identically to before; only cell 20 changes:

```
cell 1   ### Suite `cert`: ✅ pass (20 tests)
cell 2   ✅ No failures across any suite.
cell 17  ### Suite `tofu`: 1 failed, 1 root cause likely
cell 19  ✅ No failures across any suite.
cell 20  ⚠️ No tests ran — no testcases in any junit file. …
```

Golden fixtures unaffected. `make preflight` passes.

## Scope

The analyzer is advisory only (`main.go:23` — the existing gate owns the exit code), so this does not change CI pass/fail. It changes what a human triaging the run is told, and what the `ci-rca` skill reads when it enumerates failures from `analysis.md`.