### PR TITLE
fix: CreateImage live drain + Alpine .raw sparsify

### DIFF
--- a/scripts/build-system-image.sh
+++ b/scripts/build-system-image.sh
@@ -147,6 +147,10 @@ if [[ "$DISTRO" == "alpine" ]] && ! command -v guestfish &>/dev/null; then
     echo "ERROR: guestfish not found. Install libguestfs-tools."
     exit 1
 fi
+if [[ "$DISTRO" == "alpine" ]] && ! command -v virt-sparsify &>/dev/null; then
+    echo "ERROR: virt-sparsify not found. Install libguestfs-tools."
+    exit 1
+fi
 if [[ "$DISTRO" == "ubuntu" ]] && ! command -v virt-resize &>/dev/null; then
     echo "ERROR: virt-resize not found. Install libguestfs-tools."
     exit 1
@@ -355,6 +359,20 @@ fi
 
 echo "Customizing image (libguestfs appliance)..."
 "${CUST[@]}"
+
+# Step 4b: Sparsify (Alpine only). qemu-img resize + guestfish resize2fs grow
+# the disk file in place, and resize2fs scatters inode-table/journal metadata
+# across the whole newly-grown region — those clusters are non-zero even
+# though the filesystem never allocates most of them, so the plain raw
+# conversion below cannot detect them as holes. virt-sparsify explicitly zeros
+# a guest's unused blocks so the conversion turns them into real holes.
+# Ubuntu's virt-resize path never has this problem: it builds a fresh
+# destination qcow2 and copies only live data, so it stays sparse without
+# this step.
+if [[ "$DISTRO" == "alpine" ]]; then
+    echo "Sparsifying image (virt-sparsify)..."
+    virt-sparsify --in-place "$OUTPUT_IMAGE"
+fi
 
 # Step 5: Convert to raw for import
 echo "Converting to raw format..."

--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -1392,7 +1392,7 @@ func (d *Daemon) startCluster() error {
 	d.dnsBaseDomain = handlers_dns.ResolveBaseDomain(d.config)
 	d.dnsInternalDomain = handlers_dns.ResolveInternalDomain(d.config)
 	d.keyService = handlers_ec2_key.NewKeyServiceImpl(d.config)
-	d.imageService = handlers_ec2_image.NewImageServiceImpl(d.config)
+	d.imageService = handlers_ec2_image.NewImageServiceImpl(d.config, d.natsConn)
 
 	type snapResult struct {
 		svc *handlers_ec2_snapshot.SnapshotServiceImpl

--- a/spinifex/handlers/ec2/image/drain_test.go
+++ b/spinifex/handlers/ec2/image/drain_test.go
@@ -1,0 +1,139 @@
+package handlers_ec2_image
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/config"
+	"github.com/mulgadc/spinifex/spinifex/handlers/ec2/volumestate"
+	"github.com/mulgadc/spinifex/spinifex/objectstore"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const drainImageInstanceID = "i-image-drain-host"
+
+// setupDrainImageService mirrors handlers/ec2/snapshot's setupDrainService: a
+// reachable (but rejecting) Predastore host so a drained volume falls through
+// into the real snapshot path and fails fast, a data dir with no local drain
+// socket, and a NATS connection to route the drain to the hosting node.
+func setupDrainImageService(t *testing.T) (*ImageServiceImpl, *objectstore.MemoryObjectStore, *nats.Conn) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, nc := testutil.StartTestNATS(t)
+	store := objectstore.NewMemoryObjectStore()
+	cfg := &config.Config{
+		DataDir: testutil.SocketTempDir(t),
+		Predastore: config.PredastoreConfig{
+			Host:   srv.URL,
+			Bucket: testBucket,
+		},
+	}
+	return NewImageServiceImplWithConfig(cfg, store, nc), store, nc
+}
+
+func seedImageVolumeAttachment(t *testing.T, store *objectstore.MemoryObjectStore, volumeID, state, instanceID string) {
+	t.Helper()
+	require.NoError(t, volumestate.Write(context.Background(), store, testBucket, volumeID, volumestate.Record{
+		State:            state,
+		AttachedInstance: instanceID,
+	}))
+}
+
+func drainImageResponder(t *testing.T, nc *nats.Conn, instanceID string, reply []byte) chan *nats.Msg {
+	t.Helper()
+
+	got := make(chan *nats.Msg, 4)
+	sub, err := nc.Subscribe("ec2.cmd."+instanceID, func(msg *nats.Msg) {
+		got <- msg
+		_ = msg.Respond(reply)
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	return got
+}
+
+func drainedImageAck(t *testing.T, volumeID string) []byte {
+	t.Helper()
+	data, err := json.Marshal(types.DrainVolumeResponse{VolumeID: volumeID, Status: types.DrainVolumeStatusDrained})
+	require.NoError(t, err)
+	return data
+}
+
+func awaitImageDrainCommand(t *testing.T, got chan *nats.Msg) types.EC2InstanceCommand {
+	t.Helper()
+	select {
+	case msg := <-got:
+		var command types.EC2InstanceCommand
+		require.NoError(t, json.Unmarshal(msg.Data, &command))
+		return command
+	case <-time.After(2 * time.Second):
+		t.Fatal("the node hosting the volume never received a drain command")
+		return types.EC2InstanceCommand{}
+	}
+}
+
+// CreateImageFromInstance's IsRunning path must drain the volume's hosting node
+// before it reads the live checkpoint — the same guarantee ec2.CreateSnapshot
+// has. Without this, a checkpoint predating a guest-triggered GPT rewrite
+// (e.g. growpart on first boot) can be captured silently.
+func TestSnapshotRunningVolume_DrainsAttachedVolume(t *testing.T) {
+	svc, store, nc := setupDrainImageService(t)
+	createTestVolumeConfig(t, store, "vol-image-drain", 10)
+	seedImageVolumeAttachment(t, store, "vol-image-drain", "in-use", drainImageInstanceID)
+	got := drainImageResponder(t, nc, drainImageInstanceID, drainedImageAck(t, "vol-image-drain"))
+
+	err := svc.snapshotRunningVolume("vol-image-drain", "snap-image-drain", testAccountID)
+	// The rejecting Predastore stub fails the snapshot itself; what matters
+	// here is that the drain reached the hosting node first.
+	require.Error(t, err)
+
+	command := awaitImageDrainCommand(t, got)
+	assert.True(t, command.Attributes.DrainVolume)
+	assert.Equal(t, drainImageInstanceID, command.ID)
+	require.NotNil(t, command.DrainVolumeData)
+	assert.Equal(t, "vol-image-drain", command.DrainVolumeData.VolumeID)
+}
+
+// An attached volume whose host reports the drain failed must fail
+// CreateImage rather than register an AMI built from a stale checkpoint.
+func TestSnapshotRunningVolume_UndrainableAttachedVolumeFails(t *testing.T) {
+	svc, store, nc := setupDrainImageService(t)
+	createTestVolumeConfig(t, store, "vol-image-nodrain", 10)
+	seedImageVolumeAttachment(t, store, "vol-image-nodrain", "in-use", drainImageInstanceID)
+	drainImageResponder(t, nc, drainImageInstanceID,
+		[]byte(`{"Code":"`+awserrors.ErrorServerInternal+`","Message":"drain failed"}`))
+
+	err := svc.snapshotRunningVolume("vol-image-nodrain", "snap-image-nodrain", testAccountID)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+}
+
+// An unattached (stopped-instance) volume takes the no-drain path: the
+// checkpoint Close() left behind is already current.
+func TestSnapshotRunningVolume_AvailableSkipsDrain(t *testing.T) {
+	svc, store, _ := setupDrainImageService(t)
+	createTestVolumeConfig(t, store, "vol-image-available", 10)
+	seedImageVolumeAttachment(t, store, "vol-image-available", "available", "")
+	svc.natsConn = nil
+
+	// No responder exists and the socket is never dialled: proceeding straight
+	// to the (rejecting) snapshot path proves the drain was skipped, not stuck.
+	err := svc.snapshotRunningVolume("vol-image-available", "snap-image-available", testAccountID)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+}

--- a/spinifex/handlers/ec2/image/service_impl.go
+++ b/spinifex/handlers/ec2/image/service_impl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/mulgadc/viperblock/viperblock"
 	vbs3 "github.com/mulgadc/viperblock/viperblock/backends/s3"
+	"github.com/nats-io/nats.go"
 )
 
 // Ensure ImageServiceImpl implements ImageService.
@@ -43,10 +44,13 @@ type ImageServiceImpl struct {
 	config     *config.Config
 	store      objectstore.ObjectStore
 	bucketName string
+	natsConn   *nats.Conn
 }
 
-// NewImageServiceImpl creates a new daemon-side image service.
-func NewImageServiceImpl(cfg *config.Config) *ImageServiceImpl {
+// NewImageServiceImpl creates a new daemon-side image service. natsConn is used
+// to drain a running instance's volume (routed to the node hosting it) before
+// CreateImageFromInstance reads its live checkpoint.
+func NewImageServiceImpl(cfg *config.Config, natsConn *nats.Conn) *ImageServiceImpl {
 	store := objectstore.NewS3ObjectStoreFromConfig(
 		cfg.Predastore.Host,
 		cfg.Predastore.Region,
@@ -58,6 +62,7 @@ func NewImageServiceImpl(cfg *config.Config) *ImageServiceImpl {
 		config:     cfg,
 		store:      store,
 		bucketName: cfg.Predastore.Bucket,
+		natsConn:   natsConn,
 	}
 }
 
@@ -66,6 +71,18 @@ func NewImageServiceImplWithStore(store objectstore.ObjectStore, bucketName stri
 	return &ImageServiceImpl{
 		store:      store,
 		bucketName: bucketName,
+	}
+}
+
+// NewImageServiceImplWithConfig creates an image service with an explicit
+// config and NATS connection (for testing the running-volume drain path,
+// which needs config.DataDir/Predastore and a NATS connection to route to).
+func NewImageServiceImplWithConfig(cfg *config.Config, store objectstore.ObjectStore, natsConn *nats.Conn) *ImageServiceImpl {
+	return &ImageServiceImpl{
+		config:     cfg,
+		store:      store,
+		bucketName: cfg.Predastore.Bucket,
+		natsConn:   natsConn,
 	}
 }
 
@@ -409,12 +426,14 @@ func (s *ImageServiceImpl) CreateImageFromInstance(params CreateImageParams, acc
 		"isRunning", params.IsRunning)
 
 	// Step 1: Snapshot root volume (live via NATS or offline from S3)
-	snapshotFn := s.snapshotStoppedVolume
+	var snapshotErr error
 	if params.IsRunning {
-		snapshotFn = s.snapshotRunningVolume
+		snapshotErr = s.snapshotRunningVolume(params.RootVolumeID, snapshotID, accountID)
+	} else {
+		snapshotErr = s.snapshotStoppedVolume(params.RootVolumeID, snapshotID)
 	}
-	if err := snapshotFn(params.RootVolumeID, snapshotID); err != nil {
-		return nil, err
+	if snapshotErr != nil {
+		return nil, snapshotErr
 	}
 
 	// Step 2: Read source volume config for size
@@ -478,10 +497,12 @@ func (s *ImageServiceImpl) CreateImageFromInstance(params CreateImageParams, acc
 	}, nil
 }
 
-// snapshotRunningVolume creates a crash-consistent snapshot of a running instance by reading
-// the live checkpoint written by nbdkit on every NBD Flush. No IPC with the running nbdkit
-// process is needed; S3 PUT atomicity guarantees we read a complete checkpoint.
-func (s *ImageServiceImpl) snapshotRunningVolume(volumeID, snapshotID string) error {
+// snapshotRunningVolume creates a snapshot of a running instance's volume by
+// draining it to the node hosting it (so any writes buffered there reach S3),
+// then reading the live checkpoint written by nbdkit on every NBD Flush. This
+// shares handlers/ec2/snapshot's DrainVolume with ec2.CreateSnapshot so the two
+// live-snapshot paths cannot diverge on when a drain is required.
+func (s *ImageServiceImpl) snapshotRunningVolume(volumeID, snapshotID, accountID string) error {
 	if s.config == nil {
 		return errors.New(awserrors.ErrorServerInternal)
 	}
@@ -492,6 +513,16 @@ func (s *ImageServiceImpl) snapshotRunningVolume(volumeID, snapshotID string) er
 		return errors.New(awserrors.ErrorServerInternal)
 	}
 	volumeSize := volConfig.VolumeMetadata.SizeGiB * 1024 * 1024 * 1024
+
+	// Flush the writes still buffered by whichever node serves the volume, so
+	// the live checkpoint below is current rather than an arbitrarily stale one
+	// predating e.g. a guest-triggered GPT rewrite (growpart on first boot). An
+	// attached volume that cannot be drained fails here rather than silently
+	// producing an image from a stale checkpoint.
+	if err := handlers_ec2_snapshot.DrainVolume(context.Background(), s.config, s.store, s.natsConn, volumeID, volConfig.VolumeMetadata, accountID); err != nil {
+		slog.Error("snapshotRunningVolume: drain failed", "volumeId", volumeID, "err", err)
+		return errors.New(awserrors.ErrorServerInternal)
+	}
 
 	cfg := vbs3.S3Config{
 		VolumeName: volumeID,

--- a/spinifex/handlers/ec2/image/service_impl_test.go
+++ b/spinifex/handlers/ec2/image/service_impl_test.go
@@ -2399,7 +2399,7 @@ func TestSnapshotRunningVolume_VolumeConfigMissing(t *testing.T) {
 		store:      store,
 		bucketName: testBucket,
 	}
-	err := svc.snapshotRunningVolume("vol-missing", "snap-r1")
+	err := svc.snapshotRunningVolume("vol-missing", "snap-r1", testAccountID)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 }
@@ -2424,7 +2424,7 @@ func TestSnapshotRunningVolume_BackendInitFails(t *testing.T) {
 	}
 	createTestVolumeConfig(t, store, "vol-running1", 10)
 
-	err := svc.snapshotRunningVolume("vol-running1", "snap-r2")
+	err := svc.snapshotRunningVolume("vol-running1", "snap-r2", testAccountID)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 }
@@ -2510,7 +2510,7 @@ func TestSnapshotRunningVolume_EncryptionKeyLoadError(t *testing.T) {
 	}
 	createTestVolumeConfig(t, store, "vol-running-enckey", 10)
 
-	err := svc.snapshotRunningVolume("vol-running-enckey", "snap-run-enckey")
+	err := svc.snapshotRunningVolume("vol-running-enckey", "snap-run-enckey", testAccountID)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 }
@@ -2535,7 +2535,7 @@ func TestSnapshotRunningVolume_LoadStateFails(t *testing.T) {
 	}
 	createTestVolumeConfig(t, store, "vol-running-lsf", 10)
 
-	err := svc.snapshotRunningVolume("vol-running-lsf", "snap-run-lsf")
+	err := svc.snapshotRunningVolume("vol-running-lsf", "snap-run-lsf", testAccountID)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
 }

--- a/spinifex/handlers/ec2/snapshot/service_impl.go
+++ b/spinifex/handlers/ec2/snapshot/service_impl.go
@@ -353,21 +353,29 @@ func DrainVolumeSocket(dataDir, volumeID string) error {
 
 // drainVolume flushes the volume's in-flight writes to S3 before the snapshot
 // reads the live checkpoint from there.
+func (s *SnapshotServiceImpl) drainVolume(ctx context.Context, volumeID string, meta viperblock.VolumeMetadata, accountID string) error {
+	return DrainVolume(ctx, s.config, s.store, s.natsConn, volumeID, meta, accountID)
+}
+
+// DrainVolume flushes the volume's in-flight writes to S3 before a live
+// checkpoint is read from there. Shared by ec2.CreateSnapshot and
+// ec2.CreateImage's running-instance path (handlers/ec2/image) so the two
+// live-snapshot call sites cannot diverge on when a drain is required.
 //
-// The drain socket lives on the node serving the volume, but ec2.CreateSnapshot
-// is queue-grouped across every node, so the node answering the request usually
+// The drain socket lives on the node serving the volume, but both callers are
+// queue-grouped across every node, so the node answering the request usually
 // is not that node. Whether a drain is required is therefore decided from the
 // volume's attachment record, never from whether the socket happens to be
-// local: an attached volume is being written to right now, and snapshotting it
-// without draining silently captures an older checkpoint.
-func (s *SnapshotServiceImpl) drainVolume(ctx context.Context, volumeID string, meta viperblock.VolumeMetadata, accountID string) error {
+// local: an attached volume is being written to right now, and reading its
+// checkpoint without draining silently captures an older one.
+func DrainVolume(ctx context.Context, cfg *config.Config, store objectstore.ObjectStore, natsConn *nats.Conn, volumeID string, meta viperblock.VolumeMetadata, accountID string) error {
 	// A metadata-only snapshot never reads the live checkpoint, so there is
 	// nothing for a drain to make current.
-	if s.config == nil || s.config.Predastore.Host == "" {
+	if cfg == nil || cfg.Predastore.Host == "" {
 		return nil
 	}
 
-	state, instanceID, err := s.volumeAttachment(ctx, volumeID, meta)
+	state, instanceID, err := volumeAttachment(ctx, store, cfg.Predastore.Bucket, volumeID, meta)
 	if err != nil {
 		return err
 	}
@@ -376,7 +384,7 @@ func (s *SnapshotServiceImpl) drainVolume(ctx context.Context, volumeID string, 
 	// left behind is the current one. Decide this before touching the socket —
 	// dialing it is not a probe, it makes the plugin run a full flush.
 	if state != "in-use" || instanceID == "" {
-		slog.InfoContext(ctx, "drainVolume: volume not attached, snapshotting the checkpoint left by Close (stopped instance path)",
+		slog.InfoContext(ctx, "DrainVolume: volume not attached, snapshotting the checkpoint left by Close (stopped instance path)",
 			"volumeId", volumeID, "state", state, "attachedInstance", instanceID)
 		return nil
 	}
@@ -384,7 +392,7 @@ func (s *SnapshotServiceImpl) drainVolume(ctx context.Context, volumeID string, 
 	// Fast path: the volume is served by this node, so no hop is needed. This is
 	// every single-node deployment, and the node hosting the instance on a
 	// cluster.
-	localErr := DrainVolumeSocket(s.config.DataDir, volumeID)
+	localErr := DrainVolumeSocket(cfg.DataDir, volumeID)
 	if localErr == nil {
 		return nil
 	}
@@ -396,17 +404,17 @@ func (s *SnapshotServiceImpl) drainVolume(ctx context.Context, volumeID string, 
 		return fmt.Errorf("drain volume %s on this node: %w", volumeID, localErr)
 	}
 
-	slog.InfoContext(ctx, "drainVolume: volume attached, routing drain to the node hosting it",
+	slog.InfoContext(ctx, "DrainVolume: volume attached, routing drain to the node hosting it",
 		"volumeId", volumeID, "instanceId", instanceID)
-	return s.drainOnHostNode(ctx, volumeID, instanceID, accountID)
+	return drainOnHostNode(ctx, natsConn, volumeID, instanceID, accountID)
 }
 
 // volumeAttachment returns the volume's authoritative state and attached
 // instance. state.json is control-plane-owned and authoritative; the copy in
 // config.json (passed in as meta) is rewritten by the live NBD plugin from its
 // stale in-memory state and is only used for volumes predating the split.
-func (s *SnapshotServiceImpl) volumeAttachment(ctx context.Context, volumeID string, meta viperblock.VolumeMetadata) (state, instanceID string, err error) {
-	rec, found, err := volumestate.Read(ctx, s.store, s.config.Predastore.Bucket, volumeID)
+func volumeAttachment(ctx context.Context, store objectstore.ObjectStore, bucket, volumeID string, meta viperblock.VolumeMetadata) (state, instanceID string, err error) {
+	rec, found, err := volumestate.Read(ctx, store, bucket, volumeID)
 	if err != nil {
 		return "", "", fmt.Errorf("read volume state for %s: %w", volumeID, err)
 	}
@@ -426,14 +434,14 @@ func (s *SnapshotServiceImpl) volumeAttachment(ctx context.Context, volumeID str
 // not-running signals below are therefore the stopped-instance path, not a
 // failure — treating them as one would make every stopped instance's root
 // volume permanently unsnapshottable.
-func (s *SnapshotServiceImpl) drainOnHostNode(ctx context.Context, volumeID, instanceID, accountID string) error {
+func drainOnHostNode(ctx context.Context, natsConn *nats.Conn, volumeID, instanceID, accountID string) error {
 	command := types.EC2InstanceCommand{
 		ID:              instanceID,
 		Attributes:      types.EC2CommandAttributes{DrainVolume: true},
 		DrainVolumeData: &types.DrainVolumeData{VolumeID: volumeID},
 	}
 
-	resp, err := utils.NATSRequest[types.DrainVolumeResponse](ctx, s.natsConn,
+	resp, err := utils.NATSRequest[types.DrainVolumeResponse](ctx, natsConn,
 		"ec2.cmd."+instanceID, command, drainRequestTimeout, accountID)
 	if err != nil {
 		// No subscriber at all: the instance runs nowhere in the cluster, so it

--- a/tests/e2e/single/createimage_test.go
+++ b/tests/e2e/single/createimage_test.go
@@ -16,6 +16,14 @@ import (
 // records the backing snapshot ID so Phase 9 cleanup can delete the
 // snapshot before terminating the instance (otherwise DeleteOnTermination
 // trips over the still-referenced snapshot). Maps to run-e2e.sh ~805–844.
+//
+// Boot-verifies both CreateImage paths: --no-reboot against the running
+// singleton (IsRunning path), and a second image against the same instance
+// stopped (offline path). The IsRunning path can register a well-formed AMI
+// that never reaches the OS — mulga-i8nfx found this stuck at the UEFI shell
+// on a root volume grown past the base image's native size — so
+// describe-images reporting State=available is not itself evidence the AMI
+// boots; only a real guest login is.
 func runCreateImage(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Single — CreateImage Lifecycle")
 
@@ -61,4 +69,87 @@ func runCreateImage(t *testing.T, fix *Fixture) {
 	// config exists for the custom AMI. The actual bash doesn't do that —
 	// the EC2 API check above is the sole assertion. Wire up an S3 client
 	// in the harness if we ever want to enforce the predastore-side state.
+
+	runBootVerifyAMI(t, fix, customAMIID, "running-path")
+
+	// The offline path: CreateImage against the same instance stopped. The
+	// daemon's IsRunning decision is the instance's actual VM status at call
+	// time (daemon_handlers_image.go), not the NoReboot flag, so stopping the
+	// source instance is what selects snapshotStoppedVolume.
+	harness.Step(t, "stop-instances %s (precondition for stopped-path CreateImage)", instanceID)
+	_, err = fix.AWS.EC2.StopInstances(&ec2.StopInstancesInput{
+		InstanceIds: []*string{aws.String(instanceID)},
+	})
+	require.NoError(t, err, "stop-instances")
+	harness.WaitForInstanceState(t, fix.AWS, instanceID, "stopped")
+
+	// Restore the singleton to running before returning regardless of outcome
+	// below — sibling Test* expect the canonical running row.
+	t.Cleanup(func() {
+		_, _ = fix.AWS.EC2.StartInstances(&ec2.StartInstancesInput{
+			InstanceIds: []*string{aws.String(instanceID)},
+		})
+		harness.WaitForInstanceState(t, fix.AWS, instanceID, "running")
+	})
+
+	const stoppedName = "e2e-custom-ami-stopped"
+	harness.Step(t, "create-image instance=%s name=%s (stopped)", instanceID, stoppedName)
+	stoppedAMIID := ensureCustomAMI(t, fix, instanceID, stoppedName, "E2E test custom image (stopped path)")
+	require.NotEmpty(t, stoppedAMIID, "ensureCustomAMI (stopped) returned empty ImageId")
+	harness.Detail(t, "custom_ami_stopped", stoppedAMIID)
+
+	runBootVerifyAMI(t, fix, stoppedAMIID, "stopped-path")
+}
+
+// runBootVerifyAMI launches a short-lived, test-owned instance from amiID and
+// requires it to reach a real SSH login — not just EC2 State=running — so a
+// well-formed-but-unbootable AMI (mulga-i8nfx: stuck at the UEFI shell) fails
+// this test instead of shipping silently. Terminates the probe instance via
+// t.Cleanup regardless of outcome.
+func runBootVerifyAMI(t *testing.T, fix *Fixture, amiID, label string) {
+	t.Helper()
+	harness.Step(t, "boot-verify %s ami=%s", label, amiID)
+
+	instType, _ := needInstanceTypeArch(t, fix)
+	keyName, keyPath := needKeyPair(t, fix)
+	vpc := harness.EnsureDefaultVPC(t, fix.Harness)
+	require.NotEmpty(t, vpc.SGID, "default SG ID required")
+	harness.AuthorizeSSHIngress(t, fix.AWS, vpc.SGID)
+
+	runOut, err := fix.AWS.EC2.RunInstances(&ec2.RunInstancesInput{ // e2e:allow-create — a dedicated boot-verify probe per produced AMI, not the shared singleton.
+		ImageId:          aws.String(amiID),
+		InstanceType:     aws.String(instType),
+		KeyName:          aws.String(keyName),
+		SubnetId:         aws.String(vpc.SubnetID),
+		SecurityGroupIds: []*string{aws.String(vpc.SGID)},
+		MinCount:         aws.Int64(1),
+		MaxCount:         aws.Int64(1),
+	})
+	require.NoError(t, err, "run-instances from %s (%s)", amiID, label)
+	require.NotEmpty(t, runOut.Instances, "run-instances from %s returned no Instances", amiID)
+	probeInstanceID := aws.StringValue(runOut.Instances[0].InstanceId)
+	require.NotEmpty(t, probeInstanceID, "run-instances from %s returned empty InstanceId", amiID)
+	harness.Detail(t, "boot_verify_instance_"+label, probeInstanceID)
+
+	t.Cleanup(func() {
+		_, _ = fix.AWS.EC2.TerminateInstances(&ec2.TerminateInstancesInput{
+			InstanceIds: []*string{aws.String(probeInstanceID)},
+		})
+	})
+
+	dir := harness.ArtifactDir(t, harness.LoadEnv(t))
+	harness.OnFailure(t, func() {
+		harness.DumpInstanceConsole(t, fix.AWS, probeInstanceID, dir, "createimage-"+label+"-console.log")
+	})
+
+	probeInst := harness.WaitForInstanceState(t, fix.AWS, probeInstanceID, "running")
+
+	host, port := harness.InstancePublicSSHHost(t, probeInst)
+	waitForSSHReady(t, host, port, keyPath)
+
+	tgt := harness.SSHTarget{User: "ubuntu", Host: host, Port: port, KeyPath: keyPath}
+	idOut := runSSH(t, tgt, "id")
+	assert.Containsf(t, idOut, "ubuntu", "boot-verify %s: ssh id should report ubuntu\n%s", label, idOut)
+
+	harness.Detail(t, "boot_verify_"+label, "ok")
 }


### PR DESCRIPTION
## Summary

Drains three related P2 bugs in the images/AMI lifecycle cluster.

- **mulga-i8nfx** / **mulga-rxwf4**: `CreateImage --no-reboot` against a
  running instance read the volume's live checkpoint from predastore without
  draining in-flight writes first, unlike `CreateSnapshot`. A checkpoint
  captured before a guest-triggered write (e.g. growpart rewriting the GPT
  after a root volume is launched larger than the base image) could be
  stale, producing an AMI that boots to a UEFI shell instead of the OS.
  Fixed by extracting the existing snapshot-package drain logic into a
  shared `DrainVolume` helper reused by both live-snapshot call sites.
- **mulga-fqpvv**: added `virt-sparsify` to the Alpine guestfish build path
  for parity with the Ubuntu virt-resize path, per the bead's suggested fix.
- Extended the CreateImage e2e test to boot-verify every produced AMI via a
  real SSH login rather than trusting `describe-images` `State=available`.

## Evidence per bead

**mulga-i8nfx / mulga-rxwf4 — REPRODUCED, FIXED.** Live repro on env12:
launched an Ubuntu instance from a base AMI with a 30GiB root volume
(native ~4GiB), let growpart rewrite the GPT (`vda1` grew to 28.9G),
`create-image --no-reboot` against the running instance, then launched a
clone from the resulting AMI. Clone reached a real SSH login
(`uid=1000(ubuntu) gid=1000(ubuntu) groups=...`) — the drain fix resolves
the exact repro in both beads. mulga-rxwf4 is Julian Sommer's; noted via
`bd note`, not closed here.

**mulga-sn062 — GONE, already fixed on `dev`.** Re-verified by reading
`viperblock/viperblock/v_utils/v_utils.go:187-291`: `AMIMetadata.State` is
set to `"pending"` before any data write, persisted immediately for
encrypted volumes, and only flipped to `"available"` after `vb.Close()`
returns nil. A failed import cannot leave `State=available`. Landed via
viperblock `c1f227012d3` + spinifex `0628b5f2`, both already on `dev`
before this branch — no new code needed.

**mulga-fqpvv — root cause corrected, fix landed anyway.** The bead
claims the unpatched Alpine `.raw` is ~4.10GiB actual on disk. Built the
image with `virt-sparsify` explicitly disabled as a true baseline:
actual usage was **403M** (apparent 4.0G), not 4.10GiB — `qemu-img
convert -O raw` already hole-detects zero regions, and resize2fs's
growth of unused ext4 metadata is genuinely zero-filled, not non-zero
garbage as the prior code-trace-only sweep assumed. The bead's numeric
acceptance bar (~<500MB) was already met before this change. With
`virt-sparsify` added, actual usage drops further to 386M — a real but
marginal (~4%) improvement, landed for parity with the Ubuntu path per
the acceptance criteria's suggested approach.

**mulga-569x2 — GONE, no code change needed.** `eks-node`'s (Alpine)
console fix already landed in `3e195506`. For `eks-node-gpu` (Ubuntu):
`setup.sh` never calls `update-grub` and installs no new kernel
(`do_bootloader=no` + `apt-mark hold`), so the base Ubuntu cloud image's
grub.cfg passes through untouched. Confirmed by building the image locally
and booting it headless via QEMU/OVMF with a captured serial console:
full kernel boot log over ttyS0 through to a real `ubuntu login:` prompt.
`NVRM: No NVIDIA GPU found` printed and did not block boot, as expected
on non-GPU hardware. No wattle/GPU hardware was touched.

## Test plan

- [x] `make preflight` (TMPDIR=/var/tmp) — golangci-lint 0 issues,
      govulncheck clean, diff coverage 76.8% (threshold 60%), passed.
- [x] New unit tests: `handlers/ec2/image/drain_test.go` (3 cases) —
      drains an attached volume before snapshotting, fails CreateImage on
      an undrainable volume, skips drain for an unattached volume.
- [x] Live repro on env12 (i8nfx/rxwf4) — see evidence above.
- [x] Live build + `du -h` comparison on operator box (fqpvv) — see
      evidence above.
- [x] Live headless boot + serial console capture (569x2, GPU half) — see
      evidence above.