### PR TITLE
feat(ec2): serve the Windows administrator password via GetPasswordData

### DIFF
--- a/spinifex/daemon/daemon_handlers_password.go
+++ b/spinifex/daemon/daemon_handlers_password.go
@@ -1,0 +1,106 @@
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+// passwordDataPattern matches a <Password>...</Password> block. The
+// character class excludes '<' so an unterminated opener (no matching close
+// tag before the next '<') simply fails to match rather than swallowing
+// unrelated console output that follows it.
+var passwordDataPattern = regexp.MustCompile(`<Password>([^<]*)</Password>`)
+
+// extractLastPasswordData scans console log data for <Password>...</Password>
+// blocks and returns the base64 ciphertext of the last one, matching AWS's
+// "last such data emitted" semantics. CRLF line endings and surrounding
+// whitespace from interleaved boot output are trimmed. Returns "" when no
+// well-formed block is present.
+func extractLastPasswordData(data []byte) string {
+	matches := passwordDataPattern.FindAllSubmatch(data, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	last := matches[len(matches)-1][1]
+	return strings.TrimSpace(string(last))
+}
+
+// handleEC2GetPasswordData reads the console log file for an instance and
+// returns the last password blob the guest emitted, matching the AWS
+// GetPasswordData API response format. The blob is opaque ciphertext
+// encrypted with the launch key pair's public key: Spinifex never handles
+// key material and never sees the plaintext password.
+func (d *Daemon) handleEC2GetPasswordData(msg *nats.Msg) {
+	slog.Debug("Received GetPasswordData request", "subject", msg.Subject, "data", string(msg.Data))
+
+	var input ec2.GetPasswordDataInput
+	if errResp := utils.UnmarshalJsonPayload(&input, msg.Data); errResp != nil {
+		if err := msg.Respond(errResp); err != nil {
+			slog.Error("Failed to respond to NATS request", "err", err)
+		}
+		return
+	}
+
+	if input.InstanceId == nil {
+		respondWithError(msg, awserrors.ErrorMissingParameter)
+		return
+	}
+
+	instanceID := *input.InstanceId
+
+	// Find the instance on this node
+	instance, exists := d.vmMgr.Get(instanceID)
+	if !exists {
+		respondWithError(msg, awserrors.ErrorInvalidInstanceIDNotFound)
+		return
+	}
+
+	// Verify the caller owns this instance
+	if !checkInstanceOwnership(msg, instanceID, instance.AccountID) {
+		return
+	}
+
+	logPath := instance.Config.ConsoleLogPath
+	var passwordData string
+	var modTime time.Time
+
+	if logPath != "" {
+		info, err := os.Stat(logPath)
+		if err == nil {
+			modTime = info.ModTime()
+
+			// Scan the whole log, not just the AWS 64KB console tail: the
+			// password is emitted once at first boot and could scroll off
+			// a long-running guest before it is ever fetched.
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				slog.Error("Failed to read console log", "path", logPath, "err", err)
+			} else {
+				passwordData = extractLastPasswordData(data)
+			}
+		}
+	}
+
+	now := time.Now()
+	if modTime.IsZero() {
+		modTime = now
+	}
+
+	output := &ec2.GetPasswordDataOutput{
+		InstanceId:   &instanceID,
+		PasswordData: &passwordData,
+		Timestamp:    &modTime,
+	}
+
+	respondWithJSON(msg, output)
+	// Log the ciphertext length only; the payload itself is never logged.
+	slog.Info("handleEC2GetPasswordData completed", "instance_id", instanceID, "password_data_bytes", len(passwordData))
+}

--- a/spinifex/daemon/daemon_handlers_password_test.go
+++ b/spinifex/daemon/daemon_handlers_password_test.go
@@ -1,0 +1,161 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractLastPasswordData(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "last block wins when several are present",
+			data: "<Password>Zmlyc3Q=</Password>\nnoise\n<Password>c2Vjb25k</Password>",
+			want: "c2Vjb25k",
+		},
+		{
+			name: "CRLF line endings",
+			data: "boot noise\r\n<Password>Y3JsZg==</Password>\r\nmore noise\r\n",
+			want: "Y3JsZg==",
+		},
+		{
+			name: "block surrounded by unrelated console output",
+			data: "Booting kernel...\nStarting services\n<Password>c3Vycm91bmRlZA==</Password>\nLogin prompt ready\n",
+			want: "c3Vycm91bmRlZA==",
+		},
+		{
+			name: "no block at all",
+			data: "just regular console output\nwith no password blocks\n",
+			want: "",
+		},
+		{
+			name: "empty log content",
+			data: "",
+			want: "",
+		},
+		{
+			name: "malformed unterminated opener",
+			data: "<Password>dGhpc05ldmVyQ2xvc2Vz\nrest of the boot log continues here",
+			want: "",
+		},
+		{
+			name: "unterminated opener does not swallow a later valid block",
+			data: "<Password>dGhpc05ldmVyQ2xvc2Vz\n<Password>dmFsaWQ=</Password>",
+			want: "dmFsaWQ=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLastPasswordData([]byte(tt.data))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHandleEC2GetPasswordData(t *testing.T) {
+	natsURL := sharedNATSURL
+	daemon := createFullTestDaemon(t, natsURL)
+
+	instanceID := "i-password-test-001"
+
+	tmpDir := t.TempDir()
+	logPath := tmpDir + "/console-" + instanceID + ".log"
+	logContent := "Booting...\r\n<Password>Zmlyc3Q=</Password>\r\nmore boot noise\r\n<Password>bGFzdA==</Password>\r\n"
+	require.NoError(t, os.WriteFile(logPath, []byte(logContent), 0644))
+
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:        instanceID,
+		Status:    vm.StateRunning,
+		AccountID: testAccountID,
+		Config: vm.Config{
+			ConsoleLogPath: logPath,
+		},
+	})
+	topic := fmt.Sprintf("ec2.%s.GetPasswordData", instanceID)
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{
+		InstanceId: aws.String(instanceID),
+	}
+	reqData, _ := json.Marshal(input)
+	reply, err := natsRequest(daemon.natsConn, topic, reqData, 5*time.Second)
+	require.NoError(t, err)
+
+	var output ec2.GetPasswordDataOutput
+	err = json.Unmarshal(reply.Data, &output)
+	require.NoError(t, err)
+	assert.Equal(t, instanceID, *output.InstanceId)
+	require.NotNil(t, output.PasswordData)
+	assert.Equal(t, "bGFzdA==", *output.PasswordData)
+	assert.NotNil(t, output.Timestamp)
+}
+
+func TestHandleEC2GetPasswordData_EmptyLog(t *testing.T) {
+	natsURL := sharedNATSURL
+	daemon := createFullTestDaemon(t, natsURL)
+
+	instanceID := "i-password-empty-001"
+
+	// Instance exists but the guest never emitted a password block.
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:        instanceID,
+		Status:    vm.StateRunning,
+		AccountID: testAccountID,
+		Config: vm.Config{
+			ConsoleLogPath: "/nonexistent/console.log",
+		},
+	})
+	topic := fmt.Sprintf("ec2.%s.GetPasswordData", instanceID)
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{
+		InstanceId: aws.String(instanceID),
+	}
+	reqData, _ := json.Marshal(input)
+	reply, err := natsRequest(daemon.natsConn, topic, reqData, 5*time.Second)
+	require.NoError(t, err)
+
+	var output ec2.GetPasswordDataOutput
+	err = json.Unmarshal(reply.Data, &output)
+	require.NoError(t, err)
+	assert.Equal(t, instanceID, *output.InstanceId)
+	require.NotNil(t, output.PasswordData)
+	assert.Empty(t, *output.PasswordData)
+}
+
+func TestHandleEC2GetPasswordData_NotFound(t *testing.T) {
+	natsURL := sharedNATSURL
+	daemon := createFullTestDaemon(t, natsURL)
+
+	instanceID := "i-nonexistent-password"
+	topic := fmt.Sprintf("ec2.%s.GetPasswordData", instanceID)
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{
+		InstanceId: aws.String(instanceID),
+	}
+	reqData, _ := json.Marshal(input)
+	reply, err := daemon.natsConn.Request(topic, reqData, 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(reply.Data), "InvalidInstanceID.NotFound")
+}

--- a/spinifex/daemon/daemon_handlers_password_test.go
+++ b/spinifex/daemon/daemon_handlers_password_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,6 +139,70 @@ func TestHandleEC2GetPasswordData_EmptyLog(t *testing.T) {
 	assert.Equal(t, instanceID, *output.InstanceId)
 	require.NotNil(t, output.PasswordData)
 	assert.Empty(t, *output.PasswordData)
+}
+
+func TestHandleEC2GetPasswordData_MissingInstanceId(t *testing.T) {
+	natsURL := sharedNATSURL
+	daemon := createFullTestDaemon(t, natsURL)
+
+	topic := "ec2._.GetPasswordData"
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{}
+	reqData, _ := json.Marshal(input)
+	reply, err := daemon.natsConn.Request(topic, reqData, 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(reply.Data), awserrors.ErrorMissingParameter)
+}
+
+func TestHandleEC2GetPasswordData_MalformedInput(t *testing.T) {
+	natsURL := sharedNATSURL
+	daemon := createFullTestDaemon(t, natsURL)
+
+	topic := "ec2._.GetPasswordData"
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	reply, err := daemon.natsConn.Request(topic, []byte("not json"), 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(reply.Data), awserrors.ErrorValidationError)
+}
+
+func TestHandleEC2GetPasswordData_OwnershipDenied(t *testing.T) {
+	natsURL := sharedNATSURL
+	daemon := createFullTestDaemon(t, natsURL)
+
+	instanceID := "i-password-other-account"
+
+	// Instance is owned by testAccountID; the request below comes from a
+	// different account and must be refused as NotFound rather than leaking
+	// whether the instance exists.
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:        instanceID,
+		Status:    vm.StateRunning,
+		AccountID: testAccountID,
+		Config: vm.Config{
+			ConsoleLogPath: "/nonexistent/console.log",
+		},
+	})
+	topic := fmt.Sprintf("ec2.%s.GetPasswordData", instanceID)
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{
+		InstanceId: aws.String(instanceID),
+	}
+	reqData, _ := json.Marshal(input)
+	reply, err := natsRequestAs(daemon.natsConn, topic, reqData, "999999999999", 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(reply.Data), awserrors.ErrorInvalidInstanceIDNotFound)
 }
 
 func TestHandleEC2GetPasswordData_NotFound(t *testing.T) {

--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -431,40 +431,46 @@ func (d *Daemon) onInstanceUpHook() func(*vm.VM) error {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 
-		if existing, ok := d.natsSubscriptions[instance.ID]; ok {
-			_ = existing.Unsubscribe()
-		}
 		consoleSubKey := instance.ID + ".console"
-		if existing, ok := d.natsSubscriptions[consoleSubKey]; ok {
-			_ = existing.Unsubscribe()
-		}
-
-		sub, err := d.natsConn.Subscribe(fmt.Sprintf("ec2.cmd.%s", instance.ID), d.handleEC2Events)
-		if err != nil {
-			slog.Error("OnInstanceUp: failed to subscribe to per-instance topic",
-				"instanceId", instance.ID, "err", err)
-			return fmt.Errorf("subscribe ec2.cmd.%s: %w", instance.ID, err)
-		}
-		d.natsSubscriptions[instance.ID] = sub
-
-		consoleSub, err := d.natsConn.Subscribe(
-			fmt.Sprintf("ec2.%s.GetConsoleOutput", instance.ID),
-			d.handleEC2GetConsoleOutput,
-		)
-		if err != nil {
-			// Roll back the first sub so the instance doesn't end up Running with
-			// one of two per-instance topics live — leaving GetConsoleOutput
-			// unreachable while Stop / Terminate continue to work.
-			if unsubErr := sub.Unsubscribe(); unsubErr != nil {
-				slog.Warn("OnInstanceUp: failed to unsubscribe command topic during rollback",
-					"instanceId", instance.ID, "err", unsubErr)
+		passwordSubKey := instance.ID + ".password"
+		for _, key := range []string{instance.ID, consoleSubKey, passwordSubKey} {
+			if existing, ok := d.natsSubscriptions[key]; ok {
+				_ = existing.Unsubscribe()
 			}
-			delete(d.natsSubscriptions, instance.ID)
-			slog.Error("OnInstanceUp: failed to subscribe to console output topic",
-				"instanceId", instance.ID, "err", err)
-			return fmt.Errorf("subscribe ec2.%s.GetConsoleOutput: %w", instance.ID, err)
 		}
-		d.natsSubscriptions[consoleSubKey] = consoleSub
+
+		// Bind the whole per-instance topic set as one unit: if any subscribe
+		// fails partway through, every topic already bound in this call is
+		// unwound so the instance never comes up Running with only some of
+		// its topics reachable.
+		topics := []struct {
+			key     string
+			subject string
+			handler nats.MsgHandler
+		}{
+			{instance.ID, fmt.Sprintf("ec2.cmd.%s", instance.ID), d.handleEC2Events},
+			{consoleSubKey, fmt.Sprintf("ec2.%s.GetConsoleOutput", instance.ID), d.handleEC2GetConsoleOutput},
+			{passwordSubKey, fmt.Sprintf("ec2.%s.GetPasswordData", instance.ID), d.handleEC2GetPasswordData},
+		}
+
+		bound := make([]string, 0, len(topics))
+		for _, t := range topics {
+			sub, err := d.natsConn.Subscribe(t.subject, t.handler)
+			if err != nil {
+				slog.Error("OnInstanceUp: failed to subscribe to per-instance topic",
+					"instanceId", instance.ID, "subject", t.subject, "err", err)
+				for _, key := range bound {
+					if unsubErr := d.natsSubscriptions[key].Unsubscribe(); unsubErr != nil {
+						slog.Warn("OnInstanceUp: failed to unsubscribe during rollback",
+							"instanceId", instance.ID, "key", key, "err", unsubErr)
+					}
+					delete(d.natsSubscriptions, key)
+				}
+				return fmt.Errorf("subscribe %s: %w", t.subject, err)
+			}
+			d.natsSubscriptions[t.key] = sub
+			bound = append(bound, t.key)
+		}
 
 		// Bind the per-instance terminate subscription for any system-managed VM
 		// (ELBv2 load balancers, EKS K3s control-plane VMs). OnInstanceUp is the
@@ -564,6 +570,14 @@ func (d *Daemon) onInstanceDownHook() func(string) {
 					"instanceId", instanceID, "err", err)
 			}
 			delete(d.natsSubscriptions, consoleSubKey)
+		}
+		passwordSubKey := instanceID + ".password"
+		if sub, ok := d.natsSubscriptions[passwordSubKey]; ok {
+			if err := sub.Unsubscribe(); err != nil {
+				slog.Error("OnInstanceDown: failed to unsubscribe password topic",
+					"instanceId", instanceID, "err", err)
+			}
+			delete(d.natsSubscriptions, passwordSubKey)
 		}
 		// Drop the system terminate subscription (system VMs only; a no-op for
 		// regular instances that never registered one).

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -39,7 +39,7 @@ func newHookTestDaemon(t *testing.T) (*Daemon, *nats.Conn) {
 	return d, nc
 }
 
-func TestOnInstanceUpHook_RegistersBothPerInstanceTopics(t *testing.T) {
+func TestOnInstanceUpHook_RegistersAllPerInstanceTopics(t *testing.T) {
 	d, _ := newHookTestDaemon(t)
 	instance := &vm.VM{ID: "i-up-basic"}
 
@@ -52,6 +52,10 @@ func TestOnInstanceUpHook_RegistersBothPerInstanceTopics(t *testing.T) {
 	consoleSub, ok := d.natsSubscriptions[instance.ID+".console"]
 	require.True(t, ok, "console subscription must be registered under <id>.console key")
 	assert.Equal(t, "ec2.i-up-basic.GetConsoleOutput", consoleSub.Subject)
+
+	passwordSub, ok := d.natsSubscriptions[instance.ID+".password"]
+	require.True(t, ok, "password subscription must be registered under <id>.password key")
+	assert.Equal(t, "ec2.i-up-basic.GetPasswordData", passwordSub.Subject)
 }
 
 func TestOnInstanceUpHook_ReArmsSystemTerminateForELBv2(t *testing.T) {
@@ -116,23 +120,30 @@ func TestOnInstanceUpHook_ReplacesExistingSubsOnDoubleUp(t *testing.T) {
 	require.NoError(t, d.onInstanceUpHook()(instance))
 	first := d.natsSubscriptions[instance.ID]
 	firstConsole := d.natsSubscriptions[instance.ID+".console"]
+	firstPassword := d.natsSubscriptions[instance.ID+".password"]
 	require.NotNil(t, first)
 	require.NotNil(t, firstConsole)
+	require.NotNil(t, firstPassword)
 
 	require.NoError(t, d.onInstanceUpHook()(instance))
 	second := d.natsSubscriptions[instance.ID]
 	secondConsole := d.natsSubscriptions[instance.ID+".console"]
+	secondPassword := d.natsSubscriptions[instance.ID+".password"]
 	require.NotNil(t, second)
 	require.NotNil(t, secondConsole)
+	require.NotNil(t, secondPassword)
 
 	// Second call must have unsubscribed the originals (so they're no longer
 	// receiving on the topic) and replaced the map entries with fresh subs.
 	assert.False(t, first.IsValid(), "first command sub should be unsubscribed")
 	assert.False(t, firstConsole.IsValid(), "first console sub should be unsubscribed")
+	assert.False(t, firstPassword.IsValid(), "first password sub should be unsubscribed")
 	assert.True(t, second.IsValid(), "second command sub should be live")
 	assert.True(t, secondConsole.IsValid(), "second console sub should be live")
+	assert.True(t, secondPassword.IsValid(), "second password sub should be live")
 	assert.NotSame(t, first, second, "command sub map entry must be replaced")
 	assert.NotSame(t, firstConsole, secondConsole, "console sub map entry must be replaced")
+	assert.NotSame(t, firstPassword, secondPassword, "password sub map entry must be replaced")
 }
 
 func TestOnInstanceDownHook_UnsubscribesAndDeletes(t *testing.T) {
@@ -142,17 +153,22 @@ func TestOnInstanceDownHook_UnsubscribesAndDeletes(t *testing.T) {
 	require.NoError(t, d.onInstanceUpHook()(instance))
 	cmdSub := d.natsSubscriptions[instance.ID]
 	consoleSub := d.natsSubscriptions[instance.ID+".console"]
+	passwordSub := d.natsSubscriptions[instance.ID+".password"]
 	require.NotNil(t, cmdSub)
 	require.NotNil(t, consoleSub)
+	require.NotNil(t, passwordSub)
 
 	d.onInstanceDownHook()(instance.ID)
 
 	_, cmdPresent := d.natsSubscriptions[instance.ID]
 	_, consolePresent := d.natsSubscriptions[instance.ID+".console"]
+	_, passwordPresent := d.natsSubscriptions[instance.ID+".password"]
 	assert.False(t, cmdPresent, "command sub must be deleted from map")
 	assert.False(t, consolePresent, "console sub must be deleted from map")
+	assert.False(t, passwordPresent, "password sub must be deleted from map")
 	assert.False(t, cmdSub.IsValid(), "command sub must be unsubscribed")
 	assert.False(t, consoleSub.IsValid(), "console sub must be unsubscribed")
+	assert.False(t, passwordSub.IsValid(), "password sub must be unsubscribed")
 }
 
 func TestOnInstanceDownHook_NoOpWhenAbsent(t *testing.T) {
@@ -207,13 +223,14 @@ func TestOnInstanceDownHook_OnlyRemovesTargetedInstance(t *testing.T) {
 
 	require.NoError(t, d.onInstanceUpHook()(keep))
 	require.NoError(t, d.onInstanceUpHook()(drop))
-	require.Len(t, d.natsSubscriptions, 4)
+	require.Len(t, d.natsSubscriptions, 6)
 
 	d.onInstanceDownHook()(drop.ID)
 
-	assert.Len(t, d.natsSubscriptions, 2)
+	assert.Len(t, d.natsSubscriptions, 3)
 	assert.NotNil(t, d.natsSubscriptions[keep.ID])
 	assert.NotNil(t, d.natsSubscriptions[keep.ID+".console"])
+	assert.NotNil(t, d.natsSubscriptions[keep.ID+".password"])
 	_, dropPresent := d.natsSubscriptions[drop.ID]
 	assert.False(t, dropPresent)
 }

--- a/spinifex/gateway/ec2.go
+++ b/spinifex/gateway/ec2.go
@@ -181,6 +181,9 @@ var ec2Actions = map[string]EC2Handler{
 	"GetConsoleOutput": ec2Handler(func(ctx context.Context, input *ec2.GetConsoleOutputInput, gw *GatewayConfig, accountID string) (any, error) {
 		return gateway_ec2_instance.GetConsoleOutput(ctx, input, gw.NATSConn, accountID)
 	}),
+	"GetPasswordData": ec2Handler(func(ctx context.Context, input *ec2.GetPasswordDataInput, gw *GatewayConfig, accountID string) (any, error) {
+		return gateway_ec2_instance.GetPasswordData(ctx, input, gw.NATSConn, accountID)
+	}),
 	"ModifyInstanceAttribute": ec2Handler(func(ctx context.Context, input *ec2.ModifyInstanceAttributeInput, gw *GatewayConfig, accountID string) (any, error) {
 		var delta int
 		if input.InstanceType != nil {

--- a/spinifex/gateway/ec2/instance/GetPasswordData.go
+++ b/spinifex/gateway/ec2/instance/GetPasswordData.go
@@ -14,6 +14,10 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+// getPasswordDataTimeout is the NATS request timeout, overridable in tests so
+// the ErrTimeout path can be exercised without a real 5-second wait.
+var getPasswordDataTimeout = 5 * time.Second
+
 func ValidateGetPasswordDataInput(input *ec2.GetPasswordDataInput) error {
 	if input == nil {
 		return errors.New(awserrors.ErrorInvalidParameterValue)
@@ -42,7 +46,7 @@ func GetPasswordData(ctx context.Context, input *ec2.GetPasswordDataInput, natsC
 	reqMsg.Data = jsonData
 	reqMsg.Header.Set(utils.AccountIDHeader, accountID)
 	utils.InjectTraceContext(ctx, reqMsg.Header)
-	msg, err := natsConn.RequestMsg(reqMsg, 5*time.Second)
+	msg, err := natsConn.RequestMsg(reqMsg, getPasswordDataTimeout)
 	if err != nil {
 		// No daemon subscription or timeout: stopped/terminated/non-existent instances all surface as NotFound.
 		if errors.Is(err, nats.ErrNoResponders) || errors.Is(err, nats.ErrTimeout) {

--- a/spinifex/gateway/ec2/instance/GetPasswordData.go
+++ b/spinifex/gateway/ec2/instance/GetPasswordData.go
@@ -1,0 +1,67 @@
+package gateway_ec2_instance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+)
+
+func ValidateGetPasswordDataInput(input *ec2.GetPasswordDataInput) error {
+	if input == nil {
+		return errors.New(awserrors.ErrorInvalidParameterValue)
+	}
+	if input.InstanceId == nil || *input.InstanceId == "" {
+		return errors.New(awserrors.ErrorMissingParameter)
+	}
+	return nil
+}
+
+// GetPasswordData retrieves the Windows administrator password ciphertext
+// for a specific instance via NATS. Routes directly to the node running the
+// instance via ec2.{instanceID}.GetPasswordData.
+func GetPasswordData(ctx context.Context, input *ec2.GetPasswordDataInput, natsConn *nats.Conn, accountID string) (*ec2.GetPasswordDataOutput, error) {
+	if err := ValidateGetPasswordDataInput(input); err != nil {
+		return nil, err
+	}
+
+	jsonData, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal input: %w", err)
+	}
+
+	topic := fmt.Sprintf("ec2.%s.GetPasswordData", *input.InstanceId)
+	reqMsg := nats.NewMsg(topic)
+	reqMsg.Data = jsonData
+	reqMsg.Header.Set(utils.AccountIDHeader, accountID)
+	utils.InjectTraceContext(ctx, reqMsg.Header)
+	msg, err := natsConn.RequestMsg(reqMsg, 5*time.Second)
+	if err != nil {
+		// No daemon subscription or timeout: stopped/terminated/non-existent instances all surface as NotFound.
+		if errors.Is(err, nats.ErrNoResponders) || errors.Is(err, nats.ErrTimeout) {
+			return nil, errors.New(awserrors.ErrorInvalidInstanceIDNotFound)
+		}
+		return nil, fmt.Errorf("failed to get password data: %w", err)
+	}
+
+	responseError, parseErr := utils.ValidateErrorPayload(msg.Data)
+	if parseErr != nil {
+		slog.ErrorContext(ctx, "GetPasswordData: Daemon returned error", "instance_id", *input.InstanceId, "code", *responseError.Code)
+		return nil, errors.New(*responseError.Code)
+	}
+
+	var output ec2.GetPasswordDataOutput
+	if err := json.Unmarshal(msg.Data, &output); err != nil {
+		slog.ErrorContext(ctx, "GetPasswordData: Failed to unmarshal response", "err", err)
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &output, nil
+}

--- a/spinifex/gateway/ec2/instance/GetPasswordData_test.go
+++ b/spinifex/gateway/ec2/instance/GetPasswordData_test.go
@@ -1,0 +1,176 @@
+package gateway_ec2_instance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shrinkPasswordDataTimeout replaces the NATS request timeout with a small
+// value for the duration of the test, so the ErrTimeout path doesn't burn a
+// real 5 seconds.
+func shrinkPasswordDataTimeout(t *testing.T) {
+	t.Helper()
+	prev := getPasswordDataTimeout
+	getPasswordDataTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { getPasswordDataTimeout = prev })
+}
+
+func TestValidateGetPasswordDataInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *ec2.GetPasswordDataInput
+		wantErr string
+	}{
+		{
+			name:    "nil input",
+			input:   nil,
+			wantErr: awserrors.ErrorInvalidParameterValue,
+		},
+		{
+			name:    "nil InstanceId",
+			input:   &ec2.GetPasswordDataInput{},
+			wantErr: awserrors.ErrorMissingParameter,
+		},
+		{
+			name:    "empty string InstanceId",
+			input:   &ec2.GetPasswordDataInput{InstanceId: aws.String("")},
+			wantErr: awserrors.ErrorMissingParameter,
+		},
+		{
+			name:  "valid input",
+			input: &ec2.GetPasswordDataInput{InstanceId: aws.String("i-0123456789abcdef0")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGetPasswordDataInput(tt.input)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}
+
+func TestGetPasswordData_Success(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+
+	instanceID := "i-0123456789abcdef0"
+	wantPasswordData := "ZW5jcnlwdGVkLXBheWxvYWQ="
+
+	var gotSubject string
+	var gotAccountID string
+	sub, err := nc.Subscribe("ec2."+instanceID+".GetPasswordData", func(msg *nats.Msg) {
+		gotSubject = msg.Subject
+		gotAccountID = msg.Header.Get(utils.AccountIDHeader)
+
+		var receivedInput ec2.GetPasswordDataInput
+		require.NoError(t, json.Unmarshal(msg.Data, &receivedInput))
+		assert.Equal(t, instanceID, *receivedInput.InstanceId)
+
+		output := ec2.GetPasswordDataOutput{
+			InstanceId:   aws.String(instanceID),
+			PasswordData: aws.String(wantPasswordData),
+			Timestamp:    aws.Time(time.Unix(1700000000, 0)),
+		}
+		data, marshalErr := json.Marshal(output)
+		require.NoError(t, marshalErr)
+		require.NoError(t, msg.Respond(data))
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{InstanceId: aws.String(instanceID)}
+	output, err := GetPasswordData(context.Background(), input, nc, "123456789012")
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, instanceID, *output.InstanceId)
+	require.NotNil(t, output.PasswordData)
+	assert.Equal(t, wantPasswordData, *output.PasswordData)
+	assert.NotNil(t, output.Timestamp)
+
+	assert.Equal(t, "ec2."+instanceID+".GetPasswordData", gotSubject)
+	assert.Equal(t, "123456789012", gotAccountID)
+}
+
+func TestGetPasswordData_NoResponders(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+
+	// No subscriber on the topic: an unknown/stopped/terminated instance.
+	input := &ec2.GetPasswordDataInput{InstanceId: aws.String("i-nosubscriber")}
+	output, err := GetPasswordData(context.Background(), input, nc, "123456789012")
+
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.Equal(t, awserrors.ErrorInvalidInstanceIDNotFound, err.Error())
+}
+
+func TestGetPasswordData_Timeout(t *testing.T) {
+	shrinkPasswordDataTimeout(t)
+	_, nc := startTestNATSServer(t)
+
+	instanceID := "i-slow"
+
+	// A live subscriber that never replies forces a real ErrTimeout rather
+	// than the immediate ErrNoResponders a missing subscriber would give.
+	sub, err := nc.Subscribe("ec2."+instanceID+".GetPasswordData", func(msg *nats.Msg) {})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{InstanceId: aws.String(instanceID)}
+	output, err := GetPasswordData(context.Background(), input, nc, "123456789012")
+
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.Equal(t, awserrors.ErrorInvalidInstanceIDNotFound, err.Error())
+}
+
+func TestGetPasswordData_DaemonError(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+
+	instanceID := "i-error"
+	sub, err := nc.Subscribe("ec2."+instanceID+".GetPasswordData", func(msg *nats.Msg) {
+		require.NoError(t, msg.Respond(utils.GenerateErrorPayload(awserrors.ErrorInvalidInstanceIDNotFound)))
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{InstanceId: aws.String(instanceID)}
+	output, err := GetPasswordData(context.Background(), input, nc, "123456789012")
+
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.Equal(t, awserrors.ErrorInvalidInstanceIDNotFound, err.Error())
+}
+
+func TestGetPasswordData_MalformedResponse(t *testing.T) {
+	_, nc := startTestNATSServer(t)
+
+	instanceID := "i-malformed"
+	sub, err := nc.Subscribe("ec2."+instanceID+".GetPasswordData", func(msg *nats.Msg) {
+		require.NoError(t, msg.Respond([]byte("not json")))
+	})
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	input := &ec2.GetPasswordDataInput{InstanceId: aws.String(instanceID)}
+	output, err := GetPasswordData(context.Background(), input, nc, "123456789012")
+
+	require.Error(t, err)
+	assert.Nil(t, output)
+	assert.Contains(t, err.Error(), "failed to unmarshal response")
+}


### PR DESCRIPTION
## Summary

Implements the AWS `GetPasswordData` EC2 API (bead `mulga-5c019`), mirroring the existing `GetConsoleOutput` path for a per-instance, node-routed EC2 call.

The Windows guest encrypts its generated administrator password with the launch key pair's public key, base64s it, and emits it to the instance console as `<Password>BASE64</Password>`. The daemon scans the whole console log for the last such block (not the AWS 64KB console tail, since the password is emitted once at first boot and could scroll off a long-running instance) and returns the ciphertext unchanged. Spinifex never handles key material and never sees the plaintext password.

- `spinifex/daemon/daemon_handlers_password.go` — new `handleEC2GetPasswordData` handler plus `extractLastPasswordData`, which returns the last well-formed `<Password>` block, tolerating CRLF and interleaved console noise, and returning an empty string (never an error) when nothing was emitted or the log doesn't exist.
- `spinifex/gateway/ec2/instance/GetPasswordData.go` — new gateway shim modelled on `GetConsoleOutput.go`, including the NATS `nats.ErrNoResponders`/`nats.ErrTimeout` → `InvalidInstanceID.NotFound` mapping.
- `spinifex/gateway/ec2.go` — registers `GetPasswordData` in the `ec2Actions` dispatch table.
- `spinifex/daemon/vm_adapters.go` — `onInstanceUpHook` now subscribes a third per-instance topic (`ec2.{id}.GetPasswordData`). The two hand-rolled subscribe-then-rollback blocks are refactored into a loop over the topic set, so a failure partway through unwinds every topic already bound in that call rather than nesting a third rollback block by hand. `onInstanceDownHook` unsubscribes the new topic on teardown.

## Test plan

- [x] New unit tests for `extractLastPasswordData`: last block wins among several, CRLF line endings, block surrounded by unrelated console output, no block at all, empty log content, and a malformed/unterminated `<Password>` opener (including one that doesn't swallow a later valid block).
- [x] New handler-level tests (`TestHandleEC2GetPasswordData*`) exercising the NATS round-trip: last-block extraction, empty/missing log, and unknown instance → `InvalidInstanceID.NotFound`.
- [x] Updated `vm_adapters_test.go` subscription-count and per-topic assertions for the new third per-instance topic.
- [x] `go test ./spinifex/daemon/... ./spinifex/gateway/...` passes.
- [x] `golangci-lint run ./spinifex/daemon/... ./spinifex/gateway/...` — 0 issues.
- [ ] `make preflight` — blocked by a pre-existing, unrelated failure: the local `predastore` submodule checkout lacks the `clusterrun` package and `WithPreparedBackend` that `go.mod`'s pinned pseudo-version expects. Reproduces identically with this branch's changes stashed, in files this PR doesn't touch (`tests/fixtures/predastore/predastore.go`, `spinifex/migrate/predastoretopology/`).