### PR TITLE
feat: AZ-aware EKS control-plane spread and ClientRequestToken idempotency

### DIFF
--- a/spinifex/handlers/eks/clienttoken.go
+++ b/spinifex/handlers/eks/clienttoken.go
@@ -19,10 +19,9 @@ const (
 	// ClientRequestToken idempotency records.
 	kvBucketClusterTokens = "spinifex-eks-clustertokens" //nolint:gosec // G101 false positive: KV bucket name, not a credential
 
-	// clusterTokenTTL only needs to outlast SDK retry windows around the fast
-	// (synchronous) phase of CreateCluster, not the whole async cluster launch:
-	// a duplicate replays the CREATING/ACTIVE/FAILED meta by name, which the
-	// cluster's own KV record — not this one — keeps current.
+	// clusterTokenTTL only needs to outlast SDK retry windows around the
+	// synchronous phase of CreateCluster, not the async launch: a duplicate
+	// replays the meta by name, kept current by the cluster's own KV record.
 	clusterTokenTTL = 15 * time.Minute
 
 	clusterTokenStatusInFlight = "in-flight"
@@ -52,18 +51,16 @@ type clusterTokenRecord struct {
 	ClusterName string    `json:"clusterName,omitempty"`
 }
 
-// ClusterTokenStore implements CreateCluster ClientRequestToken idempotency over
-// a TTL KV bucket, mirroring the EC2 RunInstances ClientToken pattern (see
-// gateway/ec2/instance/clienttoken.go): the first caller owns the create;
-// duplicates replay (done) or poll (in-flight).
+// ClusterTokenStore implements CreateCluster ClientRequestToken idempotency
+// over a TTL KV bucket, mirroring the EC2 RunInstances ClientToken pattern:
+// the first caller owns the create, duplicates replay or poll.
 type ClusterTokenStore struct {
 	kv jetstream.KeyValue
 }
 
 // getClusterTokenStore lazily initialises s's cluster-token store via sync.Once,
-// scoped to the service instance (not the process) so each EKSServiceImpl binds
-// its own NATSConn — tests constructing independent instances never bleed a
-// stale connection into one another.
+// scoped to the service instance rather than the process, so each EKSServiceImpl
+// binds its own NATSConn instead of bleeding a stale one between instances.
 func (s *EKSServiceImpl) getClusterTokenStore(ctx context.Context) (*ClusterTokenStore, error) {
 	s.clusterTokenOnce.Do(func() {
 		js, err := jetstream.New(s.deps.NATSConn)
@@ -71,10 +68,9 @@ func (s *EKSServiceImpl) getClusterTokenStore(ctx context.Context) (*ClusterToke
 			s.clusterTokenErr = fmt.Errorf("clustertoken jetstream: %w", err)
 			return
 		}
-		// The bind happens once per service instance, so it must not inherit the
-		// first caller's cancellation: a client that disconnects mid-open would
-		// poison the store for every later create. Deadline-free, so the open
-		// falls back to the JetStream API's own timeout.
+		// The bind happens once per instance, so it must not inherit the first
+		// caller's cancellation: a disconnect mid-open would poison the store for
+		// every later create. Deadline-free, so JetStream's own timeout applies.
 		s.clusterTokenStore, s.clusterTokenErr = newClusterTokenStore(context.WithoutCancel(ctx), js)
 	})
 	return s.clusterTokenStore, s.clusterTokenErr

--- a/spinifex/handlers/eks/clienttoken.go
+++ b/spinifex/handlers/eks/clienttoken.go
@@ -1,0 +1,192 @@
+package handlers_eks
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	// kvBucketClusterTokens is the JetStream KV bucket for CreateCluster
+	// ClientRequestToken idempotency records.
+	kvBucketClusterTokens = "spinifex-eks-clustertokens" //nolint:gosec // G101 false positive: KV bucket name, not a credential
+
+	// clusterTokenTTL only needs to outlast SDK retry windows around the fast
+	// (synchronous) phase of CreateCluster, not the whole async cluster launch:
+	// a duplicate replays the CREATING/ACTIVE/FAILED meta by name, which the
+	// cluster's own KV record — not this one — keeps current.
+	clusterTokenTTL = 15 * time.Minute
+
+	clusterTokenStatusInFlight = "in-flight"
+	clusterTokenStatusDone     = "done"
+)
+
+// clusterTokenWaitTimeout caps how long a duplicate caller polls an in-flight
+// winner. clusterTokenPollStep is the inter-poll sleep. Vars so tests can shrink them.
+var (
+	clusterTokenWaitTimeout = 30 * time.Second
+	clusterTokenPollStep    = 250 * time.Millisecond
+)
+
+// errClusterTokenParamMismatch signals the same ClientRequestToken was reused
+// with different CreateClusterInput parameters (AWS IdempotentParameterMismatch).
+var errClusterTokenParamMismatch = errors.New("clienttoken: idempotent parameter mismatch")
+
+// errClusterTokenWaitTimeout signals a duplicate caller polled an in-flight
+// winner past clusterTokenWaitTimeout without the winner finishing.
+var errClusterTokenWaitTimeout = errors.New("clienttoken: timed out waiting for in-flight create")
+
+// clusterTokenRecord is the per-token idempotency record stored in the KV bucket.
+type clusterTokenRecord struct {
+	Status      string    `json:"status"`
+	ParamHash   string    `json:"paramHash"`
+	StartedAt   time.Time `json:"startedAt"`
+	ClusterName string    `json:"clusterName,omitempty"`
+}
+
+// ClusterTokenStore implements CreateCluster ClientRequestToken idempotency over
+// a TTL KV bucket, mirroring the EC2 RunInstances ClientToken pattern (see
+// gateway/ec2/instance/clienttoken.go): the first caller owns the create;
+// duplicates replay (done) or poll (in-flight).
+type ClusterTokenStore struct {
+	kv jetstream.KeyValue
+}
+
+// getClusterTokenStore lazily initialises s's cluster-token store via sync.Once,
+// scoped to the service instance (not the process) so each EKSServiceImpl binds
+// its own NATSConn — tests constructing independent instances never bleed a
+// stale connection into one another.
+func (s *EKSServiceImpl) getClusterTokenStore(ctx context.Context) (*ClusterTokenStore, error) {
+	s.clusterTokenOnce.Do(func() {
+		js, err := jetstream.New(s.deps.NATSConn)
+		if err != nil {
+			s.clusterTokenErr = fmt.Errorf("clustertoken jetstream: %w", err)
+			return
+		}
+		// The bind happens once per service instance, so it must not inherit the
+		// first caller's cancellation: a client that disconnects mid-open would
+		// poison the store for every later create. Deadline-free, so the open
+		// falls back to the JetStream API's own timeout.
+		s.clusterTokenStore, s.clusterTokenErr = newClusterTokenStore(context.WithoutCancel(ctx), js)
+	})
+	return s.clusterTokenStore, s.clusterTokenErr
+}
+
+func newClusterTokenStore(ctx context.Context, js jetstream.JetStream) (*ClusterTokenStore, error) {
+	kv, err := js.KeyValue(ctx, kvBucketClusterTokens)
+	if errors.Is(err, jetstream.ErrBucketNotFound) {
+		kv, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+			Bucket:  kvBucketClusterTokens,
+			History: 1,
+			TTL:     clusterTokenTTL,
+		})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open cluster-token bucket: %w", err)
+	}
+	return &ClusterTokenStore{kv: kv}, nil
+}
+
+func clusterTokenKey(accountID, token string) string {
+	return accountID + "." + token
+}
+
+// clusterTokenParamHash hashes the request excluding ClientRequestToken, so
+// identical params always produce the same hash. Must run before any input mutation.
+func clusterTokenParamHash(input *eks.CreateClusterInput) string {
+	clone := *input
+	clone.ClientRequestToken = nil
+	b, err := json.Marshal(&clone)
+	if err != nil {
+		// Fallback: idempotency degrades to name-only.
+		b = []byte(clusterTokenKey("", ""))
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// Claim attempts to own the create for this token.
+// Returns ("", true, nil) when the caller owns the create (must Finalize or Abort),
+// (clusterName, false, nil) to replay a completed create, or an error on mismatch/timeout.
+func (c *ClusterTokenStore) Claim(ctx context.Context, accountID, token, paramHash string) (string, bool, error) {
+	key := clusterTokenKey(accountID, token)
+	inflight, err := json.Marshal(clusterTokenRecord{
+		Status:    clusterTokenStatusInFlight,
+		ParamHash: paramHash,
+		StartedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("clustertoken marshal: %w", err)
+	}
+	if _, cerr := c.kv.Create(ctx, key, inflight); cerr == nil {
+		return "", true, nil
+	} else if !errors.Is(cerr, jetstream.ErrKeyExists) {
+		return "", false, fmt.Errorf("clustertoken create %s: %w", key, cerr)
+	}
+
+	deadline := time.Now().Add(clusterTokenWaitTimeout)
+	for {
+		entry, gerr := c.kv.Get(ctx, key)
+		if gerr != nil {
+			if errors.Is(gerr, jetstream.ErrKeyNotFound) {
+				// Owner aborted or record aged out: race for ownership.
+				if _, rcerr := c.kv.Create(ctx, key, inflight); rcerr == nil {
+					return "", true, nil
+				} else if !errors.Is(rcerr, jetstream.ErrKeyExists) {
+					return "", false, fmt.Errorf("clustertoken recreate %s: %w", key, rcerr)
+				}
+				continue
+			}
+			return "", false, fmt.Errorf("clustertoken get %s: %w", key, gerr)
+		}
+		var rec clusterTokenRecord
+		if uerr := json.Unmarshal(entry.Value(), &rec); uerr != nil {
+			return "", false, fmt.Errorf("clustertoken unmarshal %s: %w", key, uerr)
+		}
+		if rec.ParamHash != paramHash {
+			return "", false, errClusterTokenParamMismatch
+		}
+		if rec.Status == clusterTokenStatusDone {
+			return rec.ClusterName, false, nil
+		}
+		if time.Now().After(deadline) {
+			return "", false, errClusterTokenWaitTimeout
+		}
+		time.Sleep(clusterTokenPollStep)
+	}
+}
+
+// Finalize marks the token done with the created cluster's name, so duplicates
+// replay its current state via GetClusterMeta rather than a frozen snapshot.
+func (c *ClusterTokenStore) Finalize(ctx context.Context, accountID, token, paramHash, clusterName string) error {
+	key := clusterTokenKey(accountID, token)
+	data, err := json.Marshal(clusterTokenRecord{
+		Status:      clusterTokenStatusDone,
+		ParamHash:   paramHash,
+		StartedAt:   time.Now().UTC(),
+		ClusterName: clusterName,
+	})
+	if err != nil {
+		return fmt.Errorf("clustertoken finalize marshal: %w", err)
+	}
+	if _, err := c.kv.Put(ctx, key, data); err != nil {
+		return fmt.Errorf("clustertoken finalize put %s: %w", key, err)
+	}
+	return nil
+}
+
+// Abort drops the in-flight token so a retry can re-attempt the create.
+func (c *ClusterTokenStore) Abort(ctx context.Context, accountID, token string) {
+	key := clusterTokenKey(accountID, token)
+	if err := c.kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		slog.Warn("clienttoken: failed to abort token record", "key", key, "err", err)
+	}
+}

--- a/spinifex/handlers/eks/create_cluster_test.go
+++ b/spinifex/handlers/eks/create_cluster_test.go
@@ -135,6 +135,65 @@ func TestCreateCluster_FailedLaunchEagerlyPurgesInfra(t *testing.T) {
 	assert.Equal(t, ClusterStatusFailed, meta.Status)
 }
 
+// A duplicate CreateCluster call with the same ClientRequestToken and identical
+// parameters must replay the in-progress/created cluster rather than launching
+// a second control plane (AWS ClientRequestToken semantics).
+func TestCreateCluster_SameTokenSameParamsReplaysInProgressCluster(t *testing.T) {
+	f := newEKSServiceFixture(t)
+
+	in := createInput("alpha")
+	in.ClientRequestToken = aws.String("tok-replay")
+
+	out1, err := f.svc.CreateCluster(context.Background(), in, testAccountID, "")
+	require.NoError(t, err)
+
+	out2, err := f.svc.CreateCluster(context.Background(), in, testAccountID, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, aws.StringValue(out1.Cluster.Name), aws.StringValue(out2.Cluster.Name))
+	assert.Equal(t, aws.StringValue(out1.Cluster.Arn), aws.StringValue(out2.Cluster.Arn))
+
+	f.svc.WaitLaunches()
+	assert.Len(t, f.inst.launchCalls, 1, "a replayed duplicate must not launch a second control plane")
+}
+
+// Reusing a ClientRequestToken with different CreateClusterInput parameters is
+// IdempotentParameterMismatch, not a second cluster or a silent replay.
+func TestCreateCluster_SameTokenDifferentParamsIsIdempotentMismatch(t *testing.T) {
+	f := newEKSServiceFixture(t)
+
+	in1 := createInput("alpha")
+	in1.ClientRequestToken = aws.String("tok-mismatch")
+	_, err := f.svc.CreateCluster(context.Background(), in1, testAccountID, "")
+	require.NoError(t, err)
+
+	in2 := createInput("alpha")
+	in2.ClientRequestToken = aws.String("tok-mismatch")
+	in2.Version = aws.String("1.31") // same token, different param
+	_, err = f.svc.CreateCluster(context.Background(), in2, testAccountID, "")
+	require.EqualError(t, err, awserrors.ErrorIdempotentParameterMismatch)
+
+	f.svc.WaitLaunches()
+	assert.Len(t, f.inst.launchCalls, 1, "a mismatched retry must not launch a second control plane")
+}
+
+// A distinct ClientRequestToken reusing the same cluster name is a genuine
+// second create, not a duplicate — it must still hit the atomic name claim and
+// get ResourceInUse, same as with no token at all.
+func TestCreateCluster_DistinctTokenSameNameReturnsResourceInUse(t *testing.T) {
+	f := newEKSServiceFixture(t)
+
+	in1 := createInput("alpha")
+	in1.ClientRequestToken = aws.String("tok-a")
+	_, err := f.svc.CreateCluster(context.Background(), in1, testAccountID, "")
+	require.NoError(t, err)
+
+	in2 := createInput("alpha")
+	in2.ClientRequestToken = aws.String("tok-b")
+	_, err = f.svc.CreateCluster(context.Background(), in2, testAccountID, "")
+	require.EqualError(t, err, awserrors.ErrorEKSResourceInUse)
+}
+
 // A live (CREATING/ACTIVE) cluster of the same name blocks create with a
 // cluster-scoped ResourceInUseException, not the ELBv2 target-group message.
 func TestCreateCluster_ExistingClusterReturnsResourceInUse(t *testing.T) {

--- a/spinifex/handlers/eks/k3s_ha_control_plane.go
+++ b/spinifex/handlers/eks/k3s_ha_control_plane.go
@@ -38,10 +38,9 @@ var _ controlPlanePlacer = (handlers_ec2_placementgroup.PlacementGroupService)(n
 
 // HostScheduler answers capacity + placement fan-out questions for HA CP placement.
 type HostScheduler interface {
-	// SchedulableHosts returns node IDs that can fit at least one VM of instanceType,
-	// ordered so a prefix spans distinct AZs first (round-robin), then packs
-	// remaining hosts within each AZ. Taking the first N off this list therefore
-	// spreads an N-way reservation across N distinct AZs whenever that many exist.
+	// SchedulableHosts returns node IDs that fit at least one VM of instanceType,
+	// ordered so a prefix spans distinct AZs first, then packs within each AZ.
+	// Taking the first N therefore spreads across N AZs whenever that many exist.
 	SchedulableHosts(ctx context.Context, instanceType string) []string
 	// InstanceHosts maps each instance ID to its hosting node; absent entries are not yet visible.
 	InstanceHosts(ctx context.Context, instanceIDs []string) map[string]string
@@ -510,12 +509,9 @@ type azHost struct {
 	az   string
 }
 
-// spreadHostsByAZ reorders schedulable hosts so a prefix of the result spans as
-// many distinct AZs as possible: round-robin one host per AZ (in first-seen
-// order), then a second host per AZ, and so on. A spread reservation that takes
-// the first N hosts off this list lands on N distinct AZs whenever N AZs exist;
-// with fewer AZs than requested members, later picks repeat an AZ rather than
-// leaving capacity unused — every eligible host is still returned exactly once.
+// spreadHostsByAZ round-robins one host per AZ in first-seen order, then a
+// second per AZ, so a prefix spans as many distinct AZs as exist. With fewer
+// AZs than members, later picks repeat an AZ; every host is returned once.
 func spreadHostsByAZ(hosts []azHost) []string {
 	var azOrder []string
 	byAZ := make(map[string][]string, len(hosts))

--- a/spinifex/handlers/eks/k3s_ha_control_plane.go
+++ b/spinifex/handlers/eks/k3s_ha_control_plane.go
@@ -38,7 +38,10 @@ var _ controlPlanePlacer = (handlers_ec2_placementgroup.PlacementGroupService)(n
 
 // HostScheduler answers capacity + placement fan-out questions for HA CP placement.
 type HostScheduler interface {
-	// SchedulableHosts returns node IDs that can fit at least one VM of instanceType.
+	// SchedulableHosts returns node IDs that can fit at least one VM of instanceType,
+	// ordered so a prefix spans distinct AZs first (round-robin), then packs
+	// remaining hosts within each AZ. Taking the first N off this list therefore
+	// spreads an N-way reservation across N distinct AZs whenever that many exist.
 	SchedulableHosts(ctx context.Context, instanceType string) []string
 	// InstanceHosts maps each instance ID to its hosting node; absent entries are not yet visible.
 	InstanceHosts(ctx context.Context, instanceIDs []string) map[string]string
@@ -482,7 +485,7 @@ func (h *natsHostScheduler) SchedulableHosts(ctx context.Context, instanceType s
 		}
 	}
 
-	var hosts []string
+	var hosts []azHost
 	seen := make(map[string]bool)
 	h.fanout(ctx, "spinifex.node.status", func(data []byte) {
 		var st types.NodeStatusResponse
@@ -495,10 +498,48 @@ func (h *natsHostScheduler) SchedulableHosts(ctx context.Context, instanceType s
 		}
 		if fits {
 			seen[st.Node] = true
-			hosts = append(hosts, st.Node)
+			hosts = append(hosts, azHost{node: st.Node, az: st.AZ})
 		}
 	})
-	return hosts
+	return spreadHostsByAZ(hosts)
+}
+
+// azHost pairs a schedulable node with the AZ its node status reported.
+type azHost struct {
+	node string
+	az   string
+}
+
+// spreadHostsByAZ reorders schedulable hosts so a prefix of the result spans as
+// many distinct AZs as possible: round-robin one host per AZ (in first-seen
+// order), then a second host per AZ, and so on. A spread reservation that takes
+// the first N hosts off this list lands on N distinct AZs whenever N AZs exist;
+// with fewer AZs than requested members, later picks repeat an AZ rather than
+// leaving capacity unused — every eligible host is still returned exactly once.
+func spreadHostsByAZ(hosts []azHost) []string {
+	var azOrder []string
+	byAZ := make(map[string][]string, len(hosts))
+	for _, h := range hosts {
+		if _, ok := byAZ[h.az]; !ok {
+			azOrder = append(azOrder, h.az)
+		}
+		byAZ[h.az] = append(byAZ[h.az], h.node)
+	}
+
+	out := make([]string, 0, len(hosts))
+	for round := 0; len(out) < len(hosts); round++ {
+		added := false
+		for _, az := range azOrder {
+			if round < len(byAZ[az]) {
+				out = append(out, byAZ[az][round])
+				added = true
+			}
+		}
+		if !added {
+			break
+		}
+	}
+	return out
 }
 
 // nodeFitsCustomerInstance reports whether a node advertises at least one free

--- a/spinifex/handlers/eks/k3s_ha_control_plane_test.go
+++ b/spinifex/handlers/eks/k3s_ha_control_plane_test.go
@@ -89,10 +89,9 @@ func TestSpreadHostsByAZ_DistinctAZs(t *testing.T) {
 	assert.ElementsMatch(t, []string{"node-1", "node-2", "node-3", "node-4"}, out)
 }
 
-// TestSpreadHostsByAZ_FewerAZsThanHosts documents the degradation behaviour:
-// with only 2 AZs available for a 3-way spread, placement still returns every
-// host (nothing dropped) and the first 2 picks land in distinct AZs — the third
-// necessarily repeats one of them.
+// TestSpreadHostsByAZ_FewerAZsThanHosts documents the degradation: with 2 AZs
+// for a 3-way spread, every host is still returned and the first 2 picks land
+// in distinct AZs, the third necessarily repeating one.
 func TestSpreadHostsByAZ_FewerAZsThanHosts(t *testing.T) {
 	hosts := []azHost{
 		{node: "node-1", az: "az-a"},
@@ -395,11 +394,8 @@ func TestPlaceControlPlane_SpreadHappyPath(t *testing.T) {
 }
 
 // TestPlaceControlPlane_SpreadPrefersDistinctAZs runs placeControlPlane against
-// the real NATS-backed HostScheduler (not the fake) with 4 nodes across 3 AZs,
-// and a placer that reserves whatever it's offered first (mirroring
-// ReserveSpreadNodes' order-preserving selection). It demonstrates bead
-// 231.7.4's acceptance criteria: the 3 launched control-plane members land on
-// 3 distinct AZs.
+// the real NATS-backed HostScheduler with 4 nodes across 3 AZs, and a placer
+// reserving what it is offered first, as ReserveSpreadNodes does.
 func TestPlaceControlPlane_SpreadPrefersDistinctAZs(t *testing.T) {
 	_, nc := testutil.StartTestNATS(t)
 	serveNodeStatus(t, nc, []types.NodeStatusResponse{

--- a/spinifex/handlers/eks/k3s_ha_control_plane_test.go
+++ b/spinifex/handlers/eks/k3s_ha_control_plane_test.go
@@ -65,6 +65,84 @@ func TestNATSHostScheduler_SchedulableHosts(t *testing.T) {
 	require.Empty(t, sched.SchedulableHosts(context.Background(), "sys.bogus"))
 }
 
+// TestSpreadHostsByAZ_DistinctAZs covers the common case: with at least as many
+// AZs as hosts, round-robin visits every AZ once before repeating any of them,
+// so a prefix of the result spans distinct AZs.
+func TestSpreadHostsByAZ_DistinctAZs(t *testing.T) {
+	hosts := []azHost{
+		{node: "node-1", az: "az-a"},
+		{node: "node-2", az: "az-b"},
+		{node: "node-3", az: "az-a"},
+		{node: "node-4", az: "az-c"},
+	}
+	out := spreadHostsByAZ(hosts)
+	require.Len(t, out, 4)
+
+	// First 3 picks (one per AZ) must land on 3 distinct AZs.
+	azOf := map[string]string{"node-1": "az-a", "node-2": "az-b", "node-3": "az-a", "node-4": "az-c"}
+	seen := make(map[string]bool)
+	for _, n := range out[:3] {
+		seen[azOf[n]] = true
+	}
+	assert.Len(t, seen, 3, "first 3 hosts should span 3 distinct AZs, got %v", out[:3])
+	// Every host still appears exactly once; nothing is dropped.
+	assert.ElementsMatch(t, []string{"node-1", "node-2", "node-3", "node-4"}, out)
+}
+
+// TestSpreadHostsByAZ_FewerAZsThanHosts documents the degradation behaviour:
+// with only 2 AZs available for a 3-way spread, placement still returns every
+// host (nothing dropped) and the first 2 picks land in distinct AZs — the third
+// necessarily repeats one of them.
+func TestSpreadHostsByAZ_FewerAZsThanHosts(t *testing.T) {
+	hosts := []azHost{
+		{node: "node-1", az: "az-a"},
+		{node: "node-2", az: "az-a"},
+		{node: "node-3", az: "az-b"},
+	}
+	out := spreadHostsByAZ(hosts)
+	require.Len(t, out, 3, "degraded spread must still place every host")
+	assert.ElementsMatch(t, []string{"node-1", "node-2", "node-3"}, out)
+
+	azOf := map[string]string{"node-1": "az-a", "node-2": "az-a", "node-3": "az-b"}
+	assert.NotEqual(t, azOf[out[0]], azOf[out[1]], "first 2 picks should still land in distinct AZs")
+}
+
+// TestSpreadHostsByAZ_UniformAZDegradesToNodeOrder covers real deployments where
+// every node reports the same AZ (or none at all): interleaving collapses to a
+// single bucket, so the original arrival order is preserved and nothing breaks.
+func TestSpreadHostsByAZ_UniformAZDegradesToNodeOrder(t *testing.T) {
+	hosts := []azHost{
+		{node: "node-1", az: "ap-southeast-2a"},
+		{node: "node-2", az: "ap-southeast-2a"},
+		{node: "node-3", az: "ap-southeast-2a"},
+	}
+	assert.Equal(t, []string{"node-1", "node-2", "node-3"}, spreadHostsByAZ(hosts))
+}
+
+// TestNATSHostScheduler_SchedulableHosts_SpreadsByAZ exercises the fan-out path
+// end-to-end: node.status responses carrying distinct AZs must come back
+// ordered so the first haControlPlaneCount hosts span distinct AZs.
+func TestNATSHostScheduler_SchedulableHosts_SpreadsByAZ(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	serveNodeStatus(t, nc, []types.NodeStatusResponse{
+		{Node: "node-1", AZ: "az-a", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.medium", Available: 1}}},
+		{Node: "node-2", AZ: "az-a", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.medium", Available: 1}}},
+		{Node: "node-3", AZ: "az-b", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.medium", Available: 1}}},
+		{Node: "node-4", AZ: "az-c", InstanceTypes: []types.InstanceTypeCap{{Name: "t3.medium", Available: 1}}},
+	})
+	sched := NewNATSHostScheduler(nc)
+
+	hosts := sched.SchedulableHosts(context.Background(), "t3.medium")
+	require.Len(t, hosts, 4)
+
+	azOf := map[string]string{"node-1": "az-a", "node-2": "az-a", "node-3": "az-b", "node-4": "az-c"}
+	seen := make(map[string]bool)
+	for _, n := range hosts[:3] {
+		seen[azOf[n]] = true
+	}
+	assert.Len(t, seen, 3, "first 3 schedulable hosts should span 3 distinct AZs, got %v", hosts[:3])
+}
+
 // --- HA control-plane orchestrator test doubles ---
 
 // fakeHostScheduler fakes the capacity + placement fan-out. SchedulableHosts
@@ -314,6 +392,38 @@ func TestPlaceControlPlane_SpreadHappyPath(t *testing.T) {
 
 	assert.ElementsMatch(t, []string{"node-a", "node-b", "node-c"}, inst.nodes)
 	assert.Empty(t, inst.terminated)
+}
+
+// TestPlaceControlPlane_SpreadPrefersDistinctAZs runs placeControlPlane against
+// the real NATS-backed HostScheduler (not the fake) with 4 nodes across 3 AZs,
+// and a placer that reserves whatever it's offered first (mirroring
+// ReserveSpreadNodes' order-preserving selection). It demonstrates bead
+// 231.7.4's acceptance criteria: the 3 launched control-plane members land on
+// 3 distinct AZs.
+func TestPlaceControlPlane_SpreadPrefersDistinctAZs(t *testing.T) {
+	_, nc := testutil.StartTestNATS(t)
+	serveNodeStatus(t, nc, []types.NodeStatusResponse{
+		{Node: "node-a", AZ: "az-1", TotalVCPU: 32, TotalMemGB: 128},
+		{Node: "node-b", AZ: "az-1", TotalVCPU: 32, TotalMemGB: 128},
+		{Node: "node-c", AZ: "az-2", TotalVCPU: 32, TotalMemGB: 128},
+		{Node: "node-d", AZ: "az-3", TotalVCPU: 32, TotalMemGB: 128},
+	})
+	sched := NewNATSHostScheduler(nc)
+	placer := &fakePlacer{} // reserved unset: defaults to the first MaxCount EligibleNodes, like the real service.
+	vpc := &seqK3sVPC{}
+	inst := &seqK3sInst{}
+	svc := newPlacerService(sched, placer, vpc, inst)
+
+	nodes, _, err := svc.placeControlPlane(context.Background(), testHAAccountID, "alpha", validK3sInput())
+	require.NoError(t, err)
+	require.Len(t, nodes, 3)
+
+	azOf := map[string]string{"node-a": "az-1", "node-b": "az-1", "node-c": "az-2", "node-d": "az-3"}
+	seen := make(map[string]bool)
+	for _, n := range nodeIDs(nodes) {
+		seen[azOf[n]] = true
+	}
+	assert.Len(t, seen, 3, "the 3 control-plane members should land on 3 distinct AZs, got %v", nodeIDs(nodes))
 }
 
 func TestPlaceControlPlane_SpreadFirstInitsRestJoin(t *testing.T) {

--- a/spinifex/handlers/eks/service_impl.go
+++ b/spinifex/handlers/eks/service_impl.go
@@ -272,6 +272,12 @@ type EKSServiceImpl struct {
 	// spawnScanRetryBackoff paces the boot-time reconciler re-scan when JetStream
 	// enumeration is still catching up. Tests inject a small value.
 	spawnScanRetryBackoff time.Duration
+
+	// clusterTokenOnce lazily binds clusterTokenStore to this instance's
+	// NATSConn on first CreateCluster ClientRequestToken use.
+	clusterTokenOnce  sync.Once
+	clusterTokenStore *ClusterTokenStore
+	clusterTokenErr   error
 }
 
 var _ EKSService = (*EKSServiceImpl)(nil)
@@ -512,8 +518,42 @@ func (s *EKSServiceImpl) CreateCluster(ctx context.Context, input *eks.CreateClu
 		return nil, logCreateErr(name, accountID, "get account bucket", err)
 	}
 
+	// ClientRequestToken idempotency, mirroring the EC2 RunInstances ClientToken
+	// pattern: same token + identical params replays the in-progress/created
+	// cluster; same token + different params is IdempotentParameterMismatch. A
+	// distinct token reusing the same cluster name still hits claimClusterName's
+	// atomic claim below and gets ResourceInUse — this only short-circuits true
+	// duplicates, so it must resolve before that claim ever runs.
+	token := aws.StringValue(input.ClientRequestToken)
+	var tokenStore *ClusterTokenStore
+	var tokenHash string
+	if token != "" {
+		tokenStore, err = s.getClusterTokenStore(ctx)
+		if err != nil {
+			return nil, logCreateErr(name, accountID, "client token store", err)
+		}
+		tokenHash = clusterTokenParamHash(input)
+		replayName, owned, cerr := tokenStore.Claim(ctx, accountID, token, tokenHash)
+		if cerr != nil {
+			if errors.Is(cerr, errClusterTokenParamMismatch) {
+				return nil, errors.New(awserrors.ErrorIdempotentParameterMismatch)
+			}
+			return nil, logCreateErr(name, accountID, "client token claim", cerr)
+		}
+		if !owned {
+			replayMeta, gerr := GetClusterMeta(ctx, acctKV, replayName)
+			if gerr != nil {
+				return nil, logCreateErr(name, accountID, "client token replay", gerr)
+			}
+			return &eks.CreateClusterOutput{Cluster: clusterMetaToAWS(replayMeta)}, nil
+		}
+	}
+
 	vpcID, err := s.deps.VPCSubnet.GetSubnetVPC(ctx, accountID, subnetIDs[0])
 	if err != nil {
+		if tokenStore != nil {
+			tokenStore.Abort(ctx, accountID, token)
+		}
 		// Subnet resolve failure is a client fault (bad/foreign subnet).
 		slog.ErrorContext(ctx, "CreateCluster: resolve subnet VPC failed",
 			"cluster", name, "accountID", accountID, "subnet", subnetIDs[0], "err", err)
@@ -544,12 +584,23 @@ func (s *EKSServiceImpl) CreateCluster(ctx context.Context, input *eks.CreateClu
 	}
 	// Claim the cluster name before any launching; duplicate/retry handlers lose the claim.
 	if err := s.claimClusterName(ctx, accountID, acctKV, meta); err != nil {
+		if tokenStore != nil {
+			tokenStore.Abort(ctx, accountID, token)
+		}
 		return nil, err
 	}
 
 	// Respond CREATING immediately; run the slow launch on a background goroutine.
 	// The goroutine owns meta from here on — do not touch it after this point.
 	out := &eks.CreateClusterOutput{Cluster: clusterMetaToAWS(meta)}
+	if tokenStore != nil {
+		if ferr := tokenStore.Finalize(ctx, accountID, token, tokenHash, name); ferr != nil {
+			// The create itself succeeded; a finalize failure only weakens future
+			// dedup for this token, so it must not fail the request.
+			slog.WarnContext(ctx, "CreateCluster: failed to finalize client-request-token record",
+				"cluster", name, "err", ferr)
+		}
+	}
 	// The launch outlives the request, so it runs on its own background context
 	// rather than the caller's, which is cancelled once this reply is written.
 	launchCtx := context.Background()


### PR DESCRIPTION
## Summary

Two EKS backlog items, one branch, two independent commits.

Closes mulga-siv-231.7.4, mulga-siv-267.7.

## 1. AZ-aware failure-domain spread (siv-231.7.4)

HA control-plane placement spread by node only, ignoring the AZ that node status already returns.

`SchedulableHosts` now collects `azHost{node, az}` pairs and reorders them via a new `spreadHostsByAZ`: round-robin one host per AZ in first-seen order, then a second per AZ, and so on. `ReserveSpreadNodes` already takes a strict ordered prefix, so taking the first N hosts lands on N distinct AZs whenever N exist.

**Zero wire or API changes** — this exploits the existing order-preserving selection rather than adding a placement parameter.

Degradation is explicit and tested: with fewer AZs than members, later picks repeat an AZ rather than leaving capacity unused, and every eligible host is still returned exactly once. Where every node reports the same AZ (or none), interleaving collapses to a single bucket and the original arrival order is preserved.

### Two corrections worth recording

The bead's stated premise and my own brief were both wrong, found before building on them:

- The bead cites `configure-cluster.sh:16` as hardcoding `AZ=ap-southeast-2a`. **That file no longer exists.** The current uniform-AZ mechanism is `ansible/inventory/tofu.py:130` (a single environment-wide `az` tfvar becoming the `spinifex_az` group var) plus `scripts/tofu-cluster/bootstrap-install.sh:57`, which applies it identically to every node. The premise holds in substance — AZs are still uniform per environment — just not via that script.
- `spreadAllocate` (`gateway/ec2/instance/placement.go:109`) is **not** the EKS placement path. Its only caller chain is `distributeInstances` → `runInstancesInner`, i.e. generic EC2 `RunInstances`. The real path is `EKSServiceImpl.placeControlPlane` → `HostScheduler.SchedulableHosts` → `PlacementGroupServiceImpl.ReserveSpreadNodes`.

### Verification limit

Not verified end-to-end on a live environment, and it cannot be yet: every node in a real tofu-cluster environment is assigned the same AZ today. Per-node AZ provisioning is the missing prerequisite. Coverage here is unit-level against synthetic node fixtures.

Tests: `TestSpreadHostsByAZ_DistinctAZs`, `_FewerAZsThanHosts`, `_UniformAZDegradesToNodeOrder`, `TestNATSHostScheduler_SchedulableHosts_SpreadsByAZ`, and `TestPlaceControlPlane_SpreadPrefersDistinctAZs` (4 nodes / 3 AZs → 3 CP members on 3 distinct AZs, against the real NATS-backed scheduler).

## 2. ClientRequestToken idempotency (siv-267.7)

`CreateClusterInput.ClientRequestToken` was ignored by both model and handler. New `ClusterTokenStore` (TTL JetStream KV, `Claim`/`Finalize`/`Abort`, param-hash comparison) mirrors the EC2 `RunInstances` ClientToken pattern.

`CreateCluster` wires it after the account-KV resolve and before the subnet resolve: claim → replay on hash match → `IdempotentParameterMismatch` on hash mismatch → `Abort` on fast-phase failure → `Finalize` on success. The existing atomic name-claim that yields `ResourceInUse` is untouched.

The store is scoped to the service instance rather than a package-level singleton. That was not stylistic: a singleton bled a stale, closed NATS connection across independent test fixtures.

Tests, one per AWS semantic: `TestCreateCluster_SameTokenSameParamsReplaysInProgressCluster`, `_SameTokenDifferentParamsIsIdempotentMismatch`, `_DistinctTokenSameNameReturnsResourceInUse`.

## Coupling

These two were clustered on the expectation of shared surface area. They turned out not to share code beyond both living in `handlers/eks`, so they are two independent commits rather than an artificially merged change.

## Test plan
- [x] `make preflight` green — `diff coverage 69.1% meets 60% threshold`
- [x] Unit coverage for both beads' acceptance criteria
- [ ] Live AZ-spread verification — blocked on per-node AZ provisioning, see above