### PR TITLE
fix(lbagent): emit JSON logs so console attributes reach the sink as fields

### DIFF
--- a/cmd/lb-agent/main.go
+++ b/cmd/lb-agent/main.go
@@ -19,11 +19,17 @@ import (
 	"syscall"
 
 	"github.com/mulgadc/spinifex/spinifex/lbagent"
+	"github.com/mulgadc/spinifex/spinifex/otelsetup"
 
 	_ "github.com/mulgadc/spinifex/internal/fipsboot"
 )
 
 func main() {
+	// Without this the agent falls back to slog's default text handler, which folds
+	// attributes into the message so the console scraper recovers a level and nothing
+	// else. No OTLP export: the agent's only egress is the gateway it is watching.
+	otelsetup.SetDefaultJSONLogger(slog.LevelInfo)
+
 	var (
 		lbID       string
 		gatewayURL string


### PR DESCRIPTION
`cmd/lb-agent/main.go` configured no logger at all — no `slog.SetDefault`, no `otelsetup`. It therefore fell back to slog's default text handler, which folds attributes into the message.

The result in ES:

```
message: Heartbeat failed err="heartbeat: gateway returned 400: <?xml version=\"1.0\" ...
labels:  {filename, log_file_name, instance_id, level}   <- scraper metadata only
```

The cause of the failure was greppable but never queryable. Labels held only what the file scraper could infer.

## Change

One line: install the JSON handler at the top of `main`.

`otelsetup.Init` is deliberately **not** called. The agent's only network egress is the AWS gateway it exists to watch, so during the gateway blackout this pipeline was built to catch, anything shipped over that path goes dark at the same instant the heartbeat does. QEMU writes the guest serial console to a host-side file with no guest networking in the path, so the console remains the channel that survives — it just needs to carry parseable structure.

## Paired change

The Alloy console stage needs a matching `stage.json`; that lands in mulga alongside the dedup fix. It keeps the old text regex as a fallback so a partly-rolled fleet keeps parsing — verified against real Alloy v1.5.1 with a mixed-format console file:

| input | body | attributes |
| --- | --- | --- |
| JSON with err | `Heartbeat failed` | `level=ERROR`, `err="gateway returned 400"` |
| JSON without err | `Config applied` | `level=INFO` |
| old text format | `Heartbeat failed err="old text format"` | `level=ERROR` |
| kernel boot noise | unchanged | none, falls through to `vm-console` |

Guests running an older image keep working; they just don't gain the `err` field until reimaged.

## Testing

`make preflight` passes. Verified the binary's actual output:

```
{"time":"2026-07-31T11:07:39.79Z","level":"ERROR","msg":"--lb-id is required (or set LB_LB_ID)"}
```