### PR TITLE
fix: fail preflight when a security gate is killed instead of reporting it clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ quickinstall: install-system install-go install-aws
 
 lint:
 	@echo "Running golangci-lint..."
-	$(_Q)golangci-lint run ./...
+	$(_Q)scripts/run-gate.sh golangci-lint golangci-lint run ./...
 	@echo "  golangci-lint ok"
 
 fix:
@@ -262,13 +262,13 @@ fix:
 
 govulncheck:
 	@echo "Running govulncheck..."
-	$(_Q)go tool govulncheck ./...
+	$(_Q)scripts/run-gate.sh govulncheck go tool govulncheck ./...
 	@echo "  govulncheck ok"
 
 # NilAway — advisory nil-panic analysis. Not in preflight due to false positives
 nilaway:
 	@echo "Running nilaway..."
-	$(_Q)go tool nilaway -include-pkgs=github.com/mulgadc/spinifex -exclude-test-files ./...
+	$(_Q)scripts/run-gate.sh nilaway go tool nilaway -include-pkgs=github.com/mulgadc/spinifex -exclude-test-files ./...
 	@echo "  nilaway ok"
 
 # Build release tarballs — use distro-ARCH for single arch, distro for both

--- a/internal/preflightgate/rungate_test.go
+++ b/internal/preflightgate/rungate_test.go
@@ -1,0 +1,91 @@
+// Package preflightgate tests the preflight gate wrapper. It exists as a Go
+// test so `go test ./...` exercises it; the repo's shell suites are not yet
+// wired into CI.
+package preflightgate
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// scriptPath resolves scripts/run-gate.sh relative to this test file, so the
+// test does not depend on the working directory.
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "scripts", "run-gate.sh")
+}
+
+func runGate(t *testing.T, args ...string) (string, int) {
+	t.Helper()
+	cmd := exec.Command(scriptPath(t), args...)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(out), 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return string(out), exitErr.ExitCode()
+	}
+	t.Fatalf("running run-gate.sh: %v", err)
+	return "", -1
+}
+
+func TestRunGate_CleanRunPasses(t *testing.T) {
+	out, code := runGate(t, "govulncheck", "echo", "No vulnerabilities found.")
+	if code != 0 {
+		t.Fatalf("expected exit 0 for a clean run, got %d\n%s", code, out)
+	}
+	if !strings.Contains(out, "No vulnerabilities found.") {
+		t.Errorf("tool output should be forwarded, got:\n%s", out)
+	}
+}
+
+func TestRunGate_NonZeroExitFails(t *testing.T) {
+	out, code := runGate(t, "lint", "sh", "-c", "echo 3 issues.; exit 1")
+	if code == 0 {
+		t.Fatalf("expected failure for a non-zero tool exit, got 0\n%s", out)
+	}
+	if !strings.Contains(out, "lint FAILED") {
+		t.Errorf("failure should name the gate, got:\n%s", out)
+	}
+}
+
+// The defect this guards: a signal-killed scanner exiting 0 was reported clean,
+// so preflight passed without a vulnerability scan having run.
+func TestRunGate_SignalKilledWithZeroExitFails(t *testing.T) {
+	for _, sig := range []string{"killed", "terminated", "aborted"} {
+		t.Run(sig, func(t *testing.T) {
+			out, code := runGate(t, "govulncheck", "sh", "-c",
+				"echo 'go tool govulncheck: signal: "+sig+"'; exit 0")
+			if code == 0 {
+				t.Fatalf("expected failure when the tool died by signal, got 0\n%s", out)
+			}
+			if !strings.Contains(out, "did NOT complete") {
+				t.Errorf("failure should say the gate did not complete, got:\n%s", out)
+			}
+		})
+	}
+}
+
+// "signal" appearing in ordinary findings must not fail an otherwise clean run.
+func TestRunGate_SignalWordInOutputDoesNotFail(t *testing.T) {
+	out, code := runGate(t, "lint", "echo", "checked signal handling in 12 files")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d\n%s", code, out)
+	}
+}
+
+func TestRunGate_RequiresLabelAndCommand(t *testing.T) {
+	out, code := runGate(t, "govulncheck")
+	if code != 2 {
+		t.Fatalf("expected usage exit 2, got %d\n%s", code, out)
+	}
+}

--- a/scripts/run-gate.sh
+++ b/scripts/run-gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Runs a preflight gate and fails unless it actually completed.
+# A tool whose child is killed by a signal can still exit 0 through `go tool`,
+# which would let a security or lint gate pass without having run.
+set -uo pipefail
+
+if [ "$#" -lt 2 ]; then
+	echo "usage: run-gate.sh <label> <command> [args...]" >&2
+	exit 2
+fi
+
+label=$1
+shift
+
+output=$("$@" 2>&1)
+rc=$?
+
+if [ -n "$output" ]; then
+	printf '%s\n' "$output"
+fi
+
+if [ "$rc" -ne 0 ]; then
+	echo "  ${label} FAILED (exit ${rc})" >&2
+	exit 1
+fi
+
+# A zero exit alongside a signal death means the gate never produced a verdict,
+# so it must not be reported as clean.
+if printf '%s' "$output" | grep -qE 'signal: (killed|terminated|aborted|segmentation fault)'; then
+	echo "  ${label} did NOT complete: the tool was killed by a signal, so this is not a clean result" >&2
+	echo "  re-run it with more memory available before trusting a pass" >&2
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Closes **mulga-y932y**.

## Problem

`go tool <x>` can exit 0 when its child dies by signal. Observed live during this sweep:

```
go tool govulncheck: signal: killed
  govulncheck ok
```

`govulncheck` was OOM-killed on a loaded host, `make` continued, and preflight reported
`✅ Preflight passed — safe to commit.` No vulnerability scan had run.

This was initially reported to me as "the Makefile treats it as non-fatal, pre-existing
behaviour". That was wrong and worth stating, because it is the reason this looks benign:
the recipe has no `-` prefix, no `|| true`, no `.IGNORE`, and `_Q` is only `@`. Make never
suppressed anything — the tool genuinely returned 0. A silent pass on a security gate is
strictly worse than a failure, since nobody re-runs a green build.

## Change

`scripts/run-gate.sh` wraps a gate and fails it unless it actually produced a verdict:
non-zero exit fails as before, and a zero exit accompanied by
`signal: killed|terminated|aborted|segmentation fault` in the output fails with an explicit
message that the gate did not complete.

`lint`, `govulncheck` and `nilaway` in the Makefile now route through it.

## Testing

`internal/preflightgate/rungate_test.go` — a Go test, deliberately, so `go test ./...`
exercises it; the repo's shell suites are not wired into CI (`mulga-gpan3`).

- clean run passes and forwards tool output
- non-zero exit fails and names the gate
- zero exit + `signal: killed` / `terminated` / `aborted` all fail
- the word "signal" in ordinary findings does **not** fail a clean run (regression guard
  against over-matching, e.g. "checked signal handling in 12 files")
- missing arguments exit 2

`make preflight` passes on this branch, with `govulncheck` completing for real:

```
Running golangci-lint...
0 issues.
  golangci-lint ok
Running govulncheck...
=== Symbol Results ===
No vulnerabilities found.
  govulncheck ok
✅ Preflight passed — safe to commit.
```

## Note for reviewers

This does not stop the OOM itself — it stops it being mistaken for a pass. If you see the
new "did NOT complete" message, the fix is more memory, not a re-run until it goes quiet.
