### PR TITLE
fix(bedrock): Bedrock wording for ResourceNotFoundException, and stop dropping embeddingDataDeliveryEnabled

### DIFF
--- a/spinifex/awserrors/awserrors.go
+++ b/spinifex/awserrors/awserrors.go
@@ -635,7 +635,20 @@ var errorLookupByService = map[string]map[string]ErrorMessage{
 	"acm": {
 		ErrorACMResourceInUse: {HTTPCode: 400, Message: "The certificate is in use by another AWS resource in this account. Remove the reference to the certificate before deleting it."},
 	},
+	// Both keys are needed: the gateway splits bedrock from bedrock-runtime on
+	// the /model/ path prefix, so an override under one does not cover the other.
+	"bedrock": {
+		ErrorResourceNotFoundException: {HTTPCode: 404, Message: bedrockResourceNotFoundMessage},
+	},
+	"bedrock-runtime": {
+		ErrorResourceNotFoundException: {HTTPCode: 404, Message: bedrockResourceNotFoundMessage},
+	},
 }
+
+// bedrockResourceNotFoundMessage overrides the EKS wording ErrorLookup carries
+// for the shared ResourceNotFoundException wire code, which otherwise tells a
+// Bedrock caller to go and list EKS clusters.
+const bedrockResourceNotFoundMessage = "Could not resolve the foundation model from the provided model identifier."
 
 // LookupErrorMessage returns the ErrorMessage for code, scoped to service
 // where errorLookupByService has an override, otherwise ErrorLookup's global

--- a/spinifex/awserrors/awserrors_test.go
+++ b/spinifex/awserrors/awserrors_test.go
@@ -3,6 +3,7 @@ package awserrors
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -156,6 +157,33 @@ func TestLookupErrorMessage(t *testing.T) {
 	unscoped := LookupErrorMessage("ec2", ErrorInvalidParameterValue)
 	if unscoped != ErrorLookup[ErrorInvalidParameterValue] {
 		t.Errorf("LookupErrorMessage(ec2, InvalidParameterValue) = %+v, want unchanged global %+v", unscoped, ErrorLookup[ErrorInvalidParameterValue])
+	}
+}
+
+// TestLookupErrorMessage_BedrockResourceNotFound guards the second shared-code
+// collision: ResourceNotFoundException is an alias of the EKS code, so both
+// Bedrock service keys must override it rather than inherit cluster wording.
+func TestLookupErrorMessage_BedrockResourceNotFound(t *testing.T) {
+	global := ErrorLookup[ErrorResourceNotFoundException]
+
+	for _, service := range []string{"bedrock", "bedrock-runtime"} {
+		got := LookupErrorMessage(service, ErrorResourceNotFoundException)
+		if got.Message == global.Message {
+			t.Errorf("LookupErrorMessage(%s, ResourceNotFoundException) = %q, want distinct Bedrock wording", service, got.Message)
+		}
+		if got.HTTPCode != 404 {
+			t.Errorf("LookupErrorMessage(%s, ResourceNotFoundException).HTTPCode = %d, want 404", service, got.HTTPCode)
+		}
+		for _, banned := range []string{"cluster", "EKS", "ListClusters"} {
+			if strings.Contains(got.Message, banned) {
+				t.Errorf("LookupErrorMessage(%s, ResourceNotFoundException) = %q, contains EKS wording %q", service, got.Message, banned)
+			}
+		}
+	}
+
+	// EKS itself must still get its own wording from the unscoped global entry.
+	if eks := LookupErrorMessage("eks", ErrorEKSResourceNotFound); eks != global {
+		t.Errorf("LookupErrorMessage(eks, ResourceNotFoundException) = %+v, want unchanged global %+v", eks, global)
 	}
 }
 

--- a/spinifex/gateway/bedrock/logging.go
+++ b/spinifex/gateway/bedrock/logging.go
@@ -276,10 +276,11 @@ func (r *StreamRecorder) Record(ctx context.Context, rec InvocationRecord) {
 // LoggingConfig is the account's own invocation-logging preferences: where
 // to deliver, and whether body text may be included at all.
 type LoggingConfig struct {
-	S3BucketName             string `json:"s3BucketName"`
-	S3KeyPrefix              string `json:"s3KeyPrefix"`
-	TextDataDeliveryEnabled  bool   `json:"textDataDeliveryEnabled"`
-	ImageDataDeliveryEnabled bool   `json:"imageDataDeliveryEnabled"`
+	S3BucketName                 string `json:"s3BucketName"`
+	S3KeyPrefix                  string `json:"s3KeyPrefix"`
+	TextDataDeliveryEnabled      bool   `json:"textDataDeliveryEnabled"`
+	ImageDataDeliveryEnabled     bool   `json:"imageDataDeliveryEnabled"`
+	EmbeddingDataDeliveryEnabled bool   `json:"embeddingDataDeliveryEnabled"`
 }
 
 // LoggingConfigReader resolves accountID's stored logging config. ok is
@@ -400,12 +401,16 @@ func loggingConfigFromSDK(in *bedrock.LoggingConfig) (LoggingConfig, error) {
 	}
 	textEnabled := aws.BoolValue(in.TextDataDeliveryEnabled)
 	imageEnabled := aws.BoolValue(in.ImageDataDeliveryEnabled)
-	if (textEnabled || imageEnabled) && (in.S3Config == nil || aws.StringValue(in.S3Config.BucketName) == "") {
+	embeddingEnabled := aws.BoolValue(in.EmbeddingDataDeliveryEnabled)
+	// Embedding delivery joins the bucket requirement: a config enabling it with
+	// nowhere to deliver is as unusable as one enabling text or image.
+	if (textEnabled || imageEnabled || embeddingEnabled) && (in.S3Config == nil || aws.StringValue(in.S3Config.BucketName) == "") {
 		return LoggingConfig{}, errors.New(awserrors.ErrorValidationException)
 	}
 	cfg := LoggingConfig{
-		TextDataDeliveryEnabled:  textEnabled,
-		ImageDataDeliveryEnabled: imageEnabled,
+		TextDataDeliveryEnabled:      textEnabled,
+		ImageDataDeliveryEnabled:     imageEnabled,
+		EmbeddingDataDeliveryEnabled: embeddingEnabled,
 	}
 	if in.S3Config != nil {
 		cfg.S3BucketName = aws.StringValue(in.S3Config.BucketName)
@@ -418,8 +423,9 @@ func loggingConfigFromSDK(in *bedrock.LoggingConfig) (LoggingConfig, error) {
 // the AWS-parity *bedrock.LoggingConfig shape.
 func loggingConfigToSDK(cfg LoggingConfig) *bedrock.LoggingConfig {
 	out := &bedrock.LoggingConfig{
-		TextDataDeliveryEnabled:  aws.Bool(cfg.TextDataDeliveryEnabled),
-		ImageDataDeliveryEnabled: aws.Bool(cfg.ImageDataDeliveryEnabled),
+		TextDataDeliveryEnabled:      aws.Bool(cfg.TextDataDeliveryEnabled),
+		ImageDataDeliveryEnabled:     aws.Bool(cfg.ImageDataDeliveryEnabled),
+		EmbeddingDataDeliveryEnabled: aws.Bool(cfg.EmbeddingDataDeliveryEnabled),
 	}
 	if cfg.S3BucketName != "" {
 		out.S3Config = &bedrock.S3Config{

--- a/spinifex/gateway/bedrock/logging_test.go
+++ b/spinifex/gateway/bedrock/logging_test.go
@@ -84,6 +84,21 @@ func TestPutModelInvocationLoggingConfiguration_RequiresBucketWhenDeliveryEnable
 	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
 }
 
+// TestPutModelInvocationLoggingConfiguration_RequiresBucketForEmbeddingDelivery
+// covers embedding delivery on its own: enabling it with no bucket is as
+// undeliverable as text or image, so it must not slip past the same gate.
+func TestPutModelInvocationLoggingConfiguration_RequiresBucketForEmbeddingDelivery(t *testing.T) {
+	_, _, js := testutil.StartTestJetStream(t)
+	store := NewLoggingConfigStore(js, 1)
+
+	input := &bedrock.PutModelInvocationLoggingConfigurationInput{
+		LoggingConfig: &bedrock.LoggingConfig{EmbeddingDataDeliveryEnabled: aws.Bool(true)},
+	}
+	_, err := PutModelInvocationLoggingConfiguration(context.Background(), "000000000001", store, input)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
+}
+
 // TestModelInvocationLoggingConfiguration_RoundTripsViaSDKStructs drives the
 // three control-plane handlers with real aws-sdk-go v1 bedrock structs, the
 // same shapes a genuine SDK client marshals, rather than this package's own
@@ -95,9 +110,10 @@ func TestModelInvocationLoggingConfiguration_RoundTripsViaSDKStructs(t *testing.
 
 	putInput := &bedrock.PutModelInvocationLoggingConfigurationInput{
 		LoggingConfig: &bedrock.LoggingConfig{
-			S3Config:                 &bedrock.S3Config{BucketName: aws.String("acct-bucket"), KeyPrefix: aws.String("bedrock")},
-			TextDataDeliveryEnabled:  aws.Bool(true),
-			ImageDataDeliveryEnabled: aws.Bool(false),
+			S3Config:                     &bedrock.S3Config{BucketName: aws.String("acct-bucket"), KeyPrefix: aws.String("bedrock")},
+			TextDataDeliveryEnabled:      aws.Bool(true),
+			ImageDataDeliveryEnabled:     aws.Bool(false),
+			EmbeddingDataDeliveryEnabled: aws.Bool(true),
 		},
 	}
 	_, err := PutModelInvocationLoggingConfiguration(ctx, "000000000001", store, putInput)
@@ -111,6 +127,9 @@ func TestModelInvocationLoggingConfiguration_RoundTripsViaSDKStructs(t *testing.
 	assert.Equal(t, "bedrock", aws.StringValue(getOut.LoggingConfig.S3Config.KeyPrefix))
 	assert.True(t, aws.BoolValue(getOut.LoggingConfig.TextDataDeliveryEnabled))
 	assert.False(t, aws.BoolValue(getOut.LoggingConfig.ImageDataDeliveryEnabled))
+	// A flag the internal LoggingConfig has no field for is accepted by Put and
+	// then silently absent from Get, so assert the round-trip, not just the Put.
+	assert.True(t, aws.BoolValue(getOut.LoggingConfig.EmbeddingDataDeliveryEnabled))
 
 	_, err = DeleteModelInvocationLoggingConfiguration(ctx, "000000000001", store, new(bedrock.DeleteModelInvocationLoggingConfigurationInput))
 	require.NoError(t, err)


### PR DESCRIPTION
Two Ochre API-fidelity defects found during live verification on wattle. Both are narrow and independent of each other; they share this PR because they are the same cluster of customer-facing fidelity bugs in one package.

## mulga-8agpf — ResourceNotFoundException returned EKS wording (P2)

Bedrock and EKS share the `ResourceNotFoundException` wire code, so `ErrorResourceNotFoundException` is a deliberate alias of `ErrorEKSResourceNotFound` rather than a second `ErrorLookup` entry. That made EKS's message the one every Bedrock caller received:

> The specified cluster could not be found. You can view your available clusters with ListClusters. Amazon EKS clusters are Region specific.

The error code and the weights gate were both correct — only the wording was wrong, and it reached customers. 14 call sites inherited it, not just `GetFoundationModel`: `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, `ConverseStream` and `handlers/bedrock/service.go`.

The fix mechanism already existed and was unused by Bedrock. `errorLookupByService` overrides message and HTTP status per `(service, code)` pair for exactly this shared-wire-code case, and `ErrorHandler` already routes through `LookupErrorMessage(svc, code)`. Bedrock fell through to the EKS wording only because no `bedrock` key existed.

Both service keys are registered: the gateway splits `bedrock` from `bedrock-runtime` on the `/model/` path prefix, so an override under one does not cover the other. HTTP status stays 404, matching the EKS entry and real Bedrock — `recordOutcome` already reads its status from this same table, so invocation records are unaffected.

## mulga-uyrwj — embeddingDataDeliveryEnabled silently discarded (P3)

The SDK's `bedrock.LoggingConfig` defines `EmbeddingDataDeliveryEnabled`, so the value arrived on the request and was then dropped in translation — the internal `LoggingConfig` had no field for it. Put appeared to succeed and the following Get omitted it.

Carried through both translation directions and folded into the existing bucket-required validation gate: a config enabling embedding delivery with no S3 bucket is as undeliverable as one enabling text or image, and leaving it out would accept a config that can never deliver.

Persistence is a `json.Marshal` into a JetStream KV bucket, so the added field is backward-compatible — records written before this decode with it false.

## Testing

Existing Bedrock tests asserted only that `err.Error()` equalled the code string and never checked the serialized message, which is why the EKS wording shipped unnoticed.

- `TestLookupErrorMessage_BedrockResourceNotFound` asserts both service keys resolve to distinct wording at 404 and that the message contains none of `cluster` / `EKS` / `ListClusters`, so a future reuse of the code cannot quietly reintroduce this. It also asserts EKS itself still gets the unchanged global entry.
- `TestModelInvocationLoggingConfiguration_RoundTripsViaSDKStructs` now sets the embedding flag on Put and asserts it survives Get.
- `TestPutModelInvocationLoggingConfiguration_RequiresBucketForEmbeddingDelivery` covers embedding-only delivery with no bucket.

Both tests were confirmed to fail against the unfixed source, reproducing the reported symptoms exactly — the EKS cluster text verbatim, and the embedding flag absent from Get. `make preflight` passes.

Closes mulga-8agpf
Closes mulga-uyrwj