### PR TITLE
fix(daemon): exit on SIGTERM instead of deadlocking on its own wait group

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1853,9 +1853,10 @@ func (d *Daemon) startCluster() error {
 	d.ready.Store(true)
 	slog.Info("Daemon fully initialized", "node", d.node, "startupTime", time.Since(d.startTime).Round(time.Second))
 
+	// Return once bootstrap is done. Start already installed the signal handler
+	// and owns the single awaitShutdown; waiting here would block on the wait
+	// group this goroutine is itself a member of, which never resolves.
 	d.setupReload()
-	d.setupShutdown()
-	d.awaitShutdown()
 
 	return nil
 }

--- a/spinifex/daemon/shutdown_invariant_test.go
+++ b/spinifex/daemon/shutdown_invariant_test.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// awaitShutdown blocks on shutdownWg, and every goroutine registered with
+// shutdownWg.Go is a counted member of it. Calling it from inside such a
+// goroutine deadlocks: the member cannot decrement until it returns, and it
+// cannot return until the counter it is waiting on reaches zero.
+//
+// startCluster runs as a shutdownWg member and once called awaitShutdown at its
+// tail, so the daemon never exited on SIGTERM and was SIGKILLed at
+// TimeoutStopSec on every stop. Pinning both helpers to a single call site each
+// keeps that shape from returning — a second call site is the defect.
+func TestShutdownHelpersHaveASingleCallSite(t *testing.T) {
+	for _, tc := range []struct {
+		helper string
+		caller string
+		why    string
+	}{
+		{
+			helper: "awaitShutdown",
+			caller: "Start",
+			why:    "blocks on shutdownWg; a second caller is almost certainly a member of that group and will deadlock",
+		},
+		{
+			helper: "setupShutdown",
+			caller: "Start",
+			why:    "each call registers its own signal.Notify and shutdownWg goroutine, so a second caller duplicates the handler",
+		},
+	} {
+		t.Run(tc.helper, func(t *testing.T) {
+			sites := callSites(t, tc.helper)
+			if len(sites) == 1 && sites[0].caller == tc.caller {
+				return
+			}
+
+			var b strings.Builder
+			fmt.Fprintf(&b, "%s must be called exactly once, from %s — %s\n",
+				tc.helper, tc.caller, tc.why)
+			for _, s := range sites {
+				fmt.Fprintf(&b, "  %s:%d: called from %s\n", s.file, s.line, s.caller)
+			}
+			t.Fatal(b.String())
+		})
+	}
+}
+
+type callSite struct {
+	file   string
+	line   int
+	caller string
+}
+
+// callSites reports every call to a method on the daemon receiver, with the
+// enclosing function of each.
+func callSites(t *testing.T, method string) []callSite {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var found []callSite
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, name, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+
+		// Track the enclosing FuncDecl so a hit can name its caller rather than
+		// just its line.
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Name == nil || fn.Body == nil {
+				return true
+			}
+			ast.Inspect(fn.Body, func(inner ast.Node) bool {
+				sel, ok := inner.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != method {
+					return true
+				}
+				pos := fset.Position(sel.Pos())
+				found = append(found, callSite{filepath.Base(pos.Filename), pos.Line, fn.Name.Name})
+				return true
+			})
+			return true
+		})
+	}
+
+	sort.Slice(found, func(i, j int) bool {
+		if found[i].file != found[j].file {
+			return found[i].file < found[j].file
+		}
+		return found[i].line < found[j].line
+	})
+	return found
+}


### PR DESCRIPTION
Closes mulga-uifgg.

## Problem

`spinifex-daemon` never exited on SIGTERM. It logged `Shutdown complete` within ~20ms and then sat silent until systemd's `TimeoutStopSec=15` SIGKILLed it, on every stop, coordinated or not.

Because the member stop chain is strictly serialized, that 15s also gated every other unit — viperblock, predastore and nats each stop in milliseconds once reached, but could not start until the daemon was killed.

## Root cause

A deterministic `sync.WaitGroup` self-deadlock, not a slow operation and not a race.

`Start` registers `startCluster` as a member of `shutdownWg` and then waits on that group:

```go
d.setupShutdown()                       // daemon.go:1179
d.shutdownWg.Go(func() {                // daemon.go:1181
    if err := d.startCluster(); err != nil { ... }
})
d.awaitShutdown()                       // daemon.go:1187
```

`startCluster`'s tail called both again — including `awaitShutdown`, which blocks on `d.shutdownWg.Wait()`, the same group its own goroutine is a counted member of. It could not return until the counter reached zero, and the counter could not reach zero until it returned.

Captured by sending `SIGQUIT` to the hung daemon, which it does not catch, so the runtime dumps every goroutine stack:

```
goroutine 116 [chan receive, 4 minutes]:
...daemon.(*Daemon).awaitShutdown(...)  daemon.go:2119
...daemon.(*Daemon).startCluster(...)   daemon.go:1858
...daemon.(*Daemon).Start.func1()       daemon.go:1182
sync.(*WaitGroup).Go.func1()

goroutine 1 [chan receive, 4 minutes]:
...daemon.(*Daemon).awaitShutdown(...)  daemon.go:2119
...daemon.(*Daemon).Start(...)          daemon.go:1187
```

The duplicate `setupShutdown` in the same tail registered a second `signal.Notify` and a second handler goroutine, which is where the duplicated `Received shutdown signal, cleaning up...` / `Shutdown complete` lines and the duplicate NATS unsubscribe pass came from.

## Fix

Delete both tail calls. `Start` already installs the handler and owns the single wait, so `startCluster` now returns after bootstrap and decrements normally.

This is a logic fix rather than a timeout: bounding `awaitShutdown` would mask the deadlock instead of removing it.

## Verification

Live on env12, with a guest running, two back-to-back stop/start cycles:

| | baseline | run 1 | run 2 |
|---|---|---|---|
| `spinifex-daemon.service` stop duration | 15.2s, SIGKILLed | 0.026s | 0.024s |
| Total chain, daemon-stop to nats-stop | 16.35s | 1.169s | 1.201s |
| Daemon `Result` | timeout | `success` | `success` |
| `Received shutdown signal` / `Shutdown complete` | 2x each | 1x each | 1x each |

No `State 'stop-sigterm' timed out` and no SIGKILL in either run; `Deactivated successfully` both times.

Shutdown work is unchanged, not raced past — both runs show the full `GATE` → `DRAIN` → 6x NATS unsubscribe → `Shutdown complete` sequence with `"vms_stopped":1`, and the guest was drained and then relaunched on restart. No orphaned qemu, no truncated shutdown log.

## Regression test

`TestShutdownHelpersHaveASingleCallSite` pins each helper to one call site, following the AST-invariant idiom already used in `spinifex/network/invariants/`. A second call site is the defect itself rather than a symptom, so that is what it asserts. Confirmed to fail when the two lines are reintroduced:

```
awaitShutdown must be called exactly once, from Start — blocks on shutdownWg;
a second caller is almost certainly a member of that group and will deadlock
  daemon.go:1187: called from Start
  daemon.go:1858: called from startCluster
```

`make preflight` passes.

## Related

Part of the cluster in `docs/development/bugs/systemd-lifecycle-target-stop.md`. This bead is a contributing cause of mulga-tm5l6's stop-cascade window, which is being addressed separately in the ansible roles.