### PR TITLE
fix: DescribeInstances NotFound for nonexistent instance IDs

### DIFF
--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -117,7 +117,7 @@ func ec2HandlerWithReq[In any](handler func(ctx context.Context, input *In, gw *
 
 var ec2Actions = map[string]EC2Handler{
 	"DescribeInstances": ec2Handler(func(ctx context.Context, input *ec2.DescribeInstancesInput, gw *GatewayConfig, accountID string) (any, error) {
-		out, err := gateway_ec2_instance.DescribeInstances(ctx, input, gw.NATSConn, gw.DiscoverActiveNodes(ctx), accountID)
+		out, err := gateway_ec2_instance.DescribeInstancesChecked(ctx, input, gw.NATSConn, gw.DiscoverActiveNodes(ctx), accountID)
 		if err != nil {
 			return out, err
 		}

--- a/spinifex/gateway/ec2/instance/DescribeInstances.go
+++ b/spinifex/gateway/ec2/instance/DescribeInstances.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
@@ -18,8 +19,15 @@ import (
 
 // DescribeInstances fans out to all nodes via NATS and aggregates the results.
 // It is lenient: partial results from a slow or unreachable node are returned
-// without error, which is correct for user-facing describes. Callers that must
-// not act on a partial view (the quota reconcile) use DescribeInstancesForReconcile.
+// without error, and an explicitly named instance ID that is simply absent
+// from the aggregate is not an error either — the caller sees an empty list.
+// That silence is required by internal callers (the IMDS instance lookup, the
+// RDS instance-state resolver, the EKS control-plane reconciler) which treat
+// "not found" as "not currently running/present" rather than a fault.
+// The customer-facing gateway action uses DescribeInstancesChecked instead,
+// which adds the InvalidInstanceID.NotFound assertion AWS callers expect.
+// Callers that must not act on a partial view at all (the quota reconcile)
+// use DescribeInstancesForReconcile.
 func DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, natsConn *nats.Conn, expectedNodes int, accountID string) (*ec2.DescribeInstancesOutput, error) {
 	reservations, _, firstClient4xx, err := gatherInstances(ctx, input, natsConn, expectedNodes, accountID)
 	if err != nil {
@@ -29,6 +37,43 @@ func DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, n
 	if firstClient4xx != "" && len(reservations) == 0 {
 		return nil, errors.New(firstClient4xx)
 	}
+	return &ec2.DescribeInstancesOutput{Reservations: reservations}, nil
+}
+
+// DescribeInstancesChecked is the customer-facing variant served by the
+// gateway's DescribeInstances action. On top of DescribeInstances' aggregation,
+// it asserts InvalidInstanceID.NotFound for any explicitly named instance ID
+// absent from the result — but only when the sweep is provably complete
+// (every expected node answered, both KV buckets succeeded). A partial sweep
+// stays silent, the same as DescribeInstances: a node timing out during the
+// fan-out must never turn into a false NotFound for an instance that actually
+// exists on that node. A --filters-only query (no explicit IDs) is never
+// affected and keeps returning an empty list with no error.
+func DescribeInstancesChecked(ctx context.Context, input *ec2.DescribeInstancesInput, natsConn *nats.Conn, expectedNodes int, accountID string) (*ec2.DescribeInstancesOutput, error) {
+	reservations, complete, firstClient4xx, err := gatherInstances(ctx, input, natsConn, expectedNodes, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if firstClient4xx != "" && len(reservations) == 0 {
+		return nil, errors.New(firstClient4xx)
+	}
+
+	if len(input.InstanceIds) > 0 && complete {
+		found := make(map[string]bool)
+		for _, res := range reservations {
+			for _, inst := range res.Instances {
+				if inst != nil && inst.InstanceId != nil {
+					found[*inst.InstanceId] = true
+				}
+			}
+		}
+		for _, id := range input.InstanceIds {
+			if id != nil && !found[*id] {
+				return nil, errors.New(awserrors.ErrorInvalidInstanceIDNotFound)
+			}
+		}
+	}
+
 	return &ec2.DescribeInstancesOutput{Reservations: reservations}, nil
 }
 

--- a/spinifex/gateway/ec2/instance/DescribeInstances_test.go
+++ b/spinifex/gateway/ec2/instance/DescribeInstances_test.go
@@ -246,6 +246,156 @@ func TestDescribeInstances_EarlyExitWithExpectedNodes(t *testing.T) {
 	assert.Less(t, duration, 2*time.Second)
 }
 
+// subscribeEmptyInstanceBuckets makes the stopped/terminated KV bucket
+// queries in gatherInstances succeed with no instances, so a fan-out that
+// resolves fully still isn't marked incomplete just because the buckets have
+// nothing to say.
+func subscribeEmptyInstanceBuckets(t *testing.T, nc *nats.Conn) {
+	t.Helper()
+	for _, topic := range []string{"ec2.DescribeStoppedInstances", "ec2.DescribeTerminatedInstances"} {
+		_, err := nc.Subscribe(topic, func(msg *nats.Msg) {
+			data, _ := json.Marshal(&ec2.DescribeInstancesOutput{Reservations: []*ec2.Reservation{}})
+			msg.Respond(data)
+		})
+		require.NoError(t, err)
+	}
+	nc.Flush()
+}
+
+// TestDescribeInstancesChecked_ExplicitIDNotFound_CompleteSweep covers the
+// bead's primary criterion: naming a nonexistent instance ID with a
+// fully-answered fan-out returns InvalidInstanceID.NotFound instead of a
+// silent empty list.
+func TestDescribeInstancesChecked_ExplicitIDNotFound_CompleteSweep(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+	subscribeEmptyInstanceBuckets(t, nc)
+
+	_, err := nc.Subscribe("ec2.DescribeInstances", func(msg *nats.Msg) {
+		data, _ := json.Marshal(&ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{
+				{
+					ReservationId: aws.String("r-1"),
+					Instances:     []*ec2.Instance{{InstanceId: aws.String("i-real")}},
+				},
+			},
+		})
+		msg.Respond(data)
+	})
+	require.NoError(t, err)
+	nc.Flush()
+
+	input := &ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String("i-doesnotexist0000000")}}
+	_, err = DescribeInstancesChecked(context.Background(), input, nc, 1, "123456789012")
+
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidInstanceIDNotFound, err.Error())
+}
+
+// TestDescribeInstances_ExplicitIDNotFound_StaysSilent guards the internal
+// callers (IMDS lookup, RDS instance-state resolver, EKS control-plane
+// reconciler) that call the plain DescribeInstances and rely on "not found"
+// meaning an empty list, not an error. Only DescribeInstancesChecked — used
+// solely by the gateway's customer-facing action — may assert NotFound.
+func TestDescribeInstances_ExplicitIDNotFound_StaysSilent(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+	subscribeEmptyInstanceBuckets(t, nc)
+
+	// Mirrors a real node: it filters by the requested InstanceIds itself, so
+	// a query for an ID it doesn't hold gets an empty reservations list back.
+	_, err := nc.Subscribe("ec2.DescribeInstances", func(msg *nats.Msg) {
+		data, _ := json.Marshal(&ec2.DescribeInstancesOutput{Reservations: []*ec2.Reservation{}})
+		msg.Respond(data)
+	})
+	require.NoError(t, err)
+	nc.Flush()
+
+	input := &ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String("i-doesnotexist0000000")}}
+	output, err := DescribeInstances(context.Background(), input, nc, 1, "123456789012")
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Empty(t, output.Reservations)
+}
+
+// TestDescribeInstancesChecked_ExplicitIDFound_CompleteSweep is the positive
+// counterpart: the same complete sweep, but the requested ID is present, so
+// no error is raised.
+func TestDescribeInstancesChecked_ExplicitIDFound_CompleteSweep(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+	subscribeEmptyInstanceBuckets(t, nc)
+
+	_, err := nc.Subscribe("ec2.DescribeInstances", func(msg *nats.Msg) {
+		data, _ := json.Marshal(&ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{
+				{
+					ReservationId: aws.String("r-1"),
+					Instances:     []*ec2.Instance{{InstanceId: aws.String("i-real")}},
+				},
+			},
+		})
+		msg.Respond(data)
+	})
+	require.NoError(t, err)
+	nc.Flush()
+
+	input := &ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String("i-real")}}
+	output, err := DescribeInstancesChecked(context.Background(), input, nc, 1, "123456789012")
+
+	require.NoError(t, err)
+	require.Len(t, output.Reservations, 1)
+}
+
+// TestDescribeInstancesChecked_FilterOnlyNoMatch_ReturnsEmptyNotNotFound
+// covers the bead's second criterion: a --filters query that matches nothing
+// must still return rc=0 with an empty list, never NotFound (no instance IDs
+// were named).
+func TestDescribeInstancesChecked_FilterOnlyNoMatch_ReturnsEmptyNotNotFound(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+	subscribeEmptyInstanceBuckets(t, nc)
+
+	_, err := nc.Subscribe("ec2.DescribeInstances", func(msg *nats.Msg) {
+		data, _ := json.Marshal(&ec2.DescribeInstancesOutput{Reservations: []*ec2.Reservation{}})
+		msg.Respond(data)
+	})
+	require.NoError(t, err)
+	nc.Flush()
+
+	input := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{{Name: aws.String("tag:nope"), Values: []*string{aws.String("nothing")}}},
+	}
+	output, err := DescribeInstancesChecked(context.Background(), input, nc, 1, "123456789012")
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Empty(t, output.Reservations)
+}
+
+// TestDescribeInstancesChecked_ExplicitIDNotFound_NodeTimeout is the bead's
+// subtle third criterion: a node timing out during the fan-out must not
+// produce a false NotFound. Only one of two expected nodes answers, so the
+// sweep is provably incomplete and the naive found-set check must be
+// suppressed.
+func TestDescribeInstancesChecked_ExplicitIDNotFound_NodeTimeout(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+	subscribeEmptyInstanceBuckets(t, nc)
+
+	// Only one of the two expected nodes has a subscriber; the second never
+	// answers, so the fan-out hits its 3s deadline with sum.TimedOut=true.
+	_, err := nc.Subscribe("ec2.DescribeInstances", func(msg *nats.Msg) {
+		data, _ := json.Marshal(&ec2.DescribeInstancesOutput{Reservations: []*ec2.Reservation{}})
+		msg.Respond(data)
+	})
+	require.NoError(t, err)
+	nc.Flush()
+
+	input := &ec2.DescribeInstancesInput{InstanceIds: []*string{aws.String("i-on-the-slow-node")}}
+	output, err := DescribeInstancesChecked(context.Background(), input, nc, 2, "123456789012")
+
+	require.NoError(t, err, "an incomplete sweep must never assert a false NotFound")
+	require.NotNil(t, output)
+	assert.Empty(t, output.Reservations)
+}
+
 func TestDescribeInstances_ClosedConnection(t *testing.T) {
 	_, nc := startTestNATSServer(t)
 


### PR DESCRIPTION
## Summary

Gateway/EC2 API compatibility bug cluster sweep. Only one bead was REPRODUCED and fixed here; the other four are addressed with evidence in the linked beads (see below) and stay open where a live environment check is still outstanding.

### mulga-7tqq1 — DescribeInstances returns success for nonexistent instance IDs (FIXED, this PR)

`aws ec2 describe-instances --instance-ids i-doesnotexist0000000` returned rc=0 with an empty `Reservations` list instead of `InvalidInstanceID.NotFound`.

Mirrors the two-pass found-set pattern from `DescribeSecurityGroups` (`handlers/ec2/vpc/security_group.go:369-435`), but `DescribeInstances` aggregates over a NATS fan-out plus two KV bucket queries, so a naive "not in results = not found" would misreport an instance that exists on a node that timed out. Fixed by gating the NotFound assertion on `gatherInstances`' existing `complete` signal (every expected node answered, no timeout, both KV buckets succeeded).

The assertion only applies to the new `DescribeInstancesChecked`, wired into the gateway's customer-facing `DescribeInstances` action (`gateway/ec2.go:120`). The plain `DescribeInstances` stays silent — internal callers (IMDS instance lookup, the RDS instance-state resolver, the EKS control-plane reconciler) rely on "not found" meaning "not currently present", not a fault, and asserting there would turn routine miss checks into hard errors.

Evidence:
```
--- PASS: TestDescribeInstancesChecked_ExplicitIDNotFound_CompleteSweep (0.03s)
--- PASS: TestDescribeInstancesChecked_ExplicitIDFound_CompleteSweep (0.03s)
--- PASS: TestDescribeInstancesChecked_FilterOnlyNoMatch_ReturnsEmptyNotNotFound (0.03s)
--- PASS: TestDescribeInstancesChecked_ExplicitIDNotFound_NodeTimeout (3.03s)
--- PASS: TestDescribeInstances_ExplicitIDNotFound_StaysSilent (0.05s)
```
Mutation-verified: bypassing the `complete` gate makes `TestDescribeInstancesChecked_ExplicitIDNotFound_NodeTimeout` fail (`Received unexpected error: InvalidInstanceID.NotFound`); reverting the mutation restores green. `make preflight` passes.

### mulga-zjy2g — ImportKeyPair SignatureDoesNotMatch (still open)

Added `predastore/pkg/sigv4/ec2_v1signer_property_test.go`: the same EC2 query-protocol oracle test, but signing with `aws-sdk-go` v1's own `signer/v4` (the terraform AWS provider's signing lineage) instead of `aws-sdk-go-v2`. This was the one signing stack never diffed against `sigv4`'s canonicalisation. 100/100 property-fuzzed draws pass — rules out a v1-signer-specific canonicalisation gap. No defect found. Bead stays open; the next actionable step remains a live reproduction (spinifex #615's canonical-request logging is already merged) to diff the actual failing request.

### mulga-25acx — MIG GPU-slice admission (still open, P4)

Re-verified against current code: PR #513 already fixed the primary admission-gate defect. The residual — `gpu/manager.go` `Available()` ignores `freeMIGGPUs`, so an un-carved MIG GPU advertises 0 capacity until first Claim — needs a design decision (what slice count to advertise for an uncommitted profile) that can't be safely validated without real MIG hardware; a wrong guess would recreate the late-Claim-failure this bead exists to fix. Left open per the bead's own prior conclusion.

### mulga-dfzfi — add eks/ecs/storagegrowth to e2e CI defaults (still open, P4)

The cited blocker, mulga-by5sq, is now closed (fixed by spinifex#634, merged to dev at 68738752). This unblocks the bead's own documented sequence (re-validate multinode EKS, flip topology, add to defaults), but that first step needs a live 3-node multinode TestEKS run, which needs an environment not currently available to this sweep. Left open with a note naming the outstanding live check.

### mulga-rx38m — baremetal ships no OVN/OVS/journal logs (still open, P3)

Criterion 1 (forwarder code) is confirmed live: `mulga` commit `64af9f0f` (merged to main) ports the same `spinifex-alloy-ci.service` mechanism into `bm-bootstrap.sh`. Criterion 2 (a nightly producing `ovn_controller`/`ovsdb_server`/`systemd_networkd` for `ci_cell=20`) is not yet met — queried the ES sink directly and confirmed no nightly has run since the fix landed (2026-08-02 01:03 AEST); the last several nightlies (07-28 through 07-30) predate it. Left open pending the next scheduled nightly.

## Test plan

- [x] `make preflight` passes in the spinifex worktree
- [x] `go test ./gateway/ec2/instance/... ./gateway/... ./handlers/imds/... ./handlers/rds/... ./daemon/...` all green
- [x] Mutation test on the `complete` gate (see above)
- [x] `go test ./pkg/sigv4/...` in predastore, including the new v1-signer oracle test