### PR TITLE
fix(ec2): release post-launch ENIs on instance terminate

### DIFF
--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -722,28 +722,74 @@ func (a *instanceCleanerAdapter) ReleasePublicIP(instance *vm.VM) error {
 }
 
 // DetachAndDeleteENI detaches the auto-created ENI from the instance and
-// deletes it via the VPC service. NotFound is tolerated. Extra ENIs are
-// cleaned up by the load-balancer service via its own teardown loop and
-// are not touched here.
+// deletes it via the VPC service. NotFound is tolerated. It then sweeps every
+// other ENI the KV records against this instance — post-launch attaches
+// (e.g. ECS awsvpc, direct AttachNetworkInterface) never update instance.ENIId,
+// so relying on the scalar alone leaves them attached forever, pinning their
+// SG/subnet/VPC behind DependencyViolation.
 func (a *instanceCleanerAdapter) DetachAndDeleteENI(instance *vm.VM) error {
-	if instance.ENIId == "" || a.d.vpcService == nil {
+	if a.d.vpcService == nil {
 		return nil
 	}
-	// Best-effort detach; a failure here must not block deletion — the force
-	// delete below bypasses the in-use guard for the owning instance, breaking
-	// the un-terminable-ENI deadlock (ADR-0003 §2).
-	if detachErr := a.d.vpcService.DetachENI(context.Background(), instance.AccountID, instance.ENIId); detachErr != nil {
-		slog.Warn("Failed to detach ENI on termination",
-			"eni", instance.ENIId, "instanceId", instance.ID, "err", detachErr)
+
+	var primaryErr error
+	if instance.ENIId != "" {
+		// Best-effort detach; a failure here must not block deletion — the force
+		// delete below bypasses the in-use guard for the owning instance, breaking
+		// the un-terminable-ENI deadlock (ADR-0003 §2).
+		if detachErr := a.d.vpcService.DetachENI(context.Background(), instance.AccountID, instance.ENIId); detachErr != nil {
+			slog.Warn("Failed to detach ENI on termination",
+				"eni", instance.ENIId, "instanceId", instance.ID, "err", detachErr)
+		}
+		if err := a.d.vpcService.ForceDeleteInstanceENI(context.Background(), instance.AccountID, instance.ENIId); err != nil {
+			slog.Error("Failed to delete ENI on termination",
+				"eni", instance.ENIId, "instanceId", instance.ID, "err", err)
+			primaryErr = err
+		} else {
+			slog.Info("Deleted ENI on termination",
+				"eni", instance.ENIId, "instanceId", instance.ID)
+		}
 	}
-	if err := a.d.vpcService.ForceDeleteInstanceENI(context.Background(), instance.AccountID, instance.ENIId); err != nil {
-		slog.Error("Failed to delete ENI on termination",
-			"eni", instance.ENIId, "instanceId", instance.ID, "err", err)
-		return err
+
+	a.releaseAttachedENIs(instance)
+
+	return primaryErr
+}
+
+// releaseAttachedENIs enumerates the spinifex-vpc-enis KV for every record
+// still carrying this instance's ID and releases each one, independent of
+// instance.ENIId. Best-effort and idempotent per ENI: one failure is logged
+// and the sweep continues, so a partial failure never blocks the rest and a
+// re-run of terminate converges. DeleteOnTermination=false detaches only.
+func (a *instanceCleanerAdapter) releaseAttachedENIs(instance *vm.VM) {
+	records, err := a.d.vpcService.ListInstanceENIs(instance.AccountID, instance.ID)
+	if err != nil {
+		slog.Warn("Failed to enumerate attached ENIs on termination",
+			"instanceId", instance.ID, "err", err)
+		return
 	}
-	slog.Info("Deleted ENI on termination",
-		"eni", instance.ENIId, "instanceId", instance.ID)
-	return nil
+
+	for _, record := range records {
+		eniId := record.NetworkInterfaceId
+		if detachErr := a.d.vpcService.DetachENI(context.Background(), instance.AccountID, eniId); detachErr != nil {
+			slog.Warn("Failed to detach attached ENI on termination",
+				"eni", eniId, "instanceId", instance.ID, "err", detachErr)
+		}
+
+		if record.DeleteOnTermination != nil && !*record.DeleteOnTermination {
+			slog.Info("Detached attached ENI on termination, DeleteOnTermination=false",
+				"eni", eniId, "instanceId", instance.ID)
+			continue
+		}
+
+		if err := a.d.vpcService.ForceDeleteInstanceENI(context.Background(), instance.AccountID, eniId); err != nil {
+			slog.Error("Failed to delete attached ENI on termination",
+				"eni", eniId, "instanceId", instance.ID, "err", err)
+			continue
+		}
+		slog.Info("Deleted attached ENI on termination",
+			"eni", eniId, "instanceId", instance.ID)
+	}
 }
 
 // RemoveFromPlacementGroup unbinds the instance from its placement group

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -1,18 +1,23 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/gpu"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/tags"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -434,4 +439,109 @@ func TestInstanceCleanerAdapter_DetachAndDeleteENI_DeleteOnTerminationFalseDetac
 	require.NoError(t, err, "DeleteOnTermination=false must detach, not delete")
 	assert.Equal(t, "available", rec.Status)
 	assert.Empty(t, rec.InstanceId)
+}
+
+// TestInstanceCleanerAdapter_DetachAndDeleteENI_PrimaryENIReleased covers the
+// launch-time instance.ENIId path (as opposed to the KV enumeration sweep):
+// a still-attached primary ENI must be detached and force-deleted so it
+// converges to NotFound.
+func TestInstanceCleanerAdapter_DetachAndDeleteENI_PrimaryENIReleased(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+	f.vmInst.ENIId = f.eniID
+
+	_, err := f.daemon.vpcService.AttachENI(testAccountID, f.eniID, f.vmInst.ID, 0)
+	require.NoError(t, err)
+
+	cleaner := newInstanceCleanerAdapter(f.daemon)
+	require.NoError(t, cleaner.DetachAndDeleteENI(f.vmInst))
+
+	_, err = f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.Error(t, err, "the primary ENI must be deleted")
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceIDNotFound))
+}
+
+// TestInstanceCleanerAdapter_DetachAndDeleteENI_PrimaryENIDetachFailureContinues
+// proves a failed detach on the primary ENI does not abort the delete: DetachENI
+// on an ENI ID absent from the KV (e.g. already reaped) fails, but
+// ForceDeleteInstanceENI tolerates NotFound, so terminate still converges.
+func TestInstanceCleanerAdapter_DetachAndDeleteENI_PrimaryENIDetachFailureContinues(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+	f.vmInst.ENIId = "eni-never-existed"
+
+	cleaner := newInstanceCleanerAdapter(f.daemon)
+	require.NoError(t, cleaner.DetachAndDeleteENI(f.vmInst),
+		"a failed detach on a missing primary ENI must not fail terminate")
+}
+
+// TestInstanceCleanerAdapter_DetachAndDeleteENI_MultipleAttachedENIsReleased locks
+// in the fix's core scenario: several post-launch-attached ENIs on one instance
+// are all swept, each honouring its own DeleteOnTermination value.
+func TestInstanceCleanerAdapter_DetachAndDeleteENI_MultipleAttachedENIsReleased(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+
+	eniOut2, err := f.daemon.vpcService.CreateNetworkInterface(context.Background(), &ec2.CreateNetworkInterfaceInput{
+		SubnetId: aws.String(f.subnetID),
+	}, testAccountID)
+	require.NoError(t, err)
+	eniID2 := *eniOut2.NetworkInterface.NetworkInterfaceId
+
+	// eniID keeps the fixture's default DeleteOnTermination=true (deleted);
+	// eniID2 is explicitly false (detached only).
+	_, err = f.daemon.vpcService.AttachENI(testAccountID, f.eniID, f.vmInst.ID, 1)
+	require.NoError(t, err)
+	_, err = f.daemon.vpcService.AttachENI(testAccountID, eniID2, f.vmInst.ID, 2)
+	require.NoError(t, err)
+	require.NoError(t, f.daemon.vpcService.UpdateENI(testAccountID, eniID2, func(r *handlers_ec2_vpc.ENIRecord) {
+		r.DeleteOnTermination = aws.Bool(false)
+	}))
+
+	cleaner := newInstanceCleanerAdapter(f.daemon)
+	require.NoError(t, cleaner.DetachAndDeleteENI(f.vmInst))
+
+	_, err = f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.Error(t, err, "DeleteOnTermination=true ENI must be deleted")
+
+	rec2, err := f.daemon.vpcService.GetENIRecord(testAccountID, eniID2)
+	require.NoError(t, err, "DeleteOnTermination=false ENI must survive, detached")
+	assert.Equal(t, "available", rec2.Status)
+}
+
+// TestInstanceCleanerAdapter_ReleaseAttachedENIs_ListInstanceENIsErrorTolerated
+// exercises the enumeration error branch: the connection backing vpcService's
+// KV is closed before terminate runs, so ListInstanceENIs fails with a real
+// connection error. The sweep must log and return rather than panic or
+// propagate the error as the primary terminate failure.
+func TestInstanceCleanerAdapter_ReleaseAttachedENIs_ListInstanceENIsErrorTolerated(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	ns, err := server.NewServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      -1,
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+		NoLog:     true,
+		NoSigs:    true,
+	})
+	require.NoError(t, err)
+	go ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+	t.Cleanup(func() { ns.Shutdown() })
+
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	testutil.StubVpcdSGResponder(t, nc)
+
+	vpcSvc, err := handlers_ec2_vpc.NewVPCServiceImplWithNATS(t.Context(), daemon.config, nc)
+	require.NoError(t, err)
+	daemon.vpcService = vpcSvc
+	nc.Close()
+
+	cleaner := newInstanceCleanerAdapter(daemon)
+	instance := &vm.VM{ID: "i-kv-down", AccountID: testAccountID}
+
+	require.NoError(t, cleaner.DetachAndDeleteENI(instance),
+		"an enumeration failure must not surface as a terminate error")
 }

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -5,8 +5,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/gpu"
+	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/vm"
@@ -381,4 +384,54 @@ func TestBuildVMManagerDeps_WiresBeforeInstanceRelaunch(t *testing.T) {
 	require.NoError(t, deps.Hooks.BeforeInstanceRelaunch(&vm.VM{ID: "i-noop", ManagedBy: ""}))
 	require.Error(t, deps.Hooks.BeforeInstanceRelaunch(&vm.VM{ID: "i-svc", ManagedBy: tags.ManagedByELBv2}),
 		"ELBv2 VM with nil elbv2Service must error rather than silently no-op")
+}
+
+// --- DetachAndDeleteENI: post-launch attach enumeration ---
+
+// TestInstanceCleanerAdapter_DetachAndDeleteENI_ReleasesPostLaunchAttach locks
+// in the terminate-time read path: DetachAndDeleteENI must enumerate the
+// spinifex-vpc-enis KV by InstanceId rather than trusting the launch-time
+// instance.ENIId scalar alone. handleAttachNetworkInterface (the real
+// post-launch/hot-plug attach path) only ever mutates the KV record, never
+// vm.VM — so without the enumeration this ENI would survive terminate and
+// pin its SG/subnet/VPC behind DependencyViolation, exactly as observed on
+// env19.
+func TestInstanceCleanerAdapter_DetachAndDeleteENI_ReleasesPostLaunchAttach(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+
+	// Attach via the KV only — instance.ENIId is deliberately left unset,
+	// mirroring a hot-plug attach that never touches vm.VM.
+	_, err := f.daemon.vpcService.AttachENI(testAccountID, f.eniID, f.vmInst.ID, 1)
+	require.NoError(t, err)
+	require.Empty(t, f.vmInst.ENIId, "precondition: launch-time scalar must stay unset")
+
+	cleaner := newInstanceCleanerAdapter(f.daemon)
+	require.NoError(t, cleaner.DetachAndDeleteENI(f.vmInst))
+
+	_, err = f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.Error(t, err, "the ENI record must be released even though instance.ENIId was never set")
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceIDNotFound))
+}
+
+// TestInstanceCleanerAdapter_DetachAndDeleteENI_DeleteOnTerminationFalseDetachesOnly
+// proves the sweep honours DeleteOnTermination=false: the ENI is detached
+// (freed for reattachment) but not deleted, matching AWS semantics.
+func TestInstanceCleanerAdapter_DetachAndDeleteENI_DeleteOnTerminationFalseDetachesOnly(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+
+	_, err := f.daemon.vpcService.AttachENI(testAccountID, f.eniID, f.vmInst.ID, 1)
+	require.NoError(t, err)
+	require.NoError(t, f.daemon.vpcService.UpdateENI(testAccountID, f.eniID, func(r *handlers_ec2_vpc.ENIRecord) {
+		r.DeleteOnTermination = aws.Bool(false)
+	}))
+
+	cleaner := newInstanceCleanerAdapter(f.daemon)
+	require.NoError(t, cleaner.DetachAndDeleteENI(f.vmInst))
+
+	rec, err := f.daemon.vpcService.GetENIRecord(testAccountID, f.eniID)
+	require.NoError(t, err, "DeleteOnTermination=false must detach, not delete")
+	assert.Equal(t, "available", rec.Status)
+	assert.Empty(t, rec.InstanceId)
 }

--- a/spinifex/daemon/vpc_adapter.go
+++ b/spinifex/daemon/vpc_adapter.go
@@ -54,6 +54,8 @@ func (a *daemonENICreator) GetENI(_ context.Context, accountID, eniID string) (*
 		MacAddress:         rec.MacAddress,
 		Status:             rec.Status,
 		SecurityGroupIDs:   rec.SecurityGroupIds,
+		DeleteOnTermination: rec.DeleteOnTermination == nil ||
+			*rec.DeleteOnTermination,
 	}, nil
 }
 
@@ -71,4 +73,26 @@ func (a *daemonENICreator) DetachENI(ctx context.Context, accountID, eniID strin
 
 func (a *daemonENICreator) UpdateENIPublicIP(_ context.Context, accountID, eniID, publicIP, poolName string) error {
 	return a.d.vpcService.UpdateENIPublicIP(accountID, eniID, publicIP, poolName)
+}
+
+func (a *daemonENICreator) ListInstanceENIs(_ context.Context, accountID, instanceID string) ([]handlers_ec2_instance.ENIInfo, error) {
+	records, err := a.d.vpcService.ListInstanceENIs(accountID, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]handlers_ec2_instance.ENIInfo, 0, len(records))
+	for _, rec := range records {
+		out = append(out, handlers_ec2_instance.ENIInfo{
+			NetworkInterfaceID: rec.NetworkInterfaceId,
+			SubnetID:           rec.SubnetId,
+			VpcID:              rec.VpcId,
+			PrivateIpAddress:   rec.PrivateIpAddress,
+			MacAddress:         rec.MacAddress,
+			Status:             rec.Status,
+			SecurityGroupIDs:   rec.SecurityGroupIds,
+			DeleteOnTermination: rec.DeleteOnTermination == nil ||
+				*rec.DeleteOnTermination,
+		})
+	}
+	return out, nil
 }

--- a/spinifex/daemon/vpc_adapter_test.go
+++ b/spinifex/daemon/vpc_adapter_test.go
@@ -1,0 +1,132 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- daemonENICreator.GetENI: DeleteOnTermination mapping ---
+
+// TestDaemonENICreator_GetENI_DeleteOnTerminationMapping locks the nil/true/false
+// mapping onto ENIInfo.DeleteOnTermination: a nil ENIRecord flag (never attached)
+// must read as true, matching what DescribeNetworkInterfaces already advertises.
+func TestDaemonENICreator_GetENI_DeleteOnTerminationMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		dot  *bool
+		want bool
+	}{
+		{"NilDefaultsTrue", nil, true},
+		{"ExplicitTrue", aws.Bool(true), true},
+		{"ExplicitFalse", aws.Bool(false), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := createVPCTestDaemon(t)
+			vpcOut, err := d.vpcService.CreateVpc(t.Context(), &ec2.CreateVpcInput{
+				CidrBlock: aws.String("10.0.0.0/16"),
+			}, testAccountID)
+			require.NoError(t, err)
+			subnetOut, err := d.vpcService.CreateSubnet(t.Context(), &ec2.CreateSubnetInput{
+				VpcId:     vpcOut.Vpc.VpcId,
+				CidrBlock: aws.String("10.0.1.0/24"),
+			}, testAccountID)
+			require.NoError(t, err)
+			eniOut, err := d.vpcService.CreateNetworkInterface(t.Context(), &ec2.CreateNetworkInterfaceInput{
+				SubnetId: subnetOut.Subnet.SubnetId,
+			}, testAccountID)
+			require.NoError(t, err)
+			eniID := *eniOut.NetworkInterface.NetworkInterfaceId
+
+			if tt.dot != nil {
+				require.NoError(t, d.vpcService.UpdateENI(testAccountID, eniID, func(r *handlers_ec2_vpc.ENIRecord) {
+					r.DeleteOnTermination = tt.dot
+				}))
+			}
+
+			creator := &daemonENICreator{d: d}
+			info, err := creator.GetENI(context.Background(), testAccountID, eniID)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, info.DeleteOnTermination)
+		})
+	}
+}
+
+// --- daemonENICreator.ListInstanceENIs ---
+
+// TestDaemonENICreator_ListInstanceENIs_HappyPath confirms the adapter maps every
+// field off ENIRecord, including the DeleteOnTermination default AttachENI stamps
+// on first attach — this is what the terminate sweep relies on.
+func TestDaemonENICreator_ListInstanceENIs_HappyPath(t *testing.T) {
+	f := newENIHotPlugFixture(t)
+	f.vmInst.AccountID = testAccountID
+
+	_, err := f.daemon.vpcService.AttachENI(testAccountID, f.eniID, f.vmInst.ID, 2)
+	require.NoError(t, err)
+
+	creator := &daemonENICreator{d: f.daemon}
+	infos, err := creator.ListInstanceENIs(context.Background(), testAccountID, f.vmInst.ID)
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, f.eniID, infos[0].NetworkInterfaceID)
+	assert.Equal(t, f.subnetID, infos[0].SubnetID)
+	assert.Equal(t, f.vpcID, infos[0].VpcID)
+	assert.Equal(t, f.mac, infos[0].MacAddress)
+	assert.True(t, infos[0].DeleteOnTermination, "attach defaults DeleteOnTermination to true")
+}
+
+// TestDaemonENICreator_ListInstanceENIs_NoAttachments confirms an instance with no
+// KV-recorded ENIs returns an empty, non-error result.
+func TestDaemonENICreator_ListInstanceENIs_NoAttachments(t *testing.T) {
+	d := createVPCTestDaemon(t)
+	creator := &daemonENICreator{d: d}
+
+	infos, err := creator.ListInstanceENIs(context.Background(), testAccountID, "i-none")
+	require.NoError(t, err)
+	assert.Empty(t, infos)
+}
+
+// TestDaemonENICreator_ListInstanceENIs_KVError exercises the error-mapping branch:
+// the connection backing vpcService's KV is closed before enumerating, so Keys()
+// fails with a real connection error rather than jetstream.ErrNoKeysFound.
+func TestDaemonENICreator_ListInstanceENIs_KVError(t *testing.T) {
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	ns, err := server.NewServer(&server.Options{
+		Host:      "127.0.0.1",
+		Port:      -1,
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+		NoLog:     true,
+		NoSigs:    true,
+	})
+	require.NoError(t, err)
+	go ns.Start()
+	require.True(t, ns.ReadyForConnections(5*time.Second))
+	t.Cleanup(func() { ns.Shutdown() })
+
+	nc, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	testutil.StubVpcdSGResponder(t, nc)
+
+	vpcSvc, err := handlers_ec2_vpc.NewVPCServiceImplWithNATS(t.Context(), daemon.config, nc)
+	require.NoError(t, err)
+	daemon.vpcService = vpcSvc
+
+	nc.Close()
+
+	creator := &daemonENICreator{d: daemon}
+	_, err = creator.ListInstanceENIs(context.Background(), testAccountID, "i-any")
+	require.Error(t, err)
+}

--- a/spinifex/handlers/ec2/instance/service.go
+++ b/spinifex/handlers/ec2/instance/service.go
@@ -166,11 +166,15 @@ type ENIInfo struct {
 	MacAddress         string
 	Status             string
 	SecurityGroupIDs   []string
+	// DeleteOnTermination mirrors the stored ENIRecord field, defaulted true
+	// when unset. Read by the terminate sweep to decide detach-only vs delete.
+	DeleteOnTermination bool
 }
 
 // ENICreator covers the VPC/ENI operations RunInstances uses to auto-attach a
-// primary interface. DetachENI is here (not ENIDeleter) so the NAT-rollback
-// path can flip the ENI to "available" before deletion.
+// primary interface, plus the enumeration the terminate path uses to release
+// every ENI attached to an instance. DetachENI is here (not ENIDeleter) so the
+// NAT-rollback path can flip the ENI to "available" before deletion.
 type ENICreator interface {
 	GetDefaultSubnet(ctx context.Context, accountID string) (*SubnetInfo, error)
 	GetSubnet(ctx context.Context, accountID, subnetID string) (*SubnetInfo, error)
@@ -179,6 +183,10 @@ type ENICreator interface {
 	AttachENI(ctx context.Context, accountID, eniID, instanceID string, deviceIndex int64) (string, error)
 	DetachENI(ctx context.Context, accountID, eniID string) error
 	UpdateENIPublicIP(ctx context.Context, accountID, eniID, publicIP, poolName string) error
+	// ListInstanceENIs returns every ENI currently attached to instanceID.
+	// Used by the terminate sweep for post-launch attachments the launch-time
+	// ENIId scalar on vm.VM never carries.
+	ListInstanceENIs(ctx context.Context, accountID, instanceID string) ([]ENIInfo, error)
 }
 
 // PublicIPAllocator allocates a public IP to an instance/ENI from a pool.

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -2556,31 +2556,77 @@ func (s *InstanceServiceImpl) releaseInstancePublicIP(ctx context.Context, insta
 }
 
 func (s *InstanceServiceImpl) deleteInstanceENI(ctx context.Context, instance *vm.VM, instanceID string) {
-	if instance.ENIId == "" || s.eniDeleter == nil {
-		return
-	}
-	// Detach first to clear the attachment record. A stopped instance's ENI may
-	// still show Status=in-use/AttachmentId set; without the detach the
-	// force=false DeleteNetworkInterface below fails InvalidNetworkInterface.InUse,
-	// stranding the ENI record after the instance is already gone from the store
-	// and blocking VPC/subnet delete. Best-effort: the delete is
-	// the authoritative gate.
-	if s.eniCreator != nil {
-		if err := s.eniCreator.DetachENI(ctx, instance.AccountID, instance.ENIId); err != nil {
-			slog.WarnContext(ctx, "TerminateStoppedInstance: failed to detach ENI before delete",
-				"eni", instance.ENIId, "instanceId", instanceID, "err", err)
+	if instance.ENIId != "" && s.eniDeleter != nil {
+		// Detach first to clear the attachment record. A stopped instance's ENI may
+		// still show Status=in-use/AttachmentId set; without the detach the
+		// force=false DeleteNetworkInterface below fails InvalidNetworkInterface.InUse,
+		// stranding the ENI record after the instance is already gone from the store
+		// and blocking VPC/subnet delete. Best-effort: the delete is
+		// the authoritative gate.
+		if s.eniCreator != nil {
+			if err := s.eniCreator.DetachENI(ctx, instance.AccountID, instance.ENIId); err != nil {
+				slog.WarnContext(ctx, "TerminateStoppedInstance: failed to detach ENI before delete",
+					"eni", instance.ENIId, "instanceId", instanceID, "err", err)
+			}
+		}
+		_, err := s.eniDeleter.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: &instance.ENIId,
+		}, instance.AccountID)
+		switch {
+		case err == nil,
+			awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceIDNotFound),
+			awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceNotFound):
+			slog.InfoContext(ctx, "TerminateStoppedInstance: deleted ENI", "eni", instance.ENIId, "instanceId", instanceID)
+		default:
+			slog.ErrorContext(ctx, "TerminateStoppedInstance: failed to delete ENI", "eni", instance.ENIId, "err", err)
 		}
 	}
-	_, err := s.eniDeleter.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
-		NetworkInterfaceId: &instance.ENIId,
-	}, instance.AccountID)
-	switch {
-	case err == nil,
-		awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceIDNotFound),
-		awserrors.IsErrorCode(err, awserrors.ErrorInvalidNetworkInterfaceNotFound):
-		slog.InfoContext(ctx, "TerminateStoppedInstance: deleted ENI", "eni", instance.ENIId, "instanceId", instanceID)
-	default:
-		slog.ErrorContext(ctx, "TerminateStoppedInstance: failed to delete ENI", "eni", instance.ENIId, "err", err)
+
+	s.releaseAttachedENIs(ctx, instance, instanceID)
+}
+
+// releaseAttachedENIs enumerates every ENI the KV still records against
+// instanceID and releases each one, independent of instance.ENIId. Covers
+// post-launch attachments (e.g. ECS awsvpc, direct AttachNetworkInterface)
+// that never update the launch-time ENIId scalar. Best-effort and idempotent
+// per ENI: one failure is logged and the sweep continues, so a re-run of
+// terminate converges. DeleteOnTermination=false detaches only.
+func (s *InstanceServiceImpl) releaseAttachedENIs(ctx context.Context, instance *vm.VM, instanceID string) {
+	if s.eniCreator == nil || s.eniDeleter == nil {
+		return
+	}
+	records, err := s.eniCreator.ListInstanceENIs(ctx, instance.AccountID, instance.ID)
+	if err != nil {
+		slog.WarnContext(ctx, "TerminateStoppedInstance: failed to enumerate attached ENIs",
+			"instanceId", instanceID, "err", err)
+		return
+	}
+
+	for _, record := range records {
+		eniID := record.NetworkInterfaceID
+		if err := s.eniCreator.DetachENI(ctx, instance.AccountID, eniID); err != nil {
+			slog.WarnContext(ctx, "TerminateStoppedInstance: failed to detach attached ENI",
+				"eni", eniID, "instanceId", instanceID, "err", err)
+		}
+
+		if !record.DeleteOnTermination {
+			slog.InfoContext(ctx, "TerminateStoppedInstance: detached attached ENI, DeleteOnTermination=false",
+				"eni", eniID, "instanceId", instanceID)
+			continue
+		}
+
+		_, delErr := s.eniDeleter.DeleteNetworkInterface(ctx, &ec2.DeleteNetworkInterfaceInput{
+			NetworkInterfaceId: &eniID,
+		}, instance.AccountID)
+		switch {
+		case delErr == nil,
+			awserrors.IsErrorCode(delErr, awserrors.ErrorInvalidNetworkInterfaceIDNotFound),
+			awserrors.IsErrorCode(delErr, awserrors.ErrorInvalidNetworkInterfaceNotFound):
+			slog.InfoContext(ctx, "TerminateStoppedInstance: deleted attached ENI", "eni", eniID, "instanceId", instanceID)
+		default:
+			slog.ErrorContext(ctx, "TerminateStoppedInstance: failed to delete attached ENI",
+				"eni", eniID, "instanceId", instanceID, "err", delErr)
+		}
 	}
 }
 

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -2976,6 +2976,8 @@ type fakeENICreator struct {
 	updateCalls     int
 	clearCalls      int // updateCalls where publicIP is ""
 	detachCalls     int
+	instanceENIs    map[string][]ENIInfo // keyed by instanceID, for ListInstanceENIs
+	listENIsErr     error
 }
 
 func (f *fakeENICreator) GetDefaultSubnet(_ context.Context, _ string) (*SubnetInfo, error) {
@@ -3033,6 +3035,13 @@ func (f *fakeENICreator) UpdateENIPublicIP(_ context.Context, _, _, publicIP, _ 
 		f.clearCalls++
 	}
 	return nil
+}
+
+func (f *fakeENICreator) ListInstanceENIs(_ context.Context, _, instanceID string) ([]ENIInfo, error) {
+	if f.listENIsErr != nil {
+		return nil, f.listENIsErr
+	}
+	return f.instanceENIs[instanceID], nil
 }
 
 type fakeIPAllocator struct {

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -2110,6 +2110,125 @@ func TestTerminateStoppedInstance_ENIDeleteNotFoundTolerated(t *testing.T) {
 	assert.Equal(t, []string{"eni-gone"}, ed.calls)
 }
 
+// TestTerminateStoppedInstance_PrimaryENIDetachFailureContinuesToDelete proves a
+// failed detach on the primary ENI does not skip the delete: best-effort
+// cleanup must still attempt to reclaim the ENI record.
+func TestTerminateStoppedInstance_PrimaryENIDetachFailureContinuesToDelete(t *testing.T) {
+	id := "i-eni-detach-fail"
+	v := &vm.VM{ID: id, Status: vm.StateStopped, AccountID: "acc", ENIId: "eni-stuck"}
+	store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: v}}
+	ed := &fakeENIDeleter{}
+	ec := &fakeENICreator{detachErr: errors.New("detach unavailable")}
+	svc := &InstanceServiceImpl{stoppedStore: store, eniDeleter: ed, eniCreator: ec}
+
+	out, err := svc.TerminateStoppedInstance(context.Background(), &TerminateStoppedInstanceInput{InstanceID: id}, "acc")
+	require.NoError(t, err)
+	assert.Equal(t, "terminated", out.Status)
+	assert.Equal(t, 1, ec.detachCalls)
+	assert.Equal(t, []string{"eni-stuck"}, ed.calls, "delete must still run after a failed detach")
+}
+
+// TestTerminateStoppedInstance_PrimaryENIDeleteUnexpectedError proves an
+// unrecognized delete failure (not NotFound) is logged rather than aborting
+// the terminate — the switch's default branch.
+func TestTerminateStoppedInstance_PrimaryENIDeleteUnexpectedError(t *testing.T) {
+	id := "i-eni-delete-fail"
+	v := &vm.VM{ID: id, Status: vm.StateStopped, AccountID: "acc", ENIId: "eni-broken"}
+	store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: v}}
+	ed := &fakeENIDeleter{err: errors.New("server unavailable")}
+	svc := &InstanceServiceImpl{stoppedStore: store, eniDeleter: ed, eniCreator: &fakeENICreator{}}
+
+	out, err := svc.TerminateStoppedInstance(context.Background(), &TerminateStoppedInstanceInput{InstanceID: id}, "acc")
+	require.NoError(t, err, "an unexpected ENI delete failure must not abort the stopped-instance terminate")
+	assert.Equal(t, "terminated", out.Status)
+}
+
+// --- TerminateStoppedInstance: releaseAttachedENIs (post-launch attach sweep) ---
+
+// TestTerminateStoppedInstance_ReleaseAttachedENIs_ListErrorLogsAndReturns covers
+// the enumeration failure branch: ListInstanceENIs erroring must not abort
+// terminate, and no detach/delete calls follow since nothing was enumerated.
+func TestTerminateStoppedInstance_ReleaseAttachedENIs_ListErrorLogsAndReturns(t *testing.T) {
+	id := "i-list-err"
+	v := &vm.VM{ID: id, Status: vm.StateStopped, AccountID: "acc"}
+	store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: v}}
+	ed := &fakeENIDeleter{}
+	ec := &fakeENICreator{listENIsErr: errors.New("kv unreachable")}
+	svc := &InstanceServiceImpl{stoppedStore: store, eniDeleter: ed, eniCreator: ec}
+
+	out, err := svc.TerminateStoppedInstance(context.Background(), &TerminateStoppedInstanceInput{InstanceID: id}, "acc")
+	require.NoError(t, err)
+	assert.Equal(t, "terminated", out.Status)
+	assert.Empty(t, ed.calls)
+}
+
+// TestTerminateStoppedInstance_ReleaseAttachedENIs covers the post-launch
+// attachment sweep: multiple ENIs, a detach failure that must not block the
+// rest of the sweep, a DeleteOnTermination=false skip, and a delete failure
+// that must not block the remaining ENIs.
+func TestTerminateStoppedInstance_ReleaseAttachedENIs(t *testing.T) {
+	tests := []struct {
+		name       string
+		records    []ENIInfo
+		detachErr  error
+		deleteErr  error
+		wantDelete []string
+	}{
+		{
+			name: "MultipleENIsHappyPath",
+			records: []ENIInfo{
+				{NetworkInterfaceID: "eni-a", DeleteOnTermination: true},
+				{NetworkInterfaceID: "eni-b", DeleteOnTermination: true},
+			},
+			wantDelete: []string{"eni-a", "eni-b"},
+		},
+		{
+			name: "DeleteOnTerminationFalseSkipsDelete",
+			records: []ENIInfo{
+				{NetworkInterfaceID: "eni-keep", DeleteOnTermination: false},
+			},
+			wantDelete: nil,
+		},
+		{
+			name: "DetachFailureStillDeletes",
+			records: []ENIInfo{
+				{NetworkInterfaceID: "eni-c", DeleteOnTermination: true},
+			},
+			detachErr:  errors.New("detach unavailable"),
+			wantDelete: []string{"eni-c"},
+		},
+		{
+			name: "DeleteFailureContinuesToNextENI",
+			records: []ENIInfo{
+				{NetworkInterfaceID: "eni-d", DeleteOnTermination: true},
+				{NetworkInterfaceID: "eni-e", DeleteOnTermination: true},
+			},
+			deleteErr:  errors.New("delete unavailable"),
+			wantDelete: []string{"eni-d", "eni-e"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := "i-sweep-" + tt.name
+			v := &vm.VM{ID: id, Status: vm.StateStopped, AccountID: "acc"}
+			store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: v}}
+			ed := &fakeENIDeleter{err: tt.deleteErr}
+			ec := &fakeENICreator{
+				detachErr:    tt.detachErr,
+				instanceENIs: map[string][]ENIInfo{id: tt.records},
+			}
+			svc := &InstanceServiceImpl{stoppedStore: store, eniDeleter: ed, eniCreator: ec}
+
+			out, err := svc.TerminateStoppedInstance(context.Background(), &TerminateStoppedInstanceInput{InstanceID: id}, "acc")
+			require.NoError(t, err)
+			assert.Equal(t, "terminated", out.Status)
+			assert.Equal(t, len(tt.records), ec.detachCalls, "every enumerated ENI must be detached regardless of outcome")
+			assert.Equal(t, tt.wantDelete, ed.calls)
+		})
+	}
+}
+
 // --- StartStoppedInstance tests ---
 
 type fakeGPUClaimer struct {
@@ -2976,6 +3095,7 @@ type fakeENICreator struct {
 	updateCalls     int
 	clearCalls      int // updateCalls where publicIP is ""
 	detachCalls     int
+	detachErr       error                // returned by every DetachENI call when set
 	instanceENIs    map[string][]ENIInfo // keyed by instanceID, for ListInstanceENIs
 	listENIsErr     error
 }
@@ -3026,7 +3146,7 @@ func (f *fakeENICreator) AttachENI(_ context.Context, _, _, _ string, _ int64) (
 
 func (f *fakeENICreator) DetachENI(_ context.Context, _, _ string) error {
 	f.detachCalls++
-	return nil
+	return f.detachErr
 }
 
 func (f *fakeENICreator) UpdateENIPublicIP(_ context.Context, _, _, publicIP, _ string) error {

--- a/spinifex/handlers/ec2/vpc/eni.go
+++ b/spinifex/handlers/ec2/vpc/eni.go
@@ -70,6 +70,13 @@ type ENIRecord struct {
 	// transition. The reconciler ages transitions against this so it never
 	// rolls back a record a live attach/detach handler is mid-pipeline on.
 	AttachmentStateAt time.Time `json:"attachment_state_at,omitzero"`
+	// DeleteOnTermination mirrors AWS's Attachment.DeleteOnTermination: true
+	// deletes the ENI when its instance terminates, false only detaches it.
+	// A pointer so a nil value (unset, including every record written before
+	// this field existed) reads as true — the default for a system-attached
+	// interface and the value DescribeNetworkInterfaces already advertised
+	// before this field backed it.
+	DeleteOnTermination *bool `json:"delete_on_termination,omitempty"`
 }
 
 // eniIsLiveAttachment reports whether the ENI record is a live attachment to
@@ -528,6 +535,12 @@ func (s *VPCServiceImpl) attachENI(ctx context.Context, accountID, eniId, instan
 	record.AttachmentId = attachmentId
 	record.InstanceId = instanceId
 	record.DeviceIndex = deviceIndex
+	// Default DeleteOnTermination to true on first attach, matching what
+	// DescribeNetworkInterfaces already advertises; a record carrying an
+	// explicit value from an earlier attach keeps it across re-attach.
+	if record.DeleteOnTermination == nil {
+		record.DeleteOnTermination = aws.Bool(true)
+	}
 
 	data, err := json.Marshal(record)
 	if err != nil {
@@ -768,7 +781,7 @@ func (s *VPCServiceImpl) eniRecordToEC2(record *ENIRecord, accountID string) *ec
 			InstanceId:          aws.String(record.InstanceId),
 			DeviceIndex:         aws.Int64(record.DeviceIndex),
 			Status:              aws.String("attached"),
-			DeleteOnTermination: aws.Bool(true),
+			DeleteOnTermination: aws.Bool(record.DeleteOnTermination == nil || *record.DeleteOnTermination),
 		}
 	}
 

--- a/spinifex/handlers/systemvpc/systemvpc_test.go
+++ b/spinifex/handlers/systemvpc/systemvpc_test.go
@@ -656,6 +656,41 @@ func TestDeleteReclaimsTheBillableAddress(t *testing.T) {
 	assert.Empty(t, f.vpcs)
 }
 
+// TestDeleteSweepsResidualSecurityGroups locks in the residual-SG sweep in
+// Delete (systemvpc.go): DeleteVpc rejects a VPC that still owns a non-default
+// SG, and a partial create can leave one untagged so the role-tagged teardown
+// never sees it. The sweep instead lists by vpc-id and removes everything
+// except "default", which cannot be deleted on its own and goes with the VPC
+// cascade.
+func TestDeleteSweepsResidualSecurityGroups(t *testing.T) {
+	f := newFakeEC2()
+	spec := testSpec("cp-demo")
+
+	refs, err := Ensure(t.Context(), f.deps(), spec, "000000000000")
+	require.NoError(t, err)
+
+	defaultSG := &ec2.SecurityGroup{
+		GroupId:   aws.String("sg-default-0001"),
+		GroupName: aws.String("default"),
+		VpcId:     aws.String(refs.VpcID),
+	}
+	f.sgs[aws.StringValue(defaultSG.GroupId)] = defaultSG
+
+	residualSG := &ec2.SecurityGroup{
+		GroupId:   aws.String("sg-residual-0001"),
+		GroupName: aws.String("web"),
+		VpcId:     aws.String(refs.VpcID),
+	}
+	f.sgs[aws.StringValue(residualSG.GroupId)] = residualSG
+
+	require.NoError(t, Delete(t.Context(), f.deps(), spec, "000000000000", refs.VpcID))
+
+	assert.NotContains(t, f.sgs, aws.StringValue(residualSG.GroupId),
+		"a non-default SG the tagged sweep missed must still be reclaimed")
+	assert.Contains(t, f.sgs, aws.StringValue(defaultSG.GroupId),
+		"the default SG is not deletable on its own; it goes with the VPC cascade")
+}
+
 func TestDeleteOnNothingProvisionedSucceeds(t *testing.T) {
 	f := newFakeEC2()
 	// Teardown is re-driven on a timer, so a delete after a successful delete —

--- a/tests/e2e/ecs/ecs_test.go
+++ b/tests/e2e/ecs/ecs_test.go
@@ -132,6 +132,52 @@ func TestECS(t *testing.T) {
 	t.Run("ServiceWithELB", func(t *testing.T) {
 		runServiceWithELB(t, c, env, fx)
 	})
+
+	// Runs last: terminates the container instance ahead of the fixture's own
+	// teardown so the assertion below observes a clean sweep. By this point the
+	// instance carries its own primary ENI plus a post-launch-attached one per
+	// awsvpc task/service subtest above (TaskAwsvpc, TaskRoleCredentials,
+	// ServiceWithELB) — none of those ever touch vm.VM.ENIId, so this is the
+	// regression proof for mulga-73xte: relying on the launch-time scalar alone
+	// would leave every one of them attached, blocking SG/subnet/VPC teardown
+	// behind DependencyViolation.
+	t.Run("TerminateReleasesAttachedENIs", func(t *testing.T) {
+		terminateContainerInstanceAndAssertENIsReleased(t, c, fx)
+	})
+}
+
+// terminateContainerInstanceAndAssertENIsReleased terminates the fixture's
+// container instance and polls describe-network-interfaces on its subnet
+// until the count returns to zero, following the WaitForENICleanup pattern
+// (tests/e2e/harness/lb.go) but scoped by subnet-id rather than description
+// since every ENI the instance and its tasks accumulated shares this subnet.
+func terminateContainerInstanceAndAssertENIsReleased(t *testing.T, c *harness.AWSClient, fx *ecsFixture) {
+	t.Helper()
+
+	_, err := c.EC2.TerminateInstances(&ec2.TerminateInstancesInput{
+		InstanceIds: aws.StringSlice([]string{fx.InstanceID}),
+	})
+	require.NoError(t, err, "terminate-instances")
+	harness.WaitForInstanceTerminated(t, c, []string{fx.InstanceID}, 3*time.Minute)
+
+	label := fmt.Sprintf("container instance %s", fx.InstanceID)
+	harness.Step(t, "%s: waiting for ENIs in %s to drain", label, fx.SubnetAID)
+	harness.EventuallyErr(t, func() error {
+		out, derr := c.EC2.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{
+			Filters: []*ec2.Filter{{
+				Name:   aws.String("subnet-id"),
+				Values: []*string{aws.String(fx.SubnetAID)},
+			}},
+		})
+		if derr != nil {
+			return fmt.Errorf("describe ENIs in %s: %w", fx.SubnetAID, derr)
+		}
+		if len(out.NetworkInterfaces) == 0 {
+			return nil
+		}
+		return fmt.Errorf("%s: %d ENIs still present in %s", label, len(out.NetworkInterfaces), fx.SubnetAID)
+	}, 90*time.Second, 3*time.Second)
+	harness.Step(t, "%s ENIs cleaned up", label)
 }
 
 // --- Fixture --------------------------------------------------------------


### PR DESCRIPTION
Cluster PR from a bug-sweep of the "VPC teardown blocked by undeclared dependents" theme. Four beads went in, and they turned out to be in four different states — only one needed code.

## `mulga-73xte` — fixed here

Terminating an instance released only the ENI recorded at `RunInstances` time. Attachments made after boot — ECS awsvpc task ENIs, or any direct `AttachNetworkInterface` — are written to the `spinifex-vpc-enis` KV by `attachENI` (`handlers/ec2/vpc/eni.go:510-541`) and never reach `instance.ENIId`, which is all either terminate path read (`daemon/vm_adapters.go:728-748`, `handlers/ec2/instance/service_impl.go:2558-2577`). The read and the write never agreed for a post-launch attach.

The survivors held their security group, so the SG, subnet and VPC deletes all failed with `DependencyViolation`, and `delete-network-interface` failed `InvalidNetworkInterface.InUse`.

This is general, not an ECS quirk — ECS awsvpc is simply the only caller exercising post-launch attach today. ECS's own `reclaimTaskENI` is correct but a direct EC2 `TerminateInstances` never enters ECS at all, leaving only the 90s heartbeat reaper, which teardown beats comfortably.

Both paths now sweep the KV for records naming the instance, independent of the scalar. The sweep is additive, so an instance with no secondary ENIs behaves exactly as before, and best-effort per ENI, so one failure neither aborts the rest nor blocks convergence on re-run.

## `mulga-eo7k2` — same surface, fixed in the same diff

`DescribeNetworkInterfaces` advertised `DeleteOnTermination` while `ENIRecord` had no such field — `eniRecordToEC2` hardcoded `aws.Bool(true)`. The API reported an attribute nothing could act on. `ENIRecord` now carries it as a `*bool` so nil (every pre-existing record) reads as true, preserving behaviour on upgrade; `false` detaches without deleting.

## `mulga-ek43k` — closed GONE, test added here

The CP-VPC security-group teardown step already exists (`handlers/systemvpc/systemvpc.go:639-661`, landed in 84418a21). But nothing tested it — `fakeEC2.sgs` was seeded by no test — and the bead's acceptance criterion asked for exactly that coverage, so it lands here before closing.

## Verification

`make preflight` green. New unit coverage:

- `TestInstanceCleanerAdapter_DetachAndDeleteENI_ReleasesPostLaunchAttach` — attaches via KV only, never sets `instance.ENIId`, asserts the record is released
- `TestInstanceCleanerAdapter_DetachAndDeleteENI_DeleteOnTerminationFalseDetachesOnly`
- `TestDeleteSweepsResidualSecurityGroups` — sweeps the non-default SG, leaves `default` alone

Live on env19 (3 nodes), deployed from this branch and confirmed in the binary (`spx version` = `v1.14.0-37-g4ea80727` on all three):

```
--- PASS: TestECS (183.97s)
    --- PASS: TestECS/RegisterContainerInstance (85.38s)
    --- PASS: TestECS/TaskAwsvpc (15.25s)
    --- PASS: TestECS/TerminateReleasesAttachedENIs (5.73s)
```

Plus an independent manual reproduction outside the Go harness, mirroring the original precondition (post-boot attach at device index 1): terminate left the ENI `InvalidNetworkInterfaceID.NotFound`, and the SG, subnet and VPC deletes all succeeded with no `DependencyViolation`. That same sequence failed all three deletes before the fix.

## Coordination with `mulga-agz18`

`docs/development/bugs/lb-eni-leak-stale-kv-reads.md` (Planned, not started) targets two of the same files. The changes sit on different axes and compose: `agz18` changes **how** one ENI is detached and deleted (revision-carrying CAS); this changes **which** ENIs are enumerated. The diff was deliberately kept narrow to leave it a clean landing — no restructuring of `DetachENI`/`ForceDeleteInstanceENI`/`deleteNetworkInterface`, no combined detach-and-delete method, no orphan reaper. Expect a textual conflict in `DetachAndDeleteENI`, not a semantic one.

One input for that work: the new sweep calls the same NotFound-tolerant `ForceDeleteInstanceENI`, so it inherits the false-success logging documented there. Its fix should cover both call sites.

Closes mulga-73xte
Closes mulga-eo7k2
Closes mulga-ek43k