### PR TITLE
fix: tolerate CriticalAddonsOnly on konnectivity-agent so namespace GC completes

### DIFF
--- a/scripts/images/eks-node/konnectivity/konnectivity-agent.yaml
+++ b/scripts/images/eks-node/konnectivity/konnectivity-agent.yaml
@@ -7,11 +7,14 @@
 # the K3s auto-deploy dir by k3s.initd, which fills the __KONN_HOST__ /
 # __KONN_AGENT_IMAGE__ tokens at boot.
 #
-# Runs on workers only: it carries no toleration for the control-plane
-# CriticalAddonsOnly=true:NoExecute taint, so it is never scheduled onto the CP
-# nodes (which run the server, not an agent). It DOES tolerate the GPU
-# nvidia.com/gpu=present:NoSchedule taint — a GPU-only worker still needs
-# kubectl logs/exec against pods there, which routes through this agent.
+# Also tolerates the control-plane CriticalAddonsOnly=true:NoExecute taint and
+# the GPU nvidia.com/gpu=present:NoSchedule taint, matching every other
+# CP-critical addon in this repo (aws-load-balancer-controller, ebs-csi-driver,
+# argocd): a zero-worker or GPU-only cluster has no untainted node, and other
+# addons already schedule onto the CP, so it needs its own tunnel too — without
+# an agent there, kubectl logs/exec against CP-hosted pods and apiserver
+# aggregated-API egress (metrics-server discovery) both fail. Real EKS never
+# needs this: its control plane isn't a schedulable node.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -41,10 +44,14 @@ spec:
     spec:
       serviceAccountName: konnectivity-agent
       priorityClassName: system-node-critical
-      # Without this, a GPU-only worker (tainted nvidia.com/gpu=present:NoSchedule)
-      # shows DESIRED=0 for this DaemonSet and kubectl logs/exec against pods
-      # scheduled there fails "No agent available".
+      # Without these, a zero-worker or GPU-only cluster (CP tainted
+      # CriticalAddonsOnly, workers tainted nvidia.com/gpu) shows DESIRED=0 for
+      # this DaemonSet: no tunnel exists, so kubectl logs/exec against any pod
+      # fails "No agent available" and apiserver aggregated-API egress
+      # (e.g. metrics-server discovery) fails, which stalls namespace GC.
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule

--- a/tests/e2e/eks/eks_test.go
+++ b/tests/e2e/eks/eks_test.go
@@ -193,6 +193,17 @@ func TestEKS(t *testing.T) {
 		require.NoError(t, err, "addon ConfigMap must exist: %s", out)
 		assert.Contains(t, out, "delivered", "addon ConfigMap must carry the marker")
 
+		// The aggregated metrics API must be Available: apiserver discovery
+		// dials it through the konnectivity tunnel, and on a zero-worker or
+		// GPU-only cluster a konnectivity-agent gap makes it perpetually
+		// Unavailable — which is exactly what wedges namespace GC below, on
+		// every namespace, not just this one.
+		apiSvcOut, err := kc.Run(30*time.Second, "get", "apiservice", "v1beta1.metrics.k8s.io",
+			"-o", `jsonpath={.status.conditions[?(@.type=="Available")].status}`)
+		require.NoError(t, err, "get apiservice v1beta1.metrics.k8s.io: %s", apiSvcOut)
+		assert.Equal(t, "True", strings.TrimSpace(apiSvcOut),
+			"v1beta1.metrics.k8s.io must be Available or namespace GC (below) will never clear the kubernetes finalizer")
+
 		// DeleteAddon unstages the manifest; the agent GCs the rendered file and
 		// k3s' auto-deploy controller removes the objects.
 		_, err = c.EKS.DeleteAddon(&eks.DeleteAddonInput{
@@ -201,6 +212,11 @@ func TestEKS(t *testing.T) {
 		})
 		require.NoError(t, err, "delete-addon")
 
+		// Namespace GC enumerates every API group before it can clear the
+		// `kubernetes` finalizer, so a stuck aggregated API (checked above)
+		// leaves this stuck in Terminating forever rather than retrying it
+		// down — proving deletion actually completes, not just that it was
+		// attempted.
 		harness.EventuallyErr(t, func() error {
 			out, runErr := kc.Run(30*time.Second, "get", "namespace", "spinifex-noop",
 				"--ignore-not-found", "-o", `jsonpath={.metadata.name}`)


### PR DESCRIPTION
Closes **mulga-by5sq** (P1).

## Problem

No namespace could be deleted on a fresh EKS cluster with no nodegroup — GC hung forever on the
`kubernetes` finalizer, cluster-wide.

`konnectivity-agent.yaml` tolerated only `nvidia.com/gpu`, not `CriticalAddonsOnly=true:NoExecute`.
On a zero-worker cluster every node carries the `CriticalAddonsOnly` taint, so the DaemonSet had
**0 desired pods**. Without an agent, the apiserver has no tunnel into `kube-system`, so the
k3s-bundled metrics-server is unreachable, `v1beta1.metrics.k8s.io` never becomes `Available`, and
namespace GC blocks waiting on discovery it can never complete.

## Why the toleration, and not a comment change

The manifest carried a comment describing the exclusion as deliberate. It was an inconsistency, not
a decision — three other control-plane-critical addons in this repo already carry the identical
`CriticalAddonsOnly` + `nvidia.com/gpu` pair, with near-identical justifying comments, for the same
reason:

- `aws-load-balancer-controller/2.11.0/10-aws-load-balancer-controller.yaml:352-358`
- `aws-ebs-csi-driver/1.40.1/10-controller.yaml:46-52`
- every `argocd/3.0.23/argocd.yaml` controller

`k3s_server_vm.go:617` states the general rule outright: "k3s packaged addons tolerate
CriticalAddonsOnly."

There is no duplicate-agent or tunnel-loop risk: each agent identifies itself by its own node's
`HOST_IP`, so an extra replica on the control plane is one more legitimate tunnel endpoint. It also
fixes a latent collateral bug — without an agent, `kubectl logs`/`exec` against any of those
already-CP-scheduled addon pods failed with "No agent available".

## Changes

- `scripts/images/eks-node/konnectivity/konnectivity-agent.yaml:10-17,47-58` — add the toleration,
  and correct the comments that asserted the opposite behaviour.
- `tests/e2e/eks/eks_test.go:191-197,218-222` — `AddonDelivery` now asserts
  `v1beta1.metrics.k8s.io` is `Available` before the delete, so the condition cannot regress
  silently behind the existing namespace-delete wait.

## Live verification (env12, bottlebrush)

Built `spx` and the `eks-node` AMI from this branch, imported the AMI, deployed, and ran
`TestEKS/(CreateCluster|AddonDelivery|DeleteCluster)` twice against a real zero-worker cluster —
exactly the bug scenario.

```
--- PASS: TestEKS/AddonDelivery (98.75s)
--- PASS: TestEKS/AddonDelivery (98.41s)
```

```
$ kubectl get apiservices
v1beta1.metrics.k8s.io            kube-system/metrics-server   True        116s
```

Both runs land well inside the 3-minute namespace-delete bound, confirming no retry loop is hiding
the condition. No leaked VMs afterwards (`spx get instances` → "No VMs found"). `make preflight`
passes.

## Scope note

APIService-gating at cluster-creation time was considered and deliberately not done — it needs
non-trivial changes to the cluster-creation state machine, and this P1 is about deletion.

## Related

Unblocks the `AddonDelivery` subtest that `mulga-dfzfi` depends on.
