### PR TITLE
fix(deps): bump predastore and viperblock to their merged dev heads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.14.0
 	github.com/mulgadc/predastore v1.14.1-0.20260802230245-1b2e787f8591
-	github.com/mulgadc/viperblock v1.14.1-0.20260802141430-3d448922ab52
+	github.com/mulgadc/viperblock v1.14.1-0.20260803010735-4e6f5e45b479
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
 	github.com/opencontainers/runtime-spec v1.3.0
@@ -180,6 +180,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/tidwall/btree v1.8.1 // indirect
 	github.com/u-root/uio v0.0.0-20230220225925-ffce2a382923 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1319,12 +1319,10 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/mulgadc/northstar v1.14.0 h1:8JzDcS4k3SN5PF3jBdB8x9FOWC24eITCClmOdwpoY8Q=
 github.com/mulgadc/northstar v1.14.0/go.mod h1:6EArbWIQUrCFQ+XZ5ZJrGS/ep/u/rF6l+dKZh5vVIRs=
-github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4 h1:Q4/NEryYTMiALkFwbPPOrKpNgLir+d7T2hbyRpAFnWc=
-github.com/mulgadc/predastore v1.14.1-0.20260730221229-608939ef2bb4/go.mod h1:na0aNXABZF03/HfFWCrAPHrId/2FIEIUQfB82vlu1xg=
 github.com/mulgadc/predastore v1.14.1-0.20260802230245-1b2e787f8591 h1:ieayCZRTFwSO2LCCjQZ2cmNCkzgY8MTUagfzjleilyY=
 github.com/mulgadc/predastore v1.14.1-0.20260802230245-1b2e787f8591/go.mod h1:mbo8xMtF7jnsqZg88Y7Ye9S6LqGzkkc46NFP2DESfTM=
-github.com/mulgadc/viperblock v1.14.1-0.20260802141430-3d448922ab52 h1:XFgNGFofRtqv7A85F1i9WxYK8UxpzRP5X2tv6yL/zdY=
-github.com/mulgadc/viperblock v1.14.1-0.20260802141430-3d448922ab52/go.mod h1:5ENQb0OrjTplIRiLShRW/oNWOzbFvSCFgo+PkNH4858=
+github.com/mulgadc/viperblock v1.14.1-0.20260803010735-4e6f5e45b479 h1:1fY1JJNqvoBQhzfKgRSmVZAbR20Upsnlw0K0Qm+kVFc=
+github.com/mulgadc/viperblock v1.14.1-0.20260803010735-4e6f5e45b479/go.mod h1:m9SCMRGA3EQZwavdG+Mvs1ch9IHwi1/Iaea1uDhpwYQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -1570,6 +1568,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/substrait-io/substrait-go v0.4.2/go.mod h1:qhpnLmrcvAnlZsUyPXZRqldiHapPTXC3t7xFgDi3aQg=
+github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
+github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=


### PR DESCRIPTION
Two dependency bumps. CI builds off go.mod with no go.work to fall back on, so both were latent build failures that only the workspace was hiding.

## predastore

Spinifex imports `github.com/mulgadc/predastore/clusterrun`, but go.mod pinned the pre-merge pseudo-version `608939ef2bb4`, which predates that package. predastore's rpc-transport work landed after the spinifex change that consumed it, and the pin never moved. Off-workspace builds fell back to resolving the import at `@latest` — v1.14.0, whose tag sits on `main`, behind `dev` — and failed:

```
spinifex/migrate/predastoretopology/004_predastore_topology.go:20:2: module
github.com/mulgadc/predastore@latest found (v1.14.0), but does not contain
package github.com/mulgadc/predastore/clusterrun
```

## viperblock

Bumped to the merged head carrying the matching harness port (viperblock#71). This one needs `go mod tidy` rather than a bare `go get`: viperblock's ordered extent index imports `tidwall/btree`, and without the transitive go.sum entry the build fails resolving it.

Both submodules now pin the same predastore pseudo-version, so there is no MVS skew between them.

## Testing

- `GOWORK=off go build ./...` and `go vet ./...` pass, i.e. reproducing CI's resolution rather than the workspace's.
- `make preflight` passes on both commits.