### PR TITLE
fix(logrotate): declare su so spinifex logs actually rotate

### DIFF
--- a/build/logrotate/spinifex
+++ b/build/logrotate/spinifex
@@ -1,4 +1,8 @@
 /var/log/spinifex/*.log {
+    # The directory is 0775 root:spinifex so each service user can write its own
+    # log. logrotate refuses to rotate inside a group-writable directory unless
+    # it is told which user to rotate as.
+    su root spinifex
     daily
     rotate 14
     compress


### PR DESCRIPTION
Closes **mulga-w2rr4**.

## Problem

`setup.sh` creates `/var/log/spinifex` as `0775 root:spinifex` so each per-service user can write its own log. logrotate refuses to rotate inside a directory writable by a non-root group unless the config declares `su`, and `build/logrotate/spinifex` did not. Every entry was skipped, so nothing under `/var/log/spinifex` has ever rotated and the logs grow without bound.

Reproduced on env13:

```
error: skipping "/var/log/spinifex/nats.log" because parent directory has insecure
permissions (It's world writable or writable by group which is not "root")
Set "su" directive in config file to tell logrotate which user/group should be used
```

with zero rotated files present.

## Fix

`su root spinifex` in the config block, which is what the error message asks for and matches the directory's actual ownership.

## Verification — env13

After deploying, `logrotate -d` is clean, and forced rotations produce:

```
-rw-r----- 1 spinifex-nats spinifex     0 nats.log
-rw-r----- 1 spinifex-nats spinifex 55335 nats.log.1
-rw-r----- 1 spinifex-nats spinifex  8806 nats.log.2.gz
```

so `copytruncate`, `delaycompress` and `compress` all behave. `logrotate.service` is not failed.

## Note on the bead's description

The bead states `logrotate.service` fails daily on every node. On env13 the unit reported `Deactivated successfully` — logrotate exits 0 despite skipping entries, so the failure is not necessarily visible in `systemctl --failed`. The skip and the unbounded log growth are real either way, and the bare-metal nodes may differ by logrotate version.

## Delivery

`make preflight` passes. Note this config is only installed by `setup.sh`, so the fix would never have reached an already-installed node — a companion change to the ansible deploy role (mulga main) now ships it on `cluster-deploy`, the same gap as `mulga-7j5pn`.