### PR TITLE
fix: harden RDS provisioning and replies

### DIFF
--- a/cmd/rds-agent/agent_test.go
+++ b/cmd/rds-agent/agent_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -99,7 +100,7 @@ func (f *fakeControlPlane) GetBootstrapConfig(_ context.Context, id identity) (*
 
 func (f *fakeControlPlane) PollCommands(ctx context.Context, _ identity, replies []handlers_rds.CommandReply, _ time.Duration) ([]handlers_rds.Command, error) {
 	f.mu.Lock()
-	f.pollReplies = append(f.pollReplies, replies)
+	f.pollReplies = append(f.pollReplies, slices.Clone(replies))
 	err := f.pollErr
 	var out []handlers_rds.Command
 	if len(f.pollQueue) > 0 {
@@ -132,7 +133,11 @@ func (f *fakeControlPlane) snapshotStates() []submittedState {
 func (f *fakeControlPlane) snapshotReplies() [][]handlers_rds.CommandReply {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return append([][]handlers_rds.CommandReply(nil), f.pollReplies...)
+	out := make([][]handlers_rds.CommandReply, len(f.pollReplies))
+	for i := range f.pollReplies {
+		out[i] = slices.Clone(f.pollReplies[i])
+	}
+	return out
 }
 
 // testConfig points the agent's file output at a temp dir and its probe at a

--- a/cmd/rds-agent/command_test.go
+++ b/cmd/rds-agent/command_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommander_DispatchesByNameAndReplies(t *testing.T) {
@@ -99,6 +101,56 @@ func TestCommander_RunCarriesRepliesOnTheNextPoll(t *testing.T) {
 	if got := replies[1][0]; got.CommandID != "cmd-1" || got.Status != handlers_rds.CommandStatusSucceeded {
 		t.Errorf("second poll carried %+v, want the succeeded reply for cmd-1", got)
 	}
+}
+
+func TestCommander_RetainsAndRetriesTheCompletePendingBatch(t *testing.T) {
+	cp := newFakeControlPlane()
+	pending := []handlers_rds.CommandReply{
+		{CommandID: "cmd-1", Status: handlers_rds.CommandStatusSucceeded},
+		{CommandID: "cmd-2", Status: handlers_rds.CommandStatusFailed, Message: "disk full"},
+	}
+	c := newCommander(cp, commandRegistry{
+		"reload-parameters": func(context.Context, handlers_rds.Command) (string, error) {
+			return "reloaded", nil
+		},
+	}, 10*time.Millisecond)
+	c.pending = append([]handlers_rds.CommandReply(nil), pending...)
+	cp.pollErr = errors.New("reply publication failed")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+	<-cp.polled
+	cancel()
+	<-done
+
+	assert.Equal(t, pending, c.pending)
+	replies := cp.snapshotReplies()
+	require.Len(t, replies, 1)
+	assert.Equal(t, pending, replies[0])
+
+	cp.mu.Lock()
+	cp.pollErr = nil
+	cp.pollQueue = [][]handlers_rds.Command{{{
+		CommandID: "cmd-3",
+		Type:      "reload-parameters",
+	}}}
+	cp.mu.Unlock()
+
+	ctx, cancel = context.WithCancel(context.Background())
+	done = make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+	waitFor(t, func() bool {
+		return len(cp.snapshotReplies()) >= 3
+	}, "the retained batch to succeed and the new reply to reach the following poll")
+	cancel()
+	<-done
+
+	replies = cp.snapshotReplies()
+	assert.Equal(t, pending, replies[1], "the complete failed batch must be retried in order")
+	require.Len(t, replies[2], 1)
+	assert.Equal(t, "cmd-3", replies[2][0].CommandID)
+	assert.Equal(t, handlers_rds.CommandStatusSucceeded, replies[2][0].Status)
 }
 
 // A poll error must not spin the loop: without a backoff a gateway that is down

--- a/spinifex/gateway/rds/agent.go
+++ b/spinifex/gateway/rds/agent.go
@@ -183,8 +183,13 @@ func PollDBCommands(ctx context.Context, input *PollDBCommandsInput, nc *nats.Co
 	}
 
 	// Replies are published before the subscription is opened so a reply is not
-	// delayed by the poll's own wait.
-	publishReplies(ctx, nc, id, input.Replies)
+	// delayed by the poll's own wait. Publication is part of poll success: the
+	// agent retains and retries this entire batch when the poll fails.
+	if err := publishReplies(nc, id, input.Replies); err != nil {
+		slog.ErrorContext(ctx, "RDS: publish command replies failed",
+			"dbInstanceIdentifier", id.DBInstanceIdentifier, "err", err)
+		return nil, errors.New(awserrors.ErrorServerInternal)
+	}
 
 	sub, err := nc.QueueSubscribeSync(
 		handlers_rds.BusCommandSubject(id.AccountID, id.DBInstanceIdentifier),
@@ -234,9 +239,7 @@ func pollWait(requested int64) time.Duration {
 	return min(max(time.Duration(requested)*time.Second, minPollWait), maxPollWait)
 }
 
-// Failures are logged rather than returned: a lost reply times the issuer out,
-// the same outcome as a lost command and better than failing the whole poll.
-func publishReplies(ctx context.Context, nc *nats.Conn, id *agentIdentity, replies []handlers_rds.CommandReply) {
+func publishReplies(nc *nats.Conn, id *agentIdentity, replies []handlers_rds.CommandReply) error {
 	subject := handlers_rds.BusCommandReplySubject(id.AccountID, id.DBInstanceIdentifier)
 	for _, reply := range replies {
 		if reply.CommandID == "" {
@@ -244,11 +247,11 @@ func publishReplies(ctx context.Context, nc *nats.Conn, id *agentIdentity, repli
 		}
 		data, err := json.Marshal(reply)
 		if err != nil {
-			slog.ErrorContext(ctx, "RDS: marshal command reply", "commandID", reply.CommandID, "err", err)
-			continue
+			return fmt.Errorf("marshal command reply %s: %w", reply.CommandID, err)
 		}
 		if err := nc.Publish(subject, data); err != nil {
-			slog.ErrorContext(ctx, "RDS: publish command reply", "commandID", reply.CommandID, "err", err)
+			return fmt.Errorf("publish command reply %s: %w", reply.CommandID, err)
 		}
 	}
+	return nil
 }

--- a/spinifex/gateway/rds/agent_test.go
+++ b/spinifex/gateway/rds/agent_test.go
@@ -3,6 +3,7 @@ package gateway_rds
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,6 +177,62 @@ func TestPollDBCommands_DeliversPublishedCommand(t *testing.T) {
 
 // The agent's replies ride the next poll and are republished for the issuer,
 // which correlates them by command ID.
+func TestPublishReplies_ReturnsNATSPublishFailure(t *testing.T) {
+	nc := newIndexedNATS(t)
+	closed, err := nats.Connect(nc.ConnectedUrl())
+	require.NoError(t, err)
+	closed.Close()
+
+	err = publishReplies(closed, &agentIdentity{
+		AccountID: testAccountID, DBInstanceIdentifier: testDBID,
+	}, []handlers_rds.CommandReply{{CommandID: "cmd-1"}})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, nats.ErrConnectionClosed)
+}
+
+func TestPublishReplies_StopsAtFirstPublicationFailure(t *testing.T) {
+	nc := newIndexedNATS(t)
+	replySub, err := nc.SubscribeSync(handlers_rds.BusCommandReplySubject(testAccountID, testDBID))
+	require.NoError(t, err)
+	defer func() { _ = replySub.Unsubscribe() }()
+	require.NoError(t, nc.Flush())
+
+	err = publishReplies(nc, &agentIdentity{
+		AccountID: testAccountID, DBInstanceIdentifier: testDBID,
+	}, []handlers_rds.CommandReply{
+		{CommandID: "cmd-1", Status: handlers_rds.CommandStatusSucceeded},
+		{CommandID: "cmd-2", Message: strings.Repeat("x", int(nc.MaxPayload()))},
+		{CommandID: "cmd-3", Status: handlers_rds.CommandStatusSucceeded},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, nats.ErrMaxPayload)
+	msg, err := replySub.NextMsg(time.Second)
+	require.NoError(t, err)
+	var reply handlers_rds.CommandReply
+	require.NoError(t, json.Unmarshal(msg.Data, &reply))
+	assert.Equal(t, "cmd-1", reply.CommandID)
+	_, err = replySub.NextMsg(100 * time.Millisecond)
+	assert.Error(t, err, "replies after the first failure must not be published")
+}
+
+func TestPollDBCommands_FailsWhenReplyPublicationFails(t *testing.T) {
+	nc := newIndexedNATS(t)
+
+	out, err := PollDBCommands(t.Context(), &PollDBCommandsInput{
+		WaitTimeSeconds: 1,
+		Replies: []handlers_rds.CommandReply{{
+			CommandID: "cmd-too-large",
+			Message:   strings.Repeat("x", int(nc.MaxPayload())),
+		}},
+	}, nc, agentCaller())
+
+	require.Error(t, err)
+	assert.Nil(t, out)
+	assert.Equal(t, awserrors.ErrorServerInternal, err.Error())
+}
+
 func TestPollDBCommands_RepublishesReplies(t *testing.T) {
 	nc := newIndexedNATS(t)
 	replySub, err := nc.SubscribeSync(handlers_rds.BusCommandReplySubject(testAccountID, testDBID))

--- a/spinifex/handlers/rds/create.go
+++ b/spinifex/handlers/rds/create.go
@@ -44,6 +44,12 @@ func (s *Service) CreateDBInstance(ctx context.Context, input *rds.CreateDBInsta
 	if err != nil {
 		return nil, err
 	}
+	// The agent cannot bootstrap without this profile, so resolve it before the
+	// identifier reservation or any launch side effects.
+	profileARN, err := ensureInstanceProfile(s.deps.IAM, utils.GlobalAccountID)
+	if err != nil {
+		return nil, err
+	}
 	key := DBInstanceKey(req.Identifier)
 
 	// Creating the record before anything is provisioned makes the identifier
@@ -93,7 +99,7 @@ func (s *Service) CreateDBInstance(ctx context.Context, input *rds.CreateDBInsta
 		}),
 		// The system account owns the VM, so the role is ensured there too — the
 		// gateway's agent gate requires an assumed-role session in that account.
-		IamInstanceProfileArn: ensureInstanceProfile(s.deps.IAM, utils.GlobalAccountID),
+		IamInstanceProfileArn: profileARN,
 	})
 	if err != nil {
 		return nil, err

--- a/spinifex/handlers/rds/create_test.go
+++ b/spinifex/handlers/rds/create_test.go
@@ -15,6 +15,7 @@ import (
 	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 	"github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,7 @@ type createHarness struct {
 	svc     *Service
 	launch  *launchHarness
 	network *fakeNetwork
+	iam     *fakeRDSEnsurer
 	nc      *nats.Conn
 
 	// dnsChanges collects what the endpoint publish put on the bus.
@@ -133,6 +135,7 @@ func newCreateHarness(t *testing.T, baseDomain string) *createHarness {
 	h := &createHarness{
 		launch:     newLaunchHarness(),
 		network:    newFakeNetwork(),
+		iam:        &fakeRDSEnsurer{},
 		nc:         nc,
 		dnsChanges: make(chan handlers_dns.ChangeBatch, 4),
 	}
@@ -148,6 +151,7 @@ func newCreateHarness(t *testing.T, baseDomain string) *createHarness {
 		LoadCA:     newTestCA(t),
 		Launch:     h.launch.deps(),
 		Network:    h.network,
+		IAM:        testIAMProvider(h.iam),
 		BaseDomain: baseDomain,
 	})
 	return h
@@ -250,6 +254,24 @@ func TestCreateDBInstance_ProvisionsAndRecordsTheInstance(t *testing.T) {
 	assert.Equal(t, testAccountID, entry.AccountID)
 	assert.Equal(t, testDBInstanceID, entry.DBInstanceIdentifier)
 	assert.Equal(t, int64(firstVMGeneration), entry.VMGeneration)
+
+	require.NotNil(t, h.launch.launcher.input)
+	assert.Equal(t, h.iam.profileARN(utils.GlobalAccountID), h.launch.launcher.input.IamInstanceProfileArn)
+}
+
+func TestCreateDBInstance_IAMFailurePrecedesReservationAndLaunch(t *testing.T) {
+	h := newCreateHarness(t, "")
+	iamErr := errors.New("IAM store unavailable")
+	h.iam.policyErr = iamErr
+
+	_, err := h.svc.CreateDBInstance(t.Context(), validCreateInput(), testAccountID)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iamErr)
+	assert.False(t, h.recordExists(t, testDBInstanceID))
+	assert.Nil(t, h.launch.launcher.input)
+	assert.Empty(t, h.launch.enis.created)
+	assert.Empty(t, h.launch.volumes.created)
 }
 
 func TestCreateDBInstance_PublishesEndpointRecord(t *testing.T) {

--- a/spinifex/handlers/rds/iam.go
+++ b/spinifex/handlers/rds/iam.go
@@ -2,7 +2,9 @@ package handlers_rds
 
 import (
 	"encoding/json"
-	"log/slog"
+	"errors"
+	"fmt"
+	"strings"
 
 	handlers_iam "github.com/mulgadc/spinifex/spinifex/handlers/iam"
 )
@@ -52,26 +54,25 @@ var instanceRoleInlinePolicy = func() string {
 // daemon boot and fails permanently on the node that loses.
 type IAMProvider func() handlers_iam.SystemInstanceRoleEnsurer
 
-// Returns the instance-profile ARN, or "" when IAM is unwired or the ensure
-// failed. Unlike EKS there is no static-credential fallback: without the role
-// the agent cannot authenticate, so an empty ARN launches a VM whose agent
-// never registers and the reconciler marks failed.
-func ensureInstanceProfile(provider IAMProvider, accountID string) string {
+// Returns the mandatory instance-profile ARN. Unlike EKS there is no
+// static-credential fallback: without the role the agent cannot authenticate.
+func ensureInstanceProfile(provider IAMProvider, accountID string) (string, error) {
 	if provider == nil {
-		slog.Warn("rds: IAM unwired; the DB VM agent will have no gateway credentials")
-		return ""
+		return "", errors.New("rds: IAM provider is not configured")
 	}
 	iamSvc := provider()
 	if iamSvc == nil {
-		slog.Warn("rds: IAM service unavailable; the DB VM agent will have no gateway credentials")
-		return ""
+		return "", errors.New("rds: IAM service is unavailable")
 	}
 	profileARN, err := handlers_iam.EnsureSystemInstanceProfile(iamSvc, accountID,
 		InstanceRoleName, instanceRoleInlinePolicyName, instanceRoleInlinePolicy)
 	if err != nil {
-		slog.Warn("rds: ensure instance profile failed; the DB VM agent will have no gateway credentials",
-			"role", InstanceRoleName, "err", err)
-		return ""
+		return "", fmt.Errorf("rds: ensure instance profile %s for account %s: %w",
+			InstanceRoleName, accountID, err)
 	}
-	return profileARN
+	if strings.TrimSpace(profileARN) == "" {
+		return "", fmt.Errorf("rds: ensure instance profile %s for account %s: empty profile ARN",
+			InstanceRoleName, accountID)
+	}
+	return profileARN, nil
 }

--- a/spinifex/handlers/rds/iam_test.go
+++ b/spinifex/handlers/rds/iam_test.go
@@ -19,13 +19,15 @@ import (
 // asserted. The role and profile exist from the second call onward, which is the
 // state a re-launch finds.
 type fakeRDSEnsurer struct {
-	roleAcct     string
-	profileAcct  string
-	trust        string
-	policies     []iam.PutRolePolicyInput
-	roleCreates  int
-	roleExists   bool
-	profileNames []string
+	roleAcct        string
+	profileAcct     string
+	trust           string
+	policies        []iam.PutRolePolicyInput
+	roleCreates     int
+	roleExists      bool
+	profileNames    []string
+	policyErr       error
+	emptyProfileARN bool
 }
 
 func (f *fakeRDSEnsurer) GetRole(_ string, _ *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
@@ -49,6 +51,9 @@ func (f *fakeRDSEnsurer) CreateRole(acct string, in *iam.CreateRoleInput) (*iam.
 
 func (f *fakeRDSEnsurer) PutRolePolicy(_ string, in *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
 	f.policies = append(f.policies, *in)
+	if f.policyErr != nil {
+		return nil, f.policyErr
+	}
 	return &iam.PutRolePolicyOutput{}, nil
 }
 
@@ -58,7 +63,7 @@ func (f *fakeRDSEnsurer) GetInstanceProfile(_ string, _ *iam.GetInstanceProfileI
 	}
 	return &iam.GetInstanceProfileOutput{InstanceProfile: &iam.InstanceProfile{
 		InstanceProfileName: aws.String(InstanceRoleName),
-		Arn:                 aws.String("arn:aws:iam::" + f.profileAcct + ":instance-profile/" + InstanceRoleName),
+		Arn:                 aws.String(f.profileARN(f.profileAcct)),
 		Roles:               []*iam.Role{{RoleName: aws.String(InstanceRoleName)}},
 	}}, nil
 }
@@ -69,8 +74,15 @@ func (f *fakeRDSEnsurer) CreateInstanceProfile(acct string, in *iam.CreateInstan
 	f.profileNames = append(f.profileNames, name)
 	return &iam.CreateInstanceProfileOutput{InstanceProfile: &iam.InstanceProfile{
 		InstanceProfileName: aws.String(name),
-		Arn:                 aws.String("arn:aws:iam::" + acct + ":instance-profile/" + name),
+		Arn:                 aws.String(f.profileARN(acct)),
 	}}, nil
+}
+
+func (f *fakeRDSEnsurer) profileARN(accountID string) string {
+	if f.emptyProfileARN {
+		return ""
+	}
+	return "arn:aws:iam::" + accountID + ":instance-profile/" + InstanceRoleName
 }
 
 func (f *fakeRDSEnsurer) AddRoleToInstanceProfile(_ string, _ *iam.AddRoleToInstanceProfileInput) (*iam.AddRoleToInstanceProfileOutput, error) {
@@ -78,6 +90,10 @@ func (f *fakeRDSEnsurer) AddRoleToInstanceProfile(_ string, _ *iam.AddRoleToInst
 }
 
 var _ handlers_iam.SystemInstanceRoleEnsurer = (*fakeRDSEnsurer)(nil)
+
+func testIAMProvider(f *fakeRDSEnsurer) IAMProvider {
+	return func() handlers_iam.SystemInstanceRoleEnsurer { return f }
+}
 
 // A Postgres RCE on a DB VM inherits this role, so the grant must be the four
 // internal actions and nothing wildcarded that could reach the customer surface.
@@ -108,7 +124,8 @@ func TestInstanceRolePolicy_GrantsOnlyTheInternalActions(t *testing.T) {
 // invisible to the agent and it would get no credentials at all.
 func TestEnsureInstanceProfile_CreatesInSystemAccount(t *testing.T) {
 	f := &fakeRDSEnsurer{}
-	arn := ensureInstanceProfile(func() handlers_iam.SystemInstanceRoleEnsurer { return f }, utils.GlobalAccountID)
+	arn, err := ensureInstanceProfile(func() handlers_iam.SystemInstanceRoleEnsurer { return f }, utils.GlobalAccountID)
+	require.NoError(t, err)
 
 	assert.Equal(t, "arn:aws:iam::"+utils.GlobalAccountID+":instance-profile/"+InstanceRoleName, arn)
 	assert.Equal(t, utils.GlobalAccountID, f.roleAcct)
@@ -123,8 +140,10 @@ func TestEnsureInstanceProfile_IsIdempotent(t *testing.T) {
 	f := &fakeRDSEnsurer{}
 	provider := func() handlers_iam.SystemInstanceRoleEnsurer { return f }
 
-	first := ensureInstanceProfile(provider, utils.GlobalAccountID)
-	second := ensureInstanceProfile(provider, utils.GlobalAccountID)
+	first, err := ensureInstanceProfile(provider, utils.GlobalAccountID)
+	require.NoError(t, err)
+	second, err := ensureInstanceProfile(provider, utils.GlobalAccountID)
+	require.NoError(t, err)
 
 	assert.Equal(t, first, second)
 	assert.Equal(t, 1, f.roleCreates, "the second launch must find the role, not create it")
@@ -136,10 +155,43 @@ func TestEnsureInstanceProfile_IsIdempotent(t *testing.T) {
 	}
 }
 
-// Without IAM the agent has no gateway credentials at all, so the caller has to
-// see an empty ARN rather than a launch that looks provisioned.
-func TestEnsureInstanceProfile_UnwiredIAMYieldsNoProfile(t *testing.T) {
-	assert.Empty(t, ensureInstanceProfile(nil, utils.GlobalAccountID))
-	assert.Empty(t, ensureInstanceProfile(
-		func() handlers_iam.SystemInstanceRoleEnsurer { return nil }, utils.GlobalAccountID))
+// Without IAM the agent has no gateway credentials at all, so provisioning
+// must fail instead of launching a VM that can never register.
+func TestEnsureInstanceProfile_RejectsUnavailableIAM(t *testing.T) {
+	tests := map[string]IAMProvider{
+		"nil provider": nil,
+		"nil service":  func() handlers_iam.SystemInstanceRoleEnsurer { return nil },
+	}
+	for name, provider := range tests {
+		t.Run(name, func(t *testing.T) {
+			arn, err := ensureInstanceProfile(provider, utils.GlobalAccountID)
+			require.Error(t, err)
+			assert.Empty(t, arn)
+			assert.Contains(t, err.Error(), "IAM")
+		})
+	}
+}
+
+func TestEnsureInstanceProfile_PreservesEnsureFailure(t *testing.T) {
+	ensureErr := errors.New("IAM storage unavailable")
+	f := &fakeRDSEnsurer{policyErr: ensureErr}
+
+	arn, err := ensureInstanceProfile(
+		func() handlers_iam.SystemInstanceRoleEnsurer { return f }, utils.GlobalAccountID)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ensureErr)
+	assert.Empty(t, arn)
+	assert.Contains(t, err.Error(), InstanceRoleName)
+}
+
+func TestEnsureInstanceProfile_RejectsEmptyARN(t *testing.T) {
+	f := &fakeRDSEnsurer{emptyProfileARN: true}
+
+	arn, err := ensureInstanceProfile(
+		func() handlers_iam.SystemInstanceRoleEnsurer { return f }, utils.GlobalAccountID)
+
+	require.Error(t, err)
+	assert.Empty(t, arn)
+	assert.Contains(t, err.Error(), "empty profile ARN")
 }

--- a/spinifex/handlers/rds/modify_test.go
+++ b/spinifex/handlers/rds/modify_test.go
@@ -30,6 +30,7 @@ type modifyHarness struct {
 	nc      *nats.Conn
 	launch  *launchHarness
 	network *fakeNetwork
+	iam     *fakeRDSEnsurer
 	cmdr    *fakeInstanceCommander
 	storage *fakeVolumeResizer
 	vmState *fakeInstanceState
@@ -51,6 +52,7 @@ func newModifyHarnessWithAgent(t *testing.T, agentFails bool) *modifyHarness {
 		nc:      nc,
 		launch:  newLaunchHarness(),
 		network: newFakeNetwork(),
+		iam:     &fakeRDSEnsurer{},
 		cmdr:    &fakeInstanceCommander{vm: vmState},
 		storage: newFakeVolumeResizer(testDataVolume, 20),
 		vmState: vmState,
@@ -60,6 +62,7 @@ func newModifyHarnessWithAgent(t *testing.T, agentFails bool) *modifyHarness {
 		LoadCA:        newTestCA(t),
 		Launch:        h.launch.deps(),
 		Network:       h.network,
+		IAM:           testIAMProvider(h.iam),
 		Instances:     h.cmdr,
 		Storage:       h.storage,
 		InstanceState: h.vmState,

--- a/spinifex/handlers/rds/replace.go
+++ b/spinifex/handlers/rds/replace.go
@@ -53,6 +53,12 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 		}
 		instanceType = resolved
 	}
+	// Resolve the profile before stopping the engine or terminating its VM. A
+	// profile failure must leave the current database serving.
+	profileARN, err := ensureInstanceProfile(s.deps.IAM, utils.GlobalAccountID)
+	if err != nil {
+		return err
+	}
 
 	// Checkpointed first so the replacement boots on a clean datadir rather than
 	// one it has to replay a WAL over. A wedged agent degrades this rather than
@@ -75,7 +81,7 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 		}
 	}
 
-	launched, err := s.launchReplacementVM(ctx, accountID, rec, instanceType)
+	launched, err := s.launchReplacementVM(ctx, accountID, rec, instanceType, profileARN)
 	if err != nil {
 		return err
 	}
@@ -119,7 +125,7 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 // (D8): it gets the port, the resolved parameters and a freshly minted serving
 // cert, but no master password, and rds-init skips initdb on the datadir it
 // finds already initialised.
-func (s *Service) launchReplacementVM(ctx context.Context, accountID string, rec *DBInstanceRecord, instanceType string) (*LaunchOutput, error) {
+func (s *Service) launchReplacementVM(ctx context.Context, accountID string, rec *DBInstanceRecord, instanceType, profileARN string) (*LaunchOutput, error) {
 	launched, err := LaunchDBInstanceVM(ctx, s.deps.Launch, LaunchInput{
 		DBInstanceIdentifier: rec.DBInstanceIdentifier,
 		AccountID:            accountID,
@@ -139,7 +145,7 @@ func (s *Service) launchReplacementVM(ctx context.Context, accountID string, rec
 			EngineVersion:        rec.EngineVersion,
 			EnginePort:           rec.Port,
 		}),
-		IamInstanceProfileArn: ensureInstanceProfile(s.deps.IAM, utils.GlobalAccountID),
+		IamInstanceProfileArn: profileARN,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("launch the replacement VM for %s: %w", rec.DBInstanceIdentifier, err)

--- a/spinifex/handlers/rds/replace_test.go
+++ b/spinifex/handlers/rds/replace_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -58,6 +59,27 @@ func TestReplaceInstanceVM_ReusesTheEndpointENIAndDataVolume(t *testing.T) {
 
 // The engine is checkpointed and the old VM is gone before the new one comes
 // up, or two VMs hold the same datadir.
+func TestReplaceInstanceVM_IAMFailureLeavesTheCurrentVMServing(t *testing.T) {
+	h := newModifyHarness(t)
+	rec := seedReplaceable(t, h, modifiableRecord())
+	iamErr := errors.New("IAM store unavailable")
+	h.iam.policyErr = iamErr
+
+	err := h.svc.replaceInstanceVM(t.Context(), h.kv(t), testAccountID, &rec, replaceInput{
+		GrowStorageToGiB: 80,
+		Reason:           "the instance class changed",
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iamErr)
+	assert.Empty(t, h.agent.received())
+	assert.Empty(t, h.launch.launcher.terminated)
+	assert.Empty(t, h.launch.enis.deleted)
+	assert.Empty(t, h.storage.modified)
+	assert.Nil(t, h.launch.launcher.input)
+	assert.Equal(t, testInstance, h.record(t).InstanceID)
+}
+
 func TestReplaceInstanceVM_StopsTheEngineAndTerminatesTheOldVMFirst(t *testing.T) {
 	h := newModifyHarness(t)
 	rec := seedReplaceable(t, h, modifiableRecord())
@@ -298,4 +320,5 @@ func TestReplaceInstanceVM_LaunchesWithTheInstancesOwnIdentity(t *testing.T) {
 	assert.Equal(t, testAccountID, h.launch.launcher.input.ExtraENIs[0].AccountID)
 	assert.NotEqual(t, testAccountID, h.launch.launcher.input.AccountID,
 		"the VM and its management NIC live in the system account")
+	assert.Equal(t, h.iam.profileARN(utils.GlobalAccountID), h.launch.launcher.input.IamInstanceProfileArn)
 }

--- a/spinifex/handlers/rds/restore.go
+++ b/spinifex/handlers/rds/restore.go
@@ -63,6 +63,12 @@ func (s *Service) RestoreDBInstanceFromDBSnapshot(ctx context.Context, input *rd
 	if err != nil {
 		return nil, err
 	}
+	// The agent cannot bootstrap without this profile, so resolve it before the
+	// identifier reservation or restored-volume creation.
+	profileARN, err := ensureInstanceProfile(s.deps.IAM, utils.GlobalAccountID)
+	if err != nil {
+		return nil, err
+	}
 
 	// The record is the identifier's reservation, exactly as at create, and is
 	// withdrawn on any failure below.
@@ -124,7 +130,7 @@ func (s *Service) RestoreDBInstanceFromDBSnapshot(ctx context.Context, input *rd
 			EngineVersion:        req.EngineVersion,
 			EnginePort:           req.Port,
 		}),
-		IamInstanceProfileArn: ensureInstanceProfile(s.deps.IAM, utils.GlobalAccountID),
+		IamInstanceProfileArn: profileARN,
 	})
 	if err != nil {
 		return nil, err

--- a/spinifex/handlers/rds/restore_test.go
+++ b/spinifex/handlers/rds/restore_test.go
@@ -66,6 +66,25 @@ func TestRestoreDBInstanceFromDBSnapshot_BuildsANewInstanceOnTheSnapshotsData(t 
 	assert.True(t, stored.Bootstrap.Consumed)
 	require.NotNil(t, stored.Bootstrap.ConsumedAt)
 	assert.Empty(t, stored.Bootstrap.MasterUserPassword)
+
+	require.NotNil(t, h.launch.launcher.input)
+	assert.Equal(t, h.iam.profileARN(utils.GlobalAccountID), h.launch.launcher.input.IamInstanceProfileArn)
+}
+
+func TestRestoreDBInstanceFromDBSnapshot_IAMFailurePrecedesReservationAndVolume(t *testing.T) {
+	h := newSnapshotHarness(t, false)
+	h.seedSnapshot(t)
+	iamErr := errors.New("IAM store unavailable")
+	h.iam.policyErr = iamErr
+
+	_, err := h.svc.RestoreDBInstanceFromDBSnapshot(t.Context(), restoreInput(), testAccountID)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, iamErr)
+	assert.False(t, h.instanceExists(t, testRestoredID))
+	assert.Empty(t, h.launch.volumes.created)
+	assert.Empty(t, h.launch.enis.created)
+	assert.Nil(t, h.launch.launcher.input)
 }
 
 // Everything the request left out comes from the snapshot, so a bare restore

--- a/spinifex/handlers/rds/snapshot_test.go
+++ b/spinifex/handlers/rds/snapshot_test.go
@@ -24,6 +24,7 @@ type snapshotHarness struct {
 	svc     *Service
 	launch  *launchHarness
 	network *fakeNetwork
+	iam     *fakeRDSEnsurer
 	snaps   *fakeSnapshots
 	agent   *stubAgent
 	nc      *nats.Conn
@@ -36,6 +37,7 @@ func newSnapshotHarness(t *testing.T, agentFails bool) *snapshotHarness {
 	h := &snapshotHarness{
 		launch:  newLaunchHarness(),
 		network: newFakeNetwork(),
+		iam:     &fakeRDSEnsurer{},
 		snaps:   &fakeSnapshots{},
 		nc:      nc,
 	}
@@ -49,6 +51,7 @@ func newSnapshotHarness(t *testing.T, agentFails bool) *snapshotHarness {
 		LoadCA:    newTestCA(t),
 		Launch:    h.launch.deps(),
 		Network:   h.network,
+		IAM:       testIAMProvider(h.iam),
 		Snapshots: h.snaps,
 	})
 	return h


### PR DESCRIPTION
## Summary
- Fail RDS create and restore before identifier or resource side effects when the mandatory instance profile cannot be provisioned.
- Fail RDS replacement before stopping or terminating the current VM when IAM provisioning fails.
- Make command reply publication part of poll success so the agent retains and retries completed replies after publication failures.
- Add focused handler, gateway, and agent regression coverage.

## Testing
- `GOFIPS140=v1.0.0 LOG_IGNORE=1 go test -timeout 180s ./spinifex/... ./cmd/... ./internal/...`
- `make preflight`

## Tracking
- `mulga-xgto4`
