### PR TITLE
chore(deps): bump viperblock for the nearfull throttle fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.14.0
 	github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4
-	github.com/mulgadc/viperblock v1.14.1-0.20260731125954-4512c8210625
+	github.com/mulgadc/viperblock v1.14.1-0.20260801020443-da01d991be6c
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1321,8 +1321,8 @@ github.com/mulgadc/northstar v1.14.0 h1:8JzDcS4k3SN5PF3jBdB8x9FOWC24eITCClmOdwpo
 github.com/mulgadc/northstar v1.14.0/go.mod h1:6EArbWIQUrCFQ+XZ5ZJrGS/ep/u/rF6l+dKZh5vVIRs=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4 h1:Q4/NEryYTMiALkFwbPPOrKpNgLir+d7T2hbyRpAFnWc=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4/go.mod h1:na0aNXABZF03/HfFWCrAPHrId/2FIEIUQfB82vlu1xg=
-github.com/mulgadc/viperblock v1.14.1-0.20260731125954-4512c8210625 h1:7dnvG+5NKbvAGfKNVWwlOkLPfPRWs6CXSWtS8FuNBO8=
-github.com/mulgadc/viperblock v1.14.1-0.20260731125954-4512c8210625/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
+github.com/mulgadc/viperblock v1.14.1-0.20260801020443-da01d991be6c h1:MMqR9AOZ+1c+c1YaLke892wJJBQjGIJtuFSZXX7m8GQ=
+github.com/mulgadc/viperblock v1.14.1-0.20260801020443-da01d991be6c/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
Picks up mulgadc/viperblock#64.

## Why spx needs this, not just the plugin

Predastore's store has two free-space bands: nearfull at 15% free, where it kicks a compaction pass
but **accepts** the write and sets `X-Predastore-Pool-Pressure: nearfull` on the 200; and full at 5%,
where it returns `ErrStoreFull` -> 507. viperblock's `WriteAtCtx` treated both identically and
returned `ErrNoSpace` as soon as the nearfull header was latched, so it refused writes the backend
would have accepted — costing every pool the capacity between the two watermarks and failing every
attached volume at the same instant.

`spx admin images import` runs viperblock in-process against the module-cache build, so the
plugin-side fix alone left the control plane on the old behaviour. `make dev-deploy`'s source-drift
guard refuses to ship that split.

## Verification

Deployed on the dev host with predastore at **11.6% free** — inside the nearfull band that
previously rejected everything. Launched a debian instance: booted to a login prompt, cloud-init
completed, guest wrote its SSH host keys, zero `ErrNoSpace` in the journal.

Preflight green: golangci-lint 0 issues, govulncheck clean.