### PR TITLE
fix(ec2): report Platform=windows for Windows images and instances

### DIFF
--- a/spinifex/handlers/ec2/image/service_impl.go
+++ b/spinifex/handlers/ec2/image/service_impl.go
@@ -272,6 +272,7 @@ func (s *ImageServiceImpl) DescribeImages(ctx context.Context, input *ec2.Descri
 			Description:        aws.String(amiMeta.Description),
 			Architecture:       aws.String(amiMeta.Architecture),
 			PlatformDetails:    aws.String(amiMeta.PlatformDetails),
+			Platform:           utils.PlatformFromDetails(amiMeta.PlatformDetails),
 			CreationDate:       aws.String(amiMeta.CreationDate.Format("2006-01-02T15:04:05.000Z")),
 			RootDeviceType:     aws.String(amiMeta.RootDeviceType),
 			VirtualizationType: aws.String(amiMeta.Virtualization),

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -551,6 +551,10 @@ func (s *InstanceServiceImpl) PrepareRunInstances(ctx context.Context, input *ec
 		}
 		instance.BootMode = amiMeta.BootMode
 
+		// Stamped at launch so DescribeInstances keeps reporting the AMI's platform
+		// even if the image is later deregistered.
+		ec2Instance.Platform = utils.PlatformFromDetails(amiMeta.PlatformDetails)
+
 		// Terraform may pass subnet/SG via NetworkInterfaces[0]; lift to top-level.
 		if (input.SubnetId == nil || *input.SubnetId == "") &&
 			len(input.NetworkInterfaces) > 0 && input.NetworkInterfaces[0] != nil {

--- a/spinifex/utils/platform.go
+++ b/spinifex/utils/platform.go
@@ -1,0 +1,22 @@
+package utils
+
+import "strings"
+
+// PlatformWindows is the only value AWS ever puts in the ec2 Platform field.
+const PlatformWindows = "windows"
+
+// PlatformFromDetails derives the AWS Platform field from PlatformDetails,
+// returning nil for anything that is not Windows.
+//
+// The two fields are not interchangeable: PlatformDetails is a billing string
+// covering every OS ("Linux/UNIX", "Red Hat Enterprise Linux", "Windows",
+// "Windows BYOL"), while Platform is either "windows" or absent. The AWS SDKs
+// and the Terraform provider key off Platform to decide an image or instance is
+// Windows, so a Windows AMI that omits it reads as Linux.
+func PlatformFromDetails(platformDetails string) *string {
+	if !strings.HasPrefix(strings.ToLower(platformDetails), PlatformWindows) {
+		return nil
+	}
+	p := PlatformWindows
+	return &p
+}

--- a/spinifex/utils/platform_test.go
+++ b/spinifex/utils/platform_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import "testing"
+
+func TestPlatformFromDetails(t *testing.T) {
+	tests := []struct {
+		name            string
+		platformDetails string
+		want            string
+	}{
+		{name: "windows", platformDetails: "Windows", want: PlatformWindows},
+		{name: "windows byol", platformDetails: "Windows BYOL", want: PlatformWindows},
+		{name: "windows with sql", platformDetails: "Windows with SQL Server Standard", want: PlatformWindows},
+		{name: "lowercase windows", platformDetails: "windows", want: PlatformWindows},
+		{name: "linux", platformDetails: "Linux/UNIX", want: ""},
+		{name: "rhel", platformDetails: "Red Hat Enterprise Linux", want: ""},
+		{name: "empty", platformDetails: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PlatformFromDetails(tt.platformDetails)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("PlatformFromDetails(%q) = %q, want nil", tt.platformDetails, *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("PlatformFromDetails(%q) = nil, want %q", tt.platformDetails, tt.want)
+			}
+			if *got != tt.want {
+				t.Fatalf("PlatformFromDetails(%q) = %q, want %q", tt.platformDetails, *got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`DescribeImages` and `DescribeInstances` only ever populated `PlatformDetails`. That is a billing string covering every OS (`Linux/UNIX`, `Red Hat Enterprise Linux`, `Windows`, `Windows BYOL`). The AWS SDKs and the Terraform provider key off the separate `Platform` field, which AWS sets to `windows` or omits entirely.

Result: the Windows AMI imported on env12 (`ami-925a78ad4f10cc77c`) reports `Platform: None`, so anything downstream reads it as Linux.

## Change

New `utils.PlatformFromDetails` derives `Platform` from `PlatformDetails`, returning nil for anything non-Windows. Wired into the `DescribeImages` projection and stamped onto the EC2 instance at launch alongside `BootMode`.

Deriving rather than persisting a new field on viperblock's `AMIMetadata` avoids a cross-repo bump and fixes already-imported AMIs without a re-import.

## Testing

Table-driven unit test over `Windows`, `Windows BYOL`, `Windows with SQL Server Standard`, lowercase, `Linux/UNIX`, `Red Hat Enterprise Linux` and empty. `make preflight` passes.

Live verification on env12 against the existing Windows AMI to follow.

Bead: `mulga-qu3s2`