### PR TITLE
chore(deps): bump viperblock for the nbdkit plugin stderr fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.14.0
 	github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4
-	github.com/mulgadc/viperblock v1.14.1-0.20260729042700-9b253946d091
+	github.com/mulgadc/viperblock v1.14.1-0.20260731043757-9c4ece252152
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1323,6 +1323,8 @@ github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4 h1:Q4/NEryYT
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4/go.mod h1:na0aNXABZF03/HfFWCrAPHrId/2FIEIUQfB82vlu1xg=
 github.com/mulgadc/viperblock v1.14.1-0.20260729042700-9b253946d091 h1:P+KZWeIYh3uVmje6wad6TuCqAkV0Fn/4oVM4ldBaED0=
 github.com/mulgadc/viperblock v1.14.1-0.20260729042700-9b253946d091/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
+github.com/mulgadc/viperblock v1.14.1-0.20260731043757-9c4ece252152 h1:pnFcpWkPU8V0fT4g9bqP6nFhGDPcOXdvsRd2LQwFPEw=
+github.com/mulgadc/viperblock v1.14.1-0.20260731043757-9c4ece252152/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
## What

Bumps `github.com/mulgadc/viperblock` from `9b253946d091` to `9c4ece252152` (viperblock `dev` HEAD).

Picks up:
- viperblock #57 — routes the JSON slog handler to stderr so the nbdkit plugin's logs reach journald
- viperblock #56 — removes a per-call allocation from the per-block cache instrument

## Why the bump is needed

No spinifex code depends on either change. `spx` does not import `viperblock/telemetry` at all, and has its own `otelsetup.SetDefaultJSONLogger`.

The bump is required by the build role's drift gate (`ansible/roles/build/tasks/main.yml:126-188`). `spx` is built `GOWORK=off`, so its viperblock comes from the module cache at this pin, while the nbdkit plugin is built from the submodule tree. The role compares the two viperblock sources and hard-fails on a mismatch, so moving the submodule onto `9c4ece2` without this bump breaks the build even though the change is a no-op for `spx`.

## Background on #57

nbdkit repoints a plugin's fd 1 at `/dev/null` while leaving fd 2 on the parent's journald socket, so every line the viperblock nbdkit plugin logged was discarded. The OTLP fan-out hid it in steady state, but not during host shutdown: the observability agent stopped before the graceful drain, so the volume seal ran with no live OTLP endpoint and no journald fallback, and the seal window reached Elasticsearch as nothing.

Verified end to end on env12, together with the Alloy stop-ordering fix in mulga `d9f51511`: the seal path now lands as 7 documents where the previous reboot produced 0.

## Testing

`make preflight` passes.

It initially failed here, and identically on `dev`, for a reason unrelated to this change: `go.work` resolved predastore to the mulga submodule at `3210b6f`, 4 commits behind the `608939ef2bb4` this repo's `go.mod` already pins, and the older tree lacks `(*sigv4.SignedRequest).CanonicalRequest()` used by `spinifex/gateway/auth.go:175`. Fixed by aligning the monorepo checkout with the existing pin in mulga `876f0d98`; no pin moved.