### PR TITLE
fix(ec2): tell the caller when a launch key pair cannot decrypt a password

### DIFF
--- a/spinifex/awserrors/awserrors.go
+++ b/spinifex/awserrors/awserrors.go
@@ -201,6 +201,7 @@ var (
 	ErrorInvalidKeyPairDuplicate                               = "InvalidKeyPair.Duplicate"
 	ErrorInvalidKeyPairFormat                                  = "InvalidKeyPair.Format"
 	ErrorInvalidKeyPairNotFound                                = "InvalidKeyPair.NotFound"
+	ErrorInvalidKeyPairType                                    = "InvalidKeyPair.Type"
 	ErrorInvalidLaunchTargets                                  = "InvalidLaunchTargets"
 	ErrorInvalidLaunchTemplateIdMalformed                      = "InvalidLaunchTemplateId.Malformed"
 	ErrorInvalidLaunchTemplateIdNotFound                       = "InvalidLaunchTemplateId.NotFound"
@@ -883,6 +884,7 @@ var ErrorLookup = map[string]ErrorMessage{
 	ErrorInvalidKeyPairDuplicate:                               {HTTPCode: 409, Message: "The key pair name already exists in that AWS Region. If you are creating or importing a key pair, ensure that you use a unique name."},
 	ErrorInvalidKeyPairFormat:                                  {HTTPCode: 400, Message: "The format of the public key you are attempting to import is not valid."},
 	ErrorInvalidKeyPairNotFound:                                {HTTPCode: 404, Message: "The specified key pair name does not exist. Ensure that you specify the AWS Region in which the key pair is located, if it's not in the default Region."},
+	ErrorInvalidKeyPairType:                                    {HTTPCode: 400, Message: "The instance was launched with an ED25519 key pair, which cannot decrypt a Windows administrator password. Only RSA can perform the PKCS#1 v1.5 encryption the guest uses. Relaunch the instance with a key pair created using --key-type rsa."},
 	ErrorInvalidLaunchTargets:                                  {HTTPCode: 400, Message: "One or more specified targets are invalid. Verify the capacity for the Capacity Reservation selected or verify the ID."},
 	ErrorInvalidLaunchTemplateIdMalformed:                      {HTTPCode: 400, Message: "The ID for the launch template is malformed. Ensure that you specify the launch template ID in the form lt-xxxxxxxxxxxxxxxxx."},
 	ErrorInvalidLaunchTemplateIdNotFound:                       {HTTPCode: 404, Message: "The specified launch template ID does not exist. Ensure that you specify the AWS Region in which the launch template is located."},

--- a/spinifex/daemon/daemon_handlers_password.go
+++ b/spinifex/daemon/daemon_handlers_password.go
@@ -7,10 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
+	"golang.org/x/crypto/ssh"
 )
 
 // passwordDataPattern matches a <Password>...</Password> block. The
@@ -31,6 +34,31 @@ func extractLastPasswordData(data []byte) string {
 	}
 	last := matches[len(matches)-1][1]
 	return strings.TrimSpace(string(last))
+}
+
+// launchKeyCannotEncrypt reports whether the instance's launch key pair is
+// incapable of wrapping a password. Only Windows instances are judged: no other
+// platform emits one, so a Linux instance keeps AWS's empty result.
+//
+// Every uncertainty answers false. A key that cannot be resolved, or a platform
+// that was never stamped, is not evidence of the wrong key type, and turning a
+// lookup blip into a terminal error would be worse than the empty string.
+func (d *Daemon) launchKeyCannotEncrypt(instance *vm.VM) bool {
+	if instance.Instance == nil || aws.StringValue(instance.Instance.Platform) != utils.PlatformWindows {
+		return false
+	}
+	keyName := aws.StringValue(instance.Instance.KeyName)
+	if keyName == "" || d.keyService == nil {
+		return false
+	}
+	material, err := d.keyService.GetPublicKeyMaterial(instance.AccountID, keyName)
+	if err != nil {
+		slog.Warn("GetPasswordData: could not resolve launch key type", "instance_id", instance.ID, "key_name", keyName, "err", err)
+		return false
+	}
+	// The OpenSSH algorithm prefix is the key type; ssh-rsa is the only one that
+	// can do the PKCS#1 v1.5 encryption the guest agent performs.
+	return material != "" && !strings.HasPrefix(material, ssh.KeyAlgoRSA+" ")
 }
 
 // handleEC2GetPasswordData reads the console log file for an instance and
@@ -87,6 +115,14 @@ func (d *Daemon) handleEC2GetPasswordData(msg *nats.Msg) {
 				passwordData = extractLastPasswordData(data)
 			}
 		}
+	}
+
+	// An empty result is ordinarily "the guest has not emitted one yet", which is
+	// worth retrying. A non-RSA launch key never will, so name that case instead
+	// of returning the same empty string for a condition that cannot resolve.
+	if passwordData == "" && d.launchKeyCannotEncrypt(instance) {
+		respondWithError(msg, awserrors.ErrorInvalidKeyPairType)
+		return
 	}
 
 	now := time.Now()

--- a/spinifex/daemon/daemon_handlers_password_test.go
+++ b/spinifex/daemon/daemon_handlers_password_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -223,4 +224,150 @@ func TestHandleEC2GetPasswordData_NotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, string(reply.Data), "InvalidInstanceID.NotFound")
+}
+
+// importPasswordTestKey seeds a key pair on the daemon's key service so the
+// launch-key type is resolvable, and returns the key name.
+func importPasswordTestKey(t *testing.T, daemon *Daemon, keyName, pubKey string) string {
+	t.Helper()
+	_, err := daemon.keyService.ImportKeyPair(context.Background(), &ec2.ImportKeyPairInput{
+		KeyName:           aws.String(keyName),
+		PublicKeyMaterial: []byte(pubKey),
+	}, testAccountID)
+	require.NoError(t, err)
+	return keyName
+}
+
+const (
+	passwordTestRSAPubKey     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDP9LrByKWpgbX+prxBwnlf7lrmI5AfDwuiCofuvOAzt9/PwIDMMIAhlvlpm09jjOuuH/MRQApJB5A714Auv+hBKVK0lCq9KcTrnKZOpRj2aGgIZgaoO6P/POoZc+kBf9Y/GP18DCKc4y/XyBsp69dPP6XRdYBlEdeIeVZdgCPYrM7s5FjT7aML2ba2Y2EvH116hPxv+nJZGwM6yqWxWRyTOoNMMTAfNYmoKkNy2zC1FARUyqDwumJ2z5Fvo4ZdN1qoFPOsfPc3iB0NUtSZbLU1awScvHb0rwR5PRnelTZ3Nbkw8I8A0IAhBTE5veW9D38hDIJhRd4nW73BUhgmzDL7"
+	passwordTestED25519PubKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+)
+
+// An ED25519 launch key can never produce a password, so the empty result is
+// replaced by an error that names the cause. Every other shape of "empty" stays
+// empty, because it may still resolve on a later poll.
+func TestLaunchKeyCannotEncrypt(t *testing.T) {
+	daemon := createFullTestDaemon(t, sharedNATSURL)
+
+	ed := importPasswordTestKey(t, daemon, "pw-ed25519", passwordTestED25519PubKey)
+	rsa := importPasswordTestKey(t, daemon, "pw-rsa", passwordTestRSAPubKey)
+
+	windows := aws.String("windows")
+
+	tests := []struct {
+		name     string
+		instance *vm.VM
+		want     bool
+	}{
+		{
+			name: "windows with an ed25519 key",
+			instance: &vm.VM{AccountID: testAccountID, Instance: &ec2.Instance{
+				Platform: windows, KeyName: aws.String(ed)}},
+			want: true,
+		},
+		{
+			name: "windows with an rsa key",
+			instance: &vm.VM{AccountID: testAccountID, Instance: &ec2.Instance{
+				Platform: windows, KeyName: aws.String(rsa)}},
+			want: false,
+		},
+		{
+			// Linux never emits a password, so it keeps the AWS empty result
+			// rather than being told its key type is wrong.
+			name: "linux with an ed25519 key",
+			instance: &vm.VM{AccountID: testAccountID, Instance: &ec2.Instance{
+				KeyName: aws.String(ed)}},
+			want: false,
+		},
+		{
+			name: "windows launched with no key pair",
+			instance: &vm.VM{AccountID: testAccountID, Instance: &ec2.Instance{
+				Platform: windows}},
+			want: false,
+		},
+		{
+			// A key that cannot be resolved is not evidence of the wrong type.
+			name: "windows with an unresolvable key",
+			instance: &vm.VM{AccountID: testAccountID, Instance: &ec2.Instance{
+				Platform: windows, KeyName: aws.String("pw-missing")}},
+			want: false,
+		},
+		{
+			name:     "legacy instance with no EC2 metadata",
+			instance: &vm.VM{AccountID: testAccountID},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, daemon.launchKeyCannotEncrypt(tt.instance))
+		})
+	}
+}
+
+// End to end: the caller sees InvalidKeyPair.Type rather than an empty string
+// they would otherwise keep polling.
+func TestHandleEC2GetPasswordData_NonRSALaunchKey(t *testing.T) {
+	daemon := createFullTestDaemon(t, sharedNATSURL)
+	instanceID := "i-password-ed25519-001"
+
+	keyName := importPasswordTestKey(t, daemon, "pw-handler-ed25519", passwordTestED25519PubKey)
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:        instanceID,
+		Status:    vm.StateRunning,
+		AccountID: testAccountID,
+		Config:    vm.Config{ConsoleLogPath: "/nonexistent/console.log"},
+		Instance: &ec2.Instance{
+			Platform: aws.String("windows"),
+			KeyName:  aws.String(keyName),
+		},
+	})
+
+	topic := fmt.Sprintf("ec2.%s.GetPasswordData", instanceID)
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	reqData, _ := json.Marshal(&ec2.GetPasswordDataInput{InstanceId: aws.String(instanceID)})
+	reply, err := natsRequest(daemon.natsConn, topic, reqData, 5*time.Second)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(reply.Data), awserrors.ErrorInvalidKeyPairType)
+}
+
+// A populated blob always wins: the key-type check only ever replaces an empty
+// result, so a Windows guest that did emit one is never second-guessed.
+func TestHandleEC2GetPasswordData_BlobBeatsKeyTypeCheck(t *testing.T) {
+	daemon := createFullTestDaemon(t, sharedNATSURL)
+	instanceID := "i-password-blob-wins-001"
+
+	logPath := t.TempDir() + "/console.log"
+	require.NoError(t, os.WriteFile(logPath, []byte("<Password>Zmlyc3Q=</Password>\n"), 0644))
+
+	keyName := importPasswordTestKey(t, daemon, "pw-blob-ed25519", passwordTestED25519PubKey)
+	daemon.vmMgr.Insert(&vm.VM{
+		ID:        instanceID,
+		Status:    vm.StateRunning,
+		AccountID: testAccountID,
+		Config:    vm.Config{ConsoleLogPath: logPath},
+		Instance: &ec2.Instance{
+			Platform: aws.String("windows"),
+			KeyName:  aws.String(keyName),
+		},
+	})
+
+	topic := fmt.Sprintf("ec2.%s.GetPasswordData", instanceID)
+	sub, err := daemon.natsConn.Subscribe(topic, daemon.handleEC2GetPasswordData)
+	require.NoError(t, err)
+	defer sub.Unsubscribe()
+
+	reqData, _ := json.Marshal(&ec2.GetPasswordDataInput{InstanceId: aws.String(instanceID)})
+	reply, err := natsRequest(daemon.natsConn, topic, reqData, 5*time.Second)
+	require.NoError(t, err)
+
+	var output ec2.GetPasswordDataOutput
+	require.NoError(t, json.Unmarshal(reply.Data, &output))
+	require.NotNil(t, output.PasswordData)
+	assert.Equal(t, "Zmlyc3Q=", *output.PasswordData)
 }


### PR DESCRIPTION
## Problem

`GetPasswordData` returned an empty string in two very different situations: the guest has not emitted a password yet, and the guest never will because the launch key pair is ED25519 and cannot perform PKCS#1 v1.5 encryption. The first is worth retrying; the second never resolves. They were indistinguishable, so a caller in the second case polls forever with no signal.

This is the silent-failure half of `mulga-h7m2y`. The default key type stays ED25519 — that was decided separately (`mulga-8oeka`) — which makes this failure mode permanent rather than transitional, so it needs to name itself.

## Change

When a Windows instance yields an empty result and its launch key pair is not RSA, respond `InvalidKeyPair.Type` instead:

> The instance was launched with an ED25519 key pair, which cannot decrypt a Windows administrator password. Only RSA can perform the PKCS#1 v1.5 encryption the guest uses. Relaunch the instance with a key pair created using `--key-type rsa`.

The check runs in the daemon, which already has both the instance record and the key service, so it costs no extra round trip. Every uncertainty keeps the old empty result:

- a populated blob always wins — the check only ever replaces an empty one
- only Windows is judged; no other platform emits a password, so Linux keeps AWS's empty result
- an unresolvable key, an absent key name, or an instance with no EC2 metadata is not evidence of the wrong key type, and turning a lookup blip into a terminal error would be worse than the empty string

This deviates from AWS, which returns empty. That is the point: the condition is terminal and unrecoverable, unlike the empty result it replaces.

## Testing

`make preflight` passes. `TestLaunchKeyCannotEncrypt` covers all six branches; two handler-level tests cover the error path end to end and the blob-wins precedence.

Live on env12 after `make cluster-deploy`:

- Windows + ED25519 launch key → `An error occurred (InvalidKeyPair.Type) ... Relaunch the instance with a key pair created using --key-type rsa`
- Windows + RSA launch key, guest not yet booted far enough → `"PasswordData": ""`, unchanged
- Linux + ED25519 launch key → `"PasswordData": ""`, unchanged

Closes `mulga-0e6yb`.