### PR TITLE
fix: scope golangci-lint cache per worktree, correct eks-node-gpu catalog description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Thumbs.db
 
 # Test reports
 *-report.txt
+
+# Per-worktree golangci-lint cache
+/.cache/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 GO_PROJECT_NAME := spx
 SHELL := /bin/bash
 
+# golangci-lint's default cache (~/.cache/golangci-lint) is keyed by module
+# path, not worktree path, so parallel worktrees of this module collide and
+# surface each other's issues. Scope it per worktree.
+export GOLANGCI_LINT_CACHE := $(CURDIR)/.cache/golangci-lint
+
 # Detect architecture for cross-platform support
 ARCH := $(shell uname -m)
 ifeq ($(ARCH),x86_64)

--- a/spinifex/utils/images.go
+++ b/spinifex/utils/images.go
@@ -440,7 +440,7 @@ var AvailableImages = map[string]Images{
 	// tags — CreateNodegroup selects it for GPU instance types instead of the Alpine AMI.
 	"spinifex-eks-node-gpu": {
 		Name:         "spinifex-eks-node-gpu",
-		Description:  "Mulga EKS GPU node image — Ubuntu 26.04 + NVIDIA driver + K3s v1.32.5 + eks-token-webhook (server|agent role selected at first boot)",
+		Description:  "Mulga EKS GPU node image — Ubuntu 26.04 + NVIDIA driver + K3s v1.32.5, agent-only (GPU nodes never run the EKS control plane, so no role selector or eks-token-webhook)",
 		Distro:       "ubuntu",
 		Version:      "26.04",
 		Arch:         "x86_64",


### PR DESCRIPTION
Two unrelated small fixes batched for review throughput. Closes **mulga-94bbb** and **mulga-iml2l**.

## mulga-94bbb — phantom lint issues from sibling worktrees

`golangci-lint`'s cache is keyed by module path, not worktree path, so every worktree of this module shared `/home/tf-user/.cache/golangci-lint` and `make preflight` in one worktree reported issues originating in another. Confirmed via `golangci-lint cache status` before changing anything.

The Makefile now exports `GOLANGCI_LINT_CACHE := $(CURDIR)/.cache/golangci-lint` once at the top, so `lint` and `fix` both inherit it without per-target edits, and `/.cache/` is gitignored. `GOLANGCI_LINT_CACHE` is a recognised variable in the installed binary (v2.12.2).

Cross-worktree contamination is now structurally impossible rather than merely unlikely, and no manual cache clean is needed between worktrees. `make lint` completes with `0 issues.`, populating only the scoped directory.

## mulga-iml2l — eks-node-gpu catalog description claimed a capability the image lacks

`utils/images.go:443` advertised the GPU node image as shipping a `server|agent` role selector and `eks-token-webhook`. It does not — GPU nodes never run the EKS control plane. The description now matches `IMAGE_DESCRIPTION` in `scripts/images/eks-node-gpu/manifest.conf:2`.

The sibling non-GPU entry at `images.go:426` was checked for the same drift and is accurate — the Alpine `eks-node` image genuinely does ship the role selector and webhook — so it was left alone.

No test asserts on `Description` (`handlers/eks/k3s_server_vm_test.go:752` references only `Name`), so there is no test change.

## Note on mulga-e3u6d

Also investigated in this branch, no change needed. The XML sibling-order flake was already fixed by `23de2ad8` (#597) before this branch started. Verified 100/100 clean and swept every `gateway/**/*_test.go` for the same exposure — none found. Closed separately with that evidence.

`make preflight` passes: 0 lint issues, no vulnerabilities.