### PR TITLE
feat(imds): allow HttpTokens=optional per instance

### DIFF
--- a/docs/identity/imds/README.md
+++ b/docs/identity/imds/README.md
@@ -215,7 +215,7 @@ The signed forms (`signature`, `pkcs7`, `rsa2048`) currently return 404 — they
 
 ## Metadata Options
 
-Metadata options are managed from the **control plane** with the standard EC2 commands. Because the platform is IMDSv2-only, the only mutable knob is the PUT response hop limit.
+Metadata options are managed from the **control plane** with the standard EC2 commands. The mutable knobs are the PUT response hop limit and `HttpTokens`; the remaining fields are fixed.
 
 ### Inspect
 
@@ -254,9 +254,23 @@ aws ec2 modify-instance-metadata-options \
 
 Raise the hop limit above the default of 1 when containers on the instance need IMDS access through an extra routing hop (e.g. containers on a bridge network fetching role credentials). Valid range is 1–64.
 
+### Enabling IMDSv1
+
+Instances default to `HttpTokens=required`, so every read needs a token. Set `optional` to also serve untokened reads:
+
+```bash
+aws ec2 run-instances \
+  --image-id ami-0123456789abcdef0 \
+  --instance-type t3.micro \
+  --metadata-options "HttpTokens=optional"
+```
+
+This exists for guest agents that cannot perform the IMDSv2 handshake. The main one is **cloudbase-init**, the standard Windows bootstrap agent, whose `EC2Service` has no token support in any released version — a Windows instance left at `required` gets 401 on every read and so never receives its hostname, injected administrator password or user-data.
+
+Prefer `required` everywhere else. IMDSv1 has no defence against a confused-deputy SSRF in a guest workload reaching the metadata endpoint on an attacker's behalf, which is the whole reason IMDSv2 binds tokens to the requesting interface.
+
 Rejected settings:
 
-- `--http-tokens optional` → `UnsupportedOperation` (IMDSv2 cannot be relaxed)
 - `--http-endpoint disabled` → `UnsupportedOperation` (the endpoint cannot be turned off)
 - `--http-protocol-ipv6 enabled` → `UnsupportedOperation`
 - `--instance-metadata-tags enabled` → `UnsupportedOperation`
@@ -278,9 +292,9 @@ Useful background for host-side troubleshooting:
 | Token binding | Issuing network interface; in-memory, not persisted |
 | Role credential lifetime | 3600 seconds, refreshed 5 minutes before expiry |
 | PUT response hop limit | Default 1, valid 1–64 |
-| `HttpTokens` | Always `required` (immutable) |
+| `HttpTokens` | `required` (default) or `optional` |
 | `HttpEndpoint` | Always `enabled` (immutable) |
-| Tokenless GET | `401 Unauthorized`, empty body |
+| Tokenless GET | `401 Unauthorized`, empty body, unless `HttpTokens=optional` |
 | `X-Forwarded-For` present | `403 Forbidden` |
 | Wrong method | `405 Method Not Allowed` |
 | Unknown/unsupported path | `404 Not Found` |
@@ -291,7 +305,8 @@ Useful background for host-side troubleshooting:
 
 The request is missing a valid token. Common causes:
 
-- No `X-aws-ec2-metadata-token` header — IMDSv1-style access is not supported; obtain a token first.
+- No `X-aws-ec2-metadata-token` header, on an instance at the default `HttpTokens=required` — obtain a token first, or set `HttpTokens=optional` if the guest agent cannot do the handshake.
+- A change to `HttpTokens` can take up to 30 seconds to take effect: the per-instance setting is cached on the untokened path so an unauthenticated caller cannot drive repeated `DescribeInstances` fan-outs.
 - The token expired — reissue with a fresh `PUT /latest/api/token`.
 - The token was issued to a different instance/interface — tokens are interface-bound and rejected elsewhere, identically to unknown tokens.
 - The token endpoint itself never 401s; if the `PUT` fails, check for a `400` (bad TTL header) instead.

--- a/spinifex/handlers/ec2/instance/metadata_options.go
+++ b/spinifex/handlers/ec2/instance/metadata_options.go
@@ -11,17 +11,22 @@ import (
 // defaultMetadataHopLimit matches the AWS default applied when none is requested.
 const defaultMetadataHopLimit = int64(1)
 
-// buildMetadataOptions returns the constant IMDSv2-only block stamped at launch.
-// Every field but the hop limit is a platform invariant; hopLimit applies only in
-// the AWS-valid 1-64 range, otherwise falling back to the default.
-func buildMetadataOptions(hopLimit *int64) *ec2.InstanceMetadataOptionsResponse {
+// buildMetadataOptions returns the metadata-options block stamped at launch.
+// hopLimit applies only in the AWS-valid 1-64 range, otherwise falling back to
+// the default. An empty httpTokens stamps "required", so an instance that does
+// not ask for IMDSv1 never silently gets it.
+func buildMetadataOptions(hopLimit *int64, httpTokens string) *ec2.InstanceMetadataOptionsResponse {
 	limit := defaultMetadataHopLimit
 	if hopLimit != nil && *hopLimit >= 1 && *hopLimit <= 64 {
 		limit = *hopLimit
 	}
+	tokens := ec2.HttpTokensStateRequired
+	if httpTokens == ec2.HttpTokensStateOptional {
+		tokens = ec2.HttpTokensStateOptional
+	}
 	return &ec2.InstanceMetadataOptionsResponse{
 		State:                   aws.String(ec2.InstanceMetadataOptionsStateApplied),
-		HttpTokens:              aws.String(ec2.HttpTokensStateRequired),
+		HttpTokens:              aws.String(tokens),
 		HttpEndpoint:            aws.String(ec2.InstanceMetadataEndpointStateEnabled),
 		HttpProtocolIpv6:        aws.String(ec2.InstanceMetadataProtocolStateDisabled),
 		InstanceMetadataTags:    aws.String(ec2.InstanceMetadataTagsStateDisabled),
@@ -29,12 +34,15 @@ func buildMetadataOptions(hopLimit *int64) *ec2.InstanceMetadataOptionsResponse 
 	}
 }
 
-// validateMetadataOptions rejects any request that weakens the IMDSv2-only
-// posture or enables an unmodelled feature. Empty values are "leave unchanged"
-// no-ops; only the hop limit (AWS-valid 1-64) is mutable. Shared by RunInstances
-// and ModifyInstanceMetadataOptions.
+// validateMetadataOptions rejects any request that enables an unmodelled
+// feature. Empty values are "leave unchanged" no-ops; the hop limit (AWS-valid
+// 1-64) and httpTokens are mutable. Shared by RunInstances and
+// ModifyInstanceMetadataOptions.
 func validateMetadataOptions(httpTokens, httpEndpoint, ipv6, tags string, hopLimit *int64) error {
-	if httpTokens != "" && httpTokens != ec2.HttpTokensStateRequired {
+	// IMDSv1 is opt-in per instance, matching AWS, so that IMDSv1-only guest
+	// agents such as cloudbase-init can bootstrap. The launch default stays
+	// "required"; see buildMetadataOptions.
+	if httpTokens != "" && httpTokens != ec2.HttpTokensStateRequired && httpTokens != ec2.HttpTokensStateOptional {
 		return errors.New(awserrors.ErrorUnsupportedOperation)
 	}
 	if httpEndpoint != "" && httpEndpoint != ec2.InstanceMetadataEndpointStateEnabled {
@@ -52,14 +60,17 @@ func validateMetadataOptions(httpTokens, httpEndpoint, ipv6, tags string, hopLim
 	return nil
 }
 
-// applyMetadataOptions stamps the constant block onto a legacy nil-block instance
-// or moves the mutable hop limit. Callers must guard a nil instance.
-func applyMetadataOptions(instance *ec2.Instance, hopLimit *int64) {
+// applyMetadataOptions stamps the block onto a legacy nil-block instance or
+// moves the mutable fields. Callers must guard a nil instance.
+func applyMetadataOptions(instance *ec2.Instance, hopLimit *int64, httpTokens string) {
 	if instance.MetadataOptions == nil {
-		instance.MetadataOptions = buildMetadataOptions(hopLimit)
+		instance.MetadataOptions = buildMetadataOptions(hopLimit, httpTokens)
 		return
 	}
 	if hopLimit != nil {
 		instance.MetadataOptions.HttpPutResponseHopLimit = hopLimit
+	}
+	if httpTokens != "" {
+		instance.MetadataOptions.HttpTokens = aws.String(httpTokens)
 	}
 }

--- a/spinifex/handlers/ec2/instance/metadata_options_test.go
+++ b/spinifex/handlers/ec2/instance/metadata_options_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // The shared validator passes the secure/default values (and AWS "leave
-// unchanged" empties) as no-ops, rejects any posture downgrade or unmodelled
-// feature with UnsupportedOperation, and bounds the hop limit to 1-64.
+// unchanged" empties) as no-ops, accepts either http-tokens state, rejects any
+// unmodelled feature with UnsupportedOperation, and bounds the hop limit to 1-64.
 func TestValidateMetadataOptions(t *testing.T) {
 	cases := map[string]struct {
 		httpTokens, httpEndpoint, ipv6, tags string
@@ -26,7 +26,8 @@ func TestValidateMetadataOptions(t *testing.T) {
 		"secure values":          {ec2.HttpTokensStateRequired, ec2.InstanceMetadataEndpointStateEnabled, ec2.InstanceMetadataProtocolStateDisabled, ec2.InstanceMetadataTagsStateDisabled, aws.Int64(1), ""},
 		"hop limit lower bound":  {hopLimit: aws.Int64(1)},
 		"hop limit upper bound":  {hopLimit: aws.Int64(64)},
-		"tokens optional":        {httpTokens: ec2.HttpTokensStateOptional, wantCode: awserrors.ErrorUnsupportedOperation},
+		"tokens optional":        {httpTokens: ec2.HttpTokensStateOptional},
+		"tokens unrecognised":    {httpTokens: "sometimes", wantCode: awserrors.ErrorUnsupportedOperation},
 		"endpoint disabled":      {httpEndpoint: ec2.InstanceMetadataEndpointStateDisabled, wantCode: awserrors.ErrorUnsupportedOperation},
 		"ipv6 enabled":           {ipv6: ec2.InstanceMetadataProtocolStateEnabled, wantCode: awserrors.ErrorUnsupportedOperation},
 		"tags enabled":           {tags: ec2.InstanceMetadataTagsStateEnabled, wantCode: awserrors.ErrorUnsupportedOperation},
@@ -46,25 +47,47 @@ func TestValidateMetadataOptions(t *testing.T) {
 	}
 }
 
-// Re-enabling IMDSv1 is refused with UnsupportedOperation and the instance is
-// left untouched — no partial application of a rejected request.
-func TestModifyInstanceMetadataOptions_RejectV1(t *testing.T) {
+// Enabling IMDSv1 on an existing instance is applied and echoed back; IMDSv1-only
+// guest agents can be switched on after launch without a relaunch.
+func TestModifyInstanceMetadataOptions_EnableV1(t *testing.T) {
 	owner := utils.GlobalAccountID
 	id := "i-imdsv1"
 	v := &vm.VM{
 		ID: id, AccountID: owner, Status: vm.StateRunning,
-		Instance: &ec2.Instance{InstanceId: aws.String(id), MetadataOptions: buildMetadataOptions(nil)},
+		Instance: &ec2.Instance{InstanceId: aws.String(id), MetadataOptions: buildMetadataOptions(nil, "")},
+	}
+	svc := &InstanceServiceImpl{vmMgr: mgrWith(map[string]*vm.VM{id: v})}
+
+	out, err := svc.ModifyInstanceMetadataOptions(context.Background(), &ec2.ModifyInstanceMetadataOptionsInput{
+		InstanceId: aws.String(id),
+		HttpTokens: aws.String(ec2.HttpTokensStateOptional),
+	}, owner)
+	require.NoError(t, err)
+	require.NotNil(t, out.InstanceMetadataOptions)
+	assert.Equal(t, ec2.HttpTokensStateOptional, aws.StringValue(out.InstanceMetadataOptions.HttpTokens))
+	assert.Equal(t, ec2.HttpTokensStateOptional, aws.StringValue(v.Instance.MetadataOptions.HttpTokens))
+	// The hop limit was not in the request, so it must not move.
+	assert.Equal(t, int64(1), aws.Int64Value(v.Instance.MetadataOptions.HttpPutResponseHopLimit))
+}
+
+// An unrecognised http-tokens state is still refused, and the instance is left
+// untouched — no partial application of a rejected request.
+func TestModifyInstanceMetadataOptions_RejectUnknownTokensState(t *testing.T) {
+	owner := utils.GlobalAccountID
+	id := "i-imdsbad"
+	v := &vm.VM{
+		ID: id, AccountID: owner, Status: vm.StateRunning,
+		Instance: &ec2.Instance{InstanceId: aws.String(id), MetadataOptions: buildMetadataOptions(nil, "")},
 	}
 	svc := &InstanceServiceImpl{vmMgr: mgrWith(map[string]*vm.VM{id: v})}
 
 	_, err := svc.ModifyInstanceMetadataOptions(context.Background(), &ec2.ModifyInstanceMetadataOptionsInput{
 		InstanceId: aws.String(id),
-		HttpTokens: aws.String(ec2.HttpTokensStateOptional),
+		HttpTokens: aws.String("sometimes"),
 	}, owner)
 	require.Error(t, err)
 	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorUnsupportedOperation), "got %v", err)
 	assert.Equal(t, ec2.HttpTokensStateRequired, aws.StringValue(v.Instance.MetadataOptions.HttpTokens))
-	assert.Equal(t, int64(1), aws.Int64Value(v.Instance.MetadataOptions.HttpPutResponseHopLimit))
 }
 
 // A hop-limit change on a running instance persists and is echoed back — AWS
@@ -75,7 +98,7 @@ func TestModifyInstanceMetadataOptions_HopLimitRunning(t *testing.T) {
 	id := "i-hop-run"
 	v := &vm.VM{
 		ID: id, AccountID: owner, Status: vm.StateRunning,
-		Instance: &ec2.Instance{InstanceId: aws.String(id), MetadataOptions: buildMetadataOptions(nil)},
+		Instance: &ec2.Instance{InstanceId: aws.String(id), MetadataOptions: buildMetadataOptions(nil, "")},
 	}
 	svc := &InstanceServiceImpl{vmMgr: mgrWith(map[string]*vm.VM{id: v})}
 
@@ -97,7 +120,7 @@ func TestModifyInstanceMetadataOptions_HopLimitStopped(t *testing.T) {
 	id := "i-hop-stop"
 	stored := &vm.VM{
 		ID: id, AccountID: owner, Status: vm.StateStopped,
-		Instance: &ec2.Instance{InstanceId: aws.String(id), MetadataOptions: buildMetadataOptions(nil)},
+		Instance: &ec2.Instance{InstanceId: aws.String(id), MetadataOptions: buildMetadataOptions(nil, "")},
 	}
 	store := &fakeStoppedStore{loadByID: map[string]*vm.VM{id: stored}}
 	svc := &InstanceServiceImpl{vmMgr: mgrWith(map[string]*vm.VM{}), stoppedStore: store}
@@ -180,7 +203,7 @@ func TestModifyInstanceMetadataOptions_LegacyNilBlockStamped(t *testing.T) {
 // The constant block reports the IMDSv2-only posture: required tokens, endpoint
 // enabled, IPv6/tags metadata disabled, state applied. Only the hop limit moves.
 func TestBuildMetadataOptions_ConstantBlock(t *testing.T) {
-	opts := buildMetadataOptions(nil)
+	opts := buildMetadataOptions(nil, "")
 	require.NotNil(t, opts)
 	assert.Equal(t, ec2.InstanceMetadataOptionsStateApplied, aws.StringValue(opts.State))
 	assert.Equal(t, ec2.HttpTokensStateRequired, aws.StringValue(opts.HttpTokens))
@@ -204,13 +227,15 @@ func TestBuildMetadataOptions_HopLimit(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, aws.Int64Value(buildMetadataOptions(tc.in).HttpPutResponseHopLimit))
+			assert.Equal(t, tc.want, aws.Int64Value(buildMetadataOptions(tc.in, "").HttpPutResponseHopLimit))
 		})
 	}
 }
 
-// Every instance launched after this change carries the constant block so
-// DescribeInstances surfaces the IMDSv2-only posture without a projection change.
+// Every instance launched after this change carries the block so
+// DescribeInstances surfaces the posture without a projection change. A launch
+// that says nothing about http-tokens must still land on "required" — this is
+// the guard against the IMDSv1 opt-in becoming the default by accident.
 func TestRunInstance_MetadataOptionsSeeded(t *testing.T) {
 	svc := &InstanceServiceImpl{
 		instanceTypes: map[string]*ec2.InstanceTypeInfo{"t3.micro": {InstanceType: aws.String("t3.micro")}},
@@ -226,17 +251,36 @@ func TestRunInstance_MetadataOptionsSeeded(t *testing.T) {
 	assert.Equal(t, int64(1), aws.Int64Value(ec2Instance.MetadataOptions.HttpPutResponseHopLimit))
 }
 
-// A run-instances launch that tries to re-enable IMDSv1 is rejected before any
-// capacity is allocated — the same UnsupportedOperation the modify path returns.
-// Validation precedes the instance-type lookup, so a bare service suffices.
-func TestPrepareRunInstances_RejectV1MetadataOptions(t *testing.T) {
-	svc := &InstanceServiceImpl{}
-	_, _, _, err := svc.PrepareRunInstances(context.Background(), &ec2.RunInstancesInput{
+// A launch asking for IMDSv1 passes validation and the opt-in reaches the
+// instance, which is what lets an IMDSv1-only guest agent bootstrap.
+func TestRunInstance_MetadataOptionsTokensOptional(t *testing.T) {
+	svc := &InstanceServiceImpl{
+		instanceTypes: map[string]*ec2.InstanceTypeInfo{"t3.micro": {InstanceType: aws.String("t3.micro")}},
+	}
+
+	_, ec2Instance, err := svc.RunInstance(&ec2.RunInstancesInput{
 		ImageId:         aws.String("ami-0abcdef1234567890"),
 		InstanceType:    aws.String("t3.micro"),
-		MinCount:        aws.Int64(1),
-		MaxCount:        aws.Int64(1),
 		MetadataOptions: &ec2.InstanceMetadataOptionsRequest{HttpTokens: aws.String(ec2.HttpTokensStateOptional)},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ec2Instance.MetadataOptions)
+	assert.Equal(t, ec2.HttpTokensStateOptional, aws.StringValue(ec2Instance.MetadataOptions.HttpTokens))
+}
+
+// An unmodelled metadata option is still rejected before any capacity is
+// allocated. Validation precedes the instance-type lookup, so a bare service
+// suffices.
+func TestPrepareRunInstances_RejectUnsupportedMetadataOptions(t *testing.T) {
+	svc := &InstanceServiceImpl{}
+	_, _, _, err := svc.PrepareRunInstances(context.Background(), &ec2.RunInstancesInput{
+		ImageId:      aws.String("ami-0abcdef1234567890"),
+		InstanceType: aws.String("t3.micro"),
+		MinCount:     aws.Int64(1),
+		MaxCount:     aws.Int64(1),
+		MetadataOptions: &ec2.InstanceMetadataOptionsRequest{
+			HttpEndpoint: aws.String(ec2.InstanceMetadataEndpointStateDisabled),
+		},
 	}, utils.GlobalAccountID, "")
 	require.Error(t, err)
 	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorUnsupportedOperation), "got %v", err)

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -231,13 +231,15 @@ func (s *InstanceServiceImpl) RunInstance(input *ec2.RunInstancesInput) (*vm.VM,
 		ec2Instance.SetArchitecture(arch)
 	}
 
-	// Stamp the constant IMDSv2-only block so DescribeInstances reports the
-	// posture; only the hop limit is request-driven.
+	// Stamp the metadata-options block so DescribeInstances reports the posture;
+	// the hop limit and the IMDSv1 opt-in are request-driven.
 	var hopLimit *int64
+	var httpTokens string
 	if input.MetadataOptions != nil {
 		hopLimit = input.MetadataOptions.HttpPutResponseHopLimit
+		httpTokens = aws.StringValue(input.MetadataOptions.HttpTokens)
 	}
-	ec2Instance.MetadataOptions = buildMetadataOptions(hopLimit)
+	ec2Instance.MetadataOptions = buildMetadataOptions(hopLimit, httpTokens)
 
 	// IAM instance profile attached at launch: gateway has already resolved
 	// the reference to a canonical ARN and enforced iam:PassRole; here we
@@ -2143,7 +2145,7 @@ func (s *InstanceServiceImpl) ModifyInstanceMetadataOptions(ctx context.Context,
 			integrityErr = true
 			return false
 		}
-		applyMetadataOptions(v.Instance, input.HttpPutResponseHopLimit)
+		applyMetadataOptions(v.Instance, input.HttpPutResponseHopLimit, aws.StringValue(input.HttpTokens))
 		opt := *v.Instance.MetadataOptions
 		options = &opt
 		return true
@@ -2190,7 +2192,7 @@ func (s *InstanceServiceImpl) ModifyInstanceMetadataOptions(ctx context.Context,
 		return nil, errors.New(awserrors.ErrorServerInternal)
 	}
 
-	applyMetadataOptions(instance.Instance, input.HttpPutResponseHopLimit)
+	applyMetadataOptions(instance.Instance, input.HttpPutResponseHopLimit, aws.StringValue(input.HttpTokens))
 	if err := s.stoppedStore.WriteStoppedInstance(instanceID, instance); err != nil {
 		slog.ErrorContext(ctx, "ModifyInstanceMetadataOptions: failed to persist stopped instance", "instanceId", instanceID, "err", err)
 		return nil, errors.New(awserrors.ErrorServerInternal)

--- a/spinifex/handlers/imds/imdsv1.go
+++ b/spinifex/handlers/imds/imdsv1.go
@@ -1,0 +1,84 @@
+package handlers_imds
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// v1AllowTTL bounds how long a per-instance HttpTokens decision is reused. The
+// decision only changes via ModifyInstanceMetadataOptions, so a short TTL costs
+// little and keeps the untokened path off the NATS fan-out.
+const v1AllowTTL = 30 * time.Second
+
+type v1AllowEntry struct {
+	allowed bool
+	expires time.Time
+}
+
+// v1AllowCache memoises whether an instance permits IMDSv1. It exists for
+// amplification control: the untokened path is reachable without credentials, so
+// resolving HttpTokens per request would let any guest drive unbounded
+// DescribeInstances fan-outs.
+type v1AllowCache struct {
+	mu      sync.Mutex
+	entries map[string]v1AllowEntry
+}
+
+func newV1AllowCache() *v1AllowCache {
+	return &v1AllowCache{entries: make(map[string]v1AllowEntry)}
+}
+
+func (c *v1AllowCache) get(instanceID string, now time.Time) (bool, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[instanceID]
+	if !ok || now.After(e.expires) {
+		return false, false
+	}
+	return e.allowed, true
+}
+
+func (c *v1AllowCache) put(instanceID string, allowed bool, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[instanceID] = v1AllowEntry{allowed: allowed, expires: now.Add(v1AllowTTL)}
+}
+
+func (c *v1AllowCache) sweep(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, e := range c.entries {
+		if now.After(e.expires) {
+			delete(c.entries, id)
+		}
+	}
+}
+
+// imdsV1Allowed reports whether this ENI's instance was launched or modified
+// with HttpTokens=optional, which is the only case where an untokened GET is
+// served. Defaults closed: an unattached ENI, a lookup failure or a missing
+// instance all deny.
+func (s *IMDSServiceImpl) imdsV1Allowed(ctx context.Context, eni *eniFacts) bool {
+	if eni.instanceID == "" {
+		return false
+	}
+	if allowed, ok := s.v1Allow.get(eni.instanceID, s.now()); ok {
+		return allowed
+	}
+
+	inst, err := s.resolver.resolveInstance(ctx, eni)
+	if err != nil {
+		slog.WarnContext(ctx, "IMDS: HttpTokens lookup failed, denying untokened request",
+			"instance_id", eni.instanceID, "err", err)
+	}
+	allowed := err == nil && inst != nil && inst.httpTokens == ec2.HttpTokensStateOptional
+
+	// Cached even on failure: without that, a guest could replay a failing
+	// lookup to keep the fan-out running.
+	s.v1Allow.put(eni.instanceID, allowed, s.now())
+	return allowed
+}

--- a/spinifex/handlers/imds/imdsv1_test.go
+++ b/spinifex/handlers/imds/imdsv1_test.go
@@ -1,0 +1,146 @@
+package handlers_imds
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingResolver wraps fakeResolver to count instance lookups, so the cache
+// can be shown to keep the untokened path off the DescribeInstances fan-out.
+type countingResolver struct {
+	fakeResolver
+
+	calls int
+}
+
+func (c *countingResolver) resolveInstance(ctx context.Context, eni *eniFacts) (*instanceFacts, error) {
+	c.calls++
+	return c.fakeResolver.resolveInstance(ctx, eni)
+}
+
+func v1Resolver(httpTokens string) *countingResolver {
+	return &countingResolver{fakeResolver: fakeResolver{
+		eni:  testENI(),
+		inst: &instanceFacts{httpTokens: httpTokens},
+	}}
+}
+
+// An instance left at the default still 401s an untokened GET, so the IMDSv1
+// opt-in cannot leak to instances that never asked for it.
+func TestHTTP_TokenlessGETRejectedWhenTokensRequired(t *testing.T) {
+	svc, _ := newTestService(v1Resolver(ec2.HttpTokensStateRequired), &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	rec := get(t, h, prefixMetaData+"instance-id", "")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Empty(t, rec.Body.String())
+}
+
+// HttpTokens=optional is what lets an IMDSv1-only agent such as cloudbase-init
+// read metadata without performing the token handshake.
+func TestHTTP_TokenlessGETServedWhenTokensOptional(t *testing.T) {
+	svc, _ := newTestService(v1Resolver(ec2.HttpTokensStateOptional), &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	rec := get(t, h, prefixMetaData+"instance-id", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "i-0123456789", rec.Body.String())
+}
+
+// IMDSv2 keeps working unchanged on an instance that also permits v1.
+func TestHTTP_TokenedGETStillServedWhenTokensOptional(t *testing.T) {
+	svc, _ := newTestService(v1Resolver(ec2.HttpTokensStateOptional), &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	rec := get(t, h, prefixMetaData+"instance-id", issueToken(t, h))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "i-0123456789", rec.Body.String())
+}
+
+// A valid token short-circuits before the http-tokens lookup, so compliant
+// IMDSv2 clients never pay for the opt-in check.
+func TestIMDSv1_TokenedRequestSkipsLookup(t *testing.T) {
+	res := v1Resolver(ec2.HttpTokensStateRequired)
+	svc, _ := newTestService(res, &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	token := issueToken(t, h)
+	rec := get(t, h, prefixMetaData+"local-ipv4", token)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Zero(t, res.calls, "a valid token must not trigger an http-tokens lookup")
+}
+
+// The untokened path is reachable without credentials, so repeated requests must
+// not each drive a DescribeInstances fan-out.
+func TestIMDSv1_LookupIsCached(t *testing.T) {
+	res := v1Resolver(ec2.HttpTokensStateOptional)
+	svc, _ := newTestService(res, &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	for range 5 {
+		require.Equal(t, http.StatusOK, get(t, h, prefixMetaData+"instance-id", "").Code)
+	}
+	assert.Equal(t, 1, res.calls, "http-tokens must be resolved once and cached")
+}
+
+// A failed lookup denies and is cached too: without caching the failure, a guest
+// could replay a failing request to keep the fan-out running.
+func TestIMDSv1_LookupFailureDeniesAndCaches(t *testing.T) {
+	res := &countingResolver{fakeResolver: fakeResolver{
+		eni:     testENI(),
+		instErr: errors.New("gather timeout"),
+	}}
+	svc, _ := newTestService(res, &fakeIAM{}, &fakeAssumer{})
+	h := withTapENI(svc.httpHandler(), testENI())
+
+	for range 3 {
+		assert.Equal(t, http.StatusUnauthorized, get(t, h, prefixMetaData+"instance-id", "").Code)
+	}
+	assert.Equal(t, 1, res.calls, "a failing lookup must not be retried per request")
+}
+
+// An expired entry is re-resolved, so flipping HttpTokens takes effect without a
+// vpcd restart.
+func TestIMDSv1_CacheExpires(t *testing.T) {
+	c := newV1AllowCache()
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	c.put("i-1", true, now)
+	allowed, ok := c.get("i-1", now.Add(v1AllowTTL-time.Second))
+	require.True(t, ok)
+	assert.True(t, allowed)
+
+	_, ok = c.get("i-1", now.Add(v1AllowTTL+time.Second))
+	assert.False(t, ok, "entry must expire after the TTL")
+}
+
+// sweep drops expired entries so the map cannot grow without bound across
+// instance churn.
+func TestIMDSv1_CacheSweep(t *testing.T) {
+	c := newV1AllowCache()
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	c.put("i-old", true, now)
+	c.put("i-new", true, now.Add(v1AllowTTL))
+	c.sweep(now.Add(v1AllowTTL + time.Second))
+
+	_, ok := c.get("i-old", now.Add(v1AllowTTL+time.Second))
+	assert.False(t, ok)
+	assert.Len(t, c.entries, 1, "only the live entry survives the sweep")
+}
+
+// An ENI with no attached instance denies without attempting a lookup.
+func TestIMDSv1_UnattachedENIDenies(t *testing.T) {
+	res := v1Resolver(ec2.HttpTokensStateOptional)
+	svc, _ := newTestService(res, &fakeIAM{}, &fakeAssumer{})
+
+	assert.False(t, svc.imdsV1Allowed(context.Background(), &eniFacts{eniID: "eni-x"}))
+	assert.Zero(t, res.calls)
+}

--- a/spinifex/handlers/imds/instance_lookup.go
+++ b/spinifex/handlers/imds/instance_lookup.go
@@ -82,6 +82,9 @@ func (l *natsInstanceLookup) describe(ctx context.Context, accountID, instanceID
 	if inst.IamInstanceProfile != nil {
 		facts.iamInstanceProfileArn = aws.StringValue(inst.IamInstanceProfile.Arn)
 	}
+	if inst.MetadataOptions != nil {
+		facts.httpTokens = aws.StringValue(inst.MetadataOptions.HttpTokens)
+	}
 
 	facts.userData = l.userData(ctx, accountID, instanceID)
 	return facts, nil

--- a/spinifex/handlers/imds/metadata.go
+++ b/spinifex/handlers/imds/metadata.go
@@ -124,8 +124,10 @@ func (s *IMDSServiceImpl) handleMetadata(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// IMDSv2: valid ENI-bound token required; any failure is 401 to prevent probing.
-	if !s.tokens.validate(r.Header.Get(hdrToken), eni.eniID, s.now()) {
+	// IMDSv2 by default: a valid ENI-bound token is required. Without one the
+	// request is served only if the instance opted into IMDSv1 via
+	// HttpTokens=optional; otherwise 401, to prevent probing.
+	if !s.tokens.validate(r.Header.Get(hdrToken), eni.eniID, s.now()) && !s.imdsV1Allowed(r.Context(), eni) {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}

--- a/spinifex/handlers/imds/metadata_test.go
+++ b/spinifex/handlers/imds/metadata_test.go
@@ -132,6 +132,7 @@ func newTestService(res eniResolver, fIAM profileLookup, assumer stsAssumer) (*I
 	return &IMDSServiceImpl{
 		resolver:   res,
 		tokens:     newTokenStore(),
+		v1Allow:    newV1AllowCache(),
 		creds:      newCredCache(assumer),
 		iam:        fIAM,
 		pubKeys:    &fakePublicKeys{},

--- a/spinifex/handlers/imds/resolver.go
+++ b/spinifex/handlers/imds/resolver.go
@@ -53,6 +53,7 @@ type instanceFacts struct {
 	architecture          string
 	reservationID         string
 	lifecycleType         string // "spot" for spot-launched instances, else empty (on-demand)
+	httpTokens            string // "optional" permits IMDSv1; empty or "required" does not
 	amiLaunchIndex        int64
 	pendingTime           time.Time
 	userData              []byte

--- a/spinifex/handlers/imds/service.go
+++ b/spinifex/handlers/imds/service.go
@@ -62,6 +62,7 @@ type eniResolver interface {
 type IMDSServiceImpl struct {
 	resolver       eniResolver
 	tokens         *tokenStore
+	v1Allow        *v1AllowCache
 	creds          *credCache
 	iam            profileLookup
 	pubKeys        publicKeyLookup
@@ -136,6 +137,7 @@ func NewIMDSServiceImpl(ctx context.Context, natsConn *nats.Conn, sts stsAssumer
 			lookup:   &natsInstanceLookup{nc: natsConn, expectedNodes: expectedNodes},
 		},
 		tokens:         newTokenStore(),
+		v1Allow:        newV1AllowCache(),
 		creds:          newCredCache(sts),
 		iam:            iamSvc,
 		pubKeys:        pubKeys,
@@ -225,6 +227,7 @@ func (s *IMDSServiceImpl) sweepExpired(ctx context.Context) {
 			now := s.now()
 			s.tokens.sweep(now)
 			s.creds.sweep(now)
+			s.v1Allow.sweep(now)
 		}
 	}
 }


### PR DESCRIPTION
Plan: `docs/development/feature/imds-http-tokens-optional.md` · Bead: `mulga-zm6j4` · Blocks: `mulga-1c3e7`

## Problem

Spinifex IMDS is IMDSv2-only: `handleMetadata` 401s any GET without a valid ENI-bound token, and
`validateMetadataOptions` rejects `HttpTokens=optional` with `UnsupportedOperation`.

That makes Windows guests impossible. cloudbase-init is the only realistic Windows bootstrap agent
and it is IMDSv1-only — its `EC2Service` has no token-acquisition code in the 1.1.8 release tag or on
current master. A Windows guest gets 401 on every metadata read, so it never receives a hostname, an
injected administrator password, or user-data.

Two reasons per-instance opt-in is the right answer rather than patching the agent:

- AWS itself defaults `HttpTokens` to `optional`. Spinifex is currently *stricter* than the API it
  emulates, so this is parity work, not a weakening — the Spinifex launch default stays `required`.
- Patching cloudbase-init and shipping it inside a Mulga-built golden image would leave any
  customer-supplied Windows AMI broken, contradicting the BYOI parity principle: metadata is served
  by the platform and must work for any image.

## Change

`validateMetadataOptions` accepts `optional` and `required` and keeps rejecting every other
non-default field, so `HttpEndpoint`, IPv6 and tags stay unsupported. `buildMetadataOptions` falls
back to `required` when empty, so an unspecified launch is unchanged, and `applyMetadataOptions` can
move `HttpTokens` on an existing instance alongside the hop limit.

`handleMetadata` no longer 401s unconditionally on a failed token check: it falls through to a
per-instance check and serves the request when that instance is `optional`. A valid token
short-circuits first, so compliant IMDSv2 clients pay nothing.

The per-instance value comes from `DescribeInstances`, a NATS fan-out. Consulting it on the
untokened path would let an unauthenticated guest drive unbounded fan-outs, so results are held in a
30s TTL cache keyed by instance ID — including failures, otherwise a guest could replay a failing
lookup to keep the fan-out running.

## Tests

Three existing tests asserted the old rejection and are inverted. The default-stamping tests are
deliberately untouched — they are what proves the default did not drift to `optional`.

New: `required` still 401s an untokened GET; `optional` is served; tokened GETs work under both; a
valid token skips the lookup entirely; the untokened path resolves once and caches; a failed lookup
denies and caches; entries expire and sweep; an unattached ENI denies without a lookup.

Verified live before the dev box was rebuilt: an instance at `optional` served an untokened v1 GET
(200, correct instance-id) while one at the default 401'd, and IMDSv2 worked on both.

Preflight green: golangci-lint 0 issues, govulncheck clean, diff coverage 92.5%.