### PR TITLE
fix(viperblockd): branch on the plugin's seal receipt, not on a deleted directory

### DIFF
--- a/spinifex/services/viperblockd/viperblockd.go
+++ b/spinifex/services/viperblockd/viperblockd.go
@@ -253,16 +253,75 @@ func isAuxVolume(volumeName string) bool {
 	return strings.HasSuffix(volumeName, "-efi")
 }
 
-// volumeNeedsSeal reports whether an unmounted volume must be sealed to
-// predastore on this node: it carries durable guest data (not an auxiliary
-// volume) and has local viperblock state under baseDir/<volume> to flush. A
-// node that never held the local WAL has nothing to seal.
+// volumeNeedsSeal reports whether an unmounted volume has local viperblock
+// state under baseDir/<volume> to flush. A node that never held the local
+// WAL has nothing to seal. Callers handle auxiliary volumes separately (see
+// isAuxVolume).
 func volumeNeedsSeal(volumeName, baseDir string) bool {
-	if isAuxVolume(volumeName) {
-		return false
-	}
 	_, err := os.Stat(filepath.Join(baseDir, volumeName))
 	return err == nil
+}
+
+// sealReceiptSuffix names the file the nbdkit plugin leaves at
+// baseDir/<volume>.sealed after a successful seal.
+const sealReceiptSuffix = ".sealed"
+
+// sealReceipt is the fixed shape the nbdkit plugin writes after a successful
+// seal. PID is diagnostic only: it is never used to judge staleness, since a
+// receipt is cleared at mount instead (see clearStaleSealReceipt).
+type sealReceipt struct {
+	Volume   string    `json:"volume"`
+	PID      int       `json:"pid"`
+	SealedAt time.Time `json:"sealed_at"`
+}
+
+// sealReceiptPath returns the receipt path for a volume under baseDir.
+func sealReceiptPath(baseDir, volume string) string {
+	return filepath.Join(baseDir, volume+sealReceiptSuffix)
+}
+
+// consumeSealReceipt reads and deletes baseDir/<volume>.sealed, reporting
+// whether a valid receipt was there. It never fails the unmount: the seal it
+// attests to already happened, so a missing or unreadable receipt only costs
+// the caller a WARN.
+func consumeSealReceipt(baseDir, volume string) bool {
+	path := sealReceiptPath(baseDir, volume)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("failed to read seal receipt", "volume", volume, "path", path, "err", err)
+		}
+		return false
+	}
+
+	// Delete unconditionally, even if the contents below turn out to be
+	// invalid, so a malformed receipt cannot linger and be misread later.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove seal receipt", "volume", volume, "path", path, "err", err)
+	}
+
+	var receipt sealReceipt
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		slog.Warn("malformed seal receipt", "volume", volume, "path", path, "err", err)
+		return false
+	}
+	if receipt.Volume != volume || receipt.SealedAt.IsZero() {
+		slog.Warn("seal receipt missing required fields", "volume", volume, "path", path, "receipt", receipt)
+		return false
+	}
+	return true
+}
+
+// clearStaleSealReceipt removes any seal receipt left by a previous mount of
+// this volume. Staleness is handled here, at mount, rather than by matching
+// PIDs at unmount: once this runs, any receipt found at the next unmount can
+// only have come from the plugin instance this mount is about to start.
+func clearStaleSealReceipt(baseDir, volume string) {
+	path := sealReceiptPath(baseDir, volume)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to clear stale seal receipt", "volume", volume, "path", path, "err", err)
+	}
 }
 
 // openLoadedVolumeVB opens a detached volume and fully restores its state for a
@@ -532,18 +591,27 @@ func launchService(cfg *Config) (err error) {
 			// nbdkit is now dead, so no process writes the shared BaseDir: seal
 			// the block map to predastore for volumes that hold local state to
 			// flush (see volumeNeedsSeal).
-			if volumeNeedsSeal(matched.Name, cfg.BaseDir) {
+			if isAuxVolume(matched.Name) {
+				// Auxiliary volumes carry no durable guest data, so there is
+				// nothing to seal even when local state is present.
+			} else if volumeNeedsSeal(matched.Name, cfg.BaseDir) {
+				// Local state survived: the plugin's seal either failed or was
+				// cut short, so this fallback is the real seal.
 				if err := cfg.seal(matched.Name); err != nil {
 					slog.ErrorContext(ctx, "ebs.unmount: failed to seal volume to predastore", "volume", matched.Name, "err", err)
 					ebsResponse.Error = fmt.Sprintf("seal volume: %v", err)
 				} else {
 					slog.InfoContext(ctx, "ebs.unmount: volume sealed to predastore", "volume", matched.Name)
 				}
-			} else if !isAuxVolume(matched.Name) {
-				// A durable volume reached unmount with no local WAL under
-				// BaseDir: this node never held its state, so there is nothing to
-				// seal. WARN since a missing local WAL for a volume we expected to
-				// seal can mask the durability gap the seal closes.
+			} else if consumeSealReceipt(cfg.BaseDir, matched.Name) {
+				// Healthy path: the plugin sealed to predastore and removed
+				// its local state itself, leaving this receipt as proof.
+				slog.InfoContext(ctx, "ebs.unmount: volume already sealed by nbdkit plugin", "volume", matched.Name)
+			} else {
+				// A durable volume reached unmount with no local WAL and no
+				// seal receipt: this node never held its state, so there is
+				// nothing to seal. WARN since this can mask a durability gap
+				// the seal would otherwise close.
 				slog.WarnContext(ctx, "ebs.unmount: no local viperblock state for volume, skipping seal", "volume", matched.Name, "baseDir", cfg.BaseDir)
 			}
 
@@ -724,6 +792,10 @@ func launchService(cfg *Config) (err error) {
 		}
 
 		slog.InfoContext(ctx, "ebs.mount", "request", ebsRequest)
+
+		// Clear any receipt left by a previous mount before anything else can
+		// return early, so a stale receipt can never survive into this mount.
+		clearStaleSealReceipt(cfg.BaseDir, ebsRequest.Name)
 
 		_, mountSpan := otel.Tracer(viperblockdTracerName).Start(ctx, "ebs.mount",
 			trace.WithAttributes(attribute.String("volume.id", ebsRequest.Name)))

--- a/spinifex/services/viperblockd/viperblockd_integration_test.go
+++ b/spinifex/services/viperblockd/viperblockd_integration_test.go
@@ -5,10 +5,13 @@ package viperblockd
 //   go test -short ./spinifex/services/viperblockd/...  # unit tests only
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -76,6 +79,56 @@ func createMockVolumeState(t *testing.T, baseDir, volumeName string) {
 
 	err = os.WriteFile(stateFile, data, 0644)
 	assert.NoError(t, err)
+}
+
+// writeSealReceipt writes a valid seal receipt for volumeName, matching the
+// fixed shape the nbdkit plugin produces after a successful seal.
+func writeSealReceipt(t *testing.T, baseDir, volumeName string) {
+	t.Helper()
+
+	receipt := sealReceipt{
+		Volume:   volumeName,
+		PID:      4242,
+		SealedAt: time.Now().UTC(),
+	}
+	data, err := json.Marshal(receipt)
+	require.NoError(t, err)
+
+	err = os.WriteFile(sealReceiptPath(baseDir, volumeName), data, 0644)
+	require.NoError(t, err)
+}
+
+// syncBuffer is a concurrency-safe io.Writer, used to capture slog output
+// while the service is running its own goroutines.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// captureLogs swaps the process-wide default slog logger for one that writes
+// to the returned buffer, restoring the previous logger on test cleanup.
+// Callers must not run in parallel with other tests that log, so do not call
+// this from a test that also calls t.Parallel().
+func captureLogs(t *testing.T) *syncBuffer {
+	t.Helper()
+
+	buf := &syncBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
 }
 
 // TestIntegration_ServiceStartWithEmbeddedNATS tests service startup with embedded NATS.
@@ -402,6 +455,228 @@ func TestIntegration_EBSUnmountSealFailureKeepsVolumeMounted(t *testing.T) {
 	defer cfg.mu.Unlock()
 	require.Len(t, cfg.MountedVolumes, 1, "a failed seal must leave the volume in MountedVolumes for retry")
 	assert.Equal(t, "vol-seal-fail", cfg.MountedVolumes[0].Name)
+}
+
+// TestIntegration_EBSUnmountReceiptSkipsFallbackSeal verifies the healthy
+// path: a seal receipt with no local WAL directory means the plugin already
+// sealed and cleaned up, so the fallback seal must not run and no WARN
+// should fire. Not parallel: it swaps the process-wide slog default to
+// assert on log output (see captureLogs).
+func TestIntegration_EBSUnmountReceiptSkipsFallbackSeal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	logs := captureLogs(t)
+
+	ns, natsURL := setupEmbeddedNATS(t)
+	defer ns.Shutdown()
+
+	cfg := setupTestConfig(t, natsURL)
+	writeSealReceipt(t, cfg.BaseDir, "vol-clean-receipt")
+	var sealCalls atomic.Int32
+	cfg.sealVolume = func(volumeName string) error {
+		sealCalls.Add(1)
+		return nil
+	}
+	cfg.MountedVolumes = []MountedVolume{
+		{Name: "vol-clean-receipt", PID: 99999},
+	}
+
+	go func() { launchService(cfg) }()
+	time.Sleep(500 * time.Millisecond)
+
+	nc, err := nats.Connect(natsURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	requestData, err := json.Marshal(types.EBSRequest{Name: "vol-clean-receipt"})
+	require.NoError(t, err)
+
+	msg, err := nc.Request("ebs.test-node.unmount", requestData, 5*time.Second)
+	require.NoError(t, err)
+
+	var resp types.EBSUnMountResponse
+	require.NoError(t, json.Unmarshal(msg.Data, &resp))
+	assert.Empty(t, resp.Error, "a receipt on the healthy path must not surface as an unmount error")
+	assert.Equal(t, int32(0), sealCalls.Load(), "a receipt present with no local WAL must not trigger the fallback seal")
+
+	output := logs.String()
+	assert.NotContains(t, output, "no local viperblock state for volume", "the healthy receipt path must not WARN")
+	assert.Contains(t, output, "level=INFO", "the healthy receipt path should log at Info, not silently")
+	assert.Contains(t, output, "vol-clean-receipt")
+
+	_, statErr := os.Stat(sealReceiptPath(cfg.BaseDir, "vol-clean-receipt"))
+	assert.True(t, os.IsNotExist(statErr), "the receipt must be deleted once consumed")
+}
+
+// TestIntegration_EBSUnmountStateDirSealsRegardlessOfReceipt verifies that a
+// surviving local WAL directory always triggers the fallback seal, even when
+// a seal receipt is also present — local state is the durability signal that
+// takes precedence.
+func TestIntegration_EBSUnmountStateDirSealsRegardlessOfReceipt(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ns, natsURL := setupEmbeddedNATS(t)
+	defer ns.Shutdown()
+
+	cfg := setupTestConfig(t, natsURL)
+	createMockVolumeState(t, cfg.BaseDir, "vol-state-and-receipt")
+	writeSealReceipt(t, cfg.BaseDir, "vol-state-and-receipt")
+	var sealCalls atomic.Int32
+	cfg.sealVolume = func(volumeName string) error {
+		sealCalls.Add(1)
+		return nil
+	}
+	cfg.MountedVolumes = []MountedVolume{
+		{Name: "vol-state-and-receipt", PID: 99999},
+	}
+
+	go func() { launchService(cfg) }()
+	time.Sleep(500 * time.Millisecond)
+
+	nc, err := nats.Connect(natsURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	requestData, err := json.Marshal(types.EBSRequest{Name: "vol-state-and-receipt"})
+	require.NoError(t, err)
+
+	msg, err := nc.Request("ebs.test-node.unmount", requestData, 5*time.Second)
+	require.NoError(t, err)
+
+	var resp types.EBSUnMountResponse
+	require.NoError(t, json.Unmarshal(msg.Data, &resp))
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, int32(1), sealCalls.Load(), "a surviving local WAL must trigger the fallback seal regardless of any receipt")
+}
+
+// TestIntegration_EBSUnmountAuxVolumeNeverSeals pins that auxiliary volumes
+// stay excluded from sealing even when local state survives. The aux check
+// used to live inside volumeNeedsSeal; splitting it out put branch ordering
+// in play, and an -efi volume must never reach the fallback seal.
+func TestIntegration_EBSUnmountAuxVolumeNeverSeals(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ns, natsURL := setupEmbeddedNATS(t)
+	defer ns.Shutdown()
+
+	cfg := setupTestConfig(t, natsURL)
+	createMockVolumeState(t, cfg.BaseDir, "vol-aux-efi")
+	var sealCalls atomic.Int32
+	cfg.sealVolume = func(volumeName string) error {
+		sealCalls.Add(1)
+		return nil
+	}
+	cfg.MountedVolumes = []MountedVolume{
+		{Name: "vol-aux-efi", PID: 99999},
+	}
+
+	go func() { launchService(cfg) }()
+	time.Sleep(500 * time.Millisecond)
+
+	nc, err := nats.Connect(natsURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	requestData, err := json.Marshal(types.EBSRequest{Name: "vol-aux-efi"})
+	require.NoError(t, err)
+
+	msg, err := nc.Request("ebs.test-node.unmount", requestData, 5*time.Second)
+	require.NoError(t, err)
+
+	var resp types.EBSUnMountResponse
+	require.NoError(t, json.Unmarshal(msg.Data, &resp))
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, int32(0), sealCalls.Load(), "an auxiliary volume must never be sealed, even with local state present")
+}
+
+// TestIntegration_EBSUnmountNoStateNoReceiptWarns verifies the WARN is
+// preserved for the case it actually describes: no local WAL and no seal
+// receipt, meaning this node never held state to seal. Not parallel: it
+// swaps the process-wide slog default to assert on log output.
+func TestIntegration_EBSUnmountNoStateNoReceiptWarns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	logs := captureLogs(t)
+
+	ns, natsURL := setupEmbeddedNATS(t)
+	defer ns.Shutdown()
+
+	cfg := setupTestConfig(t, natsURL)
+	var sealCalls atomic.Int32
+	cfg.sealVolume = func(volumeName string) error {
+		sealCalls.Add(1)
+		return nil
+	}
+	cfg.MountedVolumes = []MountedVolume{
+		{Name: "vol-no-state-no-receipt", PID: 99999},
+	}
+
+	go func() { launchService(cfg) }()
+	time.Sleep(500 * time.Millisecond)
+
+	nc, err := nats.Connect(natsURL)
+	require.NoError(t, err)
+	defer nc.Close()
+
+	requestData, err := json.Marshal(types.EBSRequest{Name: "vol-no-state-no-receipt"})
+	require.NoError(t, err)
+
+	msg, err := nc.Request("ebs.test-node.unmount", requestData, 5*time.Second)
+	require.NoError(t, err)
+
+	var resp types.EBSUnMountResponse
+	require.NoError(t, json.Unmarshal(msg.Data, &resp))
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, int32(0), sealCalls.Load(), "neither state nor receipt must not trigger the fallback seal")
+	assert.Contains(t, logs.String(), "no local viperblock state for volume, skipping seal")
+}
+
+// TestIntegration_EBSMountClearsStaleSealReceipt verifies staleness is
+// handled at mount: a receipt left over from a previous mount of this volume
+// must not survive into a new one, so it can't later be misread as proof
+// this mount's plugin sealed.
+func TestIntegration_EBSMountClearsStaleSealReceipt(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ns, natsURL := setupEmbeddedNATS(t)
+	defer ns.Shutdown()
+
+	cfg := setupTestConfig(t, natsURL)
+	writeSealReceipt(t, cfg.BaseDir, "vol-mount-clear")
+	receiptPath := sealReceiptPath(cfg.BaseDir, "vol-mount-clear")
+
+	go func() { launchService(cfg) }()
+	time.Sleep(500 * time.Millisecond)
+
+	nc, err := nats.Connect(natsURL)
+	require.NoError(t, err)
+	defer nc.Close()
+	nc.Flush()
+
+	requestData, err := json.Marshal(types.EBSRequest{Name: "vol-mount-clear", VolType: "gp3"})
+	require.NoError(t, err)
+
+	// Fire-and-forget: the mount will fail deep in the mocked S3 backend, but
+	// the receipt is cleared before any of that, so don't wait for a response.
+	require.NoError(t, nc.Publish("ebs.test-node.mount", requestData))
+
+	assert.Eventually(t, func() bool {
+		_, statErr := os.Stat(receiptPath)
+		return os.IsNotExist(statErr)
+	}, 3*time.Second, 20*time.Millisecond, "mount must clear a pre-existing receipt for the volume it is mounting")
 }
 
 // TestIntegration_ConcurrentMountRequests tests multiple concurrent mount requests.


### PR DESCRIPTION
The consumer half of `mulga-6scno`. The producer is viperblock PR #62; this side degrades safely without it — an absent receipt just keeps the current WARN.

## Problem

On `ebs.unmount`, `viperblockd` kills nbdkit and then decides whether to run its fallback seal by stat-ing `BaseDir/<volume>`. The plugin deletes that directory as the last step of a *successful* seal, so:

- the stat always fails on the healthy path
- the fallback seal is unreachable whenever the plugin exits cleanly
- the `else` branch WARNs `no local viperblock state for volume, skipping seal` on every clean unmount

Verified on env12: two volumes, two warnings, both directories confirmed present minutes earlier, with `Removing local files` logged 193ms before the stat. Data was safe — the plugin sealed it — but the signal is inverted: the healthy path is the one that warns.

Two facts from earlier work in this batch make it fixable. `RemoveLocalFiles` now runs only on a fully successful close, so directory absence really does imply the seal succeeded. And the plugin's shutdown is bounded at 20s, well inside `killProcessGracePeriod` of 120s, so when `KillProcess` returns the plugin has finished — no race, no routine SIGKILL.

## Change

`consumeSealReceipt(baseDir, volume)` reads and deletes `<baseDir>/<volume>.sealed`, reporting whether a valid one was there. It never fails the unmount: a malformed or unreadable receipt is logged, deleted anyway so it cannot linger, and treated as absent.

The unmount branch becomes:

1. `isAuxVolume` → nothing to seal
2. local state present → fallback seal, which is now genuinely reachable (a failed or deadline-aborted plugin close keeps the state)
3. receipt present → Info, the healthy path
4. neither → the original WARN, now meaning what it says

`volumeNeedsSeal` loses its folded-in aux check so the branches read cleanly, which puts ordering in play: the aux check has to come **first**, or an `-efi` volume with local state would newly reach the fallback seal it was always excluded from. `TestIntegration_EBSUnmountAuxVolumeNeverSeals` pins that, and fails if the two are swapped.

Staleness is handled at **mount**, not unmount: `ebs.mount` clears any pre-existing receipt before anything can return early. A receipt found at unmount can then only have come from this mount's plugin, so no PID matching is needed.

## Tests

In the existing viperblockd integration package, using the injectable `cfg.sealVolume` hook to observe the fallback:

- receipt present, no state dir → no WARN, fallback seal not called, receipt removed
- state dir present → fallback seal called, whatever the receipt says
- neither → WARN preserved, seal not called
- aux volume with local state → never sealed
- mount clears a pre-existing receipt, so a stale one cannot suppress a later genuine WARN

Load-bearing checks: reverting the branch rework fails the first test (the WARN fires and the receipt is not deleted); restoring the old aux-check ordering fails the aux test. `make preflight` passes.

## Verification still outstanding

Live on env12 at the batch close: graceful reboot, then assert zero `no local viperblock state for volume` WARNs and a matching count of seal-path Info lines in ES.