### PR TITLE
fix(systemd): keep in-use nbdkit alive across a viperblock restart

### DIFF
--- a/build/systemd/spinifex-viperblock.service
+++ b/build/systemd/spinifex-viperblock.service
@@ -15,10 +15,11 @@ ExecStart=/usr/local/bin/spx service viperblock start
 Restart=on-failure
 RestartSec=5
 OOMScoreAdjust=-500
-# Backstop for the in-use nbdkit children SIGTERMed with this cgroup. Their
-# plugin bounds its own shutdown drain at 20s, so 30s lets that fire first and
-# keeps SIGKILL exceptional; the 90s default let a slow backend stall the whole
-# target-stop transaction.
+# KillMode=process: nbdkit still serving a guest survives a restart here, the
+# way guest QEMU survives a daemon restart. Tearing one out mid-write corrupts
+# that guest's filesystem; idle nbdkit is reaped explicitly on shutdown.
+KillMode=process
+# Bounds this process's own WAL drain, which the plugin caps at 20s.
 TimeoutStopSec=30
 EnvironmentFile=/etc/spinifex/systemd.env
 Environment=SPINIFEX_CONFIG_PATH=/etc/spinifex/spinifex.toml

--- a/spinifex/systemd/units_invariants_test.go
+++ b/spinifex/systemd/units_invariants_test.go
@@ -228,6 +228,14 @@ func TestGracefulDrainOrdering(t *testing.T) {
 		t.Error("spinifex-daemon.service must keep KillMode=process — guests survive daemon restart (DDIL)")
 	}
 
+	// shutdownVolumes deliberately spares nbdkit that a guest is still writing
+	// through. Without KillMode=process the cgroup SIGTERMs then SIGKILLs it
+	// anyway at TimeoutStopSec, which is the corruption that skip exists to avoid.
+	viperblock := readUnit(t, dir, "spinifex-viperblock.service")
+	if !hasDirective(viperblock, "KillMode=process") {
+		t.Error("spinifex-viperblock.service must keep KillMode=process — in-use nbdkit survives a viperblock restart (DDIL)")
+	}
+
 	target := readUnit(t, dir, "spinifex.target")
 	if !strings.Contains(target, "spinifex-shutdown.service") {
 		t.Error("spinifex.target Wants= must include spinifex-shutdown.service")


### PR DESCRIPTION
Closes **mulga-jf2bb**.

## Problem

`shutdownVolumes` (`spinifex/services/viperblockd/viperblockd.go:1095-1099`) deliberately does *not* kill nbdkit that a guest is still writing through, because "killing an nbdkit a guest is still writing through corrupts that guest's filesystem". `TestShutdownVolumes_InUseNotKilled` already asserts that intent.

But `spinifex-viperblock.service` left `KillMode` at the default `control-group`, so systemd SIGTERMed those same children with the cgroup and SIGKILLed them at `TimeoutStopSec`. The code's skip achieved nothing. Two symptoms:

1. `systemctl stop spinifex-viperblock` stalls the full 30s on any node with an attached guest.
2. The SIGKILL is exactly the mid-write teardown the skip exists to prevent.

## Fix

`KillMode=process`, matching `spinifex-daemon.service`, where guest QEMU already survives a daemon restart for DDIL reattach. Idle nbdkit is still reaped explicitly by `shutdownVolumes`, so nothing leaks.

The `TimeoutStopSec=30` comment was also wrong — it described itself as a backstop for cgroup-SIGTERMed children. It now bounds this process's own WAL drain, which is what it actually does.

## Verification — env12, A/B on one host with a guest attached

| KillMode | Stop duration | nbdkit | systemd result |
|---|---|---|---|
| `control-group` (old) | **30.08s** | SIGKILLed while guest attached | `Failed with result 'timeout'` |
| `process` (fix) | sub-second | both survive | `Deactivated successfully` |

Under the old mode QEMU was left running with **zero ESTAB nbd sockets** — a live VM whose block device had vanished. Under the fix, journal shows `Unit process 117900 (nbdkit) remains running after unit stopped`, both NBD connections stay ESTAB, and restarting viperblock leaves exactly 2 nbdkit with no duplicates.

## Test

Extends `TestGracefulDrainOrdering`, which already encodes the daemon's `KillMode=process` DDIL contract. Mutation-checked: commenting out the directive fails with `spinifex-viperblock.service must keep KillMode=process`.

`make preflight` passes.