### PR TITLE
fix: stop a concurrent CreateLoadBalancer stealing an in-flight name claim

### DIFF
--- a/spinifex/handlers/elbv2/name_claim_test.go
+++ b/spinifex/handlers/elbv2/name_claim_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -50,18 +51,40 @@ func TestCreateLoadBalancer_ConcurrentSameNameSingleOwner(t *testing.T) {
 	require.NotNil(t, rec)
 }
 
-// A name claim whose owner lbID resolves to no live record is a crashed prior
-// create. A fresh CreateLoadBalancer with that name must reclaim the orphan and
-// succeed, not wedge on DuplicateLoadBalancerName forever.
+// TestClaimLBName_PendingClaimBlocksSecondClaimer isolates the orphan-reclaim
+// window: a claim with no persisted LB record yet — the gap a real create
+// leaves open — must not be stealable by a second claimer within the TTL.
+func TestClaimLBName_PendingClaimBlocksSecondClaimer(t *testing.T) {
+	svc := setupTestService(t)
+
+	ok1, dup1, err := svc.store.ClaimLBName(t.Context(), "pending-lb", testAccountID, "lb-first")
+	require.NoError(t, err)
+	require.True(t, ok1)
+	require.False(t, dup1)
+
+	// lb-first has not persisted a record yet — the second claimer must not
+	// mistake that for a crash orphan.
+	ok2, dup2, err := svc.store.ClaimLBName(t.Context(), "pending-lb", testAccountID, "lb-second")
+	require.NoError(t, err)
+	assert.False(t, ok2, "a pending claim within its TTL must not be stealable")
+	assert.True(t, dup2, "the second claimer must see the name as unavailable")
+}
+
+// A name claim whose owner resolves to no live record, past its TTL, is a
+// crashed prior create. A fresh CreateLoadBalancer must reclaim it and succeed.
+// The injectable clock ages the claim so the test never sleeps.
 func TestCreateLoadBalancer_ReclaimsCrashOrphanNameClaim(t *testing.T) {
 	svc := setupTestService(t)
 
 	// Seed a name claim pointing at a non-existent LB (crashed create left no
-	// record). ClaimLBName writes the key with this bogus owner.
+	// record), stamped as claimed well before the TTL via a fake clock.
+	realNow := svc.store.now
+	svc.store.now = func() time.Time { return realNow().Add(-2 * lbNameClaimTTL) }
 	ok, dup, err := svc.store.ClaimLBName(t.Context(), "orphan-lb", testAccountID, "lb-doesnotexist")
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.False(t, dup)
+	svc.store.now = realNow
 
 	// A fresh create for the same name reclaims the orphan and succeeds.
 	out, err := svc.CreateLoadBalancer(context.Background(), &elbv2.CreateLoadBalancerInput{
@@ -92,4 +115,25 @@ func TestDeleteLoadBalancer_ReleasesNameForReuse(t *testing.T) {
 		Name: aws.String("reuse-lb"),
 	}, testAccountID)
 	require.NoError(t, err)
+}
+
+// A create that claims the name but then fails before PutLoadBalancer (here, ENI
+// provisioning on a nonexistent subnet) must release the claim on its way out, so
+// a retry with the same name is not permanently locked out by the failed attempt.
+func TestCreateLoadBalancer_FailureAfterClaimReleasesNameForRetry(t *testing.T) {
+	svc, _ := setupTestServiceWithVPC(t)
+
+	_, err := svc.CreateLoadBalancer(context.Background(), &elbv2.CreateLoadBalancerInput{
+		Name:    aws.String("retry-lb"),
+		Subnets: []*string{aws.String("subnet-doesnotexist")},
+	}, testAccountID)
+	require.Error(t, err, "ENI creation on a nonexistent subnet must fail")
+
+	// The failed attempt released the claim: a retry with no subnets (nothing
+	// left to fail) succeeds under the same name.
+	out, err := svc.CreateLoadBalancer(context.Background(), &elbv2.CreateLoadBalancerInput{
+		Name: aws.String("retry-lb"),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.LoadBalancers, 1)
 }

--- a/spinifex/handlers/elbv2/store.go
+++ b/spinifex/handlers/elbv2/store.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/mulgadc/spinifex/spinifex/migrate"
@@ -32,6 +33,11 @@ const (
 
 	// maxLBNameClaimRetries bounds the crash-orphan CAS-reclaim loop in ClaimLBName.
 	maxLBNameClaimRetries = 5
+
+	// lbNameClaimTTL bounds how long an unresolved claim blocks other creators
+	// before ClaimLBName treats it as a crash orphan. A legitimate create finishes
+	// well under this window; it only exists to reclaim an abandoned name.
+	lbNameClaimTTL = 5 * time.Minute
 )
 
 // Store provides CRUD operations for ELBv2 resources backed by JetStream KV.
@@ -40,6 +46,31 @@ const (
 // internal wait the legacy KV API applied.
 type Store struct {
 	kv jetstream.KeyValue
+
+	// now and claimTTL back ClaimLBName's pending-vs-orphan check. Both are
+	// overridden in tests (same package) so the crash-orphan reclaim path never
+	// needs a real sleep past the TTL.
+	now      func() time.Time
+	claimTTL time.Duration
+}
+
+// lbNameClaim is the value stored at a name-claim key. ClaimedAt lets a second
+// claimer distinguish a legitimate in-flight creator (no LB record yet, but the
+// claim is fresh) from a crash orphan (no record, and the claim is stale).
+type lbNameClaim struct {
+	OwnerID   string    `json:"ownerId"`
+	ClaimedAt time.Time `json:"claimedAt"`
+}
+
+// decodeLBNameClaim parses a name-claim value. A value that isn't valid JSON
+// predates ClaimedAt tracking (the bare owner lbID); treat it as maximally
+// stale so it stays immediately reclaimable, matching the old behaviour.
+func decodeLBNameClaim(raw []byte) lbNameClaim {
+	var claim lbNameClaim
+	if err := json.Unmarshal(raw, &claim); err != nil || claim.OwnerID == "" {
+		return lbNameClaim{OwnerID: string(raw)}
+	}
+	return claim
 }
 
 // NewStore creates a new ELBv2 store using the provided NATS connection. The
@@ -61,7 +92,7 @@ func NewStore(ctx context.Context, nc *nats.Conn) (*Store, error) {
 	}
 
 	slog.Info("ELBv2 store initialized", "bucket", KVBucketELBv2)
-	return &Store{kv: kv}, nil
+	return &Store{kv: kv, now: time.Now, claimTTL: lbNameClaimTTL}, nil
 }
 
 // --- Load Balancer CRUD ---
@@ -72,12 +103,17 @@ func LBNameKey(name, accountID string) string {
 }
 
 // ClaimLBName atomically claims the LB name; ok=true means this caller owns it,
-// dup=true means a live LB already holds it. An orphaned claim (owner resolves to
-// no record) is reclaimed via CAS. Idempotency barrier for CreateLoadBalancer.
+// dup=true means it's unavailable (a live LB, or another claim within its TTL).
+// A claim past its TTL with no LB record is a crash orphan, reclaimed via CAS.
 func (s *Store) ClaimLBName(ctx context.Context, name, accountID, lbID string) (ok bool, dup bool, err error) {
 	key := LBNameKey(name, accountID)
+	now := s.now()
+	claimBytes, merr := json.Marshal(lbNameClaim{OwnerID: lbID, ClaimedAt: now})
+	if merr != nil {
+		return false, false, fmt.Errorf("marshal LB name claim %s: %w", key, merr)
+	}
 	for range maxLBNameClaimRetries {
-		if _, cerr := s.kv.Create(ctx, key, []byte(lbID)); cerr == nil {
+		if _, cerr := s.kv.Create(ctx, key, claimBytes); cerr == nil {
 			return true, false, nil
 		} else if !errors.Is(cerr, jetstream.ErrKeyExists) {
 			return false, false, fmt.Errorf("kv create %s: %w", key, cerr)
@@ -89,18 +125,24 @@ func (s *Store) ClaimLBName(ctx context.Context, name, accountID, lbID string) (
 			}
 			return false, false, fmt.Errorf("kv get %s: %w", key, gerr)
 		}
-		ownerID := string(entry.Value())
-		if ownerID != "" && ownerID != lbID {
-			rec, rerr := s.GetLoadBalancer(ctx, ownerID)
+		claim := decodeLBNameClaim(entry.Value())
+		if claim.OwnerID != "" && claim.OwnerID != lbID {
+			rec, rerr := s.GetLoadBalancer(ctx, claim.OwnerID)
 			if rerr != nil {
-				return false, false, fmt.Errorf("resolve LB name owner %s: %w", ownerID, rerr)
+				return false, false, fmt.Errorf("resolve LB name owner %s: %w", claim.OwnerID, rerr)
 			}
 			if rec != nil {
 				return false, true, nil // live LB holds the name
 			}
+			// No record yet: either a legitimate create still mid-flight, or a
+			// crashed one. Only a claim older than the TTL is an abandoned
+			// orphan; a fresh one blocks a second claimer like a live LB would.
+			if now.Sub(claim.ClaimedAt) < s.claimTTL {
+				return false, true, nil
+			}
 		}
-		// Orphaned (crashed prior create) or already ours: CAS-take the claim.
-		if _, uerr := s.kv.Update(ctx, key, []byte(lbID), entry.Revision()); uerr != nil {
+		// Orphaned (crashed prior create, past its TTL) or already ours: CAS-take.
+		if _, uerr := s.kv.Update(ctx, key, claimBytes, entry.Revision()); uerr != nil {
 			if errors.Is(uerr, jetstream.ErrKeyExists) {
 				continue // lost the CAS race; re-read
 			}


### PR DESCRIPTION
Closes **mulga-1cwaz**.

## The bead's stated cause was wrong

The bead says "the check and the write can interleave". `kv.Create` in `ClaimLBName` is genuinely atomic, so that is not the mechanism.

The real defect is the **orphan-reclaim window**. `ClaimLBName` (`handlers/elbv2/store.go:77-112`) treated any owner whose `GetLoadBalancer` lookup returns `nil` as a crash orphan and CAS-stole the claim. A legitimate *in-flight* creator has the identical signature — no record persisted yet — during the gap between `ClaimLBName` (`service_impl.go:1349`) and `PutLoadBalancer` (`:1486`), with real ENI/SG provisioning in between. So a second concurrent create for the same name could not distinguish "crashed" from "still working", stole the claim, and both callers persisted a record.

Confirmed by running the pre-existing `TestCreateLoadBalancer_ConcurrentSameNameSingleOwner` 30x under `-race`; it failed intermittently (~1 in 6 to 1 in 30) with two `CreateLoadBalancer accepted` lines for one name.

## Approach: TTL grace period, not a committed-state flip

A genuine crash — panic escaping recovery, `kill -9`, node power loss — runs **no** failure-path code at all, so a committed-state design still needs a TTL backstop for that case regardless. It would not remove the TTL, only add a second release mechanism whose correctness depends on wiring every failure path perfectly. The TTL alone is sufficient and lower-risk.

The failure paths between claim and persist were audited anyway, and all three already release the claim (pre-existing code, unchanged here):

- `createNLBManagedSG` failure → `releaseLBNameClaim` (`service_impl.go:1381`)
- `CreateNetworkInterface` failure → `rollbackLBInfra` → `releaseLBNameClaim` (`:1407`, rollback at `:1691`)
- `PutLoadBalancer` failure → `rollbackLBInfra` → `releaseLBNameClaim` (`:1485-1489`)

There are no other failure returns between the two points, so `service_impl.go` needed no changes — the fix is entirely in `store.go`'s tie-break logic.

## Changes

`handlers/elbv2/store.go`:
- The claim value is now `lbNameClaim{OwnerID, ClaimedAt}` JSON rather than a bare `lbID` string. `decodeLBNameClaim` treats old bare-string values as maximally stale, so any pre-existing claim stays immediately reclaimable.
- `Store.now` and `Store.claimTTL` (defaults `time.Now` / 5 min), overridable in same-package tests — no test ever sleeps.
- `ClaimLBName` only treats a recordless owner as a crash orphan once `now.Sub(claim.ClaimedAt) >= claimTTL`; otherwise it returns `dup=true`, exactly as if a live load balancer held the name.

## Testing

`TestClaimLBName_PendingClaimBlocksSecondClaimer` is fully sequential with no goroutines and reproduces the window directly. Pre-fix it failed **100% of the time**, unlike the flaky original:

```
name_claim_test.go:107: Error: Should be false   (a pending claim within its TTL must not be stealable)
name_claim_test.go:108: Error: Should be true    (the second claimer must see the name as unavailable)
```

`TestCreateLoadBalancer_FailureAfterClaimReleasesNameForRetry` covers the leak this fix could have introduced — ENI creation fails after the claim but before persist, and a retry with the same name succeeds.

**Crash-orphan reclaim still works**, which is the regression this most easily breaks: `TestCreateLoadBalancer_ReclaimsCrashOrphanNameClaim` ages the seeded claim two TTL periods via the injectable clock and passed every run.

All 6 name-claim tests pass 25x under `-race`; full `handlers/elbv2` suite green. `make preflight` passes.