### PR TITLE
fix: report image removal as bytes deleted, not bytes freed

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -903,8 +903,10 @@ func runimagesRemoveCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("✅ Removed AMI %s (freed %s across %d objects).\n",
-		imageID, utils.HumanBytes(utils.SafeInt64ToUint64(res.BytesFreed)), res.ObjectsDeleted)
+	// BytesDeleted is logical: predastore reclaims the underlying disk space
+	// asynchronously via background compaction, not at delete time.
+	fmt.Printf("✅ Removed AMI %s (%d objects, %s marked for deletion; disk space is reclaimed by background compaction).\n",
+		imageID, res.ObjectsDeleted, utils.HumanBytes(utils.SafeInt64ToUint64(res.BytesDeleted)))
 }
 
 func printDependents(w io.Writer, d admin.Dependents) {

--- a/spinifex/admin/images_remove.go
+++ b/spinifex/admin/images_remove.go
@@ -29,9 +29,14 @@ type RemoveImageOpts struct {
 }
 
 // RemoveImageResult summarises what was deleted from object storage.
+//
+// BytesDeleted is the logical size of the deleted objects, not physical disk
+// space: predastore reclaims a deleted object's bytes asynchronously via
+// background compaction, so this count can be freed well after the call
+// returns, or briefly not at all if compaction is stalled.
 type RemoveImageResult struct {
 	ObjectsDeleted int
-	BytesFreed     int64
+	BytesDeleted   int64
 }
 
 // Dependents lists every resource that transitively backs an admin-imported
@@ -259,7 +264,7 @@ func RemoveSystemImage(store objectstore.ObjectStore, bucket string, opts Remove
 			return nil, fmt.Errorf("delete config: %w", err)
 		}
 		result.ObjectsDeleted += n
-		result.BytesFreed += b
+		result.BytesDeleted += b
 	}
 
 	// Step 2: drop the rest of ami-<id>/ (chunks, WAL, checkpoints).
@@ -268,7 +273,7 @@ func RemoveSystemImage(store objectstore.ObjectStore, bucket string, opts Remove
 		return nil, fmt.Errorf("delete ami prefix: %w", err)
 	}
 	result.ObjectsDeleted += n
-	result.BytesFreed += b
+	result.BytesDeleted += b
 
 	// Step 3: drop snap-<amiID>/ (the viperblock-internal snap checkpoint).
 	n, b, err = deletePrefix(store, bucket, SnapPrefix(opts.ImageID)+"/")
@@ -276,12 +281,12 @@ func RemoveSystemImage(store objectstore.ObjectStore, bucket string, opts Remove
 		return nil, fmt.Errorf("delete snap prefix: %w", err)
 	}
 	result.ObjectsDeleted += n
-	result.BytesFreed += b
+	result.BytesDeleted += b
 
 	slog.Info("RemoveSystemImage completed",
 		"imageId", opts.ImageID,
 		"objectsDeleted", result.ObjectsDeleted,
-		"bytesFreed", result.BytesFreed,
+		"bytesDeleted", result.BytesDeleted,
 		"force", opts.Force,
 	)
 	return result, nil

--- a/spinifex/admin/images_remove_test.go
+++ b/spinifex/admin/images_remove_test.go
@@ -128,7 +128,7 @@ func TestRemoveSystemImage_HappyPath(t *testing.T) {
 	res, err := RemoveSystemImage(store, testRemoveBucket, RemoveImageOpts{ImageID: id})
 	require.NoError(t, err)
 	assert.Equal(t, preview.AMIObjectCount+preview.SnapObjectCount, res.ObjectsDeleted)
-	assert.Equal(t, preview.AMIBytesTotal+preview.SnapBytesTotal, res.BytesFreed)
+	assert.Equal(t, preview.AMIBytesTotal+preview.SnapBytesTotal, res.BytesDeleted)
 	assert.Equal(t, 0, store.Count())
 }
 


### PR DESCRIPTION
Addresses acceptance criterion 4 of **mulga-nfpk4**.

## Problem

`spx admin images remove` printed `freed 5.7 GiB` when **no disk space was freed at all**. The bytes
were deleted from the S3 namespace; physical reclamation is a separate, asynchronous concern handled
by predastore segment compaction.

This wording is a large part of why the underlying compaction bug stayed invisible: the operator was
told the space came back, so nobody checked `du`.

## Change

- `RemoveImageResult.BytesFreed` renamed to `BytesDeleted`, with a doc comment stating it is logical
  (object bytes removed from the S3 namespace), not physical, and that space is reclaimed later by
  background compaction.
- The `slog.Info` field updated to match.
- The CLI print in `cmd/spinifex/cmd/admin.go` changed from `freed %s` to
  `%s marked for deletion; disk space is reclaimed by background compaction`.

## Testing

`make preflight` passes (14 changed lines, below the diff-coverage threshold). No behaviour change —
this is a naming and reporting correction, so the honesty of the message is the deliverable.

## Related

The compaction defect that made this wording actively misleading is predastore #71. That one is the
reason nothing was reclaimed; this one is the reason it went unnoticed.