### PR TITLE
fix(ec2): report the AMI's real state in DescribeImages instead of a hardcoded available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.14.0
 	github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4
-	github.com/mulgadc/viperblock v1.14.1-0.20260801020443-da01d991be6c
+	github.com/mulgadc/viperblock v1.14.1-0.20260801113714-c1f227012d30
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1321,8 +1321,8 @@ github.com/mulgadc/northstar v1.14.0 h1:8JzDcS4k3SN5PF3jBdB8x9FOWC24eITCClmOdwpo
 github.com/mulgadc/northstar v1.14.0/go.mod h1:6EArbWIQUrCFQ+XZ5ZJrGS/ep/u/rF6l+dKZh5vVIRs=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4 h1:Q4/NEryYTMiALkFwbPPOrKpNgLir+d7T2hbyRpAFnWc=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4/go.mod h1:na0aNXABZF03/HfFWCrAPHrId/2FIEIUQfB82vlu1xg=
-github.com/mulgadc/viperblock v1.14.1-0.20260801020443-da01d991be6c h1:MMqR9AOZ+1c+c1YaLke892wJJBQjGIJtuFSZXX7m8GQ=
-github.com/mulgadc/viperblock v1.14.1-0.20260801020443-da01d991be6c/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
+github.com/mulgadc/viperblock v1.14.1-0.20260801113714-c1f227012d30 h1:UMZDKxm+WCbDb5hwQ/7uL2KmlYTiX76dk4dxNawmgDM=
+github.com/mulgadc/viperblock v1.14.1-0.20260801113714-c1f227012d30/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/spinifex/handlers/ec2/image/service_impl.go
+++ b/spinifex/handlers/ec2/image/service_impl.go
@@ -261,7 +261,7 @@ func (s *ImageServiceImpl) DescribeImages(ctx context.Context, input *ec2.Descri
 			ImageOwnerAlias:    aws.String(amiMeta.ImageOwnerAlias),
 			OwnerId:            aws.String(ownerID),
 			Public:             aws.Bool(false),
-			State:              aws.String("available"),
+			State:              aws.String(amiImageState(amiMeta.State)),
 			ImageType:          aws.String("machine"),
 			Hypervisor:         aws.String("xen"), // Default hypervisor
 			BootMode:           aws.String(amiMeta.BootMode),
@@ -302,6 +302,17 @@ func (s *ImageServiceImpl) DescribeImages(ctx context.Context, input *ec2.Descri
 	return &ec2.DescribeImagesOutput{
 		Images: images,
 	}, nil
+}
+
+// amiImageState maps AMIMetadata.State to the ec2.Image state string. An
+// empty State means the AMI was registered before the field existed, and
+// MUST report as "available" — those images are already complete and
+// launchable, so treating empty as anything else would hide them.
+func amiImageState(state string) string {
+	if state == "" {
+		return "available"
+	}
+	return state
 }
 
 // imageMatchesFilters checks whether an ec2.Image satisfies all parsed filters.
@@ -451,6 +462,8 @@ func (s *ImageServiceImpl) CreateImageFromInstance(params CreateImageParams, acc
 		BootMode:        sourceAMI.BootMode,
 		Distro:          sourceAMI.Distro,
 		DistroFamily:    sourceAMI.DistroFamily,
+		// Snapshot succeeded before this point, so the image is complete.
+		State: "available",
 	}
 
 	if err := s.putAMIConfig(context.Background(), amiID, meta); err != nil {
@@ -967,6 +980,9 @@ func (s *ImageServiceImpl) CopyImage(ctx context.Context, input *ec2.CopyImageIn
 		CreationDate:    time.Now(),
 		BootMode:        srcMeta.BootMode,
 		Tags:            tags,
+		// Zero-copy: the new config shares the source's already-durable
+		// snapshot, so the image is complete as soon as this is written.
+		State: "available",
 	}
 
 	if err := s.putAMIConfig(ctx, newImageID, meta); err != nil {
@@ -1170,6 +1186,9 @@ func (s *ImageServiceImpl) RegisterImage(ctx context.Context, input *ec2.Registe
 		CreationDate:    time.Now(),
 		Tags:            tags,
 		BootMode:        aws.StringValue(input.BootMode),
+		// The referenced snapshot already exists (checked above), so the
+		// image is complete as soon as this config is written.
+		State: "available",
 	}
 
 	if err := s.putAMIConfig(ctx, amiID, meta); err != nil {

--- a/spinifex/handlers/ec2/image/service_impl_test.go
+++ b/spinifex/handlers/ec2/image/service_impl_test.go
@@ -248,6 +248,47 @@ func TestDescribeImages_BootModeProjection(t *testing.T) {
 		"legacy AMIs (empty BootMode) must pass through as empty, not be backfilled")
 }
 
+// TestDescribeImages_StateProjection asserts that AMIMetadata.State drives the
+// reported ec2.Image state. An AMI with no State at all (registered before the
+// field existed) is the legacy-compatibility case and MUST report "available",
+// or every pre-existing AMI on every deployment would vanish from normal use.
+func TestDescribeImages_StateProjection(t *testing.T) {
+	tests := []struct {
+		name      string
+		amiState  string
+		wantState string
+	}{
+		{name: "pending state reports pending", amiState: "pending", wantState: "pending"},
+		{name: "available state reports available", amiState: "available", wantState: "available"},
+		{name: "no state reports available (legacy compatibility)", amiState: "", wantState: "available"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, store := setupTestImageService(t)
+
+			createTestAMIConfigRich(t, store, viperblock.AMIMetadata{
+				ImageID:         "ami-state001",
+				Name:            "state-image",
+				Architecture:    "x86_64",
+				PlatformDetails: "Linux/UNIX",
+				Virtualization:  "hvm",
+				RootDeviceType:  "ebs",
+				VolumeSizeGiB:   8,
+				ImageOwnerAlias: testAccountID,
+				State:           tt.amiState,
+			})
+
+			result, err := svc.DescribeImages(context.Background(), &ec2.DescribeImagesInput{
+				ImageIds: []*string{aws.String("ami-state001")},
+			}, testAccountID)
+			require.NoError(t, err)
+			require.Len(t, result.Images, 1)
+			assert.Equal(t, tt.wantState, aws.StringValue(result.Images[0].State))
+		})
+	}
+}
+
 func TestGetVolumeConfig(t *testing.T) {
 	svc, store := setupTestImageService(t)
 


### PR DESCRIPTION
Consumer half of mulga-sn062. The viperblock half landed in viperblock#65: `AMIMetadata` now carries `State`, written `pending` before the image data is flushed and flipped to `available` only after a clean close.

`spx admin images import` against a full backend exits non-zero, but `describe-images` still listed the AMI as `available`, so a partial image was indistinguishable from a complete one and could be launched.

`DescribeImages` hardcoded `State: aws.String("available")`, so any AMI whose `config.json` existed reported available regardless of whether its data ever arrived. It now projects the AMI's own state.

**Compatibility:** every AMI registered before this field existed has an empty `State`, and empty is treated as `available`. Those images are complete and launchable, and treating empty as anything else would hide every existing AMI on every deployment. The helper exists specifically to make that explicit at the call site rather than implicit in a zero value.

The three creation paths — `CreateImageFromInstance`, `RegisterImage` and `CopyImage` — now set `available` explicitly rather than leaning on that fallback. Each only writes AMI metadata after its snapshot or source data is already durable, so the state is honest, and being explicit means they do not depend on a shim that exists only for pre-field AMIs.

`images_promote.go` and `images_remove.go` marshal the whole `AMIMetadata` struct rather than copying field by field, so `State` round-trips without changes there.

Includes the `go.mod` pin move to `viperblock v1.14.1-0.20260801113714-c1f227012d30` (dev @ `c1f2270`), which is what makes the field available to the deployed binary — the ansible build role builds with `GOWORK=off`, so the pin is what ships, not the workspace overlay.

## Testing

`make preflight` passes. Table-driven cases on `DescribeImages`:

- `State: "pending"` reports `pending` — the case that fails without this change
- `State: "available"` reports `available`
- no `State` at all reports `available`, the legacy-compatibility case

Closes mulga-sn062.