### PR TITLE
fix(gateway): set aws_action/aws_service labels for REST-JSON services

### DIFF
--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -427,6 +427,12 @@ func (gw *GatewayConfig) checkPolicy(r *http.Request, service, action string) er
 // auth context, allows (pre-IAM compatibility). Used by EC2 paths that
 // enforce iam:PassRole before attaching an instance profile.
 func (gw *GatewayConfig) checkPolicyResource(r *http.Request, service, action, resource string) error {
+	// Every dispatcher — query-protocol and REST-JSON alike — reaches this
+	// point with its resolved action, so telemetry enrichment lives here
+	// rather than duplicated per REST-JSON handler. Runs before the IAM
+	// checks below so it still fires when IAM is unconfigured.
+	recordResolvedAction(r.Context(), service, action)
+
 	if gw.IAMService == nil {
 		slog.Warn("checkPolicy: IAM service not available, skipping policy check",
 			"service", service, "action", action)
@@ -720,22 +726,40 @@ func (gw *GatewayConfig) DiscoverActiveNodes(ctx context.Context) int {
 	return activeNodes
 }
 
+// recordResolvedAction renames the current span to service.action, tags it
+// with aws.service/aws.action, and updates the request's metric action name.
+// Query-protocol services resolve their action during SigV4 auth, before
+// dispatch; REST-JSON services (path-routed or X-Amz-Target-routed) only know
+// it once checkPolicyResource runs. Called from both paths, so it must be
+// idempotent — the last call before the response is written wins.
+func recordResolvedAction(ctx context.Context, service, action string) {
+	if action == "" {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	name := action
+	if service != "" {
+		name = service + "." + action
+		span.SetAttributes(attribute.String("aws.service", service))
+	}
+	span.SetName(name)
+	span.SetAttributes(attribute.String("aws.action", action))
+	otelsetup.SetRequestAction(ctx, name)
+}
+
 // traceActionEnricher renames the server span to the resolved SigV4
 // service.Action and tags account/region once auth populated the context.
+// Only fires here for query-protocol services, whose action is known before
+// dispatch; REST-JSON services get the same treatment later, from
+// checkPolicyResource, once their dispatcher resolves the action.
 func traceActionEnricher(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		action, _ := ctx.Value(ctxAction).(string)
+		svc, _ := ctx.Value(ctxService).(string)
+		recordResolvedAction(ctx, svc, action)
+
 		span := trace.SpanFromContext(ctx)
-		if action, _ := ctx.Value(ctxAction).(string); action != "" {
-			name := action
-			if svc, _ := ctx.Value(ctxService).(string); svc != "" {
-				name = svc + "." + action
-				span.SetAttributes(attribute.String("aws.service", svc))
-			}
-			span.SetName(name)
-			span.SetAttributes(attribute.String("aws.action", action))
-			otelsetup.SetRequestAction(ctx, name)
-		}
 		if acct, _ := ctx.Value(ctxAccountID).(string); acct != "" {
 			span.SetAttributes(attribute.String("aws.account_id", acct))
 		}


### PR DESCRIPTION
Addresses **mulga-2da81**. Root cause identified (criterion 3); criterion 2 pending a deploy.

## The bead was wrong about the symptom, in two ways

It says "EKS service emits zero telemetry to the ES sink". It does not — the live sink holds EKS
documents and `labels.service` is set, so criterion 1 was already satisfied before any change.

The real field names are `labels.aws_action` and `labels.aws_service`, flattened from the OTel span
attributes `aws.action`/`aws.service` — not `labels.action`. Confirmed by diffing a working
`ec2.RunInstances` transaction document (both fields present) against an EKS `POST /clusters`
document (neither present, only the unconditional `aws_account_id`/`aws_region`).

## Actual defect, and it is not EKS-specific

`gateway/gateway.go:723` `traceActionEnricher` was the only place setting those attributes, and only
when `ctxAction` was already in the request context.

`ctxAction` is populated exactly once, at `gateway/auth.go:154-158`, by parsing `Action=` out of a
query-protocol SigV4 body. So EC2, IAM, STS, ELBv2, RDS and spinifex get it — and every REST-JSON
dispatcher does not, because they resolve their action only *after* that middleware has run:

- EKS — path routing (`eks.go`)
- ECS, ACM, tagging, ECR — `X-Amz-Target` header (`ecs.go`, `acm.go`, `tagging.go`, `ecrapi.go`)
- Bedrock — path routing (`bedrock.go`, `bedrockruntime.go`)

Every REST-JSON service was unsearchable by action, not just the two operations the bead names.

## Fix, at the shared layer

Extracted `recordResolvedAction(ctx, service, action)` and call it from `checkPolicyResource`
(`gateway.go:429`) — the one function all twelve dispatchers already call with their resolved
`(service, action)` pair: `ec2.go:550`, `iam.go:326`, `ecs.go:39`, `acm.go:91`, `ecrapi.go:38`,
`tagging.go:48`, `eks.go:258`, `bedrock.go:85`, `bedrockruntime.go:91`, `elbv2.go:175`,
`spinifex.go:38`, `rds.go:49`.

`traceActionEnricher` still calls it too, so STS — which skips `checkPolicy` entirely — keeps
working exactly as before. Fixing this per-service would have left the same hole open for the next
REST-JSON service added.

## Testing

`make preflight` passes: golangci-lint 0 issues, govulncheck ok, all `gateway/...` tests green.

## Pending

Live confirmation needs a deploy, which was not available. Afterwards:

```
GET traces-apm*/_search
{"query":{"bool":{"must":[
  {"term":{"labels.aws_service":"eks"}},
  {"term":{"labels.aws_action":"CreateCluster"}}
]}}}
```