### PR TITLE
fix(systemd): backstop viperblock stop at 30s instead of the 90s default

### DIFF
--- a/build/systemd/spinifex-viperblock.service
+++ b/build/systemd/spinifex-viperblock.service
@@ -15,6 +15,11 @@ ExecStart=/usr/local/bin/spx service viperblock start
 Restart=on-failure
 RestartSec=5
 OOMScoreAdjust=-500
+# Backstop for the in-use nbdkit children SIGTERMed with this cgroup. Their
+# plugin bounds its own shutdown drain at 20s, so 30s lets that fire first and
+# keeps SIGKILL exceptional; the 90s default let a slow backend stall the whole
+# target-stop transaction.
+TimeoutStopSec=30
 EnvironmentFile=/etc/spinifex/systemd.env
 Environment=SPINIFEX_CONFIG_PATH=/etc/spinifex/spinifex.toml
 Environment=SPINIFEX_BASE_DIR=/var/lib/spinifex/viperblock/


### PR DESCRIPTION
The systemd half of `mulga-wtvw5`. The plugin half is viperblock PR #61; this one is unit-file only, so it needs no `go.mod` repin and can land independently.

## Why

`KillMode=control-group` SIGTERMs every process in the `spinifex-viperblock` cgroup, including the in-use nbdkit children viperblockd deliberately leaves alive. Each runs the plugin's `Close`/`Unload`, which drains to predastore. Against a slow or unreachable backend that drain used to block indefinitely, so systemd waited out the 90s `TimeoutStopSec` default and then SIGKILLed — stalling the whole `spinifex.target` stop transaction, which is a large part of why `cluster-deploy` is slow.

viperblock #61 bounds the plugin's drain and close at 20s. 30s here sits above that, so the plugin's own bound fires first and SIGKILL stays a genuine backstop rather than the normal path.

## Scope

`spinifex-viperblock.service` only — that is the unit with the measured stall. Peer units were left alone rather than blanket-applied: `spinifex-predastore.service` stops *after* viperblock (viperblock is `After=spinifex-predastore.service`), so it is already gated by this unit's stop rather than adding its own delay.

Safe because an aborted drain is recoverable: committed writes are in the fsync'd local WAL and replay on the next attach.

Verified with `systemd-analyze verify` and `make preflight`. Live verification of the stop time is deferred to the end of the viperblock durability batch (`mulga-8bplk`), when env12 runs every member together.