### PR TITLE
chore(deps): bump viperblock for the durability batch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.14.0
 	github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4
-	github.com/mulgadc/viperblock v1.14.1-0.20260731043757-9c4ece252152
+	github.com/mulgadc/viperblock v1.14.1-0.20260731125954-4512c8210625
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1321,10 +1321,8 @@ github.com/mulgadc/northstar v1.14.0 h1:8JzDcS4k3SN5PF3jBdB8x9FOWC24eITCClmOdwpo
 github.com/mulgadc/northstar v1.14.0/go.mod h1:6EArbWIQUrCFQ+XZ5ZJrGS/ep/u/rF6l+dKZh5vVIRs=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4 h1:Q4/NEryYTMiALkFwbPPOrKpNgLir+d7T2hbyRpAFnWc=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4/go.mod h1:na0aNXABZF03/HfFWCrAPHrId/2FIEIUQfB82vlu1xg=
-github.com/mulgadc/viperblock v1.14.1-0.20260729042700-9b253946d091 h1:P+KZWeIYh3uVmje6wad6TuCqAkV0Fn/4oVM4ldBaED0=
-github.com/mulgadc/viperblock v1.14.1-0.20260729042700-9b253946d091/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
-github.com/mulgadc/viperblock v1.14.1-0.20260731043757-9c4ece252152 h1:pnFcpWkPU8V0fT4g9bqP6nFhGDPcOXdvsRd2LQwFPEw=
-github.com/mulgadc/viperblock v1.14.1-0.20260731043757-9c4ece252152/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
+github.com/mulgadc/viperblock v1.14.1-0.20260731125954-4512c8210625 h1:7dnvG+5NKbvAGfKNVWwlOkLPfPRWs6CXSWtS8FuNBO8=
+github.com/mulgadc/viperblock v1.14.1-0.20260731125954-4512c8210625/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
The single repin the viperblock durability batch (`mulga-8bplk`) was organised around. Six merged changes, one bump: `9c4ece2` → `4512c82`.

## What lands with it

| viperblock PR | change | bead |
| --- | --- | --- |
| #58 | `Close` keeps local files when the WAL cannot be uploaded, instead of deleting the only copy | `mulga-nsqtw` |
| #59 | WAL generations stranded by a failed chunk upload are retried; `backendFull` stops flapping | `mulga-bs473` |
| #60 | test-only: pins that FLUSH covers every write acked before it | `mulga-ey51e` |
| #61 | the nbdkit plugin's shutdown drain and close bounded at 20s | `mulga-wtvw5` |
| #62 | seal receipt written after a clean seal | `mulga-6scno` |
| #63 | FLUSH fsyncs the WAL before reporting success | `mulga-aqnj9` |

Two already-merged spinifex changes are the other half of two of these, and only take effect with this bump:

- #620's receipt consumer has had nothing to read until now
- #619's `TimeoutStopSec=30` is the systemd backstop above #61's 20s drain bound

## Behaviour changes worth knowing

- **FLUSH now fsyncs.** A guest barrier costs one fsync — 40µs measured over 200 write+flush cycles on a dev host, to be re-measured on env12's NVMe. This closes a 200ms window in which acknowledged writes could be lost to power loss.
- **A failed close no longer deletes local state.** Volumes whose seal fails keep their WAL for recovery, and `viperblockd`'s fallback seal is finally reachable.
- **Shutdown is bounded.** In-use nbdkit children stop within 20s rather than blocking until systemd's timeout.

`make preflight` passes against the new pin.

## Next

The mulga submodule pointers follow once this merges, then env12 verifies the batch end to end: stop time inside `TimeoutStopSec` without SIGKILL, zero false seal WARNs, and an ungraceful-loss canary via `sysrq-trigger`.