### PR TITLE
fix(spx): detect a production install from a marker a reset cannot remove

### DIFF
--- a/cmd/spinifex/cmd/admin.go
+++ b/cmd/spinifex/cmd/admin.go
@@ -1314,7 +1314,7 @@ func runAdminInit(cmd *cobra.Command, args []string) {
 	}
 
 	// Create config directory
-	if err := os.MkdirAll(configDir, 0700); err != nil {
+	if err := EnsureConfigDir(configDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating config directory: %v\n", err)
 		os.Exit(1)
 	}
@@ -2174,7 +2174,7 @@ func runAdminJoin(cmd *cobra.Command, args []string) {
 		configDir = DefaultConfigDir()
 	}
 
-	if err := os.MkdirAll(configDir, 0700); err != nil {
+	if err := EnsureConfigDir(configDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating config directory: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/spinifex/cmd/paths.go
+++ b/cmd/spinifex/cmd/paths.go
@@ -1,17 +1,22 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
 )
 
+// productionConfigDir is the config directory of a production install, and the
+// path the systemd units read their configuration from. Overridable in tests.
+var productionConfigDir = "/etc/spinifex"
+
 // DefaultConfigDir returns the default configuration directory.
-// Production: /etc/spinifex (when /etc/spinifex exists)
+// Production: /etc/spinifex
 // Development: ~/spinifex/config.
 func DefaultConfigDir() string {
 	if isProductionLayout() {
-		return "/etc/spinifex"
+		return productionConfigDir
 	}
 	return filepath.Join(realUserHomeDir(), "spinifex", "config")
 }
@@ -54,16 +59,43 @@ func DefaultConfigFile() string {
 	return filepath.Join(DefaultConfigDir(), "spinifex.toml")
 }
 
-// productionMarkerPath identifies a production install by directory presence.
-// Created by setup.sh during binary install. Overridable in tests.
-var productionMarkerPath = "/etc/spinifex"
+// productionMarkerPaths identify a production install by presence. Overridable
+// in tests. The systemd target is the durable marker: setup.sh installs it and
+// only an uninstall removes it, whereas /etc/spinifex is state that a node reset
+// legitimately clears.
+var productionMarkerPaths = []string{
+	"/etc/systemd/system/spinifex.target",
+	productionConfigDir,
+}
 
 // isProductionLayout returns true when running in a production install.
 // No root check — allows non-root users (e.g. tf-user) to run CLI commands
 // like `spx get nodes` without sudo or --config flags.
 func isProductionLayout() bool {
-	if info, err := os.Stat(productionMarkerPath); err == nil && info.IsDir() {
-		return true
+	for _, marker := range productionMarkerPaths {
+		if _, err := os.Stat(marker); err == nil {
+			return true
+		}
 	}
 	return false
+}
+
+// EnsureConfigDir prepares the config directory, and refuses to proceed when a
+// production node has lost it.
+//
+// setup.sh owns that tree: the per-service subdirectories and their ownership
+// (spinifex-nats, spinifex-gw, ...) come from there, not from init. Recreating
+// just the top level would produce a node that inits cleanly and then fails at
+// service start on a missing nats.conf, so say so now instead.
+func EnsureConfigDir(dir string) error {
+	if _, err := os.Stat(dir); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	if dir == productionConfigDir && isProductionLayout() {
+		return fmt.Errorf("%s is missing on a production install: re-run setup.sh to rebuild the config tree, then init", dir)
+	}
+	return os.MkdirAll(dir, 0750)
 }

--- a/cmd/spinifex/cmd/paths_test.go
+++ b/cmd/spinifex/cmd/paths_test.go
@@ -1,21 +1,22 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// withProductionMarker temporarily overrides the marker path used to detect a
-// production install. Tests that pass an empty string force "dev" mode by
-// pointing at a non-existent path; tests that pass t.TempDir() force
-// "production" mode by pointing at a real directory.
-func withProductionMarker(t *testing.T, path string) {
+// withProductionMarker temporarily overrides the marker paths used to detect a
+// production install. Tests that pass non-existent paths force "dev" mode; tests
+// that pass a real path such as t.TempDir() force "production" mode.
+func withProductionMarker(t *testing.T, paths ...string) {
 	t.Helper()
-	orig := productionMarkerPath
-	productionMarkerPath = path
-	t.Cleanup(func() { productionMarkerPath = orig })
+	orig := productionMarkerPaths
+	productionMarkerPaths = paths
+	t.Cleanup(func() { productionMarkerPaths = orig })
 }
 
 func TestIsProductionLayout(t *testing.T) {
@@ -26,6 +27,71 @@ func TestIsProductionLayout(t *testing.T) {
 	t.Run("present marker returns true", func(t *testing.T) {
 		withProductionMarker(t, t.TempDir())
 		assert.True(t, isProductionLayout())
+	})
+	// A node reset clears /etc/spinifex but leaves the systemd units installed.
+	// If that combination reads as "dev", init rebuilds the node under the
+	// invoking user's home while the units keep reading /etc/spinifex.
+	t.Run("surviving marker keeps production layout after a reset", func(t *testing.T) {
+		unit := filepath.Join(t.TempDir(), "spinifex.target")
+		require.NoError(t, os.WriteFile(unit, nil, 0600))
+		withProductionMarker(t, unit, filepath.Join(t.TempDir(), "etc-spinifex-removed"))
+
+		assert.True(t, isProductionLayout())
+		assert.Equal(t, "/etc/spinifex", DefaultConfigDir())
+		assert.Equal(t, "/var/lib/spinifex", DefaultDataDir())
+	})
+	t.Run("no markers at all returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		withProductionMarker(t, filepath.Join(dir, "no-unit"), filepath.Join(dir, "no-etc"))
+		assert.False(t, isProductionLayout())
+	})
+}
+
+func TestEnsureConfigDir(t *testing.T) {
+	// Outside a production install a missing config dir is ordinary: a dev tree
+	// is built on demand under the user's home.
+	t.Run("creates a missing dev directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "nested", "config")
+		require.NoError(t, EnsureConfigDir(dir))
+
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+	// A deploy may legitimately widen the mode of an existing config dir, so
+	// re-init must leave one it did not create alone.
+	t.Run("leaves an existing directory untouched", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.Chmod(dir, 0755))
+		require.NoError(t, EnsureConfigDir(dir))
+
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
+	})
+	t.Run("reports the error when the path is unusable", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(file, nil, 0600))
+		require.Error(t, EnsureConfigDir(filepath.Join(file, "config")))
+	})
+	// The regression: init used to reroute to ~/spinifex and report success,
+	// leaving the units reading a /etc/spinifex that was never rebuilt. Only
+	// setup.sh can restore the per-service subtree, so name it and stop.
+	t.Run("refuses when a production node has lost its config dir", func(t *testing.T) {
+		dir := t.TempDir()
+		unit := filepath.Join(dir, "spinifex.target")
+		require.NoError(t, os.WriteFile(unit, nil, 0600))
+		withProductionMarker(t, unit)
+
+		missing := filepath.Join(dir, "etc-spinifex-removed")
+		orig := productionConfigDir
+		productionConfigDir = missing
+		t.Cleanup(func() { productionConfigDir = orig })
+
+		err := EnsureConfigDir(missing)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "re-run setup.sh")
+		assert.NoDirExists(t, missing)
 	})
 }
 


### PR DESCRIPTION
Closes mulga-kujjo.

## Problem

`isProductionLayout()` decided the layout by stat-ing `/etc/spinifex`. A node reset legitimately removes that directory, so `spx` silently fell back to the dev layout and built the entire node — configs, keys, `nats.conf` — under the invoking user's home. Cluster formation reported full success, the systemd units kept reading `/etc/spinifex`, and every service then failed with "no such file or directory" for a cluster with 0 Ready nodes. Found on the three-node hardware run; cost a full wipe-and-reform cycle to diagnose.

## Reproduced

On env13, same host, same instant, with `/etc/spinifex` moved aside and the 19 systemd units still installed:

```
--- OLD spx (installed) ---
  --config-dir string     Configuration directory (default "/home/tf-user/spinifex/config")
  --spinifex-dir string   Spinifex base directory (default "/home/tf-user/spinifex")
--- NEW spx (fixed) ---
  --config-dir string     Configuration directory (default "/etc/spinifex")
  --spinifex-dir string   Spinifex base directory (default "/var/lib/spinifex")
```

## Changes

**Detection no longer depends on removable state.** `productionMarkerPaths` now also accepts `/etc/systemd/system/spinifex.target`. setup.sh installs it, only an uninstall removes it, and it is the very thing that hardcodes the `/etc/spinifex` paths — so detection now agrees with what actually consumes them.

**`init` and `join` refuse rather than half-build.** Both called `os.MkdirAll(configDir, 0700)`. With detection fixed that would recreate `/etc/spinifex` as `root:root` while the per-service subdirectories (`nats` owned by `spinifex-nats`, `awsgw` by `spinifex-gw`, ...) stayed absent — a node that inits cleanly and still dies at service start. Verified on env13: recreating only the top level left `/etc/spinifex/nats` missing and `predastore`/`viperblock` as `root:root`. setup.sh owns that tree, so `EnsureConfigDir` now stops with the remedy:

```
Error creating config directory: /etc/spinifex is missing on a production install: re-run setup.sh to rebuild the config tree, then init
exit=1
```

Nothing is left half-built. An existing config dir is left exactly as found — the `dev-telemetry` role widens it to `0755` and re-init is not the place to argue with that.

## Verification

- `make preflight` passes.
- New regression tests: production layout survives a reset that clears `/etc/spinifex`; `init` refuses on a production node that has lost it; an existing dir keeps its mode.
- env13 rebuilt with this binary via `make cluster-reset`: target active, 0 failed units, 12 running, `/etc/spinifex/nats` back under `spinifex-nats`, and the layout still resolves to `/etc/spinifex` with the directory moved away.

## Note

The bead records a workaround in `spinifex/scripts/node-reset.sh`. That file does not exist anywhere in the tree, so the product was carrying the defect unmitigated.