### PR TITLE
feat: add spx admin ochre endpoint ensure/describe/list/delete

### DIFF
--- a/cmd/spinifex/cmd/admin_ochre_endpoint.go
+++ b/cmd/spinifex/cmd/admin_ochre_endpoint.go
@@ -1,0 +1,304 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	handlers_bedrock "github.com/mulgadc/spinifex/spinifex/handlers/bedrock"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
+
+var ochreEndpointCmd = &cobra.Command{
+	Use:   "endpoint",
+	Short: "Drive the serving-endpoint lifecycle for self-host models",
+	Long: `Operator surface over the daemon's serving-endpoint lifecycle: request an
+endpoint for a staged model, inspect its state, and tear it down.
+
+The gateway does not yet request endpoints itself, so until it does this is
+the only way to start a serving VM.`,
+}
+
+var ochreEndpointEnsureCmd = &cobra.Command{
+	Use:   "ensure",
+	Short: "Request a serving endpoint for a self-host model",
+	Long: `ensure asks the daemon to bring up a serving VM for --model-id, which must
+already have staged weights.
+
+Idempotent: a model whose endpoint is already STARTING or READY returns the
+current record rather than launching a second VM.
+
+The daemon replies STARTING as soon as it has claimed the model, and the
+launch continues in the background. Pass --wait to poll until the endpoint
+reaches READY and report how long the cold start took.`,
+	Run: runOchreEndpointEnsure,
+}
+
+var ochreEndpointDescribeCmd = &cobra.Command{
+	Use:   "describe",
+	Short: "Show a model's current serving-endpoint record",
+	Run:   runOchreEndpointDescribe,
+}
+
+var ochreEndpointListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List every serving-endpoint record",
+	Run:   runOchreEndpointList,
+}
+
+var ochreEndpointDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Tear down a model's serving endpoint and release its VM",
+	Long: `delete moves a READY endpoint to DRAINING and tears its VM down, releasing
+the GPU. Idempotent: an endpoint that is already absent reports success.`,
+	Run: runOchreEndpointDelete,
+}
+
+func init() {
+	ochreCmd.AddCommand(ochreEndpointCmd)
+	ochreEndpointCmd.AddCommand(ochreEndpointEnsureCmd)
+	ochreEndpointCmd.AddCommand(ochreEndpointDescribeCmd)
+	ochreEndpointCmd.AddCommand(ochreEndpointListCmd)
+	ochreEndpointCmd.AddCommand(ochreEndpointDeleteCmd)
+
+	ochreEndpointEnsureCmd.Flags().String("model-id", "", "Catalog model ID to bring an endpoint up for (required)")
+	ochreEndpointEnsureCmd.Flags().Bool("wait", false, "Poll until the endpoint is READY and report the elapsed cold start")
+	ochreEndpointEnsureCmd.Flags().Duration("timeout", defaultEndpointWaitTimeout, "How long --wait polls before giving up")
+	_ = ochreEndpointEnsureCmd.MarkFlagRequired("model-id")
+
+	ochreEndpointDescribeCmd.Flags().String("model-id", "", "Model ID to describe (required)")
+	_ = ochreEndpointDescribeCmd.MarkFlagRequired("model-id")
+
+	ochreEndpointDeleteCmd.Flags().String("model-id", "", "Model ID whose endpoint to tear down (required)")
+	_ = ochreEndpointDeleteCmd.MarkFlagRequired("model-id")
+}
+
+const (
+	// defaultEndpointWaitTimeout is deliberately generous: the cold start this
+	// waits on has never been measured, so a tight default would report a
+	// timeout for what is really a slow first launch.
+	defaultEndpointWaitTimeout = 15 * time.Minute
+	// endpointPollInterval trades responsiveness against KV read volume. A
+	// cold start is minutes, so seconds of granularity is plenty.
+	endpointPollInterval = 2 * time.Second
+)
+
+// errEndpointLaunchAborted reports a STARTING endpoint that went back to
+// ABSENT. A failed launch deletes the record rather than parking it in a
+// terminal state, so its disappearance IS the failure signal.
+var errEndpointLaunchAborted = errors.New("endpoint launch aborted: the record returned to ABSENT, which is how a failed launch or readiness timeout reports itself")
+
+// errEndpointWaitTimeout reports that the poll window closed with the
+// endpoint still STARTING. The endpoint is deliberately left running.
+var errEndpointWaitTimeout = errors.New("timed out waiting for the endpoint to become READY")
+
+// endpointWaitClock indirects time so the poll loop is testable without
+// sleeping through a real cold start.
+type endpointWaitClock struct {
+	now   func() time.Time
+	sleep func(time.Duration)
+}
+
+func realEndpointWaitClock() endpointWaitClock {
+	return endpointWaitClock{now: time.Now, sleep: time.Sleep}
+}
+
+// waitForEndpointReady polls Describe until the endpoint is READY, has gone
+// back to ABSENT, or the timeout expires, and returns the record it settled
+// on plus how long that took.
+func waitForEndpointReady(ctx context.Context, svc handlers_bedrock.EndpointService, modelID string,
+	timeout time.Duration, clock endpointWaitClock) (handlers_bedrock.EndpointRecord, time.Duration, error) {
+	start := clock.now()
+	for {
+		out, err := svc.Describe(ctx, &handlers_bedrock.DescribeEndpointInput{ModelID: modelID}, utils.GlobalAccountID)
+		if err != nil {
+			return handlers_bedrock.EndpointRecord{}, clock.now().Sub(start), err
+		}
+		switch out.Endpoint.State {
+		case handlers_bedrock.StateReady:
+			return out.Endpoint, clock.now().Sub(start), nil
+		case handlers_bedrock.StateAbsent:
+			return out.Endpoint, clock.now().Sub(start), errEndpointLaunchAborted
+		}
+
+		// Check the deadline only after a Describe, so a timeout already at
+		// zero still reports the endpoint's actual state rather than nothing.
+		if elapsed := clock.now().Sub(start); elapsed >= timeout {
+			return out.Endpoint, elapsed, errEndpointWaitTimeout
+		}
+		clock.sleep(endpointPollInterval)
+	}
+}
+
+// formatEndpointRecord renders one record as aligned key/value lines, omitting
+// fields that are only set once a launch has progressed far enough to have them.
+func formatEndpointRecord(rec handlers_bedrock.EndpointRecord) string {
+	rows := [][2]string{
+		{"Model ID", rec.ModelID},
+		{"State", string(rec.State)},
+	}
+	if rec.InstanceID != "" {
+		rows = append(rows, [2]string{"Instance ID", rec.InstanceID})
+	}
+	if rec.NodeID != "" {
+		rows = append(rows, [2]string{"Node ID", rec.NodeID})
+	}
+	if rec.BaseURL != "" {
+		rows = append(rows, [2]string{"Base URL", rec.BaseURL})
+	}
+	if rec.WeightsVolumeID != "" {
+		rows = append(rows, [2]string{"Weights volume", rec.WeightsVolumeID})
+	}
+	if !rec.CreatedAt.IsZero() {
+		rows = append(rows, [2]string{"Created at", rec.CreatedAt.Format(time.RFC3339)})
+	}
+	if !rec.ReadyAt.IsZero() {
+		rows = append(rows, [2]string{"Ready at", rec.ReadyAt.Format(time.RFC3339)})
+		if !rec.CreatedAt.IsZero() {
+			rows = append(rows, [2]string{"Startup", rec.ReadyAt.Sub(rec.CreatedAt).Round(time.Second).String()})
+		}
+	}
+
+	out := ""
+	for _, row := range rows {
+		out += fmt.Sprintf("%-15s %s\n", row[0]+":", row[1])
+	}
+	return out
+}
+
+// listEndpointsOutput renders 'ochre endpoint list'. Split from its Run
+// function so it is testable against a fake service with no NATS connection.
+func listEndpointsOutput(ctx context.Context, svc handlers_bedrock.EndpointService) (string, error) {
+	out, err := svc.List(ctx, &handlers_bedrock.ListEndpointsInput{}, utils.GlobalAccountID)
+	if err != nil {
+		return "", err
+	}
+	if len(out.Endpoints) == 0 {
+		return "No serving endpoints.", nil
+	}
+
+	tableData := pterm.TableData{{"MODEL ID", "STATE", "INSTANCE ID", "BASE URL"}}
+	for _, e := range out.Endpoints {
+		tableData = append(tableData, []string{e.ModelID, string(e.State), e.InstanceID, e.BaseURL})
+	}
+	return pterm.DefaultTable.WithHasHeader().WithData(tableData).Srender()
+}
+
+// runEnsureEndpoint is the testable core of 'ochre endpoint ensure': request
+// the endpoint, then optionally wait for it. Returns the message to print.
+func runEnsureEndpoint(ctx context.Context, svc handlers_bedrock.EndpointService, modelID string,
+	wait bool, timeout time.Duration, clock endpointWaitClock) (string, error) {
+	out, err := svc.Ensure(ctx, &handlers_bedrock.EnsureEndpointInput{ModelID: modelID}, utils.GlobalAccountID)
+	if err != nil {
+		return "", err
+	}
+	if !wait {
+		return fmt.Sprintf("Endpoint for %s is %s.\n\n%s", modelID, out.Endpoint.State, formatEndpointRecord(out.Endpoint)), nil
+	}
+
+	// Already READY before any polling means this was a warm request, not a
+	// cold start, so reporting an elapsed time would be misleading.
+	if out.Endpoint.State == handlers_bedrock.StateReady {
+		return fmt.Sprintf("Endpoint for %s was already READY.\n\n%s", modelID, formatEndpointRecord(out.Endpoint)), nil
+	}
+
+	fmt.Printf("Endpoint for %s is %s; waiting up to %s for READY ...\n", modelID, out.Endpoint.State, timeout)
+	rec, elapsed, err := waitForEndpointReady(ctx, svc, modelID, timeout, clock)
+	if err != nil {
+		return "", fmt.Errorf("after %s: %w\n\n%s", elapsed.Round(time.Second), err, formatEndpointRecord(rec))
+	}
+	return fmt.Sprintf("✅ Endpoint for %s is READY after %s.\n\n%s", modelID, elapsed.Round(time.Second), formatEndpointRecord(rec)), nil
+}
+
+// endpointServiceFn indirects the NATS-backed client so the Run functions'
+// connect/exit control flow can be tested without a live daemon.
+var endpointServiceFn = func() (handlers_bedrock.EndpointService, func(), error) {
+	_, nc, err := loadConfigAndConnectFn()
+	if err != nil {
+		return nil, nil, err
+	}
+	return handlers_bedrock.NewNATSEndpointService(nc), nc.Close, nil
+}
+
+func runOchreEndpointEnsure(cmd *cobra.Command, _ []string) {
+	modelID, _ := cmd.Flags().GetString("model-id")
+	wait, _ := cmd.Flags().GetBool("wait")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+
+	svc, closeFn, err := endpointServiceFn()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		ochreExit(1)
+		return
+	}
+	defer closeFn()
+
+	msg, err := runEnsureEndpoint(context.Background(), svc, modelID, wait, timeout, realEndpointWaitClock())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		ochreExit(1)
+		return
+	}
+	fmt.Println(msg)
+}
+
+func runOchreEndpointDescribe(cmd *cobra.Command, _ []string) {
+	modelID, _ := cmd.Flags().GetString("model-id")
+
+	svc, closeFn, err := endpointServiceFn()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		ochreExit(1)
+		return
+	}
+	defer closeFn()
+
+	out, err := svc.Describe(context.Background(), &handlers_bedrock.DescribeEndpointInput{ModelID: modelID}, utils.GlobalAccountID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		ochreExit(1)
+		return
+	}
+	fmt.Print(formatEndpointRecord(out.Endpoint))
+}
+
+func runOchreEndpointList(_ *cobra.Command, _ []string) {
+	svc, closeFn, err := endpointServiceFn()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		ochreExit(1)
+		return
+	}
+	defer closeFn()
+
+	msg, err := listEndpointsOutput(context.Background(), svc)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		ochreExit(1)
+		return
+	}
+	fmt.Println(msg)
+}
+
+func runOchreEndpointDelete(cmd *cobra.Command, _ []string) {
+	modelID, _ := cmd.Flags().GetString("model-id")
+
+	svc, closeFn, err := endpointServiceFn()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		ochreExit(1)
+		return
+	}
+	defer closeFn()
+
+	if _, err := svc.Delete(context.Background(), &handlers_bedrock.DeleteEndpointInput{ModelID: modelID}, utils.GlobalAccountID); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		ochreExit(1)
+		return
+	}
+	fmt.Printf("Endpoint for %s torn down.\n", modelID)
+}

--- a/cmd/spinifex/cmd/admin_ochre_endpoint_test.go
+++ b/cmd/spinifex/cmd/admin_ochre_endpoint_test.go
@@ -243,3 +243,125 @@ func TestFormatEndpointRecord_AbsentIsMinimal(t *testing.T) {
 	require.Contains(t, out, "ABSENT")
 	require.Equal(t, 2, strings.Count(strings.TrimSpace(out), "\n")+1)
 }
+
+// withEndpointService swaps endpointServiceFn for one returning svc, so a Run
+// wrapper's real connect/validate/exit control flow runs without a daemon.
+func withEndpointService(t *testing.T, svc handlers_bedrock.EndpointService, connErr error) {
+	t.Helper()
+	orig := endpointServiceFn
+	t.Cleanup(func() { endpointServiceFn = orig })
+	endpointServiceFn = func() (handlers_bedrock.EndpointService, func(), error) {
+		if connErr != nil {
+			return nil, nil, connErr
+		}
+		return svc, func() {}, nil
+	}
+}
+
+func TestRunOchreEndpointEnsure_PrintsRecord(t *testing.T) {
+	withEndpointService(t, &fakeEndpointService{
+		ensure: handlers_bedrock.EndpointRecord{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+	}, nil)
+
+	cmd := *ochreEndpointEnsureCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+
+	var out string
+	code := withOchreExitCapture(t, func() {
+		out = captureStdout(t, func() { runOchreEndpointEnsure(&cmd, nil) })
+	})
+	require.Equal(t, -1, code)
+	require.Contains(t, out, "STARTING")
+}
+
+func TestRunOchreEndpointEnsure_ConnectFailureExits1(t *testing.T) {
+	withEndpointService(t, nil, errors.New("dial nats: connection refused"))
+
+	cmd := *ochreEndpointEnsureCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+
+	code := withOchreExitCapture(t, func() { runOchreEndpointEnsure(&cmd, nil) })
+	require.Equal(t, 1, code)
+}
+
+func TestRunOchreEndpointEnsure_ServiceErrorExits1(t *testing.T) {
+	withEndpointService(t, &fakeEndpointService{ensureErr: errors.New("ResourceNotFoundException")}, nil)
+
+	cmd := *ochreEndpointEnsureCmd
+	require.NoError(t, cmd.Flags().Set("model-id", "no.such.model"))
+
+	code := withOchreExitCapture(t, func() { runOchreEndpointEnsure(&cmd, nil) })
+	require.Equal(t, 1, code)
+}
+
+func TestRunOchreEndpointDescribe_PrintsRecord(t *testing.T) {
+	withEndpointService(t, &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateReady, InstanceID: "i-abc"},
+	}}, nil)
+
+	cmd := *ochreEndpointDescribeCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+
+	var out string
+	code := withOchreExitCapture(t, func() {
+		out = captureStdout(t, func() { runOchreEndpointDescribe(&cmd, nil) })
+	})
+	require.Equal(t, -1, code)
+	require.Contains(t, out, "i-abc")
+}
+
+func TestRunOchreEndpointDescribe_ErrorExits1(t *testing.T) {
+	withEndpointService(t, &fakeEndpointService{describeErr: errors.New("nats: timeout")}, nil)
+
+	cmd := *ochreEndpointDescribeCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+
+	code := withOchreExitCapture(t, func() { runOchreEndpointDescribe(&cmd, nil) })
+	require.Equal(t, 1, code)
+}
+
+func TestRunOchreEndpointList_PrintsTable(t *testing.T) {
+	withEndpointService(t, &fakeEndpointService{list: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateReady},
+	}}, nil)
+
+	var out string
+	code := withOchreExitCapture(t, func() {
+		out = captureStdout(t, func() { runOchreEndpointList(ochreEndpointListCmd, nil) })
+	})
+	require.Equal(t, -1, code)
+	require.Contains(t, out, testModelID)
+}
+
+func TestRunOchreEndpointList_ConnectFailureExits1(t *testing.T) {
+	withEndpointService(t, nil, errors.New("dial nats: connection refused"))
+
+	code := withOchreExitCapture(t, func() { runOchreEndpointList(ochreEndpointListCmd, nil) })
+	require.Equal(t, 1, code)
+}
+
+func TestRunOchreEndpointDelete_ReportsTeardown(t *testing.T) {
+	svc := &fakeEndpointService{}
+	withEndpointService(t, svc, nil)
+
+	cmd := *ochreEndpointDeleteCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+
+	var out string
+	code := withOchreExitCapture(t, func() {
+		out = captureStdout(t, func() { runOchreEndpointDelete(&cmd, nil) })
+	})
+	require.Equal(t, -1, code)
+	require.Equal(t, 1, svc.deleteCalls)
+	require.Contains(t, out, "torn down")
+}
+
+func TestRunOchreEndpointDelete_ErrorExits1(t *testing.T) {
+	withEndpointService(t, &fakeEndpointService{deleteErr: errors.New("ModelNotReadyException")}, nil)
+
+	cmd := *ochreEndpointDeleteCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+
+	code := withOchreExitCapture(t, func() { runOchreEndpointDelete(&cmd, nil) })
+	require.Equal(t, 1, code)
+}

--- a/cmd/spinifex/cmd/admin_ochre_endpoint_test.go
+++ b/cmd/spinifex/cmd/admin_ochre_endpoint_test.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	handlers_bedrock "github.com/mulgadc/spinifex/spinifex/handlers/bedrock"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEndpointService serves scripted Describe responses so the wait loop can
+// be exercised without a daemon, a VM or a real cold start.
+type fakeEndpointService struct {
+	ensure      handlers_bedrock.EndpointRecord
+	ensureErr   error
+	describes   []handlers_bedrock.EndpointRecord
+	describeErr error
+	list        []handlers_bedrock.EndpointRecord
+	listErr     error
+	deleteErr   error
+
+	describeCalls int
+	deleteCalls   int
+}
+
+func (f *fakeEndpointService) Ensure(_ context.Context, _ *handlers_bedrock.EnsureEndpointInput, _ string) (*handlers_bedrock.EnsureEndpointOutput, error) {
+	if f.ensureErr != nil {
+		return nil, f.ensureErr
+	}
+	return &handlers_bedrock.EnsureEndpointOutput{Endpoint: f.ensure}, nil
+}
+
+func (f *fakeEndpointService) Describe(_ context.Context, _ *handlers_bedrock.DescribeEndpointInput, _ string) (*handlers_bedrock.DescribeEndpointOutput, error) {
+	if f.describeErr != nil {
+		return nil, f.describeErr
+	}
+	// The last scripted response repeats, so a test that never reaches a
+	// terminal state keeps polling rather than running off the end.
+	idx := min(f.describeCalls, len(f.describes)-1)
+	f.describeCalls++
+	return &handlers_bedrock.DescribeEndpointOutput{Endpoint: f.describes[idx]}, nil
+}
+
+func (f *fakeEndpointService) List(_ context.Context, _ *handlers_bedrock.ListEndpointsInput, _ string) (*handlers_bedrock.ListEndpointsOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return &handlers_bedrock.ListEndpointsOutput{Endpoints: f.list}, nil
+}
+
+func (f *fakeEndpointService) Delete(_ context.Context, _ *handlers_bedrock.DeleteEndpointInput, _ string) (*handlers_bedrock.DeleteEndpointOutput, error) {
+	f.deleteCalls++
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	return &handlers_bedrock.DeleteEndpointOutput{}, nil
+}
+
+var _ handlers_bedrock.EndpointService = (*fakeEndpointService)(nil)
+
+// fakeClock advances a virtual now by whatever the loop sleeps, so a
+// multi-minute wait costs nothing and elapsed times are exact.
+func fakeClock(now *time.Time) endpointWaitClock {
+	return endpointWaitClock{
+		now:   func() time.Time { return *now },
+		sleep: func(d time.Duration) { *now = now.Add(d) },
+	}
+}
+
+const testModelID = "meta.llama3-2-1b-instruct-v1:0"
+
+func TestWaitForEndpointReady_ReachesReadyAndReportsElapsed(t *testing.T) {
+	svc := &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+		{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+		{ModelID: testModelID, State: handlers_bedrock.StateReady, BaseURL: "http://10.0.0.5:8000"},
+	}}
+	now := time.Unix(0, 0).UTC()
+
+	rec, elapsed, err := waitForEndpointReady(context.Background(), svc, testModelID, time.Minute, fakeClock(&now))
+	require.NoError(t, err)
+	require.Equal(t, handlers_bedrock.StateReady, rec.State)
+	require.Equal(t, "http://10.0.0.5:8000", rec.BaseURL)
+	// Two sleeps between three polls.
+	require.Equal(t, 2*endpointPollInterval, elapsed)
+}
+
+// A failed launch deletes the record, so ABSENT after STARTING is the failure
+// signal and must not be mistaken for "not started yet".
+func TestWaitForEndpointReady_AbsentAfterStartingIsAbort(t *testing.T) {
+	svc := &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+		{ModelID: testModelID, State: handlers_bedrock.StateAbsent},
+	}}
+	now := time.Unix(0, 0).UTC()
+
+	_, _, err := waitForEndpointReady(context.Background(), svc, testModelID, time.Minute, fakeClock(&now))
+	require.ErrorIs(t, err, errEndpointLaunchAborted)
+}
+
+func TestWaitForEndpointReady_TimesOutWhileStillStarting(t *testing.T) {
+	svc := &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+	}}
+	now := time.Unix(0, 0).UTC()
+
+	rec, elapsed, err := waitForEndpointReady(context.Background(), svc, testModelID, 10*time.Second, fakeClock(&now))
+	require.ErrorIs(t, err, errEndpointWaitTimeout)
+	require.Equal(t, handlers_bedrock.StateStarting, rec.State)
+	require.GreaterOrEqual(t, elapsed, 10*time.Second)
+}
+
+// A zero timeout must still report the endpoint's real state, not an empty
+// record, because the deadline is only checked after a Describe.
+func TestWaitForEndpointReady_ZeroTimeoutStillDescribesOnce(t *testing.T) {
+	svc := &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+	}}
+	now := time.Unix(0, 0).UTC()
+
+	rec, _, err := waitForEndpointReady(context.Background(), svc, testModelID, 0, fakeClock(&now))
+	require.ErrorIs(t, err, errEndpointWaitTimeout)
+	require.Equal(t, handlers_bedrock.StateStarting, rec.State)
+	require.Equal(t, 1, svc.describeCalls)
+}
+
+func TestWaitForEndpointReady_DescribeErrorSurfaces(t *testing.T) {
+	svc := &fakeEndpointService{describeErr: errors.New("nats: timeout")}
+	now := time.Unix(0, 0).UTC()
+
+	_, _, err := waitForEndpointReady(context.Background(), svc, testModelID, time.Minute, fakeClock(&now))
+	require.ErrorContains(t, err, "nats: timeout")
+}
+
+func TestRunEnsureEndpoint_NoWaitReportsStarting(t *testing.T) {
+	svc := &fakeEndpointService{ensure: handlers_bedrock.EndpointRecord{ModelID: testModelID, State: handlers_bedrock.StateStarting}}
+	now := time.Unix(0, 0).UTC()
+
+	msg, err := runEnsureEndpoint(context.Background(), svc, testModelID, false, time.Minute, fakeClock(&now))
+	require.NoError(t, err)
+	require.Contains(t, msg, "STARTING")
+	require.Equal(t, 0, svc.describeCalls, "no --wait must not poll")
+}
+
+func TestRunEnsureEndpoint_WaitReportsColdStart(t *testing.T) {
+	svc := &fakeEndpointService{
+		ensure: handlers_bedrock.EndpointRecord{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+		describes: []handlers_bedrock.EndpointRecord{
+			{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+			{ModelID: testModelID, State: handlers_bedrock.StateReady},
+		},
+	}
+	now := time.Unix(0, 0).UTC()
+
+	msg, err := runEnsureEndpoint(context.Background(), svc, testModelID, true, time.Minute, fakeClock(&now))
+	require.NoError(t, err)
+	require.Contains(t, msg, "READY after 2s")
+}
+
+// An endpoint already READY when ensure returns was a warm request; reporting
+// an elapsed cold start for it would be misleading.
+func TestRunEnsureEndpoint_AlreadyReadyDoesNotReportElapsed(t *testing.T) {
+	svc := &fakeEndpointService{ensure: handlers_bedrock.EndpointRecord{ModelID: testModelID, State: handlers_bedrock.StateReady}}
+	now := time.Unix(0, 0).UTC()
+
+	msg, err := runEnsureEndpoint(context.Background(), svc, testModelID, true, time.Minute, fakeClock(&now))
+	require.NoError(t, err)
+	require.Contains(t, msg, "already READY")
+	require.NotContains(t, msg, "after")
+	require.Equal(t, 0, svc.describeCalls)
+}
+
+func TestRunEnsureEndpoint_EnsureErrorSurfaces(t *testing.T) {
+	svc := &fakeEndpointService{ensureErr: errors.New("ResourceNotFoundException")}
+	now := time.Unix(0, 0).UTC()
+
+	_, err := runEnsureEndpoint(context.Background(), svc, "no.such.model", false, time.Minute, fakeClock(&now))
+	require.ErrorContains(t, err, "ResourceNotFoundException")
+}
+
+// A timeout must name the state the endpoint was left in, so an operator can
+// tell a slow launch from a stuck one.
+func TestRunEnsureEndpoint_WaitTimeoutIncludesRecord(t *testing.T) {
+	svc := &fakeEndpointService{
+		ensure:    handlers_bedrock.EndpointRecord{ModelID: testModelID, State: handlers_bedrock.StateStarting},
+		describes: []handlers_bedrock.EndpointRecord{{ModelID: testModelID, State: handlers_bedrock.StateStarting}},
+	}
+	now := time.Unix(0, 0).UTC()
+
+	_, err := runEnsureEndpoint(context.Background(), svc, testModelID, true, 4*time.Second, fakeClock(&now))
+	require.ErrorIs(t, err, errEndpointWaitTimeout)
+	require.ErrorContains(t, err, "STARTING")
+}
+
+func TestListEndpointsOutput_NoEndpoints(t *testing.T) {
+	svc := &fakeEndpointService{}
+	msg, err := listEndpointsOutput(context.Background(), svc)
+	require.NoError(t, err)
+	require.Equal(t, "No serving endpoints.", msg)
+}
+
+func TestListEndpointsOutput_ListsEndpoints(t *testing.T) {
+	svc := &fakeEndpointService{list: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateReady, InstanceID: "i-abc", BaseURL: "http://10.0.0.5:8000"},
+		{ModelID: "meta.llama3-2-3b-instruct-v1:0", State: handlers_bedrock.StateStarting},
+	}}
+
+	msg, err := listEndpointsOutput(context.Background(), svc)
+	require.NoError(t, err)
+	require.Contains(t, msg, testModelID)
+	require.Contains(t, msg, "i-abc")
+	require.Contains(t, msg, "STARTING")
+}
+
+func TestListEndpointsOutput_ErrorSurfaces(t *testing.T) {
+	svc := &fakeEndpointService{listErr: errors.New("nats: no responders")}
+	_, err := listEndpointsOutput(context.Background(), svc)
+	require.ErrorContains(t, err, "no responders")
+}
+
+func TestFormatEndpointRecord_OmitsUnsetFieldsAndDerivesStartup(t *testing.T) {
+	created := time.Unix(1000, 0).UTC()
+	rec := handlers_bedrock.EndpointRecord{
+		ModelID:   testModelID,
+		State:     handlers_bedrock.StateReady,
+		CreatedAt: created,
+		ReadyAt:   created.Add(97 * time.Second),
+		BaseURL:   "http://10.0.0.5:8000",
+	}
+
+	out := formatEndpointRecord(rec)
+	require.Contains(t, out, "Startup:")
+	require.Contains(t, out, "1m37s")
+	require.NotContains(t, out, "Instance ID")
+	require.NotContains(t, out, "Weights volume")
+}
+
+func TestFormatEndpointRecord_AbsentIsMinimal(t *testing.T) {
+	out := formatEndpointRecord(handlers_bedrock.EndpointRecord{ModelID: testModelID, State: handlers_bedrock.StateAbsent})
+	require.Contains(t, out, "ABSENT")
+	require.Equal(t, 2, strings.Count(strings.TrimSpace(out), "\n")+1)
+}

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -179,9 +179,20 @@ read.
 
 | Command | Flags | Description |
 |---------|-------|-------------|
-| `spx admin ochre weights stage` | `--model-id` (required), `--s3-uri` (required, `s3://bucket/prefix/`), `--tmp-dir` (default: OS temp dir) | Stages a self-host model's weights for serving. Refuses first if `--model-id` is not a self-host catalog entry (unknown or provider-served), or if `bedrock-weights` already has this model staged from the same `--s3-uri` (no-op). Then validates the prefix holds `config.json`, `tokenizer_config.json`, `tokenizer.json`, `tokenizer.model` and at least one `*.safetensors` file, failing before downloading anything if any are missing. Downloads the prefix's objects from predastore into `--tmp-dir`, packs them into an ext4 image (`mkfs.ext4 -d`), imports it into a new viperblock volume via `v_utils.ImportDiskImage` with `AMIMetadata` left empty (plain volume, no AMI registration), snapshots the closed volume, and records the source URI and snapshot ID against `--model-id` in the `bedrock-weights` KV bucket. Re-staging a different `--s3-uri` replaces the entry and reports the previous snapshot ID for separate reclamation. |
+| `spx admin ochre weights stage` | `--model-id` (required), `--s3-uri` (required, `s3://bucket/prefix/`), `--tmp-dir` (default: OS temp dir) | Stages a self-host model's weights for serving. Refuses first if `--model-id` is not a self-host catalog entry (unknown or provider-served), or if `bedrock-weights` already has this model staged from the same `--s3-uri` (no-op). Then validates the prefix holds `config.json`, `tokenizer_config.json`, at least one `*.safetensors` file, and at least one of `tokenizer.json` or `tokenizer.model`, failing before downloading anything if any are missing. Downloads the prefix's objects from predastore into `--tmp-dir`, packs them into an ext4 image (`mkfs.ext4 -d`), imports it into a new viperblock volume via `v_utils.ImportDiskImage` with `AMIMetadata` left empty (plain volume, no AMI registration), snapshots the closed volume, and records the source URI and snapshot ID against `--model-id` in the `bedrock-weights` KV bucket. Re-staging a different `--s3-uri` replaces the entry and reports the previous snapshot ID for separate reclamation. |
 | `spx admin ochre weights list` | — | Lists every staged model with its source URI and snapshot ID, so an operator can see why a model is (or isn't) advertised via `ListFoundationModels`. |
 | `spx admin ochre weights remove` | `--model-id` (required) | Drops `--model-id`'s entry from `bedrock-weights`, hiding it from `ListFoundationModels` again. Refuses if the model has no staged entry. Never deletes the underlying snapshot or source S3 objects; reclaiming that storage is a separate, explicit act. |
+
+### Ochre Serving Endpoints
+
+Operator surface over the daemon's `bedrock.endpoint.*` subjects. The gateway does not request endpoints itself yet, so until it does these are the only way to start a serving VM.
+
+| Command | Flags | Description |
+|---------|-------|-------------|
+| `spx admin ochre endpoint ensure` | `--model-id` (required), `--wait`, `--timeout` (default: 15m) | Asks the daemon to bring up a serving VM for `--model-id`, which must already have staged weights. Idempotent: a model already `STARTING` or `READY` returns the current record rather than launching a second VM. The daemon replies `STARTING` as soon as it has claimed the model and the launch continues in the background, so `--wait` polls `describe` until `READY` and reports the elapsed cold start. A launch that fails deletes its record, so a return to `ABSENT` is reported as an abort. A `--timeout` leaves the endpoint running rather than tearing it down. |
+| `spx admin ochre endpoint describe` | `--model-id` (required) | Shows the model's current endpoint record: state, instance and node IDs, base URL, weights volume, and the derived startup time once `READY`. A model with no record reads as `ABSENT`. |
+| `spx admin ochre endpoint list` | — | Lists every endpoint record with its state, instance ID and base URL. |
+| `spx admin ochre endpoint delete` | `--model-id` (required) | Moves a `READY` endpoint to `DRAINING` and tears its VM down, releasing the GPU. Idempotent: an already-absent endpoint reports success. |
 
 ### EKS Control-Plane Disaster Recovery
 

--- a/spinifex/handlers/bedrock/store.go
+++ b/spinifex/handlers/bedrock/store.go
@@ -120,6 +120,11 @@ func deleteJSON(ctx context.Context, kv jetstream.KeyValue, key string) error {
 func ListEndpoints(ctx context.Context, kv jetstream.KeyValue, accountID string) ([]EndpointRecord, error) {
 	keys, err := kvutil.Keys(ctx, kv)
 	if err != nil {
+		// An empty bucket is the normal state before any endpoint has ever
+		// been created, not a failure, matching every other kvutil.Keys caller.
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return []EndpointRecord{}, nil
+		}
 		return nil, fmt.Errorf("bedrock: list endpoint keys: %w", err)
 	}
 	prefix := endpointsPrefix(accountID)

--- a/spinifex/handlers/bedrock/store_test.go
+++ b/spinifex/handlers/bedrock/store_test.go
@@ -94,3 +94,13 @@ func TestListEndpoints_FiltersByAccountPrefix(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, recs)
 }
+
+// A bucket that has never held an endpoint is the normal pre-launch state.
+// JetStream reports it as ErrNoKeysFound, which must read as empty, not fail.
+func TestListEndpoints_EmptyBucketIsNotAnError(t *testing.T) {
+	kv := newTestBucket(t)
+
+	recs, err := ListEndpoints(t.Context(), kv, "000000000000")
+	require.NoError(t, err)
+	assert.Empty(t, recs)
+}


### PR DESCRIPTION
## Summary

Adds the operator-facing CLI for Ochre serving endpoints, completing the surface `spx admin ochre weights` started. Four subcommands under `spx admin ochre endpoint`:

- `ensure --model-id` — asks the daemon to bring up a serving VM for a model that already has staged weights. Idempotent: a model already STARTING or READY returns the current record rather than launching a second VM. Replies STARTING as soon as the model is claimed, with `--wait` to poll to READY and report the cold-start time.
- `describe --model-id` / `list` / `delete --model-id`

Also fixes `store.go` treating an empty endpoint bucket as an error rather than as "no endpoints" — the state every cluster is in before the first `ensure`.

## Why this needs a PR now

This branch has been running on wattle since the GPU verification work, because the endpoint CLI is the only way to drive a launch by hand. It is currently the sole unmerged piece of the binary deployed there: anyone rebuilding from `dev` alone silently loses these commands, which is a trap I have already walked into once this cycle.

## Testing

`make preflight` passes merged onto current `dev` (post-#688/#690), diff coverage 87.7%.

Exercised live on wattle throughout the `mulga-dz0vy` investigation — `ensure --wait` correctly reported STARTING, polled, and surfaced the ABSENT-on-failure unwind with the elapsed time, which is how the readiness-probe failure now tracked on `mulga-kzsaw` was found.