### PR TITLE
fix(ec2): render empty result containers and return NotFound for missing named resources

### DIFF
--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awsec2query"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_ec2_account "github.com/mulgadc/spinifex/spinifex/gateway/ec2/account"
@@ -66,13 +67,29 @@ func ec2Handler[In any](handler func(ctx context.Context, input *In, gw *Gateway
 		if err != nil {
 			return nil, err
 		}
-		payload := utils.GenerateXMLPayload(action+"Response", output)
-		xmlOutput, err := utils.MarshalToXML(payload)
+		xmlOutput, err := marshalEC2Response(action, output)
 		if err != nil {
-			return nil, errors.New("failed to marshal response to XML")
+			return nil, err
 		}
 		return xmlOutput, nil
 	}
+}
+
+// marshalEC2Response renders an EC2 handler's output into the action's XML
+// envelope. Every EC2 action funnels through here (via ec2Handler and
+// ec2HandlerWithReq), so wire-format fixes belong here, not in each handler.
+func marshalEC2Response(action string, output any) ([]byte, error) {
+	// BuildXML omits a nil slice's container element entirely but renders an
+	// empty one for a non-nil empty slice; AWS always renders the latter.
+	normalized := utils.NormalizeXMLOutput(output)
+	// The SDK's generated output structs never carry a RequestId field.
+	withRequestID := utils.WithRequestID(normalized, uuid.NewString())
+	payload := utils.GenerateXMLPayload(action+"Response", withRequestID)
+	xmlOutput, err := utils.MarshalToXML(payload)
+	if err != nil {
+		return nil, errors.New("failed to marshal response to XML")
+	}
+	return xmlOutput, nil
 }
 
 // ec2HandlerWithReq is ec2Handler for actions that need the original *http.Request,
@@ -90,10 +107,9 @@ func ec2HandlerWithReq[In any](handler func(ctx context.Context, input *In, gw *
 		if err != nil {
 			return nil, err
 		}
-		payload := utils.GenerateXMLPayload(action+"Response", output)
-		xmlOutput, err := utils.MarshalToXML(payload)
+		xmlOutput, err := marshalEC2Response(action, output)
 		if err != nil {
-			return nil, errors.New("failed to marshal response to XML")
+			return nil, err
 		}
 		return xmlOutput, nil
 	}

--- a/spinifex/gateway/ec2_emptyresult_test.go
+++ b/spinifex/gateway/ec2_emptyresult_test.go
@@ -1,0 +1,111 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// render drives a single EC2 action through ec2Handler exactly as the real
+// dispatch table does (see ec2Actions in ec2.go), with a stub inner handler
+// standing in for the NATS round trip. This exercises the real marshal path
+// (currently marshalEC2Response) without needing a live NATS connection.
+func render[In any](t *testing.T, action string, out any) string {
+	t.Helper()
+	h := ec2Handler(func(_ context.Context, _ *In, _ *GatewayConfig, _ string) (any, error) {
+		return out, nil
+	})
+	xmlOutput, err := h(action, map[string]string{}, &GatewayConfig{}, "acct-123", (*http.Request)(nil))
+	require.NoError(t, err)
+	return string(xmlOutput)
+}
+
+// TestEC2Describe_EmptyResult_EmitsContainer asserts on the raw wire XML for
+// an empty Describe result: real AWS renders the empty list container (e.g.
+// <keySet></keySet>); a struct-level assertion would pass even with the
+// container omitted entirely, since a nil slice unmarshals from either body.
+func TestEC2Describe_EmptyResult_EmitsContainer(t *testing.T) {
+	cases := []struct {
+		name      string
+		action    string
+		container string
+		render    func(t *testing.T) string
+	}{
+		{"DescribeKeyPairs", "DescribeKeyPairs", "keySet", func(t *testing.T) string {
+			return render[ec2.DescribeKeyPairsInput](t, "DescribeKeyPairs", ec2.DescribeKeyPairsOutput{})
+		}},
+		{"DescribeVolumes", "DescribeVolumes", "volumeSet", func(t *testing.T) string {
+			return render[ec2.DescribeVolumesInput](t, "DescribeVolumes", ec2.DescribeVolumesOutput{})
+		}},
+		{"DescribeSubnets", "DescribeSubnets", "subnetSet", func(t *testing.T) string {
+			return render[ec2.DescribeSubnetsInput](t, "DescribeSubnets", ec2.DescribeSubnetsOutput{})
+		}},
+		{"DescribeTags", "DescribeTags", "tagSet", func(t *testing.T) string {
+			return render[ec2.DescribeTagsInput](t, "DescribeTags", ec2.DescribeTagsOutput{})
+		}},
+		{"DescribeInstances", "DescribeInstances", "reservationSet", func(t *testing.T) string {
+			return render[ec2.DescribeInstancesInput](t, "DescribeInstances", ec2.DescribeInstancesOutput{})
+		}},
+		{"DescribeSnapshots", "DescribeSnapshots", "snapshotSet", func(t *testing.T) string {
+			return render[ec2.DescribeSnapshotsInput](t, "DescribeSnapshots", ec2.DescribeSnapshotsOutput{})
+		}},
+		{"DescribeImages", "DescribeImages", "imagesSet", func(t *testing.T) string {
+			return render[ec2.DescribeImagesInput](t, "DescribeImages", ec2.DescribeImagesOutput{})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.render(t)
+
+			// The bug: the container element is omitted entirely rather than
+			// rendered empty, e.g. "<DescribeKeyPairsResponse></DescribeKeyPairsResponse>".
+			openEmpty := "<" + tc.container + "></" + tc.container + ">"
+			openSelfClose := "<" + tc.container + "/>"
+			assert.Truef(t, strings.Contains(body, openEmpty) || strings.Contains(body, openSelfClose),
+				"expected empty %s container in wire XML, got: %s", tc.container, body)
+
+			// Response element must not be empty-bodied.
+			assert.NotContainsf(t, body, "<"+tc.action+"Response></"+tc.action+"Response>",
+				"response body was empty, container omitted entirely: %s", body)
+		})
+	}
+}
+
+// TestEC2Describe_EmitsRequestId asserts every EC2 response carries a
+// <requestId>, which real AWS always includes and which botocore/CLI tooling
+// relies on for diagnostics (e.g. `aws ... --debug`).
+func TestEC2Describe_EmitsRequestId(t *testing.T) {
+	requestIDPattern := regexp.MustCompile(`<requestId>[^<]+</requestId>`)
+
+	body := render[ec2.DescribeKeyPairsInput](t, "DescribeKeyPairs", ec2.DescribeKeyPairsOutput{})
+	assert.Regexp(t, requestIDPattern, body)
+
+	nonEmptyBody := render[ec2.DescribeKeyPairsInput](t, "DescribeKeyPairs", ec2.DescribeKeyPairsOutput{
+		KeyPairs: []*ec2.KeyPairInfo{{KeyName: aws.String("spinifex-key")}},
+	})
+	assert.Regexp(t, requestIDPattern, nonEmptyBody)
+}
+
+// TestEC2Describe_NonEmptyResult_Unchanged is the regression guard: a
+// populated Describe result must still render its real data untouched by the
+// empty-container/requestId fix.
+func TestEC2Describe_NonEmptyResult_Unchanged(t *testing.T) {
+	body := render[ec2.DescribeKeyPairsInput](t, "DescribeKeyPairs", ec2.DescribeKeyPairsOutput{
+		KeyPairs: []*ec2.KeyPairInfo{
+			{KeyName: aws.String("spinifex-key"), KeyPairId: aws.String("key-abc123")},
+		},
+	})
+
+	assert.Contains(t, body, "<keyName>spinifex-key</keyName>")
+	assert.Contains(t, body, "<keyPairId>key-abc123</keyPairId>")
+	assert.Contains(t, body, "<keySet>")
+	assert.NotContains(t, body, "<keySet></keySet>", "non-empty KeyPairs must not render as an empty container")
+}

--- a/spinifex/handlers/ec2/key/service_impl.go
+++ b/spinifex/handlers/ec2/key/service_impl.go
@@ -709,6 +709,31 @@ func (s *KeyServiceImpl) DescribeKeyPairs(ctx context.Context, input *ec2.Descri
 		keyPairs = append(keyPairs, keyPairInfo)
 	}
 
+	// Naming a specific key name/ID that doesn't exist is an error, unlike an
+	// unfiltered list or a --filters query that simply matches nothing.
+	if len(input.KeyNames) > 0 || len(input.KeyPairIds) > 0 {
+		foundNames := make(map[string]bool, len(keyPairs))
+		foundIDs := make(map[string]bool, len(keyPairs))
+		for _, kp := range keyPairs {
+			if kp.KeyName != nil {
+				foundNames[*kp.KeyName] = true
+			}
+			if kp.KeyPairId != nil {
+				foundIDs[*kp.KeyPairId] = true
+			}
+		}
+		for _, name := range input.KeyNames {
+			if name != nil && !foundNames[*name] {
+				return nil, errors.New(awserrors.ErrorInvalidKeyPairNotFound)
+			}
+		}
+		for _, id := range input.KeyPairIds {
+			if id != nil && !foundIDs[*id] {
+				return nil, errors.New(awserrors.ErrorInvalidKeyPairNotFound)
+			}
+		}
+	}
+
 	slog.InfoContext(ctx, "DescribeKeyPairs completed", "count", len(keyPairs))
 
 	return &ec2.DescribeKeyPairsOutput{

--- a/spinifex/handlers/ec2/key/service_impl_test.go
+++ b/spinifex/handlers/ec2/key/service_impl_test.go
@@ -683,13 +683,61 @@ func TestDescribeKeyPairs_FilterByKeyPairId(t *testing.T) {
 	assert.Equal(t, "find-by-id", *out.KeyPairs[0].KeyName)
 }
 
-func TestDescribeKeyPairs_FilterNoMatch(t *testing.T) {
+// TestDescribeKeyPairs_NotFound_ByKeyName asserts that naming a specific,
+// nonexistent key via KeyNames errors, matching real AWS: naming a missing
+// resource is a failure, unlike a --filters query that simply matches nothing.
+func TestDescribeKeyPairs_NotFound_ByKeyName(t *testing.T) {
+	svc, _ := newTestKeyService()
+
+	importTestKey(t, svc, "exists")
+
+	_, err := svc.DescribeKeyPairs(context.Background(), &ec2.DescribeKeyPairsInput{
+		KeyNames: []*string{aws.String("does-not-exist")},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidKeyPair.NotFound")
+}
+
+// TestDescribeKeyPairs_NotFound_ByKeyPairId is the KeyPairIds counterpart of
+// TestDescribeKeyPairs_NotFound_ByKeyName.
+func TestDescribeKeyPairs_NotFound_ByKeyPairId(t *testing.T) {
+	svc, _ := newTestKeyService()
+
+	importTestKey(t, svc, "exists")
+
+	_, err := svc.DescribeKeyPairs(context.Background(), &ec2.DescribeKeyPairsInput{
+		KeyPairIds: []*string{aws.String("key-doesnotexist")},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidKeyPair.NotFound")
+}
+
+// TestDescribeKeyPairs_NotFound_PartialMatch asserts that naming one existing
+// and one nonexistent key still errors: AWS requires every named key to exist.
+func TestDescribeKeyPairs_NotFound_PartialMatch(t *testing.T) {
+	svc, _ := newTestKeyService()
+
+	importTestKey(t, svc, "exists")
+
+	_, err := svc.DescribeKeyPairs(context.Background(), &ec2.DescribeKeyPairsInput{
+		KeyNames: []*string{aws.String("exists"), aws.String("does-not-exist")},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidKeyPair.NotFound")
+}
+
+// TestDescribeKeyPairs_AWSFilterNoMatch_EmptyNotError is the other half of the
+// filter-vs-explicit-id split: a --filters query that matches nothing is not
+// an error in AWS, unlike naming a specific missing KeyName/KeyPairId.
+func TestDescribeKeyPairs_AWSFilterNoMatch_EmptyNotError(t *testing.T) {
 	svc, _ := newTestKeyService()
 
 	importTestKey(t, svc, "exists")
 
 	out, err := svc.DescribeKeyPairs(context.Background(), &ec2.DescribeKeyPairsInput{
-		KeyNames: []*string{aws.String("does-not-exist")},
+		Filters: []*ec2.Filter{
+			{Name: aws.String("key-name"), Values: []*string{aws.String("does-not-exist")}},
+		},
 	}, testAccountID)
 	require.NoError(t, err)
 	require.NotNil(t, out)

--- a/spinifex/handlers/ec2/snapshot/service_impl.go
+++ b/spinifex/handlers/ec2/snapshot/service_impl.go
@@ -624,6 +624,22 @@ func (s *SnapshotServiceImpl) describeSnapshots(ctx context.Context, input *ec2.
 		snapshots = append(snapshots, snapshotConfigToEC2(cfg))
 	}
 
+	// Naming a specific, nonexistent snapshot ID is an error, unlike an
+	// unfiltered list or a --filters query that simply matches nothing.
+	if len(snapshotIDFilter) > 0 {
+		found := make(map[string]bool, len(snapshots))
+		for _, snap := range snapshots {
+			if snap.SnapshotId != nil {
+				found[*snap.SnapshotId] = true
+			}
+		}
+		for id := range snapshotIDFilter {
+			if !found[id] {
+				return nil, errors.New(awserrors.ErrorInvalidSnapshotNotFound)
+			}
+		}
+	}
+
 	slog.InfoContext(ctx, "DescribeSnapshots completed", "count", len(snapshots))
 
 	return &ec2.DescribeSnapshotsOutput{

--- a/spinifex/handlers/ec2/snapshot/service_impl_test.go
+++ b/spinifex/handlers/ec2/snapshot/service_impl_test.go
@@ -313,6 +313,26 @@ func TestDescribeSnapshots_ByID(t *testing.T) {
 	assert.Equal(t, *snap1.SnapshotId, *result.Snapshots[0].SnapshotId)
 }
 
+// TestDescribeSnapshots_NotFound asserts that naming a specific, nonexistent
+// snapshot ID errors, matching real AWS: naming a missing resource is a
+// failure, unlike a --filters query that simply matches nothing (see
+// TestDescribeSnapshots_FilterNoResults).
+func TestDescribeSnapshots_NotFound(t *testing.T) {
+	svc, store := setupTestSnapshotService(t)
+	createTestVolume(t, store, "vol-1", 50)
+
+	snap1, err := svc.CreateSnapshot(context.Background(), &ec2.CreateSnapshotInput{
+		VolumeId: aws.String("vol-1"),
+	}, testAccountID)
+	require.NoError(t, err)
+
+	_, err = svc.DescribeSnapshots(context.Background(), &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []*string{snap1.SnapshotId, aws.String("snap-0000000000000000")},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidSnapshot.NotFound")
+}
+
 // TestDescribeSnapshots_Empty tests listing snapshots when none exist.
 func TestDescribeSnapshots_Empty(t *testing.T) {
 	svc, _ := setupTestSnapshotService(t)
@@ -378,10 +398,16 @@ func TestDeleteSnapshot(t *testing.T) {
 	}, testAccountID)
 	require.NoError(t, err)
 
-	// Verify snapshot is gone
-	result, err = svc.DescribeSnapshots(context.Background(), &ec2.DescribeSnapshotsInput{
+	// Verify snapshot is gone: describing it by its now-deleted ID errors,
+	// matching real AWS (naming a specific missing resource is a failure).
+	_, err = svc.DescribeSnapshots(context.Background(), &ec2.DescribeSnapshotsInput{
 		SnapshotIds: []*string{snap.SnapshotId},
 	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "InvalidSnapshot.NotFound")
+
+	// An unfiltered list, unlike naming the deleted ID, is still empty with no error.
+	result, err = svc.DescribeSnapshots(context.Background(), &ec2.DescribeSnapshotsInput{}, testAccountID)
 	require.NoError(t, err)
 	assert.Empty(t, result.Snapshots)
 }

--- a/spinifex/utils/utils.go
+++ b/spinifex/utils/utils.go
@@ -68,6 +68,89 @@ func GenerateXMLPayload(locationName string, payload any) any {
 	return v.Interface()
 }
 
+// NormalizeXMLOutput returns a copy of output with every nil slice field
+// (recursively) replaced by a non-nil empty slice, since aws-sdk-go's
+// xmlutil.BuildXML omits a nil slice's container element entirely but
+// renders an empty one for a non-nil empty slice, unlike real AWS.
+func NormalizeXMLOutput(output any) any {
+	v := reflect.ValueOf(output)
+	if !v.IsValid() {
+		return output
+	}
+	// Work on an addressable copy: callers pass struct values, and reflection
+	// can only Set fields through an addressable Value.
+	ptr := reflect.New(v.Type())
+	ptr.Elem().Set(v)
+	normalizeNilSlices(ptr.Elem())
+	return ptr.Elem().Interface()
+}
+
+// normalizeNilSlices walks v in place, turning nil slice fields into empty
+// ones and recursing into structs, pointers, and existing slice elements.
+func normalizeNilSlices(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Pointer:
+		if !v.IsNil() {
+			normalizeNilSlices(v.Elem())
+		}
+	case reflect.Struct:
+		for _, field := range v.Fields() {
+			switch field.Kind() {
+			case reflect.Slice:
+				if field.IsNil() {
+					if field.CanSet() {
+						field.Set(reflect.MakeSlice(field.Type(), 0, 0))
+					}
+				} else {
+					for j := 0; j < field.Len(); j++ {
+						normalizeNilSlices(field.Index(j))
+					}
+				}
+			case reflect.Pointer, reflect.Struct:
+				normalizeNilSlices(field)
+			}
+		}
+	}
+}
+
+// WithRequestID returns a copy of payload's structure with a synthetic
+// RequestId field prepended, since the SDK's generated output structs never
+// carry one. payload must be a struct or pointer to struct; anything else is
+// returned unchanged.
+func WithRequestID(payload any, requestID string) any {
+	pv := reflect.ValueOf(payload)
+	for pv.Kind() == reflect.Pointer {
+		pv = pv.Elem()
+	}
+	if pv.Kind() != reflect.Struct {
+		return payload
+	}
+	pt := pv.Type()
+
+	fields := []reflect.StructField{
+		{
+			Name: "RequestId",
+			Type: reflect.TypeFor[string](),
+			Tag:  reflect.StructTag(`locationName:"requestId" type:"string"`),
+		},
+	}
+	for f := range pt.Fields() {
+		if f.PkgPath == "" { // skip unexported marker fields (e.g. "_")
+			fields = append(fields, f)
+		}
+	}
+
+	composite := reflect.New(reflect.StructOf(fields)).Elem()
+	composite.FieldByName("RequestId").SetString(requestID)
+	for i := 0; i < pt.NumField(); i++ {
+		if f := pt.Field(i); f.PkgPath == "" {
+			composite.FieldByName(f.Name).Set(pv.Field(i))
+		}
+	}
+
+	return composite.Interface()
+}
+
 // GenerateIAMXMLPayload wraps IAM output in the <ActionResponse><ActionResult>...</ActionResult></ActionResponse> structure.
 func GenerateIAMXMLPayload(action string, payload any) any {
 	resultName := action + "Result"

--- a/spinifex/utils/utils_test.go
+++ b/spinifex/utils/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -1686,4 +1687,80 @@ func TestAvailableImages_RDSPostgresEntry(t *testing.T) {
 	assert.Equal(t, "postgres", img.Tags["engine"])
 	assert.Equal(t, "18", img.Tags["engine-version"],
 		"the pinned PostgreSQL major version is what EngineVersion resolves against")
+}
+
+// --- NormalizeXMLOutput / normalizeNilSlices ---
+
+type normalizeInner struct {
+	Tags []string
+}
+
+type normalizeOuter struct {
+	Names    []string
+	Nested   *normalizeInner
+	Children []*normalizeInner
+	Value    normalizeInner
+}
+
+func TestNormalizeXMLOutput_InvalidValue(t *testing.T) {
+	var output any
+	assert.Nil(t, NormalizeXMLOutput(output))
+}
+
+func TestNormalizeXMLOutput_TopLevelNilSlice(t *testing.T) {
+	out := NormalizeXMLOutput(normalizeOuter{}).(normalizeOuter)
+	require.NotNil(t, out.Names)
+	assert.Empty(t, out.Names)
+}
+
+func TestNormalizeXMLOutput_NestedPointerStruct(t *testing.T) {
+	out := NormalizeXMLOutput(normalizeOuter{
+		Nested: &normalizeInner{},
+	}).(normalizeOuter)
+	require.NotNil(t, out.Nested)
+	require.NotNil(t, out.Nested.Tags, "nil slice inside a pointer field must be normalized")
+	assert.Empty(t, out.Nested.Tags)
+}
+
+func TestNormalizeXMLOutput_NestedValueStruct(t *testing.T) {
+	out := NormalizeXMLOutput(normalizeOuter{}).(normalizeOuter)
+	require.NotNil(t, out.Value.Tags, "nil slice inside a nested struct field must be normalized")
+}
+
+func TestNormalizeXMLOutput_RecursesIntoSliceElements(t *testing.T) {
+	out := NormalizeXMLOutput(normalizeOuter{
+		Children: []*normalizeInner{{}, {Tags: []string{"a"}}},
+	}).(normalizeOuter)
+	require.Len(t, out.Children, 2)
+	require.NotNil(t, out.Children[0].Tags, "nil slice inside a slice element must be normalized")
+	assert.Equal(t, []string{"a"}, out.Children[1].Tags, "an already-populated slice element must be left untouched")
+}
+
+func TestNormalizeXMLOutput_NilPointerFieldUntouched(t *testing.T) {
+	out := NormalizeXMLOutput(normalizeOuter{}).(normalizeOuter)
+	assert.Nil(t, out.Nested, "a nil pointer field must not be allocated")
+}
+
+// --- WithRequestID ---
+
+type requestIDPayload struct {
+	Names []string
+}
+
+func TestWithRequestID_NonStruct(t *testing.T) {
+	assert.Equal(t, "not-a-struct", WithRequestID("not-a-struct", "req-1"))
+}
+
+func TestWithRequestID_StructValue(t *testing.T) {
+	composite := WithRequestID(requestIDPayload{Names: []string{"a"}}, "req-123")
+	v := reflect.ValueOf(composite)
+	require.Equal(t, "req-123", v.FieldByName("RequestId").String())
+	require.Equal(t, []string{"a"}, v.FieldByName("Names").Interface())
+}
+
+func TestWithRequestID_PointerToStruct(t *testing.T) {
+	composite := WithRequestID(&requestIDPayload{Names: []string{"b"}}, "req-456")
+	v := reflect.ValueOf(composite)
+	require.Equal(t, "req-456", v.FieldByName("RequestId").String())
+	require.Equal(t, []string{"b"}, v.FieldByName("Names").Interface())
 }


### PR DESCRIPTION
Closes **mulga-n25x8** (P1).

Two independent defects behind one symptom: `spinifex-key` is never imported on a fresh
`cluster-bootstrap`. Both are fixed here and both were verified live on env12.

## 1. Empty result containers were omitted from the wire

`DescribeKeyPairs` on an empty account returned:

```xml
<DescribeKeyPairsResponse></DescribeKeyPairsResponse>
```

No `<keySet/>` container, and no `<requestId>`. The AWS CLI cannot parse a missing container, so
`--query length(KeyPairs)` exited 255.

Root cause, settled by experiment at the marshal layer rather than by inspection:

| input | output |
| --- | --- |
| `ec2.DescribeKeyPairsOutput{}` (nil slice) | `<DescribeKeyPairsResponse></DescribeKeyPairsResponse>` |
| `ec2.DescribeKeyPairsOutput{KeyPairs: []*ec2.KeyPairInfo{}}` | `<DescribeKeyPairsResponse><keySet></keySet></DescribeKeyPairsResponse>` |

Vendored `aws-sdk-go@v1.55.8` `private/protocol/xml/xmlutil/build.go:188` `buildList` returns early on
`value.IsNil()` — it checks nil-ness, not `Len() == 0`. So a nil slice omits its container entirely
while an empty non-nil slice renders correctly.

Fixed at the **shared** marshal path (`marshalEC2Response` in `gateway/ec2.go`, with
`NormalizeXMLOutput`/`WithRequestID` in `utils/utils.go`), so it covers every EC2 Describe rather
than key pairs alone. Normalisation recurses through nested pointers, structs and slice elements.

Reproduced empty on `describe-key-pairs`, `-images`, `-snapshots`, `-volumes`, `-instances`,
`-subnets` and `-tags` before the fix.

## 2. Naming a missing resource returned success

This is the half that actually kept the key from being imported.

`ansible/roles/cluster-post/tasks/main.yml:22` runs `describe-key-pairs --key-names spinifex-key` and
gates the import on `rc != 0` at `:37`. That command returned **rc=0** on an empty account, so the
import never fired — the wire-format fix alone did not change this.

`DescribeSecurityGroups` (`handlers/ec2/vpc/security_group.go:369-435`) already did this correctly.
That same two-pass found-set shape is now mirrored into `DescribeKeyPairs` and `DescribeSnapshots`,
reusing the existing `awserrors` constants (`ErrorInvalidKeyPairNotFound`,
`ErrorInvalidSnapshotNotFound` — no new ones needed).

**The explicit-id vs filter distinction is the thing to get right here**, and it is tested in both
directions: the check only fires when `KeyNames`/`KeyPairIds`/`SnapshotIds` are populated. A bare
`--filters` query that matches nothing still returns an empty list with `rc=0`, as on AWS.

Two pre-existing tests encoded the old buggy behaviour and were corrected rather than worked around.
All internal callers of `DescribeSnapshots`/`DescribeKeyPairs` (the RDS reconciler and delete paths)
pass only `Filters`, never explicit IDs, so they are unaffected.

## Live verification (env12)

The exact three-step sequence `cluster-post` performs:

```
$ ec2 describe-key-pairs --key-names spinifex-key      # gate command, main.yml:22
An error occurred (InvalidKeyPair.NotFound) ...
RC=254                                                  # was rc=0 — this is what makes :37 fire

$ ec2 import-key-pair --key-name spinifex-key ...
{"KeyName": "spinifex-key", "KeyPairId": "key-4a5bd83d195db2626", ...}

$ ec2 describe-key-pairs --key-names spinifex-key
{"KeyPairs": [{"KeyName": "spinifex-key", ...}]}        RC=0
```

Wire format before/after:

```
before: <DescribeKeyPairsResponse></DescribeKeyPairsResponse>
after:  <DescribeKeyPairsResponse><requestId>ae8c0cd4-...</requestId><keySet></keySet></DescribeKeyPairsResponse>
```

env12 was restored to its no-key baseline afterwards. `make preflight` passes, diff coverage 95.0%.

## Scope of the NotFound gap across other Describes

- `DescribeImages`, `DescribeVolumes`, `DescribeSubnets` — **already correct**, same pattern present.
- `DescribeSnapshots` — had the gap, **fixed here** (mechanically identical).
- `DescribeInstances` — has the same gap but is **deliberately not fixed here**. Its aggregation spans
  a NATS fan-out across nodes plus two KV lookups merged in `gatherInstances`, and the fan-out has
  intentional partial-result leniency on timeouts. A naive found-set check would return
  `InvalidInstanceID.NotFound` for an instance that exists but whose node timed out — turning a
  transient degradation into a wrong answer. That needs a design decision and is filed separately.
