### PR TITLE
docs: add the RDS quickstart Terraform workbook

### DIFF
--- a/docs/terraform-workbooks/rds-quickstart/README.md
+++ b/docs/terraform-workbooks/rds-quickstart/README.md
@@ -1,0 +1,174 @@
+---
+title: "RDS Quickstart"
+description: "Stand up a managed PostgreSQL database on Spinifex with Terraform — a VPC, a DB subnet group, a parameter group, an aws_db_instance, and a client VM inside the VPC that connects to it with psql."
+category: "Terraform Workbooks"
+tags:
+  - terraform
+  - rds
+  - postgres
+  - database
+  - vpc
+  - workbook
+sections:
+  - overview
+  - prerequisites
+  - instructions
+  - troubleshooting
+resources:
+  - title: "RDS CLI Reference"
+    url: "https://github.com/mulgadc/spinifex/blob/main/docs/COMMANDS.md#rds-postgresql"
+  - title: "Terraform AWS Provider — aws_db_instance"
+    url: "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance"
+  - title: "Spinifex Repository"
+    url: "https://github.com/mulgadc/spinifex"
+  - title: "OpenTofu"
+    url: "https://opentofu.org/"
+---
+
+# Terraform: RDS Quickstart
+
+> The smallest end-to-end RDS example on Spinifex: a VPC, a DB subnet group, a parameter group, a PostgreSQL DB instance, and a client VM in the same subnet with `psql` already pointed at the endpoint.
+
+## Overview
+
+A Spinifex DB instance runs in a VM you never see. What lands in your VPC is a single **endpoint ENI** in one of the DB subnet group's subnets, so the endpoint is **always private** — there is no `publicly_accessible` mode, and a request for one is rejected. That is why this workbook builds a client VM: it is the only place from which the database can be reached.
+
+The layout is the one that shape implies:
+
+```
+     IGW
+      │
+   10.60.1.0/24 ──┬── client VM ──psql:5432──┐
+                  │                            ▼
+                  └─────────────────── endpoint ENI ──▶ DB VM (platform-owned)
+```
+
+The client and the DB subnet group **share one subnet**, and in v1 they have to. The endpoint is reachable from clients on the endpoint ENI's own subnet only: the DB VM carries its default route on its platform-side interface, so a reply to a client in another subnet is never routed back. A subnet group spanning several subnets places the endpoint in one of them and leaves clients in the others timing out on connect. On AWS you would use two private subnets here instead.
+
+The shared subnet is "public" only in that it has an internet-gateway route, which the client needs to `apt-get` a psql. The endpoint ENI gets no public address and `publicly_accessible = true` is rejected, so sharing the subnet does not expose the database.
+
+The database security group admits `5432` from the client security group and nothing else, which compiles to an ACL on the endpoint ENI itself — the port is deny-by-default for everything else in the VPC.
+
+## Prerequisites
+
+- **Spinifex running**, with the AWS CLI configured for the `spinifex` profile (see [Installing Spinifex](/docs/install)) and OpenTofu (or Terraform) installed.
+- **The `spinifex-rds-postgres` image registered.** DB instances boot from it; it is built at `spx admin init` time.
+
+  ```bash
+  aws ec2 describe-images \
+    --filters 'Name=tag:spinifex:managed-by,Values=rds' \
+    --query 'Images[].[ImageId,Name]' --output text
+  ```
+
+- **An Ubuntu image** for the client VM, resolved here by a `*ubuntu-26.04*` / `*ubuntu-24.04*` name filter.
+- **Roughly 2 GiB of free guest memory** — one `db.t3.micro` DB VM plus one `t3.small` client.
+
+## Instructions
+
+### 1. Fetch the workbook
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/mulgadc/spinifex.git spinifex-tf
+cd spinifex-tf
+git sparse-checkout set docs/terraform-workbooks
+cd docs/terraform-workbooks/rds-quickstart
+```
+
+### 2. Apply
+
+```bash
+export AWS_PROFILE=spinifex
+
+tofu init
+tofu apply -var 'db_password=<choose-one>'
+```
+
+Creating the instance boots a VM, runs `initdb` and waits for the in-guest agent's first healthy heartbeat, so the DB is several minutes of the apply on its own. Terraform waits for `available` before it launches the client, because the client's cloud-init needs the endpoint address.
+
+### 3. Connect
+
+```bash
+tofu output ssh_to_client
+ssh -i rds-quickstart-client.pem ubuntu@<client_public_ip>
+```
+
+`PGHOST`, `PGPORT`, `PGUSER` and `PGDATABASE` are exported from `/etc/profile.d`, and the password is in `~/.pgpass` at `0600` — so `psql` on its own connects:
+
+```bash
+psql -c 'SELECT version();'
+psql -c 'CREATE TABLE hello (id int primary key, note text);'
+psql -c "INSERT INTO hello VALUES (1, 'it works');"
+psql -c 'SELECT note FROM hello;'
+```
+
+Give the client a minute after apply: `postgresql-client` is installed by cloud-init on first boot.
+
+TLS is offered but not enforced. `psql "sslmode=require"` encrypts the connection. For `sslmode=verify-full`, copy the cluster CA to the client — both the endpoint name and the endpoint IP are in the certificate's SAN set, so either address verifies:
+
+```bash
+scp -i rds-quickstart-client.pem /etc/spinifex/ca.pem ubuntu@<client_public_ip>:~/ca.pem
+psql "sslmode=verify-full sslrootcert=/home/ubuntu/ca.pem" \
+  -c 'SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid();'
+```
+
+### 4. Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `region` | `ap-southeast-2` | AWS region. |
+| `name` | `rds-quickstart` | Resource name prefix and the DB instance identifier. |
+| `spinifex_endpoint` | `https://127.0.0.1:9999` | Gateway as seen from the host running Terraform. |
+| `instance_type` | `t3.small` | EC2 type for the **client** VM. |
+| `db_instance_class` | `db.t3.micro` | DB class. One of the curated `db.*` subset. |
+| `engine_version` | `18` | PostgreSQL major. `18` is the only version served. |
+| `db_name` | `appdb` | Database created at bootstrap. |
+| `db_username` | `appuser` | Master user. `postgres`, `rdsadmin` and `pg_*` are reserved. |
+| `db_password` | `QuickstartS3cret1` | Master password — override it. No `/`, `"`, `@` or spaces. |
+| `allocated_storage` | `20` | Data-volume GiB. Grow-only, and a grow is stop/start. |
+
+### 5. Teardown
+
+```bash
+tofu destroy -var 'db_password=<the-one-you-used>'
+```
+
+The instance is created with `skip_final_snapshot = true` on purpose. A final snapshot **pins the data volume alive** until that snapshot is deleted, so a workbook that took one would leave storage behind on every destroy. For anything you care about, take one:
+
+```bash
+aws rds delete-db-instance --db-instance-identifier rds-quickstart \
+  --final-db-snapshot-identifier rds-quickstart-final
+```
+
+## Things this workbook does deliberately
+
+- **`storage_encrypted = true` is set explicitly.** Storage is always encrypted, so the instance reports `true` whether or not you asked. The provider's attribute is optional but *not* computed, so leaving it out means the read-back carries a value your configuration does not — and every subsequent `plan` shows a change on an instance nothing has touched.
+- **`instance_class` and `engine_version` are literal.** `describe-db-engine-versions` and `describe-orderable-db-instance-options` are not implemented, so the `aws_rds_engine_version` and `aws_rds_orderable_db_instance` data sources are unavailable. `aws_db_instance` needs neither.
+- **One subnet, shared.** AWS requires a DB subnet group to span two AZs. Spinifex is single-AZ — every subnet reports the same zone — so the group accepts any count, and one is what the v1 reachability rule above allows.
+- **The password is written to `~/.pgpass`, not to the environment.** A `PGPASSWORD` in `/etc/profile.d` is readable by every user on the client and leaks into `ps` output.
+
+## Troubleshooting
+
+**`apply` fails resolving the DB AMI.** The `spinifex-rds-postgres` image is not registered. Re-run the `describe-images` check in Prerequisites.
+
+**The apply sits on `aws_db_instance.main: Still creating...`.** Several minutes is normal — a VM boot plus `initdb` plus the first healthy heartbeat. Much longer is a bootstrap that did not finish:
+
+```bash
+aws rds describe-db-instances --db-instance-identifier rds-quickstart \
+  --query 'DBInstances[0].[DBInstanceStatus,StatusInfos[0].Message]' --output text
+aws rds describe-events --source-type db-instance --source-identifier rds-quickstart
+```
+
+**`psql` hangs on the client.** Three causes, in the order worth checking:
+
+- cloud-init has not finished installing `postgresql-client` — check `cloud-init status --long`.
+- the client is not in the endpoint ENI's subnet. Off-subnet clients cannot reach the endpoint in v1; put them in the DB subnet group's subnet, as this workbook does.
+- the security group is not letting you through. Nothing outside the client security group can open `5432` — that is the point of the rule — so a psql from your workstation will always time out.
+
+**`InsufficientInstanceCapacity` on the DB instance.** The node admits a launch against live free memory. Free some, or drop to a smaller `db_instance_class`.
+
+**`tofu destroy` leaves a DB instance behind.** `deletion_protection` blocks a delete outright. This workbook sets it to `false`; if you turned it on, clear it before destroying:
+
+```bash
+aws rds modify-db-instance --db-instance-identifier rds-quickstart \
+  --no-deletion-protection --apply-immediately
+```

--- a/docs/terraform-workbooks/rds-quickstart/main.tf
+++ b/docs/terraform-workbooks/rds-quickstart/main.tf
@@ -1,0 +1,454 @@
+# Example: RDS Quickstart on Spinifex
+#
+# Provisions a managed PostgreSQL instance and a client VM that connects to it:
+# a VPC, a DB subnet group, a parameter group, an aws_db_instance, and a client
+# instance whose cloud-init installs psql and points it at the endpoint.
+#
+# A Spinifex DB instance runs in a system-owned VM you never see; what lands in
+# your VPC is a single ENI in one of the DB subnet group's subnets. The endpoint
+# is therefore ALWAYS private — there is no publicly_accessible mode — so the
+# only way to reach the database is from inside the VPC, which is what the
+# client instance here is for.
+#
+# The client and the DB subnet group deliberately share ONE subnet. In v1 the
+# endpoint is reachable from clients on the endpoint ENI's own subnet only: the
+# DB VM carries its default route on a platform-side interface and the customer
+# ENI is pure ingress, so a reply to a client in another subnet is never routed
+# back. A subnet group spanning several subnets places the endpoint in one of
+# them and leaves clients in the others unable to connect. On AWS you would use
+# two private subnets here instead.
+#
+# Usage:
+#   cd spinifex/docs/terraform-workbooks/rds-quickstart
+#   export AWS_PROFILE=spinifex
+#   tofu init
+#   tofu apply -var 'db_password=<choose-one>'
+#
+# After apply, SSH to the client and connect (PGHOST/PGUSER/PGDATABASE are set
+# from /etc/profile.d, and the password comes from ~/.pgpass):
+#
+#   ssh -i rds-quickstart-client.pem ubuntu@<client_public_ip>
+#   psql -c 'SELECT version();'
+#
+# Creating the instance boots a VM, runs initdb and waits for the in-guest agent
+# to report healthy, so the apply takes several minutes before the client is
+# even launched.
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40, < 6.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+
+variable "region" {
+  type    = string
+  default = "ap-southeast-2"
+}
+
+variable "name" {
+  type        = string
+  default     = "rds-quickstart"
+  description = "Prefix for every resource this workbook creates."
+}
+
+variable "spinifex_endpoint" {
+  type        = string
+  default     = "https://127.0.0.1:9999"
+  description = "Spinifex AWS gateway endpoint as seen from the host running Terraform."
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.small"
+  description = "EC2 type for the psql client VM. Not the DB — see db_instance_class."
+}
+
+# db.* classes are a naming facade over the platform's EC2 sizing table, and only
+# a curated subset is offered. describe-orderable-db-instance-options is not
+# implemented, so pin the class here rather than reaching for the
+# aws_rds_orderable_db_instance data source.
+variable "db_instance_class" {
+  type    = string
+  default = "db.t3.micro"
+}
+
+# PostgreSQL 18 is the only version this platform serves; any other value is
+# rejected at create rather than silently substituted.
+variable "engine_version" {
+  type    = string
+  default = "18"
+}
+
+variable "db_name" {
+  type        = string
+  default     = "appdb"
+  description = "Database created inside the instance at bootstrap."
+}
+
+variable "db_username" {
+  type        = string
+  default     = "appuser"
+  description = "Master user. postgres, rdsadmin and pg_* are reserved by the engine."
+}
+
+# No '/', '"', '@' or spaces: the characters the API rejects because they break a
+# connection string or the engine's own role syntax.
+variable "db_password" {
+  type        = string
+  default     = "QuickstartS3cret1"
+  sensitive   = true
+  description = "Master password. Override this — the default exists so the workbook applies unattended."
+}
+
+variable "allocated_storage" {
+  type        = number
+  default     = 20
+  description = "Data-volume size in GiB. Grow-only, and a grow is stop/start with downtime."
+}
+
+# ---------------------------------------------------------------------------
+# Provider — point the AWS provider at Spinifex
+# ---------------------------------------------------------------------------
+
+provider "aws" {
+  region = var.region
+
+  endpoints {
+    ec2 = var.spinifex_endpoint
+    iam = var.spinifex_endpoint
+    sts = var.spinifex_endpoint
+    rds = var.spinifex_endpoint
+  }
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+}
+
+# ---------------------------------------------------------------------------
+# Data sources
+# ---------------------------------------------------------------------------
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+# The client is an ordinary Ubuntu guest — the engine image is system-owned and
+# never launched by a customer.
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["000000000000"]
+
+  filter {
+    name   = "name"
+    values = ["*ubuntu-26.04*", "*ubuntu-24.04*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# VPC — one subnet, shared by the client and the DB subnet group
+# ---------------------------------------------------------------------------
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.60.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.name}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name}-igw"
+  }
+}
+
+# Public only in the sense that it has an internet-gateway route, which the
+# client needs to apt-get a psql. The endpoint ENI in it is given no public
+# address, and PubliclyAccessible=true is rejected, so the database is not
+# exposed by sharing the subnet.
+resource "aws_subnet" "main" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.60.1.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.name}-subnet"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "${var.name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "main" {
+  subnet_id      = aws_subnet.main.id
+  route_table_id = aws_route_table.public.id
+}
+
+# ---------------------------------------------------------------------------
+# Security groups — the client SG is the only source the DB SG admits
+# ---------------------------------------------------------------------------
+
+resource "aws_security_group" "client" {
+  name        = "${var.name}-client-sg"
+  description = "RDS quickstart client: SSH inbound, all outbound"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name}-client-sg"
+  }
+}
+
+# Attached to the endpoint ENI, where it compiles to an OVN ACL on the DB VM's
+# customer-facing interface. Nothing else in the VPC can open :5432.
+resource "aws_security_group" "db" {
+  name        = "${var.name}-db-sg"
+  description = "RDS quickstart database: postgres from the client SG only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description     = "PostgreSQL from the client"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.client.id]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name}-db-sg"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# DB subnet group + parameter group
+# ---------------------------------------------------------------------------
+
+resource "aws_db_subnet_group" "main" {
+  name        = "${var.name}-subnets"
+  description = "RDS quickstart DB subnets"
+  subnet_ids  = [aws_subnet.main.id]
+
+  tags = {
+    Name = "${var.name}-subnets"
+  }
+}
+
+# Dynamic parameters are written into the engine's config and reloaded live;
+# static ones are recorded pending-reboot and adopted by the next
+# reboot-db-instance. log_min_duration_statement is dynamic.
+resource "aws_db_parameter_group" "main" {
+  name        = "${var.name}-pg18"
+  family      = "postgres18"
+  description = "RDS quickstart parameters"
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "500"
+  }
+
+  tags = {
+    Name = "${var.name}-pg18"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The DB instance
+#
+# storage_encrypted is set explicitly because the platform only offers encrypted
+# storage: the API rejects false, and leaving it unset would read back as a
+# permanent diff against an instance that reports true.
+# ---------------------------------------------------------------------------
+
+resource "aws_db_instance" "main" {
+  identifier     = var.name
+  engine         = "postgres"
+  engine_version = var.engine_version
+  instance_class = var.db_instance_class
+
+  allocated_storage = var.allocated_storage
+  storage_type      = "gp3"
+  storage_encrypted = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.db.id]
+  parameter_group_name   = aws_db_parameter_group.main.name
+
+  # Daily COW snapshots of the data volume. Retention caps at 7 days; 0 turns
+  # automated backups off. Point-in-time recovery is not implemented.
+  backup_retention_period = 7
+
+  # A final snapshot pins the data volume alive until that snapshot is deleted,
+  # which would outlive a `tofu destroy`. Take one for anything you care about.
+  skip_final_snapshot = true
+  deletion_protection = false
+
+  apply_immediately = true
+
+  tags = {
+    Name = var.name
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Client VM — psql inside the VPC, which is the only place the endpoint exists
+# ---------------------------------------------------------------------------
+
+resource "tls_private_key" "client" {
+  algorithm = "ED25519"
+}
+
+resource "aws_key_pair" "client" {
+  key_name   = "${var.name}-client"
+  public_key = tls_private_key.client.public_key_openssh
+}
+
+resource "local_file" "client_pem" {
+  filename        = "${path.module}/${var.name}-client.pem"
+  content         = tls_private_key.client.private_key_openssh
+  file_permission = "0600"
+}
+
+resource "aws_instance" "client" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.main.id
+  vpc_security_group_ids = [aws_security_group.client.id]
+  key_name               = aws_key_pair.client.key_name
+
+  # The password goes to ~/.pgpass at 0600 rather than into the environment, so
+  # it is not readable from another user's `ps` or from /etc/profile.d.
+  #
+  # It is written from runcmd, not write_files: write_files runs before
+  # users-groups, so a file under /home/ubuntu lands before the user exists and
+  # takes the home directory root-owned with it.
+  user_data = <<-USERDATA
+    #cloud-config
+    package_update: true
+    packages:
+      - postgresql-client
+    write_files:
+      - path: /etc/profile.d/rds-quickstart.sh
+        permissions: '0644'
+        content: |
+          export PGHOST=${aws_db_instance.main.address}
+          export PGPORT=${aws_db_instance.main.port}
+          export PGUSER=${var.db_username}
+          export PGDATABASE=${var.db_name}
+    runcmd:
+      - install -o ubuntu -g ubuntu -m 0600 /dev/null /home/ubuntu/.pgpass
+      - echo '${aws_db_instance.main.address}:${aws_db_instance.main.port}:${var.db_name}:${var.db_username}:${var.db_password}' > /home/ubuntu/.pgpass
+  USERDATA
+
+  tags = {
+    Name = "${var.name}-client"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+output "note" {
+  value = <<-EOT
+    The endpoint is private. Connect from the client VM, not from this host:
+
+      ssh -i ${var.name}-client.pem ubuntu@${aws_instance.client.public_ip}
+      psql -c 'SELECT version();'
+
+    cloud-init installs postgresql-client on first boot, so give the client a
+    minute after apply before the first psql.
+
+    TLS is offered but not enforced. `psql "sslmode=require"` encrypts the
+    connection; `sslmode=verify-full` additionally verifies the serving
+    certificate, which is signed by the cluster CA — copy /etc/spinifex/ca.pem
+    from a cluster node to the client and pass sslrootcert=<path>. Both the
+    endpoint name and the endpoint IP are in the certificate's SAN set.
+  EOT
+}
+
+output "db_endpoint" {
+  description = "host:port. Reachable only from inside the VPC."
+  value       = aws_db_instance.main.endpoint
+}
+
+output "db_address" {
+  value = aws_db_instance.main.address
+}
+
+output "db_identifier" {
+  value = aws_db_instance.main.identifier
+}
+
+output "client_public_ip" {
+  value = aws_instance.client.public_ip
+}
+
+output "ssh_to_client" {
+  value = "ssh -i ${var.name}-client.pem ubuntu@${aws_instance.client.public_ip}"
+}

--- a/spinifex/handlers/ec2/instance/projection.go
+++ b/spinifex/handlers/ec2/instance/projection.go
@@ -123,6 +123,27 @@ func ProjectInstance(v *vm.VM, cfg InstanceProjection) (inst *ec2.Instance, stat
 		instanceCopy.SpotInstanceRequestId = aws.String(v.SpotInstanceRequestId)
 	}
 
+	// The check is always on: OVN port security enforces it and
+	// ModifyInstanceAttribute refuses to turn it off. DescribeInstanceAttribute
+	// and DescribeNetworkInterfaces already report that; the describe did not,
+	// and the Terraform provider reads the value off the primary interface — so
+	// it read as false against a schema whose default is true, and no plan on an
+	// aws_instance ever settled. Interfaces are copied rather than mutated
+	// because instanceCopy shares their pointers with the stored instance.
+	instanceCopy.SourceDestCheck = aws.Bool(true)
+	if len(instanceCopy.NetworkInterfaces) > 0 {
+		nics := make([]*ec2.InstanceNetworkInterface, 0, len(instanceCopy.NetworkInterfaces))
+		for _, nic := range instanceCopy.NetworkInterfaces {
+			if nic == nil {
+				continue
+			}
+			nicCopy := *nic
+			nicCopy.SourceDestCheck = aws.Bool(true)
+			nics = append(nics, &nicCopy)
+		}
+		instanceCopy.NetworkInterfaces = nics
+	}
+
 	return &instanceCopy, stateMapped
 }
 

--- a/spinifex/handlers/ec2/instance/projection_test.go
+++ b/spinifex/handlers/ec2/instance/projection_test.go
@@ -128,12 +128,40 @@ func TestProjectInstance_UnmappedStatusUsesFallback(t *testing.T) {
 // its fresh copy, never back to the stored vm.VM.Instance shared under the lock.
 func TestProjectInstance_DoesNotMutateSource(t *testing.T) {
 	v := fullVM(vm.StateRunning)
+	v.Instance.NetworkInterfaces = []*ec2.InstanceNetworkInterface{{
+		NetworkInterfaceId: aws.String("eni-1"),
+	}}
 
 	_, _ = ProjectInstance(v, runningCfg())
 
 	assert.Nil(t, v.Instance.PublicIpAddress)
 	assert.Nil(t, v.Instance.State)
 	assert.Nil(t, v.Instance.Placement)
+	assert.Nil(t, v.Instance.SourceDestCheck)
+	assert.Nil(t, v.Instance.NetworkInterfaces[0].SourceDestCheck,
+		"the interfaces are shared with the stored instance, so they must be copied before they are stamped")
+}
+
+// The check is always on and cannot be turned off, but the describe never said
+// so — and the Terraform provider reads it off the primary interface against a
+// schema that defaults it to true, so an absent value left every aws_instance
+// with a diff no apply could clear.
+func TestProjectInstance_ReportsSourceDestCheckEnabled(t *testing.T) {
+	v := fullVM(vm.StateRunning)
+	v.Instance.NetworkInterfaces = []*ec2.InstanceNetworkInterface{
+		{NetworkInterfaceId: aws.String("eni-1"), Attachment: &ec2.InstanceNetworkInterfaceAttachment{
+			DeviceIndex: aws.Int64(0),
+		}},
+		{NetworkInterfaceId: aws.String("eni-2")},
+	}
+
+	got, _ := ProjectInstance(v, runningCfg())
+
+	assert.True(t, aws.BoolValue(got.SourceDestCheck))
+	require.Len(t, got.NetworkInterfaces, 2)
+	for _, nic := range got.NetworkInterfaces {
+		assert.True(t, aws.BoolValue(nic.SourceDestCheck), aws.StringValue(nic.NetworkInterfaceId))
+	}
 }
 
 // TestProjectInstance_PathsAgreeOnRetainedFields is the regression guard that

--- a/spinifex/handlers/rds/create.go
+++ b/spinifex/handlers/rds/create.go
@@ -136,6 +136,7 @@ func newDBInstanceRecord(accountID string, req *validatedCreate, placement *endp
 	now := time.Now().UTC()
 	return DBInstanceRecord{
 		DBInstanceIdentifier: req.Identifier,
+		DbiResourceID:        utils.GenerateResourceID(dbiResourceIDPrefix),
 		AccountID:            accountID,
 		Status:               StatusCreating,
 		Engine:               req.Engine.Name,
@@ -152,6 +153,8 @@ func newDBInstanceRecord(accountID string, req *validatedCreate, placement *endp
 		DBSubnetGroupName:    req.DBSubnetGroupName,
 		DBParameterGroupName: req.DBParameterGroupName,
 		DeletionProtection:   req.DeletionProtection,
+
+		AutoMinorVersionUpgrade: req.AutoMinorVersionUpgrade,
 
 		BackupRetentionPeriod:      req.BackupRetentionPeriod,
 		PreferredBackupWindow:      req.PreferredBackupWindow,

--- a/spinifex/handlers/rds/describe.go
+++ b/spinifex/handlers/rds/describe.go
@@ -11,6 +11,15 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
+// The prefix AWS gives a DB instance's immutable resource ID, and the two filter
+// names DescribeDBInstances accepts against it.
+const (
+	dbiResourceIDPrefix = "db"
+
+	filterDbiResourceID = "dbi-resource-id"
+	filterDBInstanceID  = "db-instance-id"
+)
+
 // Named DB instances that do not exist are an error, matching AWS: a client
 // polling a create would otherwise read an empty list as "gone" rather than
 // "not ready".
@@ -20,11 +29,21 @@ func (s *Service) DescribeDBInstances(ctx context.Context, input *rds.DescribeDB
 		return nil, err
 	}
 
+	var matches func(*DBInstanceRecord) bool
 	if input != nil {
+		matches, err = dbInstanceFilterMatcher(input.Filters)
+		if err != nil {
+			return nil, err
+		}
 		if id := aws.StringValue(input.DBInstanceIdentifier); id != "" {
 			rec, _, err := s.getDBInstance(ctx, kv, id)
 			if err != nil {
 				return nil, err
+			}
+			// A named instance the filters exclude is reported as absent rather than
+			// returned anyway, so the two halves of one request cannot disagree.
+			if matches != nil && !matches(rec) {
+				return nil, errors.New(awserrors.ErrorDBInstanceNotFound)
 			}
 			return &rds.DescribeDBInstancesOutput{DBInstances: []*rds.DBInstance{s.projectDBInstance(rec)}}, nil
 		}
@@ -48,9 +67,52 @@ func (s *Service) DescribeDBInstances(ctx context.Context, input *rds.DescribeDB
 		if !found {
 			continue
 		}
+		if matches != nil && !matches(&rec) {
+			continue
+		}
 		instances = append(instances, s.projectDBInstance(&rec))
 	}
 	return &rds.DescribeDBInstancesOutput{DBInstances: instances}, nil
+}
+
+// The filter names AWS documents for this action and clients actually send.
+// Ignoring them is not a safe default here: the Terraform provider keys its
+// state off DbiResourceId and reads an instance back by filtering on it, so an
+// unapplied filter answers with every instance in the account, which the
+// provider rejects as an ambiguous match. An unrecognised name is refused for
+// the same reason — a filter silently dropped returns rows the caller asked to
+// exclude.
+//
+// Returns nil when there is nothing to filter on, so the common path allocates
+// no closure.
+func dbInstanceFilterMatcher(filters []*rds.Filter) (func(*DBInstanceRecord) bool, error) {
+	if len(filters) == 0 {
+		return nil, nil
+	}
+	for _, filter := range filters {
+		switch name := aws.StringValue(filter.Name); name {
+		case filterDbiResourceID, filterDBInstanceID:
+		default:
+			return nil, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+				"unrecognized filter name: %s", name)
+		}
+	}
+	// AWS's own semantics: a record must match every filter, and matches a filter
+	// by carrying any one of its values.
+	return func(rec *DBInstanceRecord) bool {
+		for _, filter := range filters {
+			var value string
+			if aws.StringValue(filter.Name) == filterDbiResourceID {
+				value = rec.DbiResourceID
+			} else {
+				value = rec.DBInstanceIdentifier
+			}
+			if !slices.Contains(aws.StringValueSlice(filter.Values), value) {
+				return false
+			}
+		}
+		return true
+	}, nil
 }
 
 // Returns the record plus its revision, for callers that follow with a CAS.
@@ -86,13 +148,22 @@ func (s *Service) projectDBInstance(rec *DBInstanceRecord) *rds.DBInstance {
 		MultiAZ:              aws.Bool(false),
 		PubliclyAccessible:   aws.Bool(false),
 		DeletionProtection:   aws.Bool(rec.DeletionProtection),
-		InstanceCreateTime:   aws.Time(rec.CreatedAt),
+		// Echoed, not acted on: nothing upgrades a pinned version, but a client
+		// that set it has to read back what it set.
+		AutoMinorVersionUpgrade: aws.Bool(rec.AutoMinorVersionUpgrade),
+		InstanceCreateTime:      aws.Time(rec.CreatedAt),
 		// The Terraform provider reads tags from the describe as well as from
 		// ListTagsForResource, so the two have to agree.
 		TagList: tagsToAWS(rec.Tags),
 	}
 	if rec.DBName != "" {
 		out.DBName = aws.String(rec.DBName)
+	}
+	// Absent only on a record predating the field, where an empty handle would be
+	// worse than none: a client keying its state off it would store the empty
+	// string and never find the instance again.
+	if rec.DbiResourceID != "" {
+		out.DbiResourceId = aws.String(rec.DbiResourceID)
 	}
 	// The Terraform provider reads db_subnet_group_name off the describe, so an
 	// instance placed from a named group has to report it: an empty read-back is a

--- a/spinifex/handlers/rds/describe_test.go
+++ b/spinifex/handlers/rds/describe_test.go
@@ -90,6 +90,101 @@ func TestDescribeDBInstances_NamedInstanceProjectsTheRecord(t *testing.T) {
 	assert.Equal(t, testDefaultSG, aws.StringValue(instance.VpcSecurityGroups[0].VpcSecurityGroupId))
 }
 
+// The Terraform provider keys its state off DbiResourceId rather than off the
+// identifier, so an instance created without one is unmanageable by the tool
+// this service is driven with — its post-create read finds nothing.
+func TestDescribeDBInstances_ReportsAStableResourceID(t *testing.T) {
+	h := newCreateHarness(t, "")
+	rec := seedCreated(t, h, testDBInstanceID)
+	require.Regexp(t, `^db-[0-9a-f]{17}$`, rec.DbiResourceID)
+
+	other := seedCreated(t, h, "other-db")
+	assert.NotEqual(t, rec.DbiResourceID, other.DbiResourceID, "the handle is per instance")
+
+	out, err := h.svc.DescribeDBInstances(t.Context(), &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(testDBInstanceID),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.DBInstances, 1)
+	assert.Equal(t, rec.DbiResourceID, aws.StringValue(out.DBInstances[0].DbiResourceId))
+}
+
+// The read half of the same path: the provider looks an instance up by filtering
+// on the resource ID, and a filter that is parsed but not applied answers with
+// every instance in the account instead of the one asked for.
+func TestDescribeDBInstances_FiltersOnResourceIDAndIdentifier(t *testing.T) {
+	h := newCreateHarness(t, "")
+	want := seedCreated(t, h, testDBInstanceID)
+	seedCreated(t, h, "other-db")
+
+	for name, filter := range map[string]*rds.Filter{
+		filterDbiResourceID: {Name: aws.String(filterDbiResourceID), Values: aws.StringSlice([]string{want.DbiResourceID})},
+		filterDBInstanceID:  {Name: aws.String(filterDBInstanceID), Values: aws.StringSlice([]string{testDBInstanceID})},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := h.svc.DescribeDBInstances(t.Context(), &rds.DescribeDBInstancesInput{
+				Filters: []*rds.Filter{filter},
+			}, testAccountID)
+			require.NoError(t, err)
+			require.Len(t, out.DBInstances, 1)
+			assert.Equal(t, testDBInstanceID, aws.StringValue(out.DBInstances[0].DBInstanceIdentifier))
+		})
+	}
+}
+
+// Nothing acts on AutoMinorVersionUpgrade — the version is pinned — but AWS and
+// the Terraform provider both default it to true, so a describe that reported
+// false would leave every default configuration with a diff that no modify can
+// clear.
+func TestDescribeDBInstances_EchoesAutoMinorVersionUpgrade(t *testing.T) {
+	h := newCreateHarness(t, "")
+
+	unset := seedCreated(t, h, testDBInstanceID)
+	assert.True(t, unset.AutoMinorVersionUpgrade, "an unset request takes AWS's own default")
+
+	input := validCreateInput()
+	input.DBInstanceIdentifier = aws.String("opted-out-db")
+	input.AutoMinorVersionUpgrade = aws.Bool(false)
+	_, err := h.svc.CreateDBInstance(t.Context(), input, testAccountID)
+	require.NoError(t, err)
+
+	out, err := h.svc.DescribeDBInstances(t.Context(), &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String("opted-out-db"),
+	}, testAccountID)
+	require.NoError(t, err)
+	require.Len(t, out.DBInstances, 1)
+	assert.False(t, aws.BoolValue(out.DBInstances[0].AutoMinorVersionUpgrade))
+}
+
+// A filter nobody implemented is refused rather than dropped: dropping it
+// returns exactly the rows the caller asked to exclude.
+func TestDescribeDBInstances_RejectsAnUnrecognizedFilter(t *testing.T) {
+	h := newCreateHarness(t, "")
+	seedCreated(t, h, testDBInstanceID)
+
+	_, err := h.svc.DescribeDBInstances(t.Context(), &rds.DescribeDBInstancesInput{
+		Filters: []*rds.Filter{{Name: aws.String("engine"), Values: aws.StringSlice([]string{"postgres"})}},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+}
+
+// A named instance and a filter that excludes it disagree; reporting the
+// instance anyway would answer a question the caller did not ask.
+func TestDescribeDBInstances_NamedInstanceMustSatisfyTheFilters(t *testing.T) {
+	h := newCreateHarness(t, "")
+	seedCreated(t, h, testDBInstanceID)
+
+	_, err := h.svc.DescribeDBInstances(t.Context(), &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(testDBInstanceID),
+		Filters: []*rds.Filter{{
+			Name: aws.String(filterDbiResourceID), Values: aws.StringSlice([]string{"db-000000000000000ff"}),
+		}},
+	}, testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorDBInstanceNotFound)
+}
+
 // Instances live in per-account buckets, so one account's describe must not see
 // another's — the identifier is only unique within an account.
 func TestDescribeDBInstances_IsScopedToTheCallingAccount(t *testing.T) {

--- a/spinifex/handlers/rds/modify.go
+++ b/spinifex/handlers/rds/modify.go
@@ -28,6 +28,7 @@ type modifyPlan struct {
 	MasterUserPassword         string
 	SecurityGroupIDs           []string
 	DeletionProtection         *bool
+	AutoMinorVersionUpgrade    *bool
 	BackupRetentionPeriod      *int64
 	PreferredBackupWindow      string
 	PreferredMaintenanceWindow string
@@ -53,7 +54,8 @@ func (p *modifyPlan) disruptive() bool {
 // deferred must not report a configuration change that has not happened.
 func (p *modifyPlan) immediate() bool {
 	return p.MasterUserPassword != "" || p.SecurityGroupIDs != nil || p.DeletionProtection != nil ||
-		p.BackupRetentionPeriod != nil || p.PreferredBackupWindow != "" || p.PreferredMaintenanceWindow != ""
+		p.AutoMinorVersionUpgrade != nil || p.BackupRetentionPeriod != nil ||
+		p.PreferredBackupWindow != "" || p.PreferredMaintenanceWindow != ""
 }
 
 func (p *modifyPlan) empty() bool {
@@ -219,6 +221,11 @@ func (s *Service) planModify(ctx context.Context, input *rds.ModifyDBInstanceInp
 	if input.DeletionProtection != nil && aws.BoolValue(input.DeletionProtection) != rec.DeletionProtection {
 		plan.DeletionProtection = input.DeletionProtection
 	}
+	// Nothing acts on it (D19), but a value the record does not adopt is one the
+	// next describe contradicts, and the client re-sends it forever.
+	if input.AutoMinorVersionUpgrade != nil && aws.BoolValue(input.AutoMinorVersionUpgrade) != rec.AutoMinorVersionUpgrade {
+		plan.AutoMinorVersionUpgrade = input.AutoMinorVersionUpgrade
+	}
 	if err := s.planBackupSettings(input, rec, plan); err != nil {
 		return nil, err
 	}
@@ -329,6 +336,9 @@ func (s *Service) applyImmediateModify(ctx context.Context, kv jetstream.KeyValu
 		}
 		if plan.DeletionProtection != nil {
 			stored.DeletionProtection = *plan.DeletionProtection
+		}
+		if plan.AutoMinorVersionUpgrade != nil {
+			stored.AutoMinorVersionUpgrade = *plan.AutoMinorVersionUpgrade
 		}
 		if plan.BackupRetentionPeriod != nil {
 			stored.BackupRetentionPeriod = *plan.BackupRetentionPeriod

--- a/spinifex/handlers/rds/records.go
+++ b/spinifex/handlers/rds/records.go
@@ -9,6 +9,12 @@ type DBInstanceRecord struct {
 	AccountID            string `json:"accountId"`
 	Status               Status `json:"status"`
 
+	// AWS's immutable per-instance handle, distinct from the identifier a
+	// customer may reuse. The Terraform provider keys its own state off it and
+	// reads the instance back by filtering on it, so an instance without one is
+	// unmanageable by Terraform. Assigned at create and never changed.
+	DbiResourceID string `json:"dbiResourceId,omitempty"`
+
 	Engine           string `json:"engine"`
 	EngineVersion    string `json:"engineVersion"`
 	DBInstanceClass  string `json:"dbInstanceClass"`
@@ -24,6 +30,12 @@ type DBInstanceRecord struct {
 
 	// Blocks DeleteDBInstance outright (D18). Settable at create and modify.
 	DeletionProtection bool `json:"deletionProtection,omitempty"`
+
+	// Inert (D19) — the engine version is pinned, so nothing upgrades either way.
+	// Recorded anyway because a describe that does not echo it back reads as
+	// false against a Terraform schema that defaults it to true, and the plan
+	// then never settles on a change no modify can deliver.
+	AutoMinorVersionUpgrade bool `json:"autoMinorVersionUpgrade"`
 
 	// The backup policy in force. Both windows are stored in AWS's canonical text
 	// so a describe reads back the string a later modify compares against; an

--- a/spinifex/handlers/rds/restore.go
+++ b/spinifex/handlers/rds/restore.go
@@ -236,7 +236,10 @@ func resolveRestoreRequest(input *rds.RestoreDBInstanceFromDBSnapshotInput, snap
 		DBSubnetGroupName:    subnetGroup,
 		DBParameterGroupName: paramGroup,
 		DeletionProtection:   aws.BoolValue(input.DeletionProtection),
-		Tags:                 tagMap,
+
+		AutoMinorVersionUpgrade: input.AutoMinorVersionUpgrade == nil || aws.BoolValue(input.AutoMinorVersionUpgrade),
+
+		Tags: tagMap,
 	}, nil
 }
 

--- a/spinifex/handlers/rds/validate.go
+++ b/spinifex/handlers/rds/validate.go
@@ -48,6 +48,11 @@ type validatedCreate struct {
 	DBSubnetGroupName    string
 	DBParameterGroupName string
 	DeletionProtection   bool
+	// Inert, and stored only so a describe echoes back what the request set: the
+	// engine version is pinned, so nothing upgrades either way. AWS defaults it
+	// to true and so does the Terraform provider, so an unset request must not
+	// read back as false.
+	AutoMinorVersionUpgrade bool
 	// Automated backups as they will be in force: the retention defaulted when the
 	// request names none, and both windows in canonical text — assigned from the
 	// instance identifier when unnamed, never left empty (rds-9).
@@ -166,6 +171,8 @@ func (s *Service) validateCreateRequest(input *rds.CreateDBInstanceInput) (*vali
 		DBSubnetGroupName:    aws.StringValue(input.DBSubnetGroupName),
 		DBParameterGroupName: paramGroup,
 		DeletionProtection:   aws.BoolValue(input.DeletionProtection),
+
+		AutoMinorVersionUpgrade: input.AutoMinorVersionUpgrade == nil || aws.BoolValue(input.AutoMinorVersionUpgrade),
 
 		BackupRetentionPeriod:      retention,
 		PreferredBackupWindow:      backupWindow,

--- a/tests/e2e/run-tofu-examples-e2e.sh
+++ b/tests/e2e/run-tofu-examples-e2e.sh
@@ -231,6 +231,47 @@ assert_nginx_webserver() {
     wait_for_http_200 "http://${ip}/"
 }
 
+# The DB endpoint is a private VPC address and there is no publicly_accessible
+# mode, so nothing on the runner can reach it. The assertion therefore runs psql
+# from the workbook's client VM over SSH — which is also what proves the
+# security-group rule admitting :5432 from the client group is enforced.
+assert_rds_quickstart() {
+    local ip key endpoint
+    ip=$(tofu output -raw client_public_ip)
+    endpoint=$(tofu output -raw db_address)
+    key="$(pwd)/rds-quickstart-client.pem"
+    chmod 600 "$key"
+
+    log "  rds-quickstart: endpoint ${endpoint}, client ${ip}"
+
+    wait_for_ssh "$key" "$ip" || {
+        log "  rds-quickstart: client SSH not ready"
+        return 1
+    }
+
+    # cloud-init installs postgresql-client on first boot, so psql appears after
+    # sshd does. 300s covers an apt-get on a cold mirror.
+    if ! ssh "${SSH_OPTS[@]}" -i "$key" "ubuntu@${ip}" \
+        'for _ in $(seq 1 60); do command -v psql >/dev/null && exit 0; sleep 5; done; exit 1'; then
+        log "  rds-quickstart: psql never installed on the client (cloud-init stalled?)"
+        ssh "${SSH_OPTS[@]}" -i "$key" "ubuntu@${ip}" \
+            'cloud-init status --long; sudo tail -n 40 /var/log/cloud-init-output.log' 2>&1 | \
+            sed "s|^|    |" || true
+        return 1
+    fi
+
+    # A round-trip rather than a bare connect: a SELECT 1 would pass against an
+    # engine that cannot write, which is the half of a bootstrap most likely to
+    # be wrong. Run under a login shell so /etc/profile.d supplies PGHOST — an
+    # ssh command runs a non-login shell, which sources none of it.
+    printf '%s\n' \
+        "CREATE TABLE IF NOT EXISTS smoke (id int primary key, note text);" \
+        "INSERT INTO smoke VALUES (1, 'nightly') ON CONFLICT (id) DO UPDATE SET note = 'nightly';" \
+        "SELECT note FROM smoke WHERE id = 1;" |
+        ssh "${SSH_OPTS[@]}" -i "$key" "ubuntu@${ip}" \
+            'bash -lc "psql -v ON_ERROR_STOP=1 -tA"' 2>&1 | tail -1 | grep -q '^nightly$'
+}
+
 # dump_s3_webapp_guest SSHes into the webapp instance and tails cloud-init's
 # output log plus the s3-webapp unit status, so a first-boot apt/pip/egress
 # failure is distinguishable from a control-plane regression in the bundle.
@@ -281,6 +322,36 @@ assert_s3_webapp() {
     rm -f "$tmp"
 
     curl -sf "http://${ip}/" | grep -q "$sentinel"
+}
+
+# Workbooks whose describe path has to round-trip every attribute their config
+# sets. A second plan on these must be empty; a diff is a describe response that
+# failed to echo back a field Terraform sent, which makes the provider unusable
+# while every individual API call still looks correct.
+#
+# Opt-in rather than universal: the four original workbooks were never written
+# against this assertion, and a pre-existing diff in one of them would fail a
+# suite that is otherwise reporting on something else.
+CLEAN_PLAN_WORKBOOKS=" rds-quickstart "
+
+assert_clean_plan() {
+    local example="$1"
+    shift
+    case "$CLEAN_PLAN_WORKBOOKS" in
+        *" ${example} "*) ;;
+        *) return 0 ;;
+    esac
+
+    local out rc
+    out=$(tofu plan -detailed-exitcode -input=false -no-color "$@" 2>&1)
+    rc=$?
+    case "$rc" in
+        0) log "  ${example}: second plan is clean" ; return 0 ;;
+        2) log "  ${example}: second plan is not empty — a describe is not echoing back what apply sent" ;;
+        *) log "  ${example}: second plan errored (exit ${rc})" ;;
+    esac
+    echo "$out" | tail -60 | sed "s|^|    |"
+    return 1
 }
 
 # Pick an instance type available on this cluster. Workbooks default to
@@ -351,7 +422,7 @@ run_workbook() {
     fi
 
     local rc=0
-    if assert_"${example//-/_}"; then
+    if assert_"${example//-/_}" && assert_clean_plan "$example" "${apply_args[@]}"; then
         log "  PASS ${example}"
     else
         log "  FAIL ${example}: assertion"
@@ -384,8 +455,14 @@ log "Using instance_type=${INSTANCE_TYPE}"
 # tee'd log into junit-tofu.xml and the e2e-analyze action produces the same
 # RCA bundle the Go suites do (nightly cell 17). The per-workbook log() output
 # between RUN and the result line is captured as the failure diagnostics.
+#
+# rds-quickstart runs last because it is the most expensive: its apply carries a
+# DB VM boot, initdb and the first healthy agent heartbeat before Terraform even
+# launches the client, then the client's own boot and an apt-get. Budget it at
+# ~15 minutes against the ~7 the other four share, and note that its assertion
+# needs roughly 2 GiB of free guest memory for the two VMs.
 SUITE_RC=0
-for workbook in nginx-alb bastion-private-subnet nginx-webserver s3-webapp; do
+for workbook in nginx-alb bastion-private-subnet nginx-webserver s3-webapp rds-quickstart; do
     tname="TestTofuWorkbook_${workbook//-/_}"
     wb_start=$SECONDS
     echo "=== RUN   ${tname}"


### PR DESCRIPTION
Phase rds-10c of the RDS v1 epic. Ships the customer-facing Terraform workbook, registers it in CI, and fixes the three describe-side gaps that registration uncovered.

## What's here

**`docs/terraform-workbooks/rds-quickstart/`** — `main.tf` + `README.md`: a VPC, a DB subnet group, a parameter group, two security groups (the DB group admits `5432` from the client group only), an `aws_db_instance`, and a client VM whose cloud-init installs `postgresql-client`, exports the connection environment from `/etc/profile.d` and writes the master password to `~/.pgpass` at `0600`.

**`tests/e2e/run-tofu-examples-e2e.sh`** — `assert_rds_quickstart` connects from the client VM over SSH and round-trips a row, which is also what proves the security-group rule is enforced. The driver gains an opt-in **clean-plan check**: for a listed workbook, a second `tofu plan` after apply must report no changes. Opt-in rather than universal, because the four original workbooks were never written against that assertion.

## Three defects the clean-plan check found

The workbook applied and every individual API call looked correct, but no second plan ever settled.

- **`DbiResourceId` was never assigned or reported, and `DescribeDBInstances` ignored `Filters`.** The provider keys the `aws_db_instance` resource ID off `DbiResourceId` and reads the instance back with a `dbi-resource-id` filter, so the apply failed outright with *"Provider produced inconsistent result after apply: root object was present, but now absent"*. The handle is now generated at create, persisted and projected, and the `dbi-resource-id` / `db-instance-id` filters are honoured — with an unrecognised filter name refused rather than silently dropped, since a dropped filter returns rows the caller asked to exclude.
- **`AutoMinorVersionUpgrade` was not echoed.** The provider's schema defaults it to `true`, so an absent value read back as `false` and every default configuration carried a diff no modify could clear. D19 already classifies the field as an accepted no-op; it is now persisted and echoed, defaulting to `true` when unset.
- **`SourceDestCheck` was absent from `DescribeInstances`.** Pre-existing and not RDS-specific — it affects every workbook with an `aws_instance`. The check is always on and `ModifyInstanceAttribute` refuses to disable it, so the projection now reports `true` on the instance and on each interface.

## Known limitation the workbook works around

The client and the DB subnet group share **one subnet**. In v1 the endpoint is reachable only from clients on the endpoint ENI's own subnet: the DB VM carries its default route on its platform-side interface, so a reply to a client in another subnet is never routed back. Confirmed by a controlled experiment — an identical probe VM in the endpoint's subnet connected, the same VM in a sibling subnet did not. Tracked as **mulga-2t29f** (P1); both the `main.tf` header and the README state the constraint and name the AWS-portable two-private-subnet layout to restore once it is fixed.

The RDS service guide is deferred for the same reason — a guide stating a constraint due to be removed is worse than none. `docs/COMMANDS.md` carries the per-action reference in the meantime.

## Testing

- `make preflight` passes.
- `tofu fmt -check` and `tofu validate` on the workbook.
- Applied against a live single-node cluster: 14 resources, DB `available` after 2m05s, `psql` round-trip returned the expected row, `tofu plan -detailed-exitcode` exited 0, `tofu destroy` removed all 14 and left no DB instance, volume or ENI behind.

Closes mulga-eczml, mulga-fwk5t.