### PR TITLE
fix: stop viperblockd discarding the configured S3 region

### DIFF
--- a/cmd/spinifex/cmd/service.go
+++ b/cmd/spinifex/cmd/service.go
@@ -1301,9 +1301,12 @@ func init() {
 
 	serviceCmd.AddCommand(viperblockCmd)
 
+	// These override spinifex.toml only when set, and the start command tests them
+	// for emptiness to decide that. A non-empty default would make the override
+	// unconditional, discarding the configured value on every start.
 	viperblockCmd.PersistentFlags().String("s3-host", "", "Predastore (S3) host URI")
-	viperblockCmd.PersistentFlags().String("s3-bucket", "predastore", "Predastore (S3) bucket")
-	viperblockCmd.PersistentFlags().String("s3-region", "ap-southeast-2", "Predastore (S3) region")
+	viperblockCmd.PersistentFlags().String("s3-bucket", "", "Predastore (S3) bucket")
+	viperblockCmd.PersistentFlags().String("s3-region", "", "Predastore (S3) region")
 	viperblockCmd.PersistentFlags().String("plugin-path", "/opt/spinifex/lib/nbdkit-viperblock-plugin.so", "Pathname to the nbdkit viperblockplugin")
 	bindViperblockEnv()
 

--- a/cmd/spinifex/cmd/service_bind_collision_test.go
+++ b/cmd/spinifex/cmd/service_bind_collision_test.go
@@ -129,16 +129,19 @@ func TestViperblockFlagsLookUpTheirOwnCommand(t *testing.T) {
 }
 
 // TestViperblockFlagDefaultsReachViper drives the real bindViperblockEnv, so
-// a lookup pointed at the wrong command fails here: an unbound flag leaves
-// its default invisible and s3-bucket resolves "" rather than "predastore".
+// a lookup pointed at the wrong command fails here: an unbound flag leaves its
+// default invisible and plugin-path resolves "" rather than the install path.
+//
+// The s3-* flags override spinifex.toml and so must default empty, which leaves
+// plugin-path as the only default that can prove the binding.
 func TestViperblockFlagDefaultsReachViper(t *testing.T) {
 	t.Cleanup(func() { viper.Reset() })
 	viper.Reset()
 	bindViperblockEnv()
 
-	assert.Equal(t, "predastore", viper.GetString("s3-bucket"))
-	assert.Equal(t, "ap-southeast-2", viper.GetString("s3-region"))
 	assert.Equal(t, "/opt/spinifex/lib/nbdkit-viperblock-plugin.so", viper.GetString("plugin-path"))
+	assert.Empty(t, viper.GetString("s3-bucket"))
+	assert.Empty(t, viper.GetString("s3-region"))
 }
 
 // TestViperblockEnvBeatsUnchangedFlagDefault pins viper's precedence: wiring

--- a/cmd/spinifex/cmd/templates/predastore.toml
+++ b/cmd/spinifex/cmd/templates/predastore.toml
@@ -66,7 +66,7 @@ role = "state-replica"
 
 [[buckets]]
 name = "predastore"
-region = "ap-southeast-2"
+region = "{{.Region}}"
 type = "distributed"
 public = false
 encryption = ""

--- a/cmd/spinifex/cmd/viperblock_region_test.go
+++ b/cmd/spinifex/cmd/viperblock_region_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The viperblock start command applies each of these over spinifex.toml whenever
+// viper reports a non-empty value, so a non-empty flag default makes the override
+// unconditional and discards the configured value on every start.
+func TestViperblockConfigOverrideFlagsDefaultEmpty(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"s3-host", "s3-bucket", "s3-region"} {
+		flag := viperblockCmd.PersistentFlags().Lookup(name)
+		require.NotNil(t, flag, "flag %s must exist", name)
+		assert.Empty(t, flag.DefValue, "flag %s must default empty so an unset flag cannot clobber spinifex.toml", name)
+	}
+}
+
+// predastore verifies each request's SigV4 credential scope against its own
+// configured region, so a bucket pinned to a literal region breaks every client
+// on a cluster deployed anywhere else.
+func TestPredastoreTemplateBucketsUseConfiguredRegion(t *testing.T) {
+	t.Parallel()
+
+	settings := northstarSettings()
+	settings.Region = "bare-metal"
+	content := renderTemplate(t, predastoreTomlTemplate, settings)
+
+	var parsed struct {
+		Region  string `toml:"region"`
+		Buckets []struct {
+			Name   string `toml:"name"`
+			Region string `toml:"region"`
+		} `toml:"buckets"`
+	}
+	require.NoError(t, toml.Unmarshal([]byte(content), &parsed))
+
+	assert.Equal(t, "bare-metal", parsed.Region)
+	require.NotEmpty(t, parsed.Buckets)
+	for _, bucket := range parsed.Buckets {
+		assert.Equal(t, "bare-metal", bucket.Region, "bucket %s", bucket.Name)
+	}
+}


### PR DESCRIPTION
## Summary

The viperblock start command applies `--s3-host`, `--s3-bucket` and `--s3-region` over `spinifex.toml` whenever viper reports a non-empty value. `s3-bucket` and `s3-region` carried non-empty defaults, so the override fired on every start even though `spinifex-viperblock.service` passes neither the flag nor `SPINIFEX_VIPERBLOCK_*`, and the region read from the config was replaced with `ap-southeast-2`.

Any cluster deployed to another region could not launch an instance. viperblockd signed its S3 requests with `ap-southeast-2`, predastore verified them against its own configured region and rejected them, the volume mount failed, and `RunInstances` ended in `launch_failed`:

```
viperblockd  Error listing objects
  operation error S3: ListObjectsV2, StatusCode: 400,
  api error AuthorizationHeaderMalformed: malformed Authorization header:
  incorrect region "ap-southeast-2"; expected "bare-metal"
```

The bare-metal e2e cell installs with `--region bare-metal`, so every instance-backed test in it failed this way — the fast ones immediately, the rest after burning a 5m `EnsureInstance` timeout each until the package hit its 30m panic.

## Changes

- `cmd/spinifex/cmd/service.go` — default `s3-host`, `s3-bucket` and `s3-region` to empty. An unset flag now leaves the configured value alone; an explicit flag or `SPINIFEX_VIPERBLOCK_*` still wins.
- `cmd/spinifex/cmd/templates/predastore.toml` — render the main bucket's region from `{{.Region}}`. The top-level key and the northstar bucket already did.
- `cmd/spinifex/cmd/viperblock_region_test.go` — new: pins the empty defaults and asserts every rendered bucket carries the configured region. Both fail on `dev`.
- `cmd/spinifex/cmd/service_bind_collision_test.go` — `TestViperblockFlagDefaultsReachViper` proved the BindPFlag receiver via the `s3-*` defaults. Those are now empty, so it proves it via `plugin-path`, which legitimately keeps one.

## Testing

- `make preflight` passes.
- Both new tests verified failing against the unfixed tree (`s3-bucket` default `predastore`, `s3-region` default `ap-southeast-2`, bucket region `ap-southeast-2` vs configured `bare-metal`) and passing with the fix.
- Live confirmation comes from the next nightly cell-20, which must get past `EnsureInstance`.

## Evidence

E2E Nightly run 30783737091 job 91593229866; 60 matching error documents in the ES sink under `labels.ci_run_id=30783737091`, `labels.ci_cell=20`. Server side was already correct — `predastore/s3/httpserver.go:166` takes `expectedRegion` from its own config.

Closes mulga-pppub.