### PR TITLE
fix(otel): change log level in place so the gateway keeps shipping to the sink

### DIFF
--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -171,7 +171,9 @@ func (gw *GatewayConfig) SetupRoutes() http.Handler {
 		logLevel = slog.LevelInfo
 	}
 
-	otelsetup.SetDefaultJSONLogger(logLevel)
+	// Adjust the level only. Reinstalling the default logger here would drop the OTLP
+	// bridge Init fanned on at startup, blinding the sink to every line after this.
+	otelsetup.SetLevel(logLevel)
 
 	if gw.RateLimiter == nil {
 		gw.RateLimiter = NewAuthRateLimiter()

--- a/spinifex/otelsetup/slog.go
+++ b/spinifex/otelsetup/slog.go
@@ -9,12 +9,26 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// defaultLevel backs the stdout handler's level. Held in a LevelVar so verbosity can
+// change without reinstalling the handler, which would discard the OTLP bridge Init
+// fans onto whatever default is installed at the time.
+var defaultLevel = new(slog.LevelVar)
+
 // SetDefaultJSONLogger installs the process-wide slog default: JSON to
 // stdout (journald) at the given level, with trace_id/span_id stamping.
+// Call once, before Init; use SetLevel to change verbosity afterwards.
 func SetDefaultJSONLogger(level slog.Level) {
+	defaultLevel.Set(level)
 	slog.SetDefault(slog.New(NewSlogHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: level,
+		Level: defaultLevel,
 	}))))
+}
+
+// SetLevel changes the stdout handler's level in place, leaving the handler chain
+// intact. Callers that only need to adjust verbosity must use this: calling
+// SetDefaultJSONLogger again replaces the default and silently unbolts OTLP export.
+func SetLevel(level slog.Level) {
+	defaultLevel.Set(level)
 }
 
 var _ slog.Handler = (*traceHandler)(nil)

--- a/spinifex/otelsetup/slog_level_test.go
+++ b/spinifex/otelsetup/slog_level_test.go
@@ -1,0 +1,66 @@
+package otelsetup
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+)
+
+// recordingHandler stands in for the OTLP bridge: it only needs to prove it still
+// receives records after a level change.
+type recordingHandler struct{ msgs *[]string }
+
+func (recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.msgs = append(*h.msgs, r.Message)
+	return nil
+}
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+// A gateway that reinstalled the default logger to change verbosity silently detached
+// the OTLP bridge, so only startup lines ever reached the sink.
+func TestSetLevelKeepsFanoutAttached(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var got []string
+	SetDefaultJSONLogger(slog.LevelInfo)
+	addFanoutHandler(recordingHandler{msgs: &got})
+
+	SetLevel(slog.LevelDebug)
+	slog.Info("after level change")
+
+	if len(got) != 1 || got[0] != "after level change" {
+		t.Fatalf("fanout handler lost after SetLevel, got %v", got)
+	}
+
+	// The hazard SetLevel exists to avoid: reinstalling the default drops the fanout,
+	// so nothing logged afterwards reaches the bridge.
+	SetDefaultJSONLogger(slog.LevelInfo)
+	slog.Info("after reinstall")
+	if len(got) != 1 {
+		t.Fatalf("expected reinstall to detach the fanout, got %v", got)
+	}
+}
+
+func TestSetLevelChangesVerbosityInPlace(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: defaultLevel})))
+
+	SetLevel(slog.LevelError)
+	slog.Info("suppressed")
+	if buf.Len() != 0 {
+		t.Fatalf("info logged at error level: %s", buf.String())
+	}
+
+	SetLevel(slog.LevelDebug)
+	slog.Debug("emitted")
+	if !bytes.Contains(buf.Bytes(), []byte("emitted")) {
+		t.Fatalf("debug not logged after level lowered: %s", buf.String())
+	}
+}


### PR DESCRIPTION
The AWS gateway stops sending app logs to Elasticsearch moments after startup. It fronts every AWS API call, so the sink is blind to almost everything it does.

## Evidence

Nightly run 30467638631, cell 17. `awsgw` shipped **9 app-log docs, all between 16:44:07.892 and 16:44:07.925** — then nothing for the remaining 12 minutes of the cell. The journal for that same cell holds **574 gateway `request` lines** plus 3 SigV4 auth failures, none of which reached ES.

The cutoff lands exactly at gateway startup, which is the tell.

## Cause

`cmd/spinifex/cmd/service.go` calls `SetDefaultJSONLogger` and then `otelsetup.Init`, which bolts the OTLP bridge on via `addFanoutHandler`. That helper captures `slog.Default()` **at call time**.

`GatewayConfig.SetupRoutes` later called `SetDefaultJSONLogger` again — purely to set a log level. That is a bare `slog.SetDefault`, so it swapped the fanout for a stdout-only handler and the OTLP branch was gone for the life of the process. Nothing warned; stdout/journald kept working, which is why this survived so long.

## Fix

Back the stdout handler with a `slog.LevelVar` and add `SetLevel`, which mutates the level without touching the handler chain. `SetupRoutes` now calls that.

## Testing

Two regression tests. One asserts a fanout handler still receives records after `SetLevel`, and — in the same test — that reinstalling the default *does* detach it, so the hazard is pinned rather than merely avoided. The other asserts the level actually changes in place.

`make preflight` passes.

## Notes

This blocks #615: that PR logs the SigV4 canonical request on mismatch to diagnose mulga-zjy2g, and the log line could not reach ES while the gateway was blinded.

Found while investigating mulga-ju6bf, whose premise turned out to be wrong — slog attributes are not dropped. `otelslog` rewrites `error`-valued attributes to `exception.message`/`exception.type` per OTel semantic conventions, so an `err` attribute lands in `error.exception[0].message`, not `labels.err`. That is a discoverability trap, not data loss, and it is tracked separately.