### PR TITLE
fix: stop RDS modification work after lease loss

### DIFF
--- a/spinifex/handlers/rds/modify.go
+++ b/spinifex/handlers/rds/modify.go
@@ -148,9 +148,14 @@ func (s *Service) ModifyDBInstance(ctx context.Context, input *rds.ModifyDBInsta
 	}
 	// Under the lease, or the reconciler's sweep of modifying instances re-enters
 	// this same change while it is still running.
-	if _, err := s.withModifyLease(ctx, kv, id, func() error {
-		return s.applyPendingModifications(ctx, kv, accountID, moved)
+	if _, err := s.withModifyLease(ctx, kv, id, func(applyCtx context.Context) error {
+		return s.applyPendingModifications(applyCtx, kv, accountID, moved)
 	}); err != nil {
+		// Lease loss transfers recovery to another holder or the next reconcile
+		// pass; the losing worker must not fail their still-retryable transition.
+		if errors.Is(err, errModifyLeaseLost) {
+			return nil, err
+		}
 		return nil, s.failTransition(ctx, kv, accountID, moved,
 			fmt.Sprintf("the DB instance could not be modified: %v", err))
 	}

--- a/spinifex/handlers/rds/modify_lease.go
+++ b/spinifex/handlers/rds/modify_lease.go
@@ -3,6 +3,7 @@ package handlers_rds
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -18,20 +19,24 @@ import (
 // shape. Without a lease the sweep re-enters a change still in progress and runs
 // a second replaceInstanceVM against the same data volume and the same endpoint
 // ENI — two VMs on one datadir, which is the state the replace exists to avoid.
-const (
-	// Short enough that a worker that dies is taken over within a pass or two,
-	// and long enough for a renewal to be retried several times inside it.
-	modifyLeaseTTL     = 45 * time.Second
-	modifyLeaseRefresh = 15 * time.Second
-)
+// Short enough that a worker that dies is taken over within a pass or two, and
+// long enough for several refresh attempts inside it.
+const modifyLeaseTTL = 45 * time.Second
+
+var errModifyLeaseLost = errors.New("rds: modify lease lost while applying pending modifications")
 
 // Runs apply while holding the instance's modify lease, renewing it for as long
 // as the work runs and releasing it whatever the outcome. Reports whether apply
 // ran: a lease already held is not an error, it means another worker is inside
 // this change and the caller has nothing to do.
-func (s *Service) withModifyLease(ctx context.Context, kv jetstream.KeyValue, id string, apply func() error) (bool, error) {
+func (s *Service) withModifyLease(
+	ctx context.Context,
+	kv jetstream.KeyValue,
+	id string,
+	apply func(context.Context) error,
+) (bool, error) {
 	holder := s.newModifyLeaseHolder()
-	claimed, err := s.claimModifyLease(ctx, kv, id, holder)
+	claimed, expiresAt, err := s.claimModifyLease(ctx, kv, id, holder)
 	if err != nil || !claimed {
 		return false, err
 	}
@@ -40,13 +45,17 @@ func (s *Service) withModifyLease(ctx context.Context, kv jetstream.KeyValue, id
 	// leaves the lease to expire on its own and stalls the takeover it exists
 	// to enable.
 	release := context.WithoutCancel(ctx)
+	applyCtx, cancelApply := context.WithCancelCause(ctx)
 	renewing, stopRenewing := context.WithCancel(ctx)
 	var renewals sync.WaitGroup
-	renewals.Go(func() { s.renewModifyLease(renewing, kv, id, holder) })
+	renewals.Go(func() {
+		s.renewModifyLease(renewing, kv, id, holder, expiresAt, cancelApply)
+	})
 
 	defer func() {
 		stopRenewing()
 		renewals.Wait()
+		cancelApply(nil)
 		if _, err := s.updateInstanceIf(release, kv, id, func(rec *DBInstanceRecord) bool {
 			if rec.ModifyLease == nil || rec.ModifyLease.Holder != holder {
 				return false
@@ -58,7 +67,16 @@ func (s *Service) withModifyLease(ctx context.Context, kv jetstream.KeyValue, id
 				"dbInstance", id, "holder", holder, "err", err)
 		}
 	}()
-	return true, apply()
+
+	applyErr := apply(applyCtx)
+	// Stop and join before inspecting the cause, or the renewer can discover a
+	// takeover during deferred cleanup after a nil return has been chosen.
+	stopRenewing()
+	renewals.Wait()
+	if cause := context.Cause(applyCtx); cause != nil {
+		return true, errors.Join(cause, applyErr)
+	}
+	return true, applyErr
 }
 
 // The node plus a per-claim nonce: the API handler and the reconciler run on the
@@ -72,36 +90,65 @@ func (s *Service) newModifyLeaseHolder() string {
 
 // Takes the lease unless a live one belongs to someone else. Re-taking our own
 // is allowed, so a caller that already holds it is not deadlocked by itself.
-func (s *Service) claimModifyLease(ctx context.Context, kv jetstream.KeyValue, id, holder string) (bool, error) {
-	return s.updateInstanceIf(ctx, kv, id, func(rec *DBInstanceRecord) bool {
+func (s *Service) claimModifyLease(
+	ctx context.Context,
+	kv jetstream.KeyValue,
+	id, holder string,
+) (bool, time.Time, error) {
+	var expiresAt time.Time
+	claimed, err := s.updateInstanceIf(ctx, kv, id, func(rec *DBInstanceRecord) bool {
 		if rec.ModifyLease.live() && rec.ModifyLease.Holder != holder {
 			return false
 		}
-		rec.ModifyLease = &ModifyLease{Holder: holder, ExpiresAt: time.Now().UTC().Add(modifyLeaseTTL)}
+		expiresAt = time.Now().UTC().Add(s.modifyLeaseTTL())
+		rec.ModifyLease = &ModifyLease{Holder: holder, ExpiresAt: expiresAt}
 		return true
 	})
+	return claimed, expiresAt, err
 }
 
 // Pushes the expiry out until the work finishes or ctx is cancelled. A renewal
-// that finds the lease taken over stops rather than reclaiming it: another
-// worker is already inside the change, and two holders is the state this
-// prevents.
-func (s *Service) renewModifyLease(ctx context.Context, kv jetstream.KeyValue, id, holder string) {
-	ticker := time.NewTicker(modifyLeaseRefresh)
+// that finds the lease taken over cancels the guarded work rather than
+// reclaiming it. A deadline bounds each KV attempt so an outage cannot let the
+// work continue after its last successful renewal expires.
+func (s *Service) renewModifyLease(
+	ctx context.Context,
+	kv jetstream.KeyValue,
+	id, holder string,
+	expiresAt time.Time,
+	cancelApply context.CancelCauseFunc,
+) {
+	ticker := time.NewTicker(s.modifyLeaseRefresh())
 	defer ticker.Stop()
+	expiry := time.NewTimer(time.Until(expiresAt))
+	defer expiry.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-expiry.C:
+			slog.WarnContext(ctx, "rds: the modify lease expired while renewal was failing",
+				"dbInstance", id, "holder", holder)
+			cancelApply(fmt.Errorf("%w: renewals did not succeed before expiry", errModifyLeaseLost))
+			return
 		case <-ticker.C:
-			held, err := s.updateInstanceIf(ctx, kv, id, func(rec *DBInstanceRecord) bool {
+			renewCtx, cancelRenew := context.WithDeadline(ctx, expiresAt)
+			var renewedUntil time.Time
+			held, err := s.updateInstanceIf(renewCtx, kv, id, func(rec *DBInstanceRecord) bool {
 				if rec.ModifyLease == nil || rec.ModifyLease.Holder != holder {
 					return false
 				}
-				rec.ModifyLease.ExpiresAt = time.Now().UTC().Add(modifyLeaseTTL)
+				renewedUntil = time.Now().UTC().Add(s.modifyLeaseTTL())
+				rec.ModifyLease.ExpiresAt = renewedUntil
 				return true
 			})
+			cancelRenew()
 			if err != nil {
+				if !time.Now().UTC().Before(expiresAt) {
+					cancelApply(fmt.Errorf("%w: renewals did not succeed before expiry", errModifyLeaseLost))
+					return
+				}
 				slog.WarnContext(ctx, "rds: renewing the modify lease failed; retrying",
 					"dbInstance", id, "holder", holder, "err", err)
 				continue
@@ -109,8 +156,18 @@ func (s *Service) renewModifyLease(ctx context.Context, kv jetstream.KeyValue, i
 			if !held {
 				slog.WarnContext(ctx, "rds: the modify lease was taken over while the change was still running",
 					"dbInstance", id, "holder", holder)
+				cancelApply(fmt.Errorf("%w: another holder took it over", errModifyLeaseLost))
 				return
 			}
+
+			expiresAt = renewedUntil
+			if !expiry.Stop() {
+				select {
+				case <-expiry.C:
+				default:
+				}
+			}
+			expiry.Reset(time.Until(expiresAt))
 		}
 	}
 }

--- a/spinifex/handlers/rds/modify_lease_test.go
+++ b/spinifex/handlers/rds/modify_lease_test.go
@@ -1,6 +1,7 @@
 package handlers_rds
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -121,6 +122,111 @@ func TestReconciler_FailsAModifyWhoseHolderOverrunsTheBudget(t *testing.T) {
 	require.NotNil(t, stored.PendingModifiedValues, "the request stays recorded so the retry has something to run")
 }
 
+// A long-running apply has to keep its lease current, remain exclusive, and
+// stop as soon as another holder takes ownership.
+func TestWithModifyLease_RenewsAndCancelsTheApplyWhenTakenOver(t *testing.T) {
+	h := newModifyHarness(t)
+	h.svc.deps.ModifyLeaseTTL = 500 * time.Millisecond
+	h.svc.deps.ModifyLeaseRefresh = 20 * time.Millisecond
+	rec := modifyingRecord(&PendingModifiedValues{AllocatedStorage: aws.Int64(50), RequestedAt: time.Now().UTC()})
+	seedInstance(t, h.svc, rec)
+	kv := h.kv(t)
+
+	started := make(chan struct{})
+	finished := make(chan error, 1)
+	go func() {
+		_, err := h.svc.withModifyLease(t.Context(), kv, testDBID, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return context.Cause(ctx)
+		})
+		finished <- err
+	}()
+	<-started
+
+	initial := h.record(t).ModifyLease
+	require.NotNil(t, initial)
+	require.Eventually(t, func() bool {
+		lease := h.record(t).ModifyLease
+		return lease != nil && lease.ExpiresAt.After(initial.ExpiresAt)
+	}, time.Second, 10*time.Millisecond, "a blocking apply must keep extending its lease")
+
+	require.NoError(t, h.rec.reconcileOnce(t.Context()))
+	assert.Empty(t, h.storage.modified, "a reconcile pass must not claim a renewed lease")
+
+	takeoverExpiry := time.Now().UTC().Add(time.Second)
+	require.NoError(t, h.svc.updateInstance(t.Context(), kv, testDBID, func(stored *DBInstanceRecord) {
+		stored.ModifyLease = &ModifyLease{Holder: "node-b/takeover", ExpiresAt: takeoverExpiry}
+	}))
+
+	select {
+	case err := <-finished:
+		require.ErrorIs(t, err, errModifyLeaseLost)
+	case <-time.After(time.Second):
+		t.Fatal("the apply context was not cancelled after the lease takeover")
+	}
+
+	stored := h.record(t)
+	require.NotNil(t, stored.ModifyLease)
+	assert.Equal(t, "node-b/takeover", stored.ModifyLease.Holder)
+	assert.Equal(t, takeoverExpiry, stored.ModifyLease.ExpiresAt)
+}
+
+func TestModifyDBInstance_LeaseTakeoverLeavesTheTransitionRetryable(t *testing.T) {
+	h := newModifyHarness(t)
+	h.svc.deps.ModifyLeaseTTL = 500 * time.Millisecond
+	h.svc.deps.ModifyLeaseRefresh = 10 * time.Millisecond
+	seedInstance(t, h.svc, modifiableRecord())
+	kv := h.kv(t)
+
+	h.storage.onModify = func() {
+		require.NoError(t, h.svc.updateInstance(t.Context(), kv, testDBID, func(stored *DBInstanceRecord) {
+			stored.ModifyLease = heldLease(time.Second)
+		}))
+		time.Sleep(50 * time.Millisecond)
+	}
+	in := modifyInput()
+	in.AllocatedStorage, in.ApplyImmediately = aws.Int64(50), aws.Bool(true)
+
+	_, err := h.svc.ModifyDBInstance(t.Context(), in, testAccountID)
+	require.ErrorIs(t, err, errModifyLeaseLost)
+	stored := h.record(t)
+	assert.Equal(t, StatusModifying, stored.Status)
+	require.NotNil(t, stored.PendingModifiedValues)
+	assert.Equal(t, "node-b/deadbeef", stored.ModifyLease.Holder)
+	assert.Equal(t, []string{"stop:" + testInstance}, h.cmdr.calls,
+		"the losing holder must not continue to restart the VM")
+}
+
+func TestWithModifyLease_CancelsWhenRenewalsFailUntilExpiry(t *testing.T) {
+	h := newModifyHarness(t)
+	h.svc.deps.ModifyLeaseTTL = 100 * time.Millisecond
+	h.svc.deps.ModifyLeaseRefresh = 10 * time.Millisecond
+	seedInstance(t, h.svc, modifiableRecord())
+	kv := h.kv(t)
+	js, err := h.svc.js()
+	require.NoError(t, err)
+
+	bucketDeleted := make(chan error, 1)
+	finished := make(chan error, 1)
+	go func() {
+		_, applyErr := h.svc.withModifyLease(t.Context(), kv, testDBID, func(ctx context.Context) error {
+			bucketDeleted <- js.DeleteKeyValue(ctx, kv.Bucket())
+			<-ctx.Done()
+			return context.Cause(ctx)
+		})
+		finished <- applyErr
+	}()
+	require.NoError(t, <-bucketDeleted)
+
+	select {
+	case applyErr := <-finished:
+		require.ErrorIs(t, applyErr, errModifyLeaseLost)
+	case <-time.After(time.Second):
+		t.Fatal("the apply context was not cancelled when renewal failed through the lease expiry")
+	}
+}
+
 // Re-taking a lease we already hold has to be allowed, or a caller that claims
 // twice deadlocks against itself.
 func TestClaimModifyLease_RefusesAnotherHolderButNotItsOwn(t *testing.T) {
@@ -128,15 +234,15 @@ func TestClaimModifyLease_RefusesAnotherHolderButNotItsOwn(t *testing.T) {
 	seedInstance(t, h.svc, modifiableRecord())
 	kv := h.kv(t)
 
-	claimed, err := h.svc.claimModifyLease(t.Context(), kv, testDBID, "node-a/0001")
+	claimed, _, err := h.svc.claimModifyLease(t.Context(), kv, testDBID, "node-a/0001")
 	require.NoError(t, err)
 	assert.True(t, claimed)
 
-	claimed, err = h.svc.claimModifyLease(t.Context(), kv, testDBID, "node-b/0002")
+	claimed, _, err = h.svc.claimModifyLease(t.Context(), kv, testDBID, "node-b/0002")
 	require.NoError(t, err)
 	assert.False(t, claimed, "a live lease belongs to its holder alone")
 
-	claimed, err = h.svc.claimModifyLease(t.Context(), kv, testDBID, "node-a/0001")
+	claimed, _, err = h.svc.claimModifyLease(t.Context(), kv, testDBID, "node-a/0001")
 	require.NoError(t, err)
 	assert.True(t, claimed)
 }

--- a/spinifex/handlers/rds/pending.go
+++ b/spinifex/handlers/rds/pending.go
@@ -29,6 +29,9 @@ func (s *Service) applyPendingModifications(ctx context.Context, kv jetstream.Ke
 	if pending.empty() {
 		return nil
 	}
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 
 	// Parameters first, while the engine this modify started against is still
 	// the one running: the disruptive step below restarts it, which is also what
@@ -39,6 +42,9 @@ func (s *Service) applyPendingModifications(ctx context.Context, kv jetstream.Ke
 	// against the class the instance is becoming: the include lives on the data
 	// volume, so it is the replacement VM that adopts it.
 	if pending.DBParameterGroupName != "" || pending.DBInstanceClass != "" {
+		if err := context.Cause(ctx); err != nil {
+			return err
+		}
 		group := pending.DBParameterGroupName
 		if group == "" {
 			group = rec.DBParameterGroupName
@@ -58,6 +64,9 @@ func (s *Service) applyPendingModifications(ctx context.Context, kv jetstream.Ke
 	// will accept it in.
 	grewStorage := false
 	restarted := false
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	switch {
 	case pending.DBInstanceClass != "":
 		instanceType, err := InstanceTypeForClass(pending.DBInstanceClass)
@@ -95,6 +104,9 @@ func (s *Service) applyPendingModifications(ctx context.Context, kv jetstream.Ke
 	}
 
 	applied := *pending
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	return s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
 		if appliedPendingReboot {
 			stored.PendingRebootParameters = nil

--- a/spinifex/handlers/rds/pending_test.go
+++ b/spinifex/handlers/rds/pending_test.go
@@ -1,6 +1,7 @@
 package handlers_rds
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -19,6 +20,20 @@ func modifyingRecord(pending *PendingModifiedValues) DBInstanceRecord {
 	rec.TransitionStartedAt = &started
 	rec.PendingModifiedValues = pending
 	return rec
+}
+
+func TestApplyPendingModifications_StopsBeforeDestructiveWorkWhenCancelled(t *testing.T) {
+	h := newModifyHarness(t)
+	rec := modifyingRecord(&PendingModifiedValues{AllocatedStorage: aws.Int64(50), RequestedAt: time.Now().UTC()})
+	seedInstance(t, h.svc, rec)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(errModifyLeaseLost)
+
+	err := h.svc.applyPendingModifications(ctx, h.kv(t), testAccountID, &rec)
+	require.ErrorIs(t, err, errModifyLeaseLost)
+	assert.Empty(t, h.cmdr.calls)
+	assert.Empty(t, h.storage.modified)
+	assert.Empty(t, h.launch.launcher.terminated)
 }
 
 // A grow with no class change alongside it keeps the VM: it goes down, the

--- a/spinifex/handlers/rds/reconciler.go
+++ b/spinifex/handlers/rds/reconciler.go
@@ -317,10 +317,14 @@ func (r *Reconciler) reconcileModifying(ctx context.Context, kv jetstream.KeyVal
 	if !pending.empty() && !pending.growingFilesystem() {
 		// The lease is what separates the two: a change still inside its own API
 		// call holds it, and one whose worker died does not.
-		resumed, err := r.svc.withModifyLease(ctx, kv, rec.DBInstanceIdentifier, func() error {
-			return r.svc.applyPendingModifications(ctx, kv, accountID, rec)
+		resumed, err := r.svc.withModifyLease(ctx, kv, rec.DBInstanceIdentifier, func(applyCtx context.Context) error {
+			return r.svc.applyPendingModifications(applyCtx, kv, accountID, rec)
 		})
 		switch {
+		case errors.Is(err, errModifyLeaseLost):
+			// Ownership moved or expired; leave the pending transition for its
+			// current holder or the next pass rather than failing it underneath them.
+			return nil
 		case err != nil && overrun:
 			// Claiming and releasing the lease moved the record, so this pass's
 			// revision is stale by now and a CAS on it would lose to our own

--- a/spinifex/handlers/rds/replace.go
+++ b/spinifex/handlers/rds/replace.go
@@ -63,26 +63,45 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 	// Checkpointed first so the replacement boots on a clean datadir rather than
 	// one it has to replay a WAL over. A wedged agent degrades this rather than
 	// blocking the replace, exactly as a stop does.
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	s.stopEngineOrRecordFallback(ctx, accountID, rec, "replacing its VM")
 
 	oldInstanceID := rec.InstanceID
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	if err := s.terminateInstanceVM(ctx, oldInstanceID); err != nil {
 		return fmt.Errorf("terminate the VM behind %s: %w", rec.DBInstanceIdentifier, err)
 	}
 	// The system NIC is disposable and the fresh launch mints its own; leaving
 	// this one behind would hold an address in the shared RDS system subnet.
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	s.deleteSystemENI(ctx, rec)
 
 	// The only moment the volume is held by nothing, which is the only moment
 	// ModifyVolume will take it.
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	if in.GrowStorageToGiB > 0 {
 		if err := s.growDataVolume(ctx, rec.DataVolumeID, in.GrowStorageToGiB); err != nil {
 			return err
 		}
 	}
 
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	launched, err := s.launchReplacementVM(ctx, accountID, rec, instanceType, profileARN)
 	if err != nil {
+		return err
+	}
+	if err := context.Cause(ctx); err != nil {
+		s.unwindLaunched(context.WithoutCancel(ctx), launched)
 		return err
 	}
 
@@ -90,8 +109,10 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 	// gateway is resolvable; the old entry goes first, or a superseded VM still
 	// authenticates as this instance.
 	if err := s.rewriteInstanceIndex(ctx, accountID, rec, oldInstanceID, launched.InstanceID); err != nil {
-		s.unwindLaunched(ctx, launched)
-		return err
+		return errors.Join(err, s.rollbackReplacementLaunch(ctx, accountID, rec, oldInstanceID, launched))
+	}
+	if err := context.Cause(ctx); err != nil {
+		return errors.Join(err, s.rollbackReplacementLaunch(ctx, accountID, rec, oldInstanceID, launched))
 	}
 
 	if err := s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
@@ -102,8 +123,7 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 		// this one's — the reconciler would call the replace finished at once.
 		stored.Agent = AgentState{}
 	}); err != nil {
-		s.unwindLaunched(ctx, launched)
-		return err
+		return errors.Join(err, s.rollbackReplacementLaunch(ctx, accountID, rec, oldInstanceID, launched))
 	}
 	// Kept in step so the caller's own record write does not resurrect the old
 	// VM's identity on top of this one.
@@ -170,6 +190,35 @@ func (s *Service) rewriteInstanceIndex(ctx context.Context, accountID string, re
 		return fmt.Errorf("rds: write the instance index for %s: %w", rec.DBInstanceIdentifier, err)
 	}
 	return nil
+}
+
+// Restores the index to the record's old VM before unwinding a replacement that
+// could not commit. Cleanup is bounded but detached from lease cancellation.
+func (s *Service) rollbackReplacementLaunch(
+	ctx context.Context,
+	accountID string,
+	rec *DBInstanceRecord,
+	oldInstanceID string,
+	launched *LaunchOutput,
+) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rollbackTimeout)
+	defer cancel()
+
+	var cleanupErrs []error
+	if err := s.DeleteInstanceIndex(cleanupCtx, launched.InstanceID); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("delete replacement instance index %s: %w", launched.InstanceID, err))
+	}
+	if oldInstanceID != "" {
+		if err := s.PutInstanceIndex(cleanupCtx, oldInstanceID, InstanceIndexEntry{
+			AccountID:            accountID,
+			DBInstanceIdentifier: rec.DBInstanceIdentifier,
+			VMGeneration:         rec.VMGeneration,
+		}); err != nil {
+			cleanupErrs = append(cleanupErrs, fmt.Errorf("restore old instance index %s: %w", oldInstanceID, err))
+		}
+	}
+	s.unwindLaunched(cleanupCtx, launched)
+	return errors.Join(cleanupErrs...)
 }
 
 // Best-effort: a leaked system NIC costs an address in a platform-owned subnet,

--- a/spinifex/handlers/rds/replace_test.go
+++ b/spinifex/handlers/rds/replace_test.go
@@ -1,6 +1,7 @@
 package handlers_rds
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -26,6 +27,19 @@ func seedReplaceable(t *testing.T, h *modifyHarness, rec DBInstanceRecord) DBIns
 		VMGeneration:         rec.VMGeneration,
 	}))
 	return rec
+}
+
+func TestReplaceInstanceVM_StopsBeforeDestructiveWorkWhenCancelled(t *testing.T) {
+	h := newModifyHarness(t)
+	rec := seedReplaceable(t, h, modifiableRecord())
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(errModifyLeaseLost)
+
+	err := h.svc.replaceInstanceVM(ctx, h.kv(t), testAccountID, &rec, replaceInput{Reason: "recovery"})
+	require.ErrorIs(t, err, errModifyLeaseLost)
+	assert.Empty(t, h.cmdr.calls)
+	assert.Empty(t, h.launch.launcher.terminated)
+	assert.Nil(t, h.launch.launcher.input)
 }
 
 // The endpoint ENI and the datadir outlive the VM, so a replace adopts

--- a/spinifex/handlers/rds/service.go
+++ b/spinifex/handlers/rds/service.go
@@ -57,6 +57,10 @@ type Deps struct {
 	// Overrides how long a stop waits for the fleet to report the VM down.
 	// Zero takes defaultVMStopTimeout.
 	VMStopTimeout time.Duration
+	// Override the modify lease lifetime and renewal cadence in tests. A zero
+	// TTL takes the default; a refresh outside (0, TTL) derives as TTL/3.
+	ModifyLeaseTTL     time.Duration
+	ModifyLeaseRefresh time.Duration
 	// Bounds and defaults for automated backups and the two scheduled windows.
 	// Every zero field takes the built-in default.
 	Backup BackupPolicy
@@ -110,6 +114,24 @@ func (s *Service) failureGrace() time.Duration {
 		return s.deps.FailureGrace
 	}
 	return defaultFailureGrace
+}
+
+func (s *Service) modifyLeaseTTL() time.Duration {
+	if s.deps.ModifyLeaseTTL > 0 {
+		return s.deps.ModifyLeaseTTL
+	}
+	return modifyLeaseTTL
+}
+
+func (s *Service) modifyLeaseRefresh() time.Duration {
+	ttl := s.modifyLeaseTTL()
+	if refresh := s.deps.ModifyLeaseRefresh; refresh > 0 && refresh < ttl {
+		return refresh
+	}
+	if refresh := ttl / 3; refresh > 0 {
+		return refresh
+	}
+	return time.Nanosecond
 }
 
 func (s *Service) js() (jetstream.JetStream, error) {

--- a/spinifex/handlers/rds/storage.go
+++ b/spinifex/handlers/rds/storage.go
@@ -51,12 +51,24 @@ func (s *Service) growInstanceStorage(ctx context.Context, accountID string, rec
 	}
 	// The engine is checkpointed first so the filesystem the grow extends is not
 	// one a live postmaster is still writing into.
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	s.stopEngineOrRecordFallback(ctx, accountID, rec, "growing its storage")
 
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	if err := s.stopInstanceVM(ctx, accountID, rec.InstanceID); err != nil {
 		return fmt.Errorf("stop the DB VM before growing its storage: %w", err)
 	}
+	if err := context.Cause(ctx); err != nil {
+		return err
+	}
 	if err := s.growDataVolume(ctx, rec.DataVolumeID, targetGiB); err != nil {
+		return err
+	}
+	if err := context.Cause(ctx); err != nil {
 		return err
 	}
 	if err := s.startInstanceVM(ctx, rec.InstanceID); err != nil {
@@ -84,6 +96,9 @@ func (s *Service) growDataVolume(ctx context.Context, volumeID string, targetGiB
 		slog.InfoContext(ctx, "rds: data volume is already at the requested size; skipping the modify",
 			"volumeId", volumeID, "sizeGiB", current, "targetGiB", targetGiB)
 		return nil
+	}
+	if err := context.Cause(ctx); err != nil {
+		return err
 	}
 
 	if _, err := s.deps.Storage.ModifyVolume(ctx, &ec2.ModifyVolumeInput{


### PR DESCRIPTION
## Summary

Prevent an RDS modification worker from continuing after it loses the per-instance modify lease. Without this fencing, a reconciler could claim the expired lease and start a second VM replacement against the same data volume and endpoint ENI.

## Changes

- Derive the apply context from lease ownership and cancel it when another holder takes over or renewals fail through the lease TTL.
- Make lease TTL and refresh timing injectable through `Deps` so renewal behavior is testable.
- Check cancellation between destructive storage-growth and VM-replacement steps.
- Leave a lease-lost transition in `modifying` so its new holder or the next reconcile pass can resume it safely.
- Restore the old instance index and unwind a replacement launch when cancellation prevents the replacement record from committing.