### PR TITLE
fix(gateway): log the three SigV4 paths that reject silently

### DIFF
--- a/spinifex/gateway/auth.go
+++ b/spinifex/gateway/auth.go
@@ -64,7 +64,10 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 					gw.writeSigV4Error(w, r, awserrors.ErrorSignatureDoesNotMatch)
 				default:
 					// Malformed Authorization, bad credential scope, unsupported
-					// algorithm, missing content hash: a failed auth attempt.
+					// algorithm, missing content hash: a failed auth attempt. The parse
+					// error names which, and is the only record of it.
+					slog.Warn("Auth failure: malformed signature envelope",
+						"sourceIP", clientIP, "err", err)
 					gw.RateLimiter.RecordFailure(clientIP)
 					gw.writeSigV4Error(w, r, awserrors.ErrorIncompleteSignature)
 				}

--- a/spinifex/gateway/auth.go
+++ b/spinifex/gateway/auth.go
@@ -52,7 +52,14 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 				case errors.Is(err, sigv4.ErrPayloadTooLarge):
 					gw.writeSigV4Error(w, r, awserrors.ErrorRequestEntityTooLarge)
 				case errors.Is(err, sigv4.ErrRequestTimeTooSkewed):
-					// Skew/replay: AWS returns this as SignatureDoesNotMatch.
+					// Skew/replay: AWS returns this as SignatureDoesNotMatch, which is
+					// indistinguishable on the wire from a canonicalisation mismatch.
+					// Log the timestamps so the two can be told apart after the fact.
+					slog.Warn("Auth failure: request time too skewed",
+						"sourceIP", clientIP,
+						"requestTime", signingTime(r),
+						"serverTime", time.Now().UTC().Format("20060102T150405Z"),
+						"maxSkew", sigv4.MaxClockSkew)
 					gw.RateLimiter.RecordFailure(clientIP)
 					gw.writeSigV4Error(w, r, awserrors.ErrorSignatureDoesNotMatch)
 				default:
@@ -67,6 +74,11 @@ func (gw *GatewayConfig) SigV4AuthMiddleware() func(http.Handler) http.Handler {
 			// Reject unknown services before crypto; otherwise Verify re-signs with
 			// the client-claimed service name and rubber-stamps the scope.
 			if !supportedServices[sig.Credential.Service] {
+				// Also surfaces as SignatureDoesNotMatch, so name the service that was
+				// rejected rather than leaving it to look like a signing bug.
+				slog.Warn("Auth failure: unsupported service in credential scope",
+					"accessKeyID", sig.Credential.AccessKeyID, "sourceIP", clientIP,
+					"service", sig.Credential.Service)
 				gw.writeSigV4Error(w, r, awserrors.ErrorSignatureDoesNotMatch)
 				return
 			}
@@ -180,6 +192,19 @@ func redactedCanonicalRequest(sig *sigv4.SignedRequest) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// signingTime returns the timestamp the client signed with, read straight off the
+// request. Parse rejects a skewed request before returning a SignedRequest, so the
+// raw header (or the presigned query arg) is the only copy available to log.
+func signingTime(r *http.Request) string {
+	if ts := r.Header.Get("X-Amz-Date"); ts != "" {
+		return ts
+	}
+	if ts := r.URL.Query().Get("X-Amz-Date"); ts != "" {
+		return ts
+	}
+	return r.Header.Get("Date")
 }
 
 // mismatchAction recovers the Action for a rejected query-protocol request so the log names

--- a/spinifex/gateway/auth_silentmismatch_test.go
+++ b/spinifex/gateway/auth_silentmismatch_test.go
@@ -1,0 +1,88 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// captureLogs redirects the default slog logger into a buffer for the duration
+// of a test, so an assertion can read what the middleware actually emitted.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf
+}
+
+// Both of these paths answer SignatureDoesNotMatch, which on the wire is
+// identical to a canonicalisation mismatch. Without a log there is no way to
+// tell them apart after the fact, so the log line is the contract under test.
+
+func TestSigV4Auth_SkewedRequestIsLogged(t *testing.T) {
+	handler := setupTestApp(testAccessKey, testSecretKey)
+	logs := captureLogs(t)
+
+	skewed := time.Now().UTC().Add(-30 * time.Minute)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:9999"
+	signTestRequest(t, req, nil, testAccessKey, testSecretKey, skewed)
+
+	resp := doRequest(handler, req)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	out := logs.String()
+	require.Contains(t, out, "request time too skewed")
+	// The two timestamps are the point: they are what identifies skew as the
+	// cause rather than a signing defect.
+	require.Contains(t, out, "requestTime="+skewed.Format("20060102T150405Z"))
+	require.Contains(t, out, "serverTime=")
+}
+
+func TestSigV4Auth_UnsupportedServiceIsLogged(t *testing.T) {
+	handler := setupTestApp(testAccessKey, testSecretKey)
+	logs := captureLogs(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:9999"
+
+	sum := sha256.Sum256(nil)
+	payloadHash := hex.EncodeToString(sum[:])
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	require.NoError(t, v4.NewSigner().SignHTTP(context.Background(),
+		aws.Credentials{AccessKeyID: testAccessKey, SecretAccessKey: testSecretKey},
+		req, payloadHash, "notaservice", testRegion, time.Now().UTC()))
+
+	resp := doRequest(handler, req)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	out := logs.String()
+	require.Contains(t, out, "unsupported service in credential scope")
+	require.Contains(t, out, "service=notaservice")
+}
+
+// signingTime must prefer the header, fall back to the presigned query arg, and
+// tolerate a request carrying neither rather than panicking on a nil URL query.
+func TestSigningTime_Sources(t *testing.T) {
+	hdr := httptest.NewRequest(http.MethodGet, "/", nil)
+	hdr.Header.Set("X-Amz-Date", "20260729T165540Z")
+	require.Equal(t, "20260729T165540Z", signingTime(hdr))
+
+	presigned := httptest.NewRequest(http.MethodGet, "/?X-Amz-Date=20260729T165541Z", nil)
+	require.Equal(t, "20260729T165541Z", signingTime(presigned))
+
+	none := httptest.NewRequest(http.MethodGet, "/", nil)
+	require.Empty(t, signingTime(none))
+}

--- a/spinifex/gateway/auth_silentmismatch_test.go
+++ b/spinifex/gateway/auth_silentmismatch_test.go
@@ -73,6 +73,24 @@ func TestSigV4Auth_UnsupportedServiceIsLogged(t *testing.T) {
 	require.Contains(t, out, "service=notaservice")
 }
 
+// The parse-error branch answers IncompleteSignature and was likewise silent,
+// so a malformed envelope left no record of which validation stage rejected it.
+func TestSigV4Auth_MalformedEnvelopeIsLogged(t *testing.T) {
+	handler := setupTestApp(testAccessKey, testSecretKey)
+	logs := captureLogs(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "localhost:9999"
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 Credential=nonsense, Signature=deadbeef")
+
+	resp := doRequest(handler, req)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	out := logs.String()
+	require.Contains(t, out, "malformed signature envelope")
+	require.Contains(t, out, "sourceIP=")
+}
+
 // signingTime must prefer the header, fall back to the presigned query arg, and
 // tolerate a request carrying neither rather than panicking on a nil URL query.
 func TestSigningTime_Sources(t *testing.T) {


### PR DESCRIPTION
Advances **mulga-zjy2g** (does not close it — see below).

## What the evidence actually shows

`mulga-zjy2g` has survived three sweeps of static tracing through `sigv4` on the theory that ImportKeyPair's public-key body triggers a canonicalisation or body-rewind defect. Two independent signer lineages (aws-sdk-go-v2 and v1) have now been fuzzed against the canonicalisation and both pass. This PR comes from evidence instead.

**Live A/B on env13** — three OpenTofu configs reproducing the s3-webapp provider shape exactly (explicit static creds, `s3` endpoint pointed at predastore, `s3_use_path_style`, and the real apply ordering with the S3 bucket and IAM role created before the key pair). All three applied cleanly, as did a direct `aws ec2 import-key-pair`. The request shape does not reproduce.

**The CI artefact** gives the exact failure and, critically, a gateway-minted RequestID:

```
Error: importing EC2 Key Pair (s3-webapp-demo): operation error EC2: ImportKeyPair,
https response error StatusCode: 403, RequestID: c8c83f87-9077-49c2-b73d-3dd49aa50f0f,
api error SignatureDoesNotMatch
```

`writeSigV4Error` mints that RequestID via `uuid.NewString()`, so the 403 came from this middleware. Three call sites emit `SignatureDoesNotMatch`:

| `auth.go` | Path | Logged before this PR |
|---|---|---|
| `:57` | `ErrRequestTimeTooSkewed` | **no** |
| `:70` | service not in `supportedServices` | **no** |
| `:121` | `sig.Verify` mismatch | yes (Warn) |

Elasticsearch has the failing run (`ci_run_id 30467638631`, 1.45M docs, retention covers it). awsgw shipped 141 INFO and 17 DEBUG records for it and **zero WARN/ERROR** — and DEBUG from the same service, host and run did ship, so the pipeline is not filtering by level. A `:121` rejection would have produced a WARN. It did not. The failure therefore came through one of the two silent paths, and nothing on disk can say which.

That is why the bead's own documented next step — "diff the logged canonical request against the one the SDK signed" — could never execute: it assumed the failure arrived via the one path that logs.

## Change

Both silent paths now log at Warn. The skew path records the client timestamp, the server timestamp and `MaxClockSkew`, which is what distinguishes clock drift from a signing defect. The unsupported-service path names the rejected service.

`signingTime` is needed because `Parse` rejects a skewed request before returning a `SignedRequest`, so the raw header (or presigned query arg) is the only copy of the timestamp left to log.

## Tests

Three tests in `auth_silentmismatch_test.go`, all mutation-checked — silencing either log line fails the corresponding test with `"" does not contain ...`, i.e. the empty output that is exactly the pre-fix behaviour.

`make preflight` passes.

## Why the bead stays open

Criterion 1 ("ImportKeyPair through the terraform provider is accepted") is unproven — the failure is intermittent and did not reproduce on demand. This PR makes the next occurrence diagnosable in one shot rather than another sweep of guesswork.