### PR TITLE
fix(daemon): detach every non-DeleteOnTermination volume on terminate, not just the boot volume

### DIFF
--- a/spinifex/daemon/daemon_test.go
+++ b/spinifex/daemon/daemon_test.go
@@ -1641,6 +1641,46 @@ func TestInstanceCleanerAdapter_DeleteVolumes_NonDoTBootVolumeDetachedNotDeleted
 	assert.Empty(t, cfg.VolumeMetadata.AttachedInstance, "terminate must still detach it")
 }
 
+// TestInstanceCleanerAdapter_DeleteVolumes_NonBootNonDoTVolumeDetachedNotDeleted
+// mirrors the Boot-volume case above for a non-Boot, DeleteOnTermination=false
+// data volume: terminate must still detach it (AWS semantics: it survives as
+// available, it just isn't deleted). Unlike a Boot volume, a non-Boot volume
+// was previously assumed to already be detached by shutdownAndUnmount's
+// Unmount, but Unmount only clears the attachment when its unmount seal
+// succeeds and is skipped entirely on the stuck-terminate force-complete
+// path, so that assumption left it stranded attached.
+func TestInstanceCleanerAdapter_DeleteVolumes_NonBootNonDoTVolumeDetachedNotDeleted(t *testing.T) {
+	daemon, store := createFullTestDaemonWithStore(t, sharedNATSURL)
+
+	volumeID := "vol-data-nondot-attached"
+	seedVolumeConfig(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		TenantID:         testAccountID,
+		SizeGiB:          10,
+		State:            "in-use",
+		AttachedInstance: "i-test-data-detach", // stale: Unmount's seal failed or never ran
+	})
+
+	instance := &vm.VM{
+		ID:        "i-test-data-detach",
+		AccountID: testAccountID,
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{
+				{Name: volumeID, Boot: false, DeleteOnTermination: false},
+			},
+		},
+	}
+
+	cleaner := newInstanceCleanerAdapter(daemon)
+	err := cleaner.DeleteVolumes(instance)
+	require.NoError(t, err)
+
+	cfg, err := daemon.volumeService.GetVolumeConfig(volumeID)
+	require.NoError(t, err, "a DeleteOnTermination=false volume must survive terminate")
+	assert.Equal(t, "available", cfg.VolumeMetadata.State)
+	assert.Empty(t, cfg.VolumeMetadata.AttachedInstance, "terminate must still detach it")
+}
+
 // TestTerminatedTeardownReaper_SelfHealsFailedVolumeTeardown proves the
 // go-forward self-heal: a stopped-terminate that stamped
 // Teardown[volumes]=failed on a transient error (deleteInstanceVolumes,
@@ -1713,6 +1753,121 @@ func TestTerminatedTeardownReaper_SelfHealsFailedVolumeTeardown(t *testing.T) {
 	require.Len(t, remaining, 1, "still within the visibility window: not purged yet")
 	assert.Equal(t, string(vm.TeardownDone), remaining[0].Teardown[vm.TeardownVolumes],
 		"a retry that now succeeds must flip the mark from failed to done")
+}
+
+// TestTerminatedTeardownReaper_SelfHealsFailedVolumeDetach mirrors the
+// self-heal test above for a non-Boot, DeleteOnTermination=false volume: a
+// terminate that stamped Teardown[volumes]=failed on a transient detach
+// error is retried by TerminatedTeardownReaper.Sweep through the real
+// instanceCleanerAdapter. The retry must clear the stale attachment so the
+// volume converges to available/detached instead of staying stranded
+// in-use with no automatic path back — the "no both-calls-fail" recovery
+// requirement.
+func TestTerminatedTeardownReaper_SelfHealsFailedVolumeDetach(t *testing.T) {
+	daemon, store := createFullTestDaemonWithStore(t, sharedNATSURL)
+
+	fakeStore := newFakeStateStore()
+	daemon.stateStore = fakeStore
+
+	volumeID := "vol-data-self-heal"
+	instanceID := "i-self-heal-detach"
+	seedVolumeConfig(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		TenantID:         testAccountID,
+		SizeGiB:          10,
+		State:            "in-use",
+		AttachedInstance: instanceID, // stale, left by the earlier failed terminate
+	})
+
+	instance := &vm.VM{
+		ID:           instanceID,
+		AccountID:    testAccountID,
+		Status:       vm.StateTerminated,
+		LastNode:     daemon.node,
+		TerminatedAt: time.Now(), // inside the visibility window: Sweep must not purge yet
+		Teardown: map[string]string{
+			vm.TeardownVolumes: string(vm.TeardownFailed),
+		},
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{
+				{Name: volumeID, Boot: false, DeleteOnTermination: false},
+			},
+		},
+	}
+	require.NoError(t, fakeStore.WriteTerminatedInstance(instance.ID, instance))
+
+	reaper := vm.NewManagerWithDeps(vm.Deps{
+		NodeID:          daemon.node,
+		StateStore:      fakeStore,
+		InstanceCleaner: newInstanceCleanerAdapter(daemon),
+	}).NewTerminatedTeardownReaper()
+
+	_, err := reaper.Sweep(context.Background())
+	require.NoError(t, err)
+
+	cfg, err := daemon.volumeService.GetVolumeConfig(volumeID)
+	require.NoError(t, err, "the volume must survive: DeleteOnTermination=false")
+	assert.Equal(t, "available", cfg.VolumeMetadata.State)
+	assert.Empty(t, cfg.VolumeMetadata.AttachedInstance, "the retry must clear the stale attachment")
+
+	remaining, err := fakeStore.ListTerminatedInstances()
+	require.NoError(t, err)
+	require.Len(t, remaining, 1, "still within the visibility window: not purged yet")
+	assert.Equal(t, string(vm.TeardownDone), remaining[0].Teardown[vm.TeardownVolumes],
+		"a retry that now succeeds must flip the mark from failed to done")
+}
+
+// TestStuckTerminateReaper_DetachesNonDoTVolumeWithoutUnmount proves the
+// stuck-terminate force-complete path (the second live-reproduced case)
+// detaches a non-Boot, DeleteOnTermination=false volume even though
+// shutdownAndUnmount's Unmount never ran: forceFinalizeStuckTerminate kills
+// the wedged QEMU and calls the cleaner directly, skipping Unmount entirely.
+// Before the fix, DeleteVolumes relied on Unmount to have already cleared a
+// non-Boot volume's attachment, so this path left it attached and, once the
+// instance record was gone, unrecoverable via either detach-volume or
+// delete-volume.
+func TestStuckTerminateReaper_DetachesNonDoTVolumeWithoutUnmount(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	daemon, store := createFullTestDaemonWithStore(t, sharedNATSURL)
+
+	const instanceID = "i-wedged-terminate"
+	volumeID := "vol-data-wedged"
+	seedVolumeConfig(t, store, volumeID, viperblock.VolumeMetadata{
+		VolumeID:         volumeID,
+		TenantID:         testAccountID,
+		SizeGiB:          10,
+		State:            "in-use",
+		AttachedInstance: instanceID, // never cleared: Unmount never ran on this path
+	})
+
+	fakeStore := newFakeStateStore()
+	mgr := vm.NewManagerWithDeps(vm.Deps{
+		NodeID:          daemon.node,
+		StateStore:      fakeStore,
+		InstanceCleaner: newInstanceCleanerAdapter(daemon),
+	})
+
+	mgr.InsertIfAbsent(&vm.VM{
+		ID:             instanceID,
+		AccountID:      testAccountID,
+		Status:         vm.StateShuttingDown,
+		ShuttingDownAt: time.Now().Add(-15 * time.Minute), // past the stuck-terminate backstop timeout
+		EBSRequests: types.EBSRequests{
+			Requests: []types.EBSRequest{
+				{Name: volumeID, Boot: false, DeleteOnTermination: false},
+			},
+		},
+	})
+
+	reaped, err := mgr.NewStuckTerminateReaper().Sweep(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped, "the wedged terminate must be force-completed")
+
+	cfg, err := daemon.volumeService.GetVolumeConfig(volumeID)
+	require.NoError(t, err)
+	assert.Equal(t, "available", cfg.VolumeMetadata.State,
+		"the force-complete path must still detach a non-Boot DeleteOnTermination=false volume")
+	assert.Empty(t, cfg.VolumeMetadata.AttachedInstance)
 }
 
 // TestHandleEC2Events_AttachVolume tests the attach-volume handler in handleEC2Events.

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -621,20 +621,11 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) error {
 			continue
 		}
 
-		// User-visible volumes: DeleteOnTermination=false survives terminate,
-		// but terminate still implies detach (AWS semantics). Only the Boot
-		// volume can still be attached here — shutdownAndUnmount's Unmount
-		// clears every non-Boot volume's attachment already, so a non-Boot
-		// DoT=false volume is genuinely a no-op skip. A DoT=false Boot volume
-		// is never touched by Unmount, so without this it would strand
-		// attached to the now-terminated instance forever.
+		// User-visible volumes: DeleteOnTermination=false survives terminate, but
+		// terminate still implies detach (AWS semantics) for every volume, Boot or
+		// not. Unmount's own clear is best-effort and skipped entirely on the force-complete path, so this call is the explicit guarantee.
 		if !ebsRequest.DeleteOnTermination {
-			if !ebsRequest.Boot {
-				slog.Info("Volume has DeleteOnTermination=false, skipping deletion",
-					"name", ebsRequest.Name, "id", instance.ID)
-				continue
-			}
-			slog.Info("Boot volume has DeleteOnTermination=false, detaching without deleting",
+			slog.Info("Volume has DeleteOnTermination=false, detaching without deleting",
 				"name", ebsRequest.Name, "id", instance.ID)
 			if a.d.volumeService == nil {
 				slog.Warn("Volume service not configured, cannot detach volume",


### PR DESCRIPTION
Completes mulga-t4hz1's second acceptance criterion — "a stuck terminate is backstopped **and its volume reclaims**". PR #626 delivered the backstop; this delivers the reclaim.

## The bug

A `DeleteOnTermination=false` data volume stayed `in-use` after its instance reached `terminated`, and was then unrecoverable:

- `detach-volume --force` → `InvalidInstanceID.NotFound`, because the instance record is already deleted
- `delete-volume` → `VolumeInUse`

Both calls failing is the actual harm. Reproduced twice live on env13, via a normal terminate and via a reaper force-complete.

## Root cause

`instanceCleanerAdapter.DeleteVolumes` (`daemon/vm_adapters.go:624-644`) issued the explicit `DetachVolumeOnTerminate` only for a still-attached **Boot** volume. A non-Boot volume was logged and skipped, on the assumption that `shutdownAndUnmount`'s `Unmount` had already cleared its attachment.

That assumption fails two ways, matching both live repros:

- `Unmount` (`vm_adapters.go:164-208`) only flips a non-Boot volume to `available` when the `ebs.unmount` seal succeeded, and it unconditionally returns `nil` either way — so a failed or timed-out seal silently leaves the volume attached with no error anywhere.
- `forceFinalizeStuckTerminate` (`vm/shutdown.go:306-323`) never calls `shutdownAndUnmount` at all. It force-kills QEMU and calls the cleaner directly, so on that path nothing ever touched the attachment.

Worth stating because the obvious hypothesis was wrong: **the ordering was already correct.** Both `Terminate` and `forceFinalizeStuckTerminate` run the cleaner synchronously before `finalizeTerminated` deletes the instance record. The defect was that "detach" for non-Boot volumes was never a reliable operation, just an implicit side effect of a best-effort step that can silently no-op.

This is the uncovered half of the earlier work in mulga-1dzx9, which added the explicit detach for boot volumes and reasoned that non-Boot volumes were already handled.

## Why `VolumeLeakReaper` did not catch it

The reaper only acts on instances whose `Teardown[TeardownVolumes]` is `failed`. The skip was a deliberate `continue` that returned no error, so `markTeardownResult` recorded `done` and the instance never entered the leaked set. The cleaner was falsely claiming success — a coverage gap, not a reaper bug.

## The fix

Merge the boot-only branch into one: every non-EFI, `DeleteOnTermination=false` volume gets the explicit, idempotent `DetachVolumeOnTerminate`. Both terminate paths route through the same `InstanceCleaner.DeleteVolumes`, so this one point covers both. `DeleteOnTermination=true` volumes are still deleted as before.

## Testing

`make preflight` passes. Three new tests, each verified failing first:

- terminate detaches a non-boot, non-DoT volume, leaving it `available` rather than `in-use`
- the stuck-terminate force-complete path detaches without ever calling `Unmount`
- the teardown reaper self-heals a failed detach

One earlier run hit `TestEBSConfigQueueGroup_DetachedOpenFails` (`nats: timeout`) in an untouched package. Confirmed pre-existing and load-sensitive by stashing the diff and reproducing the identical failure on a clean tree under the same full-suite load — tracked as mulga-tgnu3, not caused by this change.

Closes mulga-t4hz1.