### PR TITLE
fix: stop viper AutomaticEnv from shadowing predastore env vars

### DIFF
--- a/cmd/spinifex/cmd/predastore_bind_test.go
+++ b/cmd/spinifex/cmd/predastore_bind_test.go
@@ -138,23 +138,15 @@ func TestDerivePredastoreBind_MissingHostErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestPredastoreConfigPathNotShadowedByClusterConfigPathEnv is the
-// regression test for the E2E bootstrap failure caused by viper's
-// AutomaticEnv resolving before explicit BindEnv: SPINIFEX_CONFIG_PATH
-// (the cluster config, bound to the unrelated "config" key) has the same
-// AutomaticEnv-derived name as the bare "config-path" key used to have
-// ("SPINIFEX_" + upper(key), "-"->"_"), so setting SPINIFEX_CONFIG_PATH
-// alongside SPINIFEX_PREDASTORE_CONFIG_PATH made predastore load the
-// cluster config as its own S3 config. This must resolve to the predastore
-// path regardless of what else is set.
+// A bare "config-path" key derives the same AutomaticEnv name as the
+// unrelated cluster-config SPINIFEX_CONFIG_PATH, which made predastore load
+// the cluster config as its own S3 config.
 func TestPredastoreConfigPathNotShadowedByClusterConfigPathEnv(t *testing.T) {
 	t.Cleanup(func() { viper.Reset() })
 	viper.Reset()
 
-	// Mirrors service.go's init(): AutomaticEnv setup plus the real
-	// production binding under test, re-applied against the freshly-Reset
-	// instance (pflags survive Reset since they live on predastoreCmd, a
-	// package-level singleton already registered before any test runs).
+	// Mirrors service.go's init() against the freshly-Reset instance. pflags
+	// survive Reset: they live on predastoreCmd, a package-level singleton.
 	viper.SetEnvPrefix("SPINIFEX")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()

--- a/cmd/spinifex/cmd/predastore_bind_test.go
+++ b/cmd/spinifex/cmd/predastore_bind_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mulgadc/spinifex/spinifex/config"
@@ -135,4 +136,34 @@ func TestDerivePredastoreBind_MissingHostErrors(t *testing.T) {
 
 	_, err := derivePredastoreBind(clusterConfig)
 	require.Error(t, err)
+}
+
+// TestPredastoreConfigPathNotShadowedByClusterConfigPathEnv is the
+// regression test for the E2E bootstrap failure caused by viper's
+// AutomaticEnv resolving before explicit BindEnv: SPINIFEX_CONFIG_PATH
+// (the cluster config, bound to the unrelated "config" key) has the same
+// AutomaticEnv-derived name as the bare "config-path" key used to have
+// ("SPINIFEX_" + upper(key), "-"->"_"), so setting SPINIFEX_CONFIG_PATH
+// alongside SPINIFEX_PREDASTORE_CONFIG_PATH made predastore load the
+// cluster config as its own S3 config. This must resolve to the predastore
+// path regardless of what else is set.
+func TestPredastoreConfigPathNotShadowedByClusterConfigPathEnv(t *testing.T) {
+	t.Cleanup(func() { viper.Reset() })
+	viper.Reset()
+
+	// Mirrors service.go's init(): AutomaticEnv setup plus the real
+	// production binding under test, re-applied against the freshly-Reset
+	// instance (pflags survive Reset since they live on predastoreCmd, a
+	// package-level singleton already registered before any test runs).
+	viper.SetEnvPrefix("SPINIFEX")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+	bindPredastoreNamespacedEnv()
+
+	t.Setenv("SPINIFEX_CONFIG_PATH", "/etc/spinifex/spinifex.toml")
+	t.Setenv("SPINIFEX_PREDASTORE_CONFIG_PATH", "/etc/spinifex/predastore/predastore.toml")
+
+	got := viper.GetString("predastore-config-path")
+	assert.Equal(t, "/etc/spinifex/predastore/predastore.toml", got,
+		"predastore-config-path must resolve to the predastore config even when SPINIFEX_CONFIG_PATH is also set")
 }

--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -141,8 +141,8 @@ var predastoreStartCmd = &cobra.Command{
 
 		// Get the port from the flags
 		port := viper.GetInt("port")
-		host := viper.GetString("host")
-		basePath := viper.GetString("base-path")
+		host := viper.GetString("predastore-host")
+		basePath := viper.GetString("predastore-base-path")
 		debug := viper.GetBool("debug")
 		nodeID := viper.GetInt("node-id")
 
@@ -160,7 +160,7 @@ var predastoreStartCmd = &cobra.Command{
 				fmt.Println("Error deriving predastore bind config:", err)
 				return
 			}
-			if !viper.IsSet("host") {
+			if !viper.IsSet("predastore-host") {
 				host = bind.Host
 			}
 			if !viper.IsSet("port") {
@@ -177,7 +177,7 @@ var predastoreStartCmd = &cobra.Command{
 			return
 		}
 
-		configPath := viper.GetString("config-path")
+		configPath := viper.GetString("predastore-config-path")
 
 		if configPath == "" {
 			fmt.Println("Config path is not set")
@@ -1157,6 +1157,31 @@ var qmpCollectorStatusCmd = &cobra.Command{
 	},
 }
 
+// registerPredastoreNamespacedFlags defines predastore's host, base-path and
+// config-path flags and binds them to viper. It must only run once (from
+// init()); pflag panics on a redefined flag.
+func registerPredastoreNamespacedFlags() {
+	predastoreCmd.PersistentFlags().String("host", "0.0.0.0", "Predastore (S3) host")
+	predastoreCmd.PersistentFlags().String("base-path", "", "Predastore (S3) base path")
+	predastoreCmd.PersistentFlags().String("config-path", "", "Predastore (S3) config path")
+	bindPredastoreNamespacedEnv()
+}
+
+// bindPredastoreNamespacedEnv uses "predastore-"-prefixed viper keys so
+// AutomaticEnv's derived env var always matches the explicit BindEnv target
+// below; a bare key would let AutomaticEnv resolve an unrelated SPINIFEX_HOST
+// / SPINIFEX_BASE_PATH / SPINIFEX_CONFIG_PATH first (viper checks it before BindEnv).
+func bindPredastoreNamespacedEnv() {
+	viper.BindEnv("predastore-host", "SPINIFEX_PREDASTORE_HOST")
+	viper.BindPFlag("predastore-host", predastoreCmd.PersistentFlags().Lookup("host"))
+
+	viper.BindEnv("predastore-base-path", "SPINIFEX_PREDASTORE_BASE_PATH")
+	viper.BindPFlag("predastore-base-path", predastoreCmd.PersistentFlags().Lookup("base-path"))
+
+	viper.BindEnv("predastore-config-path", "SPINIFEX_PREDASTORE_CONFIG_PATH")
+	viper.BindPFlag("predastore-config-path", predastoreCmd.PersistentFlags().Lookup("config-path"))
+}
+
 func init() {
 	viper.SetEnvPrefix("SPINIFEX") // Prefix for environment variables
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
@@ -1172,20 +1197,9 @@ func init() {
 	viper.BindEnv("port", "SPINIFEX_PREDASTORE_PORT")
 	viper.BindPFlag("port", predastoreCmd.PersistentFlags().Lookup("port"))
 
-	// Predastore Host
-	predastoreCmd.PersistentFlags().String("host", "0.0.0.0", "Predastore (S3) host")
-	viper.BindEnv("host", "SPINIFEX_PREDASTORE_HOST")
-	viper.BindPFlag("host", predastoreCmd.PersistentFlags().Lookup("host"))
-
-	// Base path
-	predastoreCmd.PersistentFlags().String("base-path", "", "Predastore (S3) base path")
-	viper.BindEnv("base-path", "SPINIFEX_PREDASTORE_BASE_PATH")
-	viper.BindPFlag("base-path", predastoreCmd.PersistentFlags().Lookup("base-path"))
-
-	// Predastore Config Path
-	predastoreCmd.PersistentFlags().String("config-path", "", "Predastore (S3) config path")
-	viper.BindEnv("config-path", "SPINIFEX_PREDASTORE_CONFIG_PATH")
-	viper.BindPFlag("config-path", predastoreCmd.PersistentFlags().Lookup("config-path"))
+	// Predastore host, base-path, config-path (namespaced viper keys —
+	// see registerPredastoreNamespacedFlags doc comment)
+	registerPredastoreNamespacedFlags()
 
 	// Predastore Debug
 	predastoreCmd.PersistentFlags().Bool("debug", false, "Predastore (S3) debug")

--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -1167,10 +1167,9 @@ func registerPredastoreNamespacedFlags() {
 	bindPredastoreNamespacedEnv()
 }
 
-// bindPredastoreNamespacedEnv uses "predastore-"-prefixed viper keys so
-// AutomaticEnv's derived env var always matches the explicit BindEnv target
-// below; a bare key would let AutomaticEnv resolve an unrelated SPINIFEX_HOST
-// / SPINIFEX_BASE_PATH / SPINIFEX_CONFIG_PATH first (viper checks it before BindEnv).
+// bindPredastoreNamespacedEnv uses "predastore-"-prefixed viper keys so each
+// key's AutomaticEnv-derived name matches its explicit BindEnv target. Viper
+// checks AutomaticEnv first, so a bare key resolves SPINIFEX_HOST instead.
 func bindPredastoreNamespacedEnv() {
 	viper.BindEnv("predastore-host", "SPINIFEX_PREDASTORE_HOST")
 	viper.BindPFlag("predastore-host", predastoreCmd.PersistentFlags().Lookup("host"))


### PR DESCRIPTION
## Summary

Fixes mulga-t8kly (P0): dev E2E dies at bootstrap `[11/13] Importing SSH key` because predastore parses the cluster config (spinifex.toml) as its own S3 config, resulting in `InvalidAccessKeyId` for every signed request.

Root cause: `cmd/spinifex/cmd/service.go` enables viper `AutomaticEnv` with prefix `SPINIFEX` and a `-`->`_` replacer. Viper resolves `AutomaticEnv` **before** explicit `BindEnv`. The bare viper keys `config-path`, `host` and `base-path` used by the predastore command auto-derive to `SPINIFEX_CONFIG_PATH`, `SPINIFEX_HOST` and `SPINIFEX_BASE_PATH` respectively - names that happen to be used elsewhere for unrelated purposes (the global cluster config path, and root's global `--host` override). PR #656 added `Environment=SPINIFEX_CONFIG_PATH=/etc/spinifex/spinifex.toml` to the systemd unit (so `derivePredastoreBind` could find the cluster config), which meant predastore's own `config-path` key silently picked up the cluster config path instead of falling through to `SPINIFEX_PREDASTORE_CONFIG_PATH`.

## Fix

Renamed predastore's `config-path`, `host` and `base-path` viper keys to `predastore-config-path`, `predastore-host` and `predastore-base-path`. Each new key's AutomaticEnv-derived name (`SPINIFEX_` + upper(key), `-`->`_`) is now byte-identical to its explicit `BindEnv` target, so AutomaticEnv and BindEnv always agree - no shadow is possible regardless of what else is set in the environment. This does not rely on any variable being merely unset.

CLI flag names (`--host`, `--base-path`, `--config-path`) and env var names (`SPINIFEX_PREDASTORE_HOST`, `SPINIFEX_PREDASTORE_BASE_PATH`, `SPINIFEX_PREDASTORE_CONFIG_PATH`) are unchanged, so the systemd unit and `docs/COMMANDS.md` need no updates. Only the internal viper key names changed.

The flag-registration and viper-binding logic for these three keys was split into `registerPredastoreNamespacedFlags`/`bindPredastoreNamespacedEnv` so the regression test can re-run the real binding logic against a freshly-`Reset` viper instance.

I did not rename the predastore `config` key used by `derivePredastoreBind` (still `viper.GetString("config")`, still fed by `SPINIFEX_CONFIG_PATH`) - it wasn't part of the actual shadow (its own AutomaticEnv-derived name is `SPINIFEX_CONFIG`, which nothing sets) and leaving it alone kept the change minimal.

### host/base-path hazard - closed for predastore, not touched for nats/awsgw

The bead also flagged predastore's `host`/`base-path` keys as sharing the same hazard pattern (`SPINIFEX_HOST` is already globally bound in `root.go`). That's fixed here too, by the same rename. While investigating I found `host`, `port`, `debug` and `tls-cert` are *also* bare, non-namespaced viper keys shared across `predastoreCmd`, `natsCmd` and `awsgwCmd` - since `viper.BindPFlag`/`BindEnv` for a given key are last-registration-wins in some cases (pflag) and ordered-fallback in others (env), this is a latent multi-command collision independent of AutomaticEnv. It isn't mentioned in the bead and isn't currently causing E2E failures, so I left `port`/`debug`/`tls-cert`/`tls-key`/`node-id`/`encryption-key-file` untouched to keep this hotfix minimal - happy to file a follow-up bead if wanted.

## Test

Added `TestPredastoreConfigPathNotShadowedByClusterConfigPathEnv` to `cmd/spinifex/cmd/predastore_bind_test.go`: sets both `SPINIFEX_CONFIG_PATH` and `SPINIFEX_PREDASTORE_CONFIG_PATH` and asserts `predastore-config-path` resolves to the predastore file. Verified (then discarded) that the equivalent assertion against the pre-fix bare `config-path` key fails with `actual: /etc/spinifex/spinifex.toml` - proving the repro - before confirming the fixed key passes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/spinifex/cmd/...` (full package, including new + existing predastore_bind tests)
- [x] `make preflight` (manifest-check, manifest-lint, golangci-lint, govulncheck, test-cover, test-harness) - all green
- [ ] dev E2E green (this repo clones spinifex at branch `dev`, so merging this should make the next E2E run pass)