### PR TITLE
fix: stop passing nbdkit S3 credentials as literal argv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.14.0
 	github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4
-	github.com/mulgadc/viperblock v1.14.1-0.20260801113714-c1f227012d30
+	github.com/mulgadc/viperblock v1.14.1-0.20260801223811-8a4787ade83a
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1321,8 +1321,8 @@ github.com/mulgadc/northstar v1.14.0 h1:8JzDcS4k3SN5PF3jBdB8x9FOWC24eITCClmOdwpo
 github.com/mulgadc/northstar v1.14.0/go.mod h1:6EArbWIQUrCFQ+XZ5ZJrGS/ep/u/rF6l+dKZh5vVIRs=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4 h1:Q4/NEryYTMiALkFwbPPOrKpNgLir+d7T2hbyRpAFnWc=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4/go.mod h1:na0aNXABZF03/HfFWCrAPHrId/2FIEIUQfB82vlu1xg=
-github.com/mulgadc/viperblock v1.14.1-0.20260801113714-c1f227012d30 h1:UMZDKxm+WCbDb5hwQ/7uL2KmlYTiX76dk4dxNawmgDM=
-github.com/mulgadc/viperblock v1.14.1-0.20260801113714-c1f227012d30/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
+github.com/mulgadc/viperblock v1.14.1-0.20260801223811-8a4787ade83a h1:7HZ8K0hpA0tuExkWgcNmUuK1ZH7ZvjNpVsFvKLvOMrE=
+github.com/mulgadc/viperblock v1.14.1-0.20260801223811-8a4787ade83a/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/spinifex/nbd/nbd.go
+++ b/spinifex/nbd/nbd.go
@@ -7,6 +7,15 @@ import (
 	"strconv"
 )
 
+// accessKeyEnv and secretKeyEnv name the environment variables the nbdkit
+// child process reads S3 credentials from. Passing credentials this way
+// instead of via argv keeps them out of /proc/<pid>/cmdline, which is
+// world-readable for the life of the process.
+const (
+	accessKeyEnv = "VB_ACCESS_KEY"
+	secretKeyEnv = "VB_SECRET_KEY" //nolint:gosec // G101 false positive: env var name, not a credential value
+)
+
 type NBDKitConfig struct {
 	Port       int    `json:"port"`   // TCP port (when using TCP transport)
 	Socket     string `json:"socket"` // Unix socket path (when using socket transport)
@@ -62,14 +71,14 @@ func (cfg *NBDKitConfig) buildArgs() ([]string, error) {
 		args = append(args, "-v")
 	}
 
-	// Add plugin-specific arguments
+	// Add plugin-specific arguments. Credentials are deliberately not here —
+	// they are passed via cmd.Env in Execute so they never appear in argv,
+	// which is world-readable via /proc/<pid>/cmdline.
 	pluginArgs := []string{
 		fmt.Sprintf("size=%d", cfg.Size),
 		fmt.Sprintf("volume=%s", cfg.Volume),
 		fmt.Sprintf("bucket=%s", cfg.Bucket),
 		fmt.Sprintf("region=%s", cfg.Region),
-		fmt.Sprintf("access_key=%s", cfg.AccessKey),
-		fmt.Sprintf("secret_key=%s", cfg.SecretKey),
 		fmt.Sprintf("base_dir=%s", cfg.BaseDir),
 		fmt.Sprintf("host=%s", cfg.Host),
 		fmt.Sprintf("cache_size=%d", cfg.CacheSize),
@@ -86,15 +95,33 @@ func (cfg *NBDKitConfig) buildArgs() ([]string, error) {
 	return args, nil
 }
 
-func (cfg *NBDKitConfig) Execute() (*exec.Cmd, error) {
+// buildCmd constructs the nbdkit exec.Cmd with argv and environment set, but
+// does not start it. Split out from Execute so tests can inspect cmd.Env and
+// cmd.Args without spawning the real nbdkit binary.
+func (cfg *NBDKitConfig) buildCmd() (*exec.Cmd, error) {
 	args, err := cfg.buildArgs()
 	if err != nil {
 		return nil, err
 	}
 
 	cmd := exec.Command("nbdkit", args...)
+	// Credentials travel via the environment, not argv, so nbdkit's plugin
+	// can read them without exposing them in /proc/<pid>/cmdline.
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s", accessKeyEnv, cfg.AccessKey),
+		fmt.Sprintf("%s=%s", secretKeyEnv, cfg.SecretKey),
+	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	return cmd, nil
+}
+
+func (cfg *NBDKitConfig) Execute() (*exec.Cmd, error) {
+	cmd, err := cfg.buildCmd()
+	if err != nil {
+		return nil, err
+	}
 
 	return cmd, cmd.Start()
 }

--- a/spinifex/nbd/nbd_test.go
+++ b/spinifex/nbd/nbd_test.go
@@ -3,6 +3,7 @@ package nbd
 import (
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -38,8 +39,6 @@ func TestBuildArgs_TCPTransport(t *testing.T) {
 		"volume=vol-abc123",
 		"bucket=my-bucket",
 		"region=us-east-1",
-		"access_key=AKIA123",
-		"secret_key=secret",
 		"base_dir=/data",
 		"host=localhost:9000",
 		"cache_size=256",
@@ -83,8 +82,6 @@ func TestBuildArgs_UnixSocketTransport(t *testing.T) {
 		"volume=vol-def456",
 		"bucket=bucket-2",
 		"region=eu-west-1",
-		"access_key=AKIA456",
-		"secret_key=topsecret",
 		"base_dir=/mnt/data",
 		"host=10.0.0.1:9000",
 		"cache_size=128",
@@ -234,6 +231,66 @@ func TestBuildArgs_ArgOrdering(t *testing.T) {
 	}
 	if verboseIdx >= volumeIdx {
 		t.Error("-v should come before plugin args")
+	}
+}
+
+// TestBuildArgs_NoCredentialsInArgv pins the credential-exposure fix: argv
+// must carry neither an access_key=/secret_key= flag nor the raw credential
+// values anywhere, since argv is world-readable via /proc/<pid>/cmdline.
+func TestBuildArgs_NoCredentialsInArgv(t *testing.T) {
+	cfg := &NBDKitConfig{
+		Socket:     "/tmp/nbd.sock",
+		PidFile:    "/tmp/nbd.pid",
+		PluginPath: "/plugin.so",
+		AccessKey:  "AKIASECRETVALUE",
+		SecretKey:  "topsecretvalue",
+	}
+
+	args, err := cfg.buildArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "access_key=") || strings.HasPrefix(arg, "secret_key=") {
+			t.Errorf("argv must not contain a credential flag, got: %q in %v", arg, args)
+		}
+		if strings.Contains(arg, cfg.AccessKey) || strings.Contains(arg, cfg.SecretKey) {
+			t.Errorf("argv must not contain a credential value, got: %q in %v", arg, args)
+		}
+	}
+}
+
+// TestBuildCmd_CredentialsInEnv pins that credentials reach the nbdkit child
+// via cmd.Env instead of argv, and that cmd.Args stays free of them.
+func TestBuildCmd_CredentialsInEnv(t *testing.T) {
+	cfg := &NBDKitConfig{
+		Socket:     "/tmp/nbd.sock",
+		PidFile:    "/tmp/nbd.pid",
+		PluginPath: "/plugin.so",
+		AccessKey:  "AKIAENVTEST",
+		SecretKey:  "supersecretenv",
+	}
+
+	cmd, err := cfg.buildCmd()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantAccess := accessKeyEnv + "=" + cfg.AccessKey
+	wantSecret := secretKeyEnv + "=" + cfg.SecretKey
+
+	if !slices.Contains(cmd.Env, wantAccess) {
+		t.Errorf("cmd.Env missing %q, got: %v", wantAccess, cmd.Env)
+	}
+	if !slices.Contains(cmd.Env, wantSecret) {
+		t.Errorf("cmd.Env missing %q, got: %v", wantSecret, cmd.Env)
+	}
+
+	for _, arg := range cmd.Args {
+		if strings.Contains(arg, cfg.AccessKey) || strings.Contains(arg, cfg.SecretKey) {
+			t.Errorf("cmd.Args must not contain a credential value, got: %q", arg)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes **mulga-r3tim**. Pairs with viperblock **#67** (`8a4787a`), already merged.

## The exposure

`nbdkit` is spawned with the S3 access key and secret as literal argv values, so for the whole life of
the process any local user can read them:

```
cat /proc/<nbdkit-pid>/cmdline
```

`/proc/<pid>/cmdline` is world-readable regardless of the process owner, so this is not gated by being
root or by owning the process. It also lands in `ps` output, in anything that scrapes `ps`, and in core
dumps.

## The fix, in two halves

Both halves must ship together, and the second only reaches a deployed binary via the pin below.

**viperblock (`8a4787a`, merged in #67)** — `ConfigComplete` falls back to `VB_ACCESS_KEY` /
`VB_SECRET_KEY` when nbdkit's plugin argv did not set them, mirroring the existing
`ENCRYPTION_KEY_FILE` fallback. Argv still takes priority, so an unpinned spinifex keeps working
unchanged.

**spinifex (`ec945eb5`)** — the credentials move from argv to `cmd.Env`. `buildCmd` is split out of
`Execute` so a test can inspect the constructed environment without spawning anything;
`TestBuildCmd_CredentialsInEnv` asserts the values are present in `cmd.Env` and absent from `cmd.Args`.

The env var names are identical on both sides — that string match is the entire contract, so it is
worth checking explicitly at review:

```go
accessKeyEnv = "VB_ACCESS_KEY"
secretKeyEnv = "VB_SECRET_KEY" //nolint:gosec // G101 false positive: env var name, not a credential value
```

The `nolint` is on the *name* constant, not on any value.

## Why the go.mod pin is in this PR (`2c5bb3fb`)

`go.work` at the mulga root binds spinifex to the local viperblock checkout, but
`ansible/roles/build/tasks/main.yml` builds with `GOWORK=off`. So `spx` links whatever `spinifex/go.mod`
pins, and without the bump the deployed viperblock would have no `VB_ACCESS_KEY` fallback at all —
credentials would simply go missing rather than move.

```
- github.com/mulgadc/viperblock v1.14.1-0.20260801113714-c1f227012d30
+ github.com/mulgadc/viperblock v1.14.1-0.20260801223811-8a4787ade83a
```

`GOWORK=off go list -m` resolves to `8a4787ade83a`, and `GOWORK=off go build ./...` passes against it —
i.e. verified the way the deploy builds, not through the workspace overlay.

## Ordering note

Because argv keeps priority in viperblock, the halves are independently safe: an old spinifex against
new viperblock still passes argv, and a new spinifex against old viperblock is prevented by this pin.

## Not done

No live check that a running nbdkit's `/proc/<pid>/cmdline` is now clean. That is the assertion that
actually proves the leak is closed, and it needs a deployed environment with a volume attached.

## Preflight

Passes: manifest-lint OK, golangci-lint 0 issues, govulncheck clean, tests green. Diff coverage skipped
(31 changed lines, under the 100-line threshold).
