### PR TITLE
fix(ec2): default Windows AMIs to HttpTokens=optional at launch

### DIFF
--- a/spinifex/handlers/ec2/instance/metadata_options.go
+++ b/spinifex/handlers/ec2/instance/metadata_options.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 )
 
 // defaultMetadataHopLimit matches the AWS default applied when none is requested.
@@ -14,7 +15,8 @@ const defaultMetadataHopLimit = int64(1)
 // buildMetadataOptions returns the metadata-options block stamped at launch.
 // hopLimit applies only in the AWS-valid 1-64 range, otherwise falling back to
 // the default. An empty httpTokens stamps "required", so an instance that does
-// not ask for IMDSv1 never silently gets it.
+// not ask for IMDSv1 never silently gets it; applyPlatformTokenDefault later
+// relaxes that for the one platform that cannot speak IMDSv2.
 func buildMetadataOptions(hopLimit *int64, httpTokens string) *ec2.InstanceMetadataOptionsResponse {
 	limit := defaultMetadataHopLimit
 	if hopLimit != nil && *hopLimit >= 1 && *hopLimit <= 64 {
@@ -32,6 +34,27 @@ func buildMetadataOptions(hopLimit *int64, httpTokens string) *ec2.InstanceMetad
 		InstanceMetadataTags:    aws.String(ec2.InstanceMetadataTagsStateDisabled),
 		HttpPutResponseHopLimit: aws.Int64(limit),
 	}
+}
+
+// defaultHTTPTokensForPlatform returns the launch default an image's platform
+// implies. Windows guests bootstrap with cloudbase-init, which has no IMDSv2
+// token support in any release, so a Windows image has to permit IMDSv1 or its
+// agent never reads metadata at all. Every other platform keeps "required".
+func defaultHTTPTokensForPlatform(platform *string) string {
+	if aws.StringValue(platform) == utils.PlatformWindows {
+		return ec2.HttpTokensStateOptional
+	}
+	return ec2.HttpTokensStateRequired
+}
+
+// applyPlatformTokenDefault relaxes the stamped IMDSv2 posture to the platform
+// default once the launch has resolved its image. A launch that named
+// httpTokens itself is left untouched, so an explicit value always wins.
+func applyPlatformTokenDefault(instance *ec2.Instance, requestedTokens string, platform *string) {
+	if requestedTokens != "" || instance.MetadataOptions == nil {
+		return
+	}
+	instance.MetadataOptions.HttpTokens = aws.String(defaultHTTPTokensForPlatform(platform))
 }
 
 // validateMetadataOptions rejects any request that enables an unmodelled

--- a/spinifex/handlers/ec2/instance/metadata_options_test.go
+++ b/spinifex/handlers/ec2/instance/metadata_options_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/config"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/mulgadc/spinifex/spinifex/vm"
+	"github.com/mulgadc/viperblock/viperblock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -301,4 +303,105 @@ func TestRunInstance_MetadataOptionsHopLimitFromRequest(t *testing.T) {
 	require.NotNil(t, ec2Instance.MetadataOptions)
 	assert.Equal(t, int64(2), aws.Int64Value(ec2Instance.MetadataOptions.HttpPutResponseHopLimit))
 	assert.Equal(t, ec2.HttpTokensStateRequired, aws.StringValue(ec2Instance.MetadataOptions.HttpTokens))
+}
+
+// Windows is the one platform whose guest agent cannot speak IMDSv2, so it is
+// the one platform whose launch default is relaxed. Anything else — including
+// an image whose platform never resolved — stays on "required".
+func TestDefaultHTTPTokensForPlatform(t *testing.T) {
+	cases := map[string]struct {
+		in   *string
+		want string
+	}{
+		"windows":     {aws.String(utils.PlatformWindows), ec2.HttpTokensStateOptional},
+		"nil (linux)": {nil, ec2.HttpTokensStateRequired},
+		"empty":       {aws.String(""), ec2.HttpTokensStateRequired},
+		"unexpected":  {aws.String("Windows"), ec2.HttpTokensStateRequired},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, defaultHTTPTokensForPlatform(tc.in))
+		})
+	}
+}
+
+// The platform default only fills a gap: it moves a Windows instance the launch
+// said nothing about, and never overrides a value the caller named — not even
+// a Windows launch that deliberately asks for the strict posture.
+func TestApplyPlatformTokenDefault(t *testing.T) {
+	windows := aws.String(utils.PlatformWindows)
+
+	cases := map[string]struct {
+		platform  *string
+		requested string
+		want      string
+	}{
+		"windows, unspecified":         {windows, "", ec2.HttpTokensStateOptional},
+		"linux, unspecified":           {nil, "", ec2.HttpTokensStateRequired},
+		"windows, explicitly required": {windows, ec2.HttpTokensStateRequired, ec2.HttpTokensStateRequired},
+		"linux, explicitly optional":   {nil, ec2.HttpTokensStateOptional, ec2.HttpTokensStateOptional},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			instance := &ec2.Instance{MetadataOptions: buildMetadataOptions(nil, tc.requested)}
+			applyPlatformTokenDefault(instance, tc.requested, tc.platform)
+			assert.Equal(t, tc.want, aws.StringValue(instance.MetadataOptions.HttpTokens))
+		})
+	}
+}
+
+// A legacy instance carrying no metadata-options block is left alone rather
+// than panicking; stamping one is applyMetadataOptions' job.
+func TestApplyPlatformTokenDefaultNilBlock(t *testing.T) {
+	instance := &ec2.Instance{}
+	applyPlatformTokenDefault(instance, "", aws.String(utils.PlatformWindows))
+	assert.Nil(t, instance.MetadataOptions)
+}
+
+// End to end through the launch path: the default follows the resolved image's
+// PlatformDetails, and a caller who names http-tokens still gets what they
+// asked for on either platform.
+func TestPrepareRunInstances_PlatformTokenDefault(t *testing.T) {
+	tests := []struct {
+		name            string
+		platformDetails string
+		requested       string
+		want            string
+	}{
+		{"windows ami, unspecified", "Windows", "", ec2.HttpTokensStateOptional},
+		{"windows byol ami, unspecified", "Windows BYOL", "", ec2.HttpTokensStateOptional},
+		{"linux ami, unspecified", "Linux/UNIX", "", ec2.HttpTokensStateRequired},
+		{"windows ami, explicitly required", "Windows", ec2.HttpTokensStateRequired, ec2.HttpTokensStateRequired},
+		{"linux ami, explicitly optional", "Linux/UNIX", ec2.HttpTokensStateOptional, ec2.HttpTokensStateOptional},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			types, _ := defaultPrepareInstanceTypes()
+			svc := &InstanceServiceImpl{
+				config:        &config.Config{},
+				instanceTypes: types,
+				amiLoader: &fakeAMILoader{byID: map[string]viperblock.AMIMetadata{
+					"ami-1": {ImageOwnerAlias: "acc", PlatformDetails: tc.platformDetails},
+				}},
+				resourceMgr: &fakeResourceCapacityProvider{
+					instanceTypes: types,
+					canAllocFn:    func(_ *ec2.InstanceTypeInfo, count int) int { return count },
+				},
+			}
+			input := &ec2.RunInstancesInput{
+				InstanceType: aws.String("t3.micro"),
+				ImageId:      aws.String("ami-1"),
+				MinCount:     aws.Int64(1),
+				MaxCount:     aws.Int64(1),
+			}
+			if tc.requested != "" {
+				input.MetadataOptions = &ec2.InstanceMetadataOptionsRequest{HttpTokens: aws.String(tc.requested)}
+			}
+			reservation, _, _, err := svc.PrepareRunInstances(context.Background(), input, "acc", "")
+			require.NoError(t, err)
+			require.Len(t, reservation.Instances, 1)
+			require.NotNil(t, reservation.Instances[0].MetadataOptions)
+			assert.Equal(t, tc.want, aws.StringValue(reservation.Instances[0].MetadataOptions.HttpTokens))
+		})
+	}
 }

--- a/spinifex/handlers/ec2/instance/service_impl.go
+++ b/spinifex/handlers/ec2/instance/service_impl.go
@@ -555,6 +555,14 @@ func (s *InstanceServiceImpl) PrepareRunInstances(ctx context.Context, input *ec
 		// even if the image is later deregistered.
 		ec2Instance.Platform = utils.PlatformFromDetails(amiMeta.PlatformDetails)
 
+		// RunInstance has no image in hand, so the platform-derived IMDS default
+		// lands here, where the AMI is resolved.
+		var requestedTokens string
+		if input.MetadataOptions != nil {
+			requestedTokens = aws.StringValue(input.MetadataOptions.HttpTokens)
+		}
+		applyPlatformTokenDefault(ec2Instance, requestedTokens, ec2Instance.Platform)
+
 		// Terraform may pass subnet/SG via NetworkInterfaces[0]; lift to top-level.
 		if (input.SubnetId == nil || *input.SubnetId == "") &&
 			len(input.NetworkInterfaces) > 0 && input.NetworkInterfaces[0] != nil {


### PR DESCRIPTION
## Problem

`buildMetadataOptions` stamps `HttpTokens=required` whenever a launch omits `MetadataOptions`, regardless of the image. cloudbase-init — the only Windows guest agent we ship — has no IMDSv2 token support in any release: its `EC2Service` pins `_metadata_version = '2009-04-04'` and never issues a `PUT /latest/api/token`. Spinifex's IMDSv1 gate answers an untokened GET only when the instance carries `HttpTokens=optional`, so a Windows instance launched the ordinary way 401s on every metadata request, never leaves `PRE_METADATA_DISCOVERY`, and never runs `LocalScriptsPlugin` — which is what emits the encrypted administrator password.

Every successful Windows launch so far has needed `--metadata-options "HttpTokens=optional"` passed by hand, which is not something a Terraform user or the console flow would know to do.

## Change

The platform signal already exists: `utils.PlatformFromDetails(amiMeta.PlatformDetails)` returns `"windows"` or nil, and `PrepareRunInstances` already stamps it onto `ec2Instance.Platform` right after `RunInstance` returns. `RunInstance` itself resolves no AMI metadata, so the default is applied at the point where the platform becomes known.

- `defaultHTTPTokensForPlatform` returns `optional` for Windows, `required` for everything else.
- `applyPlatformTokenDefault` rewrites the stamped value only when the request said nothing about `httpTokens`, so an explicit value always wins — including a Windows launch that deliberately asks for `required`.
- `validateMetadataOptions` and `applyMetadataOptions` are untouched: `ModifyInstanceMetadataOptions` keeps taking the caller at their word, and the legacy nil-block path has no image in hand.

The documented default stays `required`; Windows is the single platform-derived exception, mirroring how AWS Windows AMIs behave in practice.

## Testing

`make preflight` passes. New unit coverage:

- `TestDefaultHTTPTokensForPlatform` — `optional` for `"windows"`, `required` for nil, empty and an unexpected value.
- `TestApplyPlatformTokenDefault` — flips an unspecified Windows launch, leaves Linux alone, and is a no-op on either platform when the caller named a value.
- `TestApplyPlatformTokenDefaultNilBlock` — a legacy instance with no metadata-options block is left alone rather than panicking.
- `TestPrepareRunInstances_PlatformTokenDefault` — end to end through the launch path over `Windows`, `Windows BYOL` and `Linux/UNIX` images. Confirmed load-bearing: reverting the call site fails the two Windows cases with `expected: "optional" / actual: "required"`.

Plan: `docs/development/bugs/windows-imds-http-tokens-default.md`. Closes `mulga-2dz0d`.