### PR TITLE
feat: close IMDS and vm_adapters trace-linking gaps

### DIFF
--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -109,11 +109,12 @@ func (a *volumeMounterAdapter) topic(action string) string {
 	return fmt.Sprintf("ebs.%s.%s", a.node, action)
 }
 
-// ebsRequestWithTrace sends an ebs.mount/ebs.unmount NATS request, opening a
-// client span and injecting it into the message headers so viperblockd's
-// consumer span (utils.StartConsumerSpan) joins this trace instead of rooting
-// a new one. VolumeMounter carries no caller context, so each call opens its
-// own trace here rather than threading one through the interface.
+// ebsRequestWithTrace sends an ebs.* NATS request, opening a client span and
+// injecting it into the message headers so viperblockd's consumer span
+// (utils.StartConsumerSpan) joins this trace instead of rooting a new one.
+//
+// VolumeMounter carries no caller context, so each call opens its own trace
+// here rather than threading one through the interface.
 func ebsRequestWithTrace(nc *nats.Conn, subject string, data []byte, timeout time.Duration) (msg *nats.Msg, err error) {
 	ctx, span := otel.Tracer(daemonTracerName).Start(context.Background(), "NATS "+subject,
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -641,7 +642,7 @@ func (a *instanceCleanerAdapter) DeleteVolumes(instance *vm.VM) error {
 				firstErr = cmp.Or(firstErr, err)
 				continue
 			}
-			deleteMsg, err := a.d.natsConn.Request("ebs.delete", ebsDeleteData, 30*time.Second)
+			deleteMsg, err := ebsRequestWithTrace(a.d.natsConn, "ebs.delete", ebsDeleteData, 30*time.Second)
 			if err != nil {
 				slog.Warn("Failed to send ebs.delete for internal volume",
 					"name", ebsRequest.Name, "id", instance.ID, "err", err)

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -17,6 +17,10 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // stateStoreAdapter satisfies vm.StateStore by delegating to JetStreamManager.
@@ -105,6 +109,34 @@ func (a *volumeMounterAdapter) topic(action string) string {
 	return fmt.Sprintf("ebs.%s.%s", a.node, action)
 }
 
+// ebsRequestWithTrace sends an ebs.mount/ebs.unmount NATS request, opening a
+// client span and injecting it into the message headers so viperblockd's
+// consumer span (utils.StartConsumerSpan) joins this trace instead of rooting
+// a new one. VolumeMounter carries no caller context, so each call opens its
+// own trace here rather than threading one through the interface.
+func ebsRequestWithTrace(nc *nats.Conn, subject string, data []byte, timeout time.Duration) (msg *nats.Msg, err error) {
+	ctx, span := otel.Tracer(daemonTracerName).Start(context.Background(), "NATS "+subject,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", subject),
+		))
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	reqMsg := nats.NewMsg(subject)
+	reqMsg.Data = data
+	utils.InjectTraceContext(ctx, reqMsg.Header)
+
+	msg, err = nc.RequestMsg(reqMsg, timeout)
+	return msg, err
+}
+
 func (a *volumeMounterAdapter) Mount(instance *vm.VM) error {
 	instance.EBSRequests.Mu.Lock()
 	defer instance.EBSRequests.Mu.Unlock()
@@ -133,7 +165,7 @@ func (a *volumeMounterAdapter) Mount(instance *vm.VM) error {
 			return rollback(err)
 		}
 
-		reply, err := a.nc.Request(a.topic("mount"), ebsMountRequest, 30*time.Second)
+		reply, err := ebsRequestWithTrace(a.nc, a.topic("mount"), ebsMountRequest, 30*time.Second)
 
 		slog.Info("Mounting volume", "Vol", v.Name, "NBDURI", v.NBDURI)
 
@@ -178,7 +210,7 @@ func (a *volumeMounterAdapter) Unmount(instance *vm.VM) error {
 		// local WAL would find no checkpoint (bad superblock). On terminate the
 		// volume is deleted regardless; on stop it stays attached/retryable.
 		sealed := true
-		msg, err := a.nc.Request(a.topic("unmount"), ebsUnMountRequest, unmountSealTimeout)
+		msg, err := ebsRequestWithTrace(a.nc, a.topic("unmount"), ebsUnMountRequest, unmountSealTimeout)
 		if err != nil {
 			slog.Error("Failed to unmount volume",
 				"name", ebsRequest.Name, "instance", instance.ID, "err", err)
@@ -215,7 +247,7 @@ func (a *volumeMounterAdapter) MountOne(req *types.EBSRequest) error {
 		return fmt.Errorf("marshal ebs.mount request: %w", err)
 	}
 
-	reply, err := a.nc.Request(a.topic("mount"), payload, 30*time.Second)
+	reply, err := ebsRequestWithTrace(a.nc, a.topic("mount"), payload, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("ebs.mount NATS request: %w", err)
 	}
@@ -253,7 +285,7 @@ func (a *volumeMounterAdapter) unmountOne(req types.EBSRequest) error {
 	if err != nil {
 		return fmt.Errorf("marshal unmount request: %w", err)
 	}
-	msg, err := a.nc.Request(a.topic("unmount"), payload, unmountSealTimeout)
+	msg, err := ebsRequestWithTrace(a.nc, a.topic("unmount"), payload, unmountSealTimeout)
 	if err != nil {
 		return fmt.Errorf("ebs.unmount NATS request: %w", err)
 	}

--- a/spinifex/daemon/vm_adapters_trace_test.go
+++ b/spinifex/daemon/vm_adapters_trace_test.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/types"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// withRecordedSpans installs a fresh SpanRecorder as the global tracer
+// provider for the duration of the test and restores the previous provider
+// on cleanup. It also installs the W3C TraceContext propagator that
+// otelsetup.Init installs in production — the global default is a no-op that
+// injects nothing, which would silently defeat InjectTraceContext here.
+func withRecordedSpans(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	prevProvider := otel.GetTracerProvider()
+	prevPropagator := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{}))
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prevProvider)
+		otel.SetTextMapPropagator(prevPropagator)
+	})
+	return sr
+}
+
+// TestEbsRequestWithTrace_HeaderCarriesTraceparent pins the minimum bar: the
+// outbound ebs.mount NATS message carries a non-empty traceparent header, so
+// a consumer that calls utils.ExtractTraceContext has something to join.
+func TestEbsRequestWithTrace_HeaderCarriesTraceparent(t *testing.T) {
+	withRecordedSpans(t)
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	headerCh := make(chan nats.Header, 1)
+	sub, err := daemon.natsConn.Subscribe("ebs.node-1.mount", func(msg *nats.Msg) {
+		headerCh <- msg.Header
+		resp := types.EBSMountResponse{URI: "nbd://traced-vol"}
+		data, marshalErr := json.Marshal(resp)
+		require.NoError(t, marshalErr)
+		require.NoError(t, msg.Respond(data))
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	adapter := newVolumeMounterAdapter(daemon.natsConn, daemon.node, nil)
+	req := &types.EBSRequest{Name: "vol-traced", DeviceName: "/dev/sdf"}
+	require.NoError(t, adapter.MountOne(req))
+
+	hdr := <-headerCh
+	assert.NotEmpty(t, hdr.Get("traceparent"), "outbound ebs.mount request must carry a traceparent header")
+}
+
+// TestEbsRequestWithTrace_ProducerConsumerLinked proves the actual parent/child
+// linkage: the consumer span opened via utils.StartConsumerSpan (the same
+// helper viperblockd's ebs.mount/ebs.unmount handlers use) shares the producer
+// span's trace ID and names it as its parent, rather than rooting a new trace
+// — the exact gap this fix closes for the 81 mount + 81 unmount rooted spans
+// the bead's CI trace-analysis run found.
+func TestEbsRequestWithTrace_ProducerConsumerLinked(t *testing.T) {
+	sr := withRecordedSpans(t)
+	daemon := createTestDaemon(t, sharedNATSURL)
+
+	sub, err := daemon.natsConn.Subscribe("ebs.node-1.unmount", func(msg *nats.Msg) {
+		// Mirrors viperblockd's ebs.unmount handler: open a consumer span
+		// joining whatever trace context the producer injected.
+		_, span := utils.StartConsumerSpan(msg)
+		defer span.End()
+
+		resp := types.EBSUnMountResponse{}
+		data, marshalErr := json.Marshal(resp)
+		require.NoError(t, marshalErr)
+		require.NoError(t, msg.Respond(data))
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	adapter := newVolumeMounterAdapter(daemon.natsConn, daemon.node, nil)
+	require.NoError(t, adapter.UnmountOne(types.EBSRequest{Name: "vol-linked"}))
+
+	spans := sr.Ended()
+	require.Len(t, spans, 2, "expected one producer span and one consumer span")
+
+	// Both spans share the "NATS ebs.node-1.unmount" name; distinguish by kind
+	// (producer = client, consumer = server, as set by ebsRequestWithTrace and
+	// utils.StartConsumerSpan respectively).
+	var producer, consumer sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		switch s.SpanKind() {
+		case trace.SpanKindClient:
+			producer = s
+		case trace.SpanKindConsumer:
+			consumer = s
+		}
+	}
+	require.NotNil(t, producer, "producer span must be recorded")
+	require.NotNil(t, consumer, "consumer span must be recorded")
+
+	assert.Equal(t, producer.SpanContext().TraceID(), consumer.SpanContext().TraceID(),
+		"consumer span must join the producer's trace, not root a new one")
+	assert.Equal(t, producer.SpanContext().SpanID(), consumer.Parent().SpanID(),
+		"consumer span's parent must be the producer span")
+}

--- a/spinifex/handlers/imds/service.go
+++ b/spinifex/handlers/imds/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/iam"
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
+	"github.com/mulgadc/spinifex/spinifex/otelsetup"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -159,12 +160,17 @@ func NewIMDSServiceImpl(ctx context.Context, natsConn *nats.Conn, sts stsAssumer
 	return svc, nil
 }
 
-// httpHandler builds the shared mux for every per-tap responder.
+// httpHandler builds the shared mux for every per-tap responder. Tracing wraps
+// outermost (mirrors daemon.go/gateway.go/spinifexui.go: HTTPMiddleware
+// outside, security/routing logic inside) so a rejectForwarded 403 is still
+// captured as a root span for the fan-out it prevented, but the span itself
+// is passive instrumentation — it cannot alter or bypass rejectForwarded's
+// decision, which still runs first inside the traced handler chain.
 func (s *IMDSServiceImpl) httpHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pathToken, s.handleToken)
 	mux.HandleFunc("/", s.handleMetadata)
-	return rejectForwarded(normalizeVersion(mux))
+	return otelsetup.HTTPMiddleware("vpcd")(rejectForwarded(normalizeVersion(mux)))
 }
 
 // Run starts the per-tap reconcile loop and the token-sweep ticker, then blocks

--- a/spinifex/handlers/imds/trace_test.go
+++ b/spinifex/handlers/imds/trace_test.go
@@ -1,0 +1,73 @@
+package handlers_imds
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// withRecordedSpans installs a fresh SpanRecorder as the global tracer
+// provider for the duration of the test and restores the previous provider
+// on cleanup, mirroring gateway/trace_test.go's pattern.
+func withRecordedSpans(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr)))
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+// TestHTTPHandler_ProducesSpan pins the httpHandler wrap added for
+// otelsetup.HTTPMiddleware: a normal guest request through the IMDS mux opens
+// one root server span, so the DescribeInstances/Attribute NATS fan-out it
+// triggers has something to parent to instead of rooting its own trace.
+func TestHTTPHandler_ProducesSpan(t *testing.T) {
+	sr := withRecordedSpans(t)
+
+	svc, _ := newTestService(&fakeResolver{eni: testENI()}, &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	rec := get(t, h, prefixMetaData+"instance-id", "")
+	// Unauthorized (no token) is expected here; the span must exist regardless
+	// of the eventual handler outcome.
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1, "expected exactly one server span for the request")
+	assert.Equal(t, "GET "+prefixMetaData+"instance-id", spans[0].Name())
+}
+
+// TestHTTPHandler_RejectedForwardedStillTraced is the load-bearing assertion
+// for the middleware-ordering call: otelsetup.HTTPMiddleware wraps OUTSIDE
+// rejectForwarded, so an X-Forwarded-For request rejected by the SSRF guard
+// still produces a span (the 431+431 rooted fan-out gap the bead reports
+// starts on requests exactly like this) — but the rejection itself is
+// unaffected by tracing being present. A span cannot let a rejected request
+// through; it only observes it.
+func TestHTTPHandler_RejectedForwardedStillTraced(t *testing.T) {
+	sr := withRecordedSpans(t)
+
+	svc, _ := newTestService(&fakeResolver{eni: testENI()}, &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+MetaDataServerIP+prefixMetaData+"instance-id", nil)
+	req.RemoteAddr = testIP + ":50000"
+	req.Header.Set(hdrForwardedFor, "203.0.113.99")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	// The security control's outcome must be unchanged by the middleware wrap.
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Empty(t, rr.Body.String())
+
+	spans := sr.Ended()
+	require.Len(t, spans, 1, "rejected request must still be traced")
+	assert.Equal(t, "GET "+prefixMetaData+"instance-id", spans[0].Name())
+}


### PR DESCRIPTION
## Beads

- **mulga-kcoy1** — trace-linking gaps. Scope shrank to 2 of the bead's 3 sub-issues: the DescribeInstances consumer span was already fixed by `3e0aab17` (#561), which routes `ec2.DescribeInstances` through `handleNATSRequest[I,O]` and so always calls `utils.StartConsumerSpan`. The raw handler the bead cites no longer exists.

## IMDS middleware

`handlers/imds/service.go` now wraps the handler chain:

```go
return otelsetup.HTTPMiddleware("vpcd")(rejectForwarded(normalizeVersion(mux)))
```

Tracing sits **outermost**, `rejectForwarded` stays inside — matching `gateway.go` (tracing outside `SigV4AuthMiddleware`) and `spinifexui.go`. `HTTPMiddleware` is passive: it opens a span and calls `next.ServeHTTP`, so it cannot alter or short-circuit the guard. A rejected request still gets a root span, and there is no path by which the span could bypass the 403.

`TestHTTPHandler_RejectedForwardedStillTraced` pins both halves of that: an `X-Forwarded-For` request still returns 403 **and** still produces exactly one span.

## vm_adapters NATS requests

New `ebsRequestWithTrace` helper opens a client span and injects it via `utils.InjectTraceContext` before `nc.RequestMsg`. Applied to all five `ebs.*` call sites — `Mount`, `Unmount`, `MountOne`, `unmountOne`, and `instanceCleanerAdapter.DeleteVolumes`'s `ebs.delete`. The last one was outside the bead's named lines but is the identical defect in the same file, so it is fixed here rather than left as a follow-up.

`VolumeMounter` carries no caller `context.Context`, and widening the interface would touch `vm/volume_mounter.go`, `vm/lifecycle.go` and several test fakes — out of scope. Each call therefore opens its own trace. That still closes the reported gap, whose acceptance criterion is "no rooted viperblockd consumer spans": viperblockd's handlers already call `utils.StartConsumerSpan`, so once the header carries a valid traceparent the consumer span becomes a child instead of rooting a new trace.

`TestEbsRequestWithTrace_ProducerConsumerLinked` asserts real linkage, not just header presence — it subscribes using the exact `StartConsumerSpan` pattern viperblockd uses and checks the consumer span's trace ID matches the producer's and its parent span ID equals the producer's span ID.

## Verification

`make preflight` green.

Worth recording: the tests needed `otel.SetTextMapPropagator(...)` installed explicitly, because the global default propagator is a no-op — without it the header stays empty even when the production code is correct. `otelsetup.Init` sets this at process startup in production, so this affects the harness only.