### PR TITLE
fix(deps): bump predastore to the commit that adds clusterrun

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.4.0
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.14.0
-	github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4
+	github.com/mulgadc/predastore v1.14.1-0.20260802230245-1b2e787f8591
 	github.com/mulgadc/viperblock v1.14.1-0.20260802141430-3d448922ab52
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0

--- a/go.sum
+++ b/go.sum
@@ -1321,6 +1321,8 @@ github.com/mulgadc/northstar v1.14.0 h1:8JzDcS4k3SN5PF3jBdB8x9FOWC24eITCClmOdwpo
 github.com/mulgadc/northstar v1.14.0/go.mod h1:6EArbWIQUrCFQ+XZ5ZJrGS/ep/u/rF6l+dKZh5vVIRs=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4 h1:Q4/NEryYTMiALkFwbPPOrKpNgLir+d7T2hbyRpAFnWc=
 github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4/go.mod h1:na0aNXABZF03/HfFWCrAPHrId/2FIEIUQfB82vlu1xg=
+github.com/mulgadc/predastore v1.14.1-0.20260802230245-1b2e787f8591 h1:ieayCZRTFwSO2LCCjQZ2cmNCkzgY8MTUagfzjleilyY=
+github.com/mulgadc/predastore v1.14.1-0.20260802230245-1b2e787f8591/go.mod h1:mbo8xMtF7jnsqZg88Y7Ye9S6LqGzkkc46NFP2DESfTM=
 github.com/mulgadc/viperblock v1.14.1-0.20260802141430-3d448922ab52 h1:XFgNGFofRtqv7A85F1i9WxYK8UxpzRP5X2tv6yL/zdY=
 github.com/mulgadc/viperblock v1.14.1-0.20260802141430-3d448922ab52/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
## Problem

`make cluster-deploy` cannot build dev at all:

```
module github.com/mulgadc/predastore@latest found (v1.14.0),
but does not contain package github.com/mulgadc/predastore/clusterrun
```

#591 adopted the new predastore API — `spinifex/services/predastore/predastore.go`, `tests/fixtures/predastore/predastore.go` and `spinifex/migrate/predastoretopology/` all import `github.com/mulgadc/predastore/clusterrun` — but `go.mod` was left pinned at `608939e`, which predates that package and still carries the since-removed `s3.WithNodeID`.

The two predastore commits are exact inverses: `608939e` has `WithNodeID` and no `clusterrun`; `1b2e787` has `clusterrun` and no `WithNodeID`. That is also why a pre-#591 branch and a post-#591 branch could not both build against the same pin.

## Why it went unnoticed

`go.work` at the mulga root redirects the module to the local `predastore` submodule checkout, which mulga HEAD already records at `1b2e787`. So developers and CI both build against a predastore that has `clusterrun`, and never resolve the pin.

The deploy path is the only consumer that resolves `go.mod` for real: `ansible/roles/build/tasks/main.yml` sets `GOWORK: "off"` so worktree deploys work without ambient shell state.

## Change

Pin `predastore` to `v1.14.1-0.20260802230245-1b2e787f8591`, matching the commit already recorded in mulga's HEAD. This is a catch-up to the submodule pointer, not a new bump.

## Testing

`GOWORK=off go build ./...` succeeds on this branch and fails on dev — that is the configuration the deploy path uses.

## Follow-up

Worth adding a `GOWORK=off go build ./...` step to `make preflight`. It is the only configuration that exercises the pins the deploy path actually uses, and it would have caught this at the commit that introduced it.

Bead: `mulga-hv86p`