### PR TITLE
fix: prevent parameter groups bricking RDS instances

### DIFF
--- a/cmd/rds-agent/agent.go
+++ b/cmd/rds-agent/agent.go
@@ -169,10 +169,10 @@ func newAgent(cfg config, cp controlPlane, probe *engineProbe) *Agent {
 		EngineVersion:        cfg.EngineVersion,
 	}
 	a := &Agent{cfg: cfg, id: id, cp: cp, probe: probe, handoffWriter: writeHandoff}
-	a.engine = newPostgresEngine(cfg, execCommandRunner, execSessionRunner)
-	a.hb = newHeartbeater(cp, probe, handlers_rds.HeartbeatInterval)
+	a.engine = newPostgresEngine(cfg, execCommandRunner, execSessionRunner, probe)
+	a.hb = newHeartbeater(cp, probe, a.engine, handlers_rds.HeartbeatInterval)
 	a.cmd = newCommander(cp, newCommandRegistry(a.engine, newGuestStorage(cfg, execCommandRunner)), cfg.PollWait)
-	a.guard = newParamGuard(a.engine, probe)
+	a.guard = newParamGuard(a.engine, probe, cp)
 	return a
 }
 
@@ -201,7 +201,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	if err := a.register(ctx); err != nil {
 		return err
 	}
-	a.hb.id, a.cmd.id = a.id, a.id
+	a.hb.id, a.cmd.id, a.guard.id = a.id, a.id, a.id
 
 	// Beating before the bootstrap keeps a stuck boot visible as a live VM with
 	// a down engine rather than as silence.

--- a/cmd/rds-agent/engine.go
+++ b/cmd/rds-agent/engine.go
@@ -49,6 +49,13 @@ type parameterRecovery interface {
 	Restart(ctx context.Context) error
 }
 
+// Records the parameter file only after the probe observes the postmaster
+// serving it. This is separate from apply, where static values are installed
+// but not adopted until a later restart.
+type servingParameterRecorder interface {
+	RecordServingParameters() error
+}
+
 // One child process. Env replaces the agent's own environment rather than
 // extending it, so a secret placed here reaches only the process that needs it.
 type command struct {
@@ -117,6 +124,7 @@ type postgresEngine struct {
 	pgData    string
 	socketDir string
 	osUser    string
+	probe     *engineProbe
 	// Set from the bootstrap config, on a different goroutine than the commands
 	// that read it.
 	port atomic.Int64
@@ -127,9 +135,13 @@ type postgresEngine struct {
 	held *quiesceHold
 }
 
-var _ engineOps = (*postgresEngine)(nil)
+var (
+	_ engineOps                = (*postgresEngine)(nil)
+	_ parameterRecovery        = (*postgresEngine)(nil)
+	_ servingParameterRecorder = (*postgresEngine)(nil)
+)
 
-func newPostgresEngine(cfg config, run commandRunner, startSess sessionRunner) *postgresEngine {
+func newPostgresEngine(cfg config, run commandRunner, startSess sessionRunner, probe *engineProbe) *postgresEngine {
 	e := &postgresEngine{
 		run:       run,
 		startSess: startSess,
@@ -139,6 +151,7 @@ func newPostgresEngine(cfg config, run commandRunner, startSess sessionRunner) *
 		pgData:    cfg.PGData,
 		socketDir: cfg.SocketDir,
 		osUser:    cfg.PGUser,
+		probe:     probe,
 	}
 	e.port.Store(int64(cfg.EnginePort))
 	return e
@@ -197,22 +210,23 @@ func (e *postgresEngine) ApplyParameters(ctx context.Context, params []handlers_
 	// the datadir's own include_dir. The window that leaves is closed from both
 	// ends: the rollback below, and the last-known-good restore the agent runs at
 	// boot when the engine does not come up.
-	previous, restore, err := e.installParameters(params)
+	_, restore, err := e.installParameters(params)
 	if err != nil {
 		return nil, err
 	}
 	if err := e.checkConfig(ctx); err != nil {
 		return nil, errors.Join(fmt.Errorf("the engine rejected the parameter set: %w", err), restore())
 	}
-	if _, err := e.psqlRun(ctx, "SELECT pg_reload_conf();\n"); err != nil {
-		return nil, errors.Join(fmt.Errorf("reload the engine configuration: %w", err), restore())
+	if state, _ := e.probe.state(ctx); state != engineServing {
+		return parameterNames(params), nil
 	}
-
-	// Recorded only once the engine has both parsed and adopted it, so the
-	// rollback target is a set that is known to work rather than the last one
-	// written.
-	if err := e.recordLastKnownGood(previous); err != nil {
-		return nil, err
+	if _, err := e.psqlRun(ctx, "SELECT pg_reload_conf();\n"); err != nil {
+		// The engine may have gone down after the first probe. In that case the
+		// new, parser-checked file is the repair set for its next start.
+		if state, _ := e.probe.state(ctx); state != engineServing {
+			return parameterNames(params), nil
+		}
+		return nil, errors.Join(fmt.Errorf("reload the engine configuration: %w", err), restore())
 	}
 
 	// Read after the reload: a setting only becomes pending_restart once the
@@ -228,6 +242,14 @@ func (e *postgresEngine) ApplyParameters(ctx context.Context, params []handlers_
 		}
 	}
 	return pending, nil
+}
+
+func parameterNames(params []handlers_rds.Parameter) []string {
+	names := make([]string, 0, len(params))
+	for _, param := range params {
+		names = append(names, param.Name)
+	}
+	return names
 }
 
 func (e *postgresEngine) parametersPath() string {
@@ -265,16 +287,13 @@ func (e *postgresEngine) installParameters(params []handlers_rds.Parameter) (pre
 	}, nil
 }
 
-// Keeps the rollback target in step with what the engine is actually running.
-// The first apply of an instance's life has no predecessor, so the freshly
-// accepted set becomes the target instead.
-func (e *postgresEngine) recordLastKnownGood(previous []byte) error {
-	content := previous
-	if content == nil {
-		var err error
-		if content, err = os.ReadFile(e.parametersPath()); err != nil {
-			return fmt.Errorf("read the accepted parameters: %w", err)
-		}
+// Snapshots the include only after the probe observes the engine serving. A
+// static-only apply cannot move this target until a restart proves the new set
+// can start and serve.
+func (e *postgresEngine) RecordServingParameters() error {
+	content, err := os.ReadFile(e.parametersPath())
+	if err != nil {
+		return fmt.Errorf("read the serving parameters: %w", err)
 	}
 	return e.writeEngineFile(e.lastGoodPath(), content)
 }

--- a/cmd/rds-agent/engine.go
+++ b/cmd/rds-agent/engine.go
@@ -45,7 +45,7 @@ type engineOps interface {
 // engine fails to come up after a parameter change.
 type parameterRecovery interface {
 	// Reports whether the installed set differed and was replaced.
-	RestoreLastKnownGoodParameters() (bool, error)
+	RestoreLastKnownGoodParameters(ctx context.Context) (bool, error)
 	Restart(ctx context.Context) error
 }
 
@@ -53,7 +53,7 @@ type parameterRecovery interface {
 // serving it. This is separate from apply, where static values are installed
 // but not adopted until a later restart.
 type servingParameterRecorder interface {
-	RecordServingParameters() error
+	RecordServingParameters(ctx context.Context) error
 }
 
 // One child process. Env replaces the agent's own environment rather than
@@ -129,6 +129,12 @@ type postgresEngine struct {
 	// that read it.
 	port atomic.Int64
 
+	// Serializes parameter installs, serving snapshots and rollback restores so
+	// none can copy or replace an intermediate configuration.
+	paramMu       sync.Mutex
+	repairTimeout time.Duration
+	repairPoll    time.Duration
+
 	// The backup mode currently held, if any. Guarded because the expiry timer
 	// releases it on its own goroutine.
 	mu   sync.Mutex
@@ -141,17 +147,24 @@ var (
 	_ servingParameterRecorder = (*postgresEngine)(nil)
 )
 
+const (
+	parameterRepairTimeout = 90 * time.Second
+	parameterRepairPoll    = time.Second
+)
+
 func newPostgresEngine(cfg config, run commandRunner, startSess sessionRunner, probe *engineProbe) *postgresEngine {
 	e := &postgresEngine{
-		run:       run,
-		startSess: startSess,
-		psql:      filepath.Join(cfg.PGBin, "psql"),
-		rcService: cfg.RCService,
-		service:   cfg.EngineService,
-		pgData:    cfg.PGData,
-		socketDir: cfg.SocketDir,
-		osUser:    cfg.PGUser,
-		probe:     probe,
+		run:           run,
+		startSess:     startSess,
+		psql:          filepath.Join(cfg.PGBin, "psql"),
+		rcService:     cfg.RCService,
+		service:       cfg.EngineService,
+		pgData:        cfg.PGData,
+		socketDir:     cfg.SocketDir,
+		osUser:        cfg.PGUser,
+		probe:         probe,
+		repairTimeout: parameterRepairTimeout,
+		repairPoll:    parameterRepairPoll,
 	}
 	e.port.Store(int64(cfg.EnginePort))
 	return e
@@ -206,6 +219,21 @@ const (
 // rolled back here rather than left on the data volume, where it would survive
 // every VM replace and turn the next restart into a boot loop.
 func (e *postgresEngine) ApplyParameters(ctx context.Context, params []handlers_rds.Parameter) ([]string, error) {
+	e.paramMu.Lock()
+	defer e.paramMu.Unlock()
+
+	initialState, _ := e.probe.state(ctx)
+	if initialState == engineRecovering {
+		return nil, errors.New("apply parameters while the engine is still starting or recovering")
+	}
+	if initialState == engineServing {
+		// A command can arrive before the first heartbeat. Seed the configuration
+		// currently being served before replacing its file in that window.
+		if err := e.recordServingParametersLocked(ctx); err != nil {
+			return nil, fmt.Errorf("record the parameters serving before the apply: %w", err)
+		}
+	}
+
 	// The check has to run against the file in place, because the engine parses
 	// the datadir's own include_dir. The window that leaves is closed from both
 	// ends: the rollback below, and the last-known-good restore the agent runs at
@@ -217,20 +245,63 @@ func (e *postgresEngine) ApplyParameters(ctx context.Context, params []handlers_
 	if err := e.checkConfig(ctx); err != nil {
 		return nil, errors.Join(fmt.Errorf("the engine rejected the parameter set: %w", err), restore())
 	}
-	if state, _ := e.probe.state(ctx); state != engineServing {
-		return parameterNames(params), nil
+
+	state, _ := e.probe.state(ctx)
+	switch state {
+	case engineAbsent:
+		return e.restartOnRepairSetLocked(ctx)
+	case engineRecovering:
+		return nil, errors.Join(errors.New("the engine entered startup or recovery during the parameter apply"), restore())
 	}
+
 	if _, err := e.psqlRun(ctx, "SELECT pg_reload_conf();\n"); err != nil {
-		// The engine may have gone down after the first probe. In that case the
-		// new, parser-checked file is the repair set for its next start.
-		if state, _ := e.probe.state(ctx); state != engineServing {
-			return parameterNames(params), nil
+		// The engine may have gone down after the first probe. In that case start
+		// it on the new, parser-checked repair set rather than restoring the set
+		// that already left it unable to serve.
+		if state, _ := e.probe.state(ctx); state == engineAbsent {
+			return e.restartOnRepairSetLocked(ctx)
 		}
 		return nil, errors.Join(fmt.Errorf("reload the engine configuration: %w", err), restore())
 	}
+	return e.pendingRestartParameters(ctx)
+}
 
-	// Read after the reload: a setting only becomes pending_restart once the
-	// engine has seen the new value and declined to adopt it live.
+func (e *postgresEngine) restartOnRepairSetLocked(ctx context.Context) ([]string, error) {
+	repairCtx, cancel := context.WithTimeout(ctx, e.repairTimeout)
+	defer cancel()
+
+	if err := e.Restart(repairCtx); err != nil {
+		return nil, fmt.Errorf("start the engine on the repaired parameter set: %w", err)
+	}
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	lastMessage := "engine did not respond"
+	for {
+		select {
+		case <-repairCtx.Done():
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("wait for the engine on the repaired parameter set: %w", ctx.Err())
+			}
+			return nil, fmt.Errorf("wait for the engine on the repaired parameter set: %s: %w", lastMessage, repairCtx.Err())
+		case <-timer.C:
+		}
+
+		state, message := e.probe.state(repairCtx)
+		if state == engineServing {
+			pending, err := e.pendingRestartParameters(repairCtx)
+			if err == nil {
+				return pending, nil
+			}
+			lastMessage = err.Error()
+		} else if message != "" {
+			lastMessage = message
+		}
+		timer.Reset(e.repairPoll)
+	}
+}
+
+func (e *postgresEngine) pendingRestartParameters(ctx context.Context) ([]string, error) {
 	out, err := e.psqlRun(ctx, "SELECT name FROM pg_settings WHERE pending_restart ORDER BY name;\n")
 	if err != nil {
 		return nil, fmt.Errorf("read the settings pending a restart: %w", err)
@@ -242,14 +313,6 @@ func (e *postgresEngine) ApplyParameters(ctx context.Context, params []handlers_
 		}
 	}
 	return pending, nil
-}
-
-func parameterNames(params []handlers_rds.Parameter) []string {
-	names := make([]string, 0, len(params))
-	for _, param := range params {
-		names = append(names, param.Name)
-	}
-	return names
 }
 
 func (e *postgresEngine) parametersPath() string {
@@ -287,21 +350,54 @@ func (e *postgresEngine) installParameters(params []handlers_rds.Parameter) (pre
 	}, nil
 }
 
-// Snapshots the include only after the probe observes the engine serving. A
-// static-only apply cannot move this target until a restart proves the new set
-// can start and serve.
-func (e *postgresEngine) RecordServingParameters() error {
+// Snapshots the include only when the running postmaster has no settings still
+// pending a restart. The parameter mutex keeps an apply from replacing the file
+// between that check and the copy.
+func (e *postgresEngine) RecordServingParameters(ctx context.Context) error {
+	e.paramMu.Lock()
+	defer e.paramMu.Unlock()
+	return e.recordServingParametersLocked(ctx)
+}
+
+func (e *postgresEngine) recordServingParametersLocked(ctx context.Context) error {
+	if _, err := os.Stat(e.parametersPath()); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("inspect the serving parameters: %w", err)
+	}
+	pending, err := e.pendingRestartParameters(ctx)
+	if err != nil {
+		return err
+	}
+	if len(pending) > 0 {
+		return nil
+	}
+
 	content, err := os.ReadFile(e.parametersPath())
 	if err != nil {
 		return fmt.Errorf("read the serving parameters: %w", err)
+	}
+	lastGood, err := os.ReadFile(e.lastGoodPath())
+	if err == nil && bytes.Equal(content, lastGood) {
+		return nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read the last known good parameters: %w", err)
 	}
 	return e.writeEngineFile(e.lastGoodPath(), content)
 }
 
 // Puts the last set the engine accepted back in place, for a restart that failed
-// after a parameter change: the instance comes back on the old parameters rather
-// than boot-looping into recovery. Reports whether anything was restored.
-func (e *postgresEngine) RestoreLastKnownGoodParameters() (bool, error) {
+// after a parameter change. The probe is checked again under the parameter lock
+// so a repair that just brought the engine back cannot be reversed.
+func (e *postgresEngine) RestoreLastKnownGoodParameters(ctx context.Context) (bool, error) {
+	e.paramMu.Lock()
+	defer e.paramMu.Unlock()
+
+	if state, _ := e.probe.state(ctx); state != engineAbsent {
+		return false, nil
+	}
 	lastGood, err := os.ReadFile(e.lastGoodPath())
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/rds-agent/engine_test.go
+++ b/cmd/rds-agent/engine_test.go
@@ -153,7 +153,7 @@ func newTestEngine(t *testing.T, run commandRunner) *postgresEngine {
 		t.Fatalf("resolve the current user: %v", err)
 	}
 	cfg.PGUser = current.Username
-	return newPostgresEngine(cfg, run, nil)
+	return newPostgresEngine(cfg, run, nil, newEngineProbe(cfg, staticProbe(0)))
 }
 
 // The password reaches psql through the environment and is re-quoted there,
@@ -276,12 +276,56 @@ func TestPostgresEngine_ApplyParametersInstallsAndReloads(t *testing.T) {
 // A reload that failed leaves the engine on its old values, so reporting the
 // apply as successful would tell the customer a change took effect that did not.
 func TestPostgresEngine_ApplyParametersSurfacesAFailedReload(t *testing.T) {
-	runner := &recordingRunner{err: errors.New("could not connect to server")}
+	runner := &reloadFailingRunner{reloadErr: errors.New("reload was rejected")}
 	engine := newTestEngine(t, runner.run)
 
 	if _, err := engine.ApplyParameters(context.Background(),
 		[]handlers_rds.Parameter{{Name: "work_mem", Value: "8MB"}}); err == nil {
 		t.Fatal("ApplyParameters succeeded against a failing reload")
+	}
+}
+
+type reloadFailingRunner struct {
+	recordingRunner
+
+	reloadErr error
+}
+
+func (r *reloadFailingRunner) run(ctx context.Context, c command) (string, error) {
+	if strings.Contains(c.Stdin, "pg_reload_conf") {
+		r.calls = append(r.calls, c)
+		return "", r.reloadErr
+	}
+	return r.recordingRunner.run(ctx, c)
+}
+
+// A failed instance cannot reload through psql. Its corrected, parser-checked
+// include must remain installed for the restart that repairs it.
+func TestPostgresEngine_ApplyParametersKeepsARepairSetWhileEngineIsDown(t *testing.T) {
+	runner := &recordingRunner{}
+	engine := newTestEngine(t, runner.run)
+	engine.probe = stubProbe(t, 2, nil)
+	params := []handlers_rds.Parameter{
+		{Name: "shared_buffers", Value: "32768"},
+		{Name: "work_mem", Value: "8192"},
+	}
+
+	pending, err := engine.ApplyParameters(context.Background(), params)
+	if err != nil {
+		t.Fatalf("ApplyParameters: %v", err)
+	}
+	if !slices.Equal(pending, []string{"shared_buffers", "work_mem"}) {
+		t.Errorf("pending = %v, want every installed setting", pending)
+	}
+	if len(runner.calls) != 1 || !slices.Contains(runner.calls[0].Args, "-C") {
+		t.Errorf("calls = %+v, want only the offline config check", runner.calls)
+	}
+	installed, err := os.ReadFile(engine.parametersPath())
+	if err != nil {
+		t.Fatalf("read installed parameters: %v", err)
+	}
+	if !strings.Contains(string(installed), "work_mem = '8192'") {
+		t.Errorf("installed parameters = %q, want the repair set retained", installed)
 	}
 }
 

--- a/cmd/rds-agent/engine_test.go
+++ b/cmd/rds-agent/engine_test.go
@@ -300,25 +300,43 @@ func (r *reloadFailingRunner) run(ctx context.Context, c command) (string, error
 }
 
 // A failed instance cannot reload through psql. Its corrected, parser-checked
-// include must remain installed for the restart that repairs it.
-func TestPostgresEngine_ApplyParametersKeepsARepairSetWhileEngineIsDown(t *testing.T) {
+// include must start the service and remain installed as the serving set.
+func TestPostgresEngine_ApplyParametersRestartsOnARepairSetWhileEngineIsDown(t *testing.T) {
 	runner := &recordingRunner{}
 	engine := newTestEngine(t, runner.run)
-	engine.probe = stubProbe(t, 2, nil)
+	codes := []int{2, 2, 0}
+	probeCall := 0
+	cfg := testProbeConfig()
+	engine.probe = newEngineProbe(cfg, func(context.Context, string, ...string) (int, error) {
+		code := codes[min(probeCall, len(codes)-1)]
+		probeCall++
+		return code, nil
+	})
+	engine.repairTimeout = 100 * time.Millisecond
+	engine.repairPoll = time.Millisecond
 	params := []handlers_rds.Parameter{
 		{Name: "shared_buffers", Value: "32768"},
 		{Name: "work_mem", Value: "8192"},
 	}
 
-	pending, err := engine.ApplyParameters(context.Background(), params)
+	pending, err := engine.ApplyParameters(t.Context(), params)
 	if err != nil {
 		t.Fatalf("ApplyParameters: %v", err)
 	}
-	if !slices.Equal(pending, []string{"shared_buffers", "work_mem"}) {
-		t.Errorf("pending = %v, want every installed setting", pending)
+	if len(pending) != 0 {
+		t.Errorf("pending = %v, want the restarted engine's actual pending set", pending)
 	}
-	if len(runner.calls) != 1 || !slices.Contains(runner.calls[0].Args, "-C") {
-		t.Errorf("calls = %+v, want only the offline config check", runner.calls)
+	if len(runner.calls) != 3 {
+		t.Fatalf("calls = %+v, want config check, service restart and pending read", runner.calls)
+	}
+	if !slices.Contains(runner.calls[0].Args, "-C") {
+		t.Errorf("first call = %+v, want the offline config check", runner.calls[0])
+	}
+	if !slices.Equal(runner.calls[1].Args, []string{"postgresql", "restart"}) {
+		t.Errorf("second call args = %v, want the service restart", runner.calls[1].Args)
+	}
+	if !strings.Contains(runner.calls[2].Stdin, "pending_restart") {
+		t.Errorf("third call = %+v, want the pending-restart read", runner.calls[2])
 	}
 	installed, err := os.ReadFile(engine.parametersPath())
 	if err != nil {
@@ -326,6 +344,26 @@ func TestPostgresEngine_ApplyParametersKeepsARepairSetWhileEngineIsDown(t *testi
 	}
 	if !strings.Contains(string(installed), "work_mem = '8192'") {
 		t.Errorf("installed parameters = %q, want the repair set retained", installed)
+	}
+}
+
+func TestPostgresEngine_ApplyParametersKeepsRepairSetWhenRestartTimesOut(t *testing.T) {
+	runner := &recordingRunner{}
+	engine := newTestEngine(t, runner.run)
+	engine.probe = stubProbe(t, 2, nil)
+	engine.repairTimeout = 10 * time.Millisecond
+	engine.repairPoll = time.Millisecond
+
+	_, err := engine.ApplyParameters(t.Context(), []handlers_rds.Parameter{{Name: "work_mem", Value: "8192"}})
+	if err == nil || !strings.Contains(err.Error(), "wait for the engine") {
+		t.Fatalf("ApplyParameters error = %v, want the repair wait failure", err)
+	}
+	installed, readErr := os.ReadFile(engine.parametersPath())
+	if readErr != nil {
+		t.Fatalf("read installed parameters: %v", readErr)
+	}
+	if !strings.Contains(string(installed), "work_mem = '8192'") {
+		t.Errorf("installed parameters = %q, want the checked repair set retained", installed)
 	}
 }
 

--- a/cmd/rds-agent/heartbeat.go
+++ b/cmd/rds-agent/heartbeat.go
@@ -13,15 +13,17 @@ import (
 type heartbeater struct {
 	cp       controlPlane
 	probe    *engineProbe
+	recorder servingParameterRecorder
 	id       identity
 	interval time.Duration
+	serving  bool
 }
 
-func newHeartbeater(cp controlPlane, probe *engineProbe, interval time.Duration) *heartbeater {
+func newHeartbeater(cp controlPlane, probe *engineProbe, recorder servingParameterRecorder, interval time.Duration) *heartbeater {
 	if interval <= 0 {
 		interval = handlers_rds.HeartbeatInterval
 	}
-	return &heartbeater{cp: cp, probe: probe, interval: interval}
+	return &heartbeater{cp: cp, probe: probe, recorder: recorder, interval: interval}
 }
 
 // Called before Run starts and from Run's own goroutine after, so the interval
@@ -34,6 +36,15 @@ func (h *heartbeater) setInterval(d time.Duration) {
 
 func (h *heartbeater) beat(ctx context.Context) {
 	health, message := h.probe.Check(ctx)
+	if health != handlers_rds.EngineHealthHealthy {
+		h.serving = false
+	} else if !h.serving && h.recorder != nil {
+		if err := h.recorder.RecordServingParameters(); err != nil {
+			slog.Warn("rds-agent: recording the serving parameters failed", "err", err)
+		} else {
+			h.serving = true
+		}
+	}
 
 	out, err := h.cp.SubmitState(ctx, h.id, health, message)
 	if err != nil {

--- a/cmd/rds-agent/heartbeat.go
+++ b/cmd/rds-agent/heartbeat.go
@@ -8,6 +8,8 @@ import (
 	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
 )
 
+const servingParameterRecordTimeout = 15 * time.Second
+
 // The beat carries the probe's result, not the agent's own liveness: an agent
 // up while the engine is down is what the recovery reconciler must see.
 type heartbeater struct {
@@ -16,7 +18,6 @@ type heartbeater struct {
 	recorder servingParameterRecorder
 	id       identity
 	interval time.Duration
-	serving  bool
 }
 
 func newHeartbeater(cp controlPlane, probe *engineProbe, recorder servingParameterRecorder, interval time.Duration) *heartbeater {
@@ -36,13 +37,14 @@ func (h *heartbeater) setInterval(d time.Duration) {
 
 func (h *heartbeater) beat(ctx context.Context) {
 	health, message := h.probe.Check(ctx)
-	if health != handlers_rds.EngineHealthHealthy {
-		h.serving = false
-	} else if !h.serving && h.recorder != nil {
-		if err := h.recorder.RecordServingParameters(); err != nil {
+	if health == handlers_rds.EngineHealthHealthy && h.recorder != nil {
+		// Checking every healthy beat also observes a restart that completed
+		// between probes. The recorder skips unchanged and pending-restart sets.
+		recordCtx, cancel := context.WithTimeout(ctx, servingParameterRecordTimeout)
+		err := h.recorder.RecordServingParameters(recordCtx)
+		cancel()
+		if err != nil {
 			slog.Warn("rds-agent: recording the serving parameters failed", "err", err)
-		} else {
-			h.serving = true
 		}
 	}
 

--- a/cmd/rds-agent/heartbeat_test.go
+++ b/cmd/rds-agent/heartbeat_test.go
@@ -35,7 +35,7 @@ func TestHeartbeater_FirstServingProbeSeedsLastKnownGood(t *testing.T) {
 	}
 }
 
-func TestHeartbeater_RecordsEachServingTransition(t *testing.T) {
+func TestHeartbeater_ChecksServingParametersOnEveryHealthyProbe(t *testing.T) {
 	code := 0
 	cfg := testProbeConfig()
 	probe := newEngineProbe(cfg, func(context.Context, string, ...string) (int, error) {
@@ -51,8 +51,8 @@ func TestHeartbeater_RecordsEachServingTransition(t *testing.T) {
 	code = 0
 	h.beat(context.Background())
 
-	if recorder.calls != 2 {
-		t.Errorf("record calls = %d, want one per serving transition", recorder.calls)
+	if recorder.calls != 3 {
+		t.Errorf("record calls = %d, want one per healthy probe", recorder.calls)
 	}
 }
 
@@ -62,7 +62,7 @@ type countingServingRecorder struct {
 
 var _ servingParameterRecorder = (*countingServingRecorder)(nil)
 
-func (r *countingServingRecorder) RecordServingParameters() error {
+func (r *countingServingRecorder) RecordServingParameters(context.Context) error {
 	r.calls++
 	return nil
 }

--- a/cmd/rds-agent/heartbeat_test.go
+++ b/cmd/rds-agent/heartbeat_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
+)
+
+// The first healthy probe is the first proof that the installed include can
+// start PostgreSQL, so it must seed recovery without an apply command.
+func TestHeartbeater_FirstServingProbeSeedsLastKnownGood(t *testing.T) {
+	runner := &recordingRunner{}
+	engine := newTestEngine(t, runner.run)
+	content := []byte("work_mem = '4096'\n")
+	if err := os.WriteFile(engine.parametersPath(), content, 0o600); err != nil {
+		t.Fatalf("write installed parameters: %v", err)
+	}
+
+	cp := newFakeControlPlane()
+	h := newHeartbeater(cp, engine.probe, engine, 0)
+	h.beat(context.Background())
+
+	lastGood, err := os.ReadFile(engine.lastGoodPath())
+	if err != nil {
+		t.Fatalf("read last known good: %v", err)
+	}
+	if string(lastGood) != string(content) {
+		t.Errorf("last known good = %q, want %q", lastGood, content)
+	}
+	states := cp.snapshotStates()
+	if len(states) != 1 || states[0].health != handlers_rds.EngineHealthHealthy {
+		t.Errorf("states = %+v, want one healthy heartbeat", states)
+	}
+}
+
+func TestHeartbeater_RecordsEachServingTransition(t *testing.T) {
+	code := 0
+	cfg := testProbeConfig()
+	probe := newEngineProbe(cfg, func(context.Context, string, ...string) (int, error) {
+		return code, nil
+	})
+	recorder := &countingServingRecorder{}
+	h := newHeartbeater(newFakeControlPlane(), probe, recorder, 0)
+
+	h.beat(context.Background())
+	h.beat(context.Background())
+	code = 2
+	h.beat(context.Background())
+	code = 0
+	h.beat(context.Background())
+
+	if recorder.calls != 2 {
+		t.Errorf("record calls = %d, want one per serving transition", recorder.calls)
+	}
+}
+
+type countingServingRecorder struct {
+	calls int
+}
+
+var _ servingParameterRecorder = (*countingServingRecorder)(nil)
+
+func (r *countingServingRecorder) RecordServingParameters() error {
+	r.calls++
+	return nil
+}

--- a/cmd/rds-agent/paramrecovery.go
+++ b/cmd/rds-agent/paramrecovery.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
 )
 
 // How long the engine is given to come up after a boot before the installed
@@ -29,12 +31,14 @@ const parameterRollbackPoll = 10 * time.Second
 type paramGuard struct {
 	engine parameterRecovery
 	probe  *engineProbe
+	cp     controlPlane
+	id     identity
 	after  time.Duration
 	poll   time.Duration
 }
 
-func newParamGuard(engine parameterRecovery, probe *engineProbe) *paramGuard {
-	return &paramGuard{engine: engine, probe: probe, after: parameterRollbackAfter, poll: parameterRollbackPoll}
+func newParamGuard(engine parameterRecovery, probe *engineProbe, cp controlPlane) *paramGuard {
+	return &paramGuard{engine: engine, probe: probe, cp: cp, after: parameterRollbackAfter, poll: parameterRollbackPoll}
 }
 
 // Runs once per agent lifetime: a rollback that did not bring the engine back
@@ -51,14 +55,17 @@ func (g *paramGuard) Run(ctx context.Context) {
 		return
 	}
 	if !restored {
-		// The engine is already running the set it last accepted, so whatever is
-		// keeping it down is not the parameters.
-		slog.Warn("rds-agent: engine is down but its parameters are the last accepted set; not rolling back")
+		slog.Warn("rds-agent: engine is down but no different last accepted parameter set is available; not rolling back")
 		return
 	}
 
-	slog.Error("rds-agent: engine did not start after a parameter change; rolled back to the last accepted set",
-		"after", g.after)
+	message := handlers_rds.ParameterRollbackMessage
+	slog.Error("rds-agent: "+message, "after", g.after)
+	if g.cp != nil {
+		if _, err := g.cp.SubmitState(ctx, g.id, handlers_rds.EngineHealthUnhealthy, message); err != nil {
+			slog.Error("rds-agent: reporting the parameter rollback failed", "err", err)
+		}
+	}
 	if err := g.engine.Restart(ctx); err != nil {
 		slog.Error("rds-agent: restart after the parameter rollback failed", "err", err)
 	}

--- a/cmd/rds-agent/paramrecovery.go
+++ b/cmd/rds-agent/paramrecovery.go
@@ -49,7 +49,7 @@ func (g *paramGuard) Run(ctx context.Context) {
 		return
 	}
 
-	restored, err := g.engine.RestoreLastKnownGoodParameters()
+	restored, err := g.engine.RestoreLastKnownGoodParameters(ctx)
 	if err != nil {
 		slog.Error("rds-agent: could not restore the last known good parameters", "err", err)
 		return

--- a/cmd/rds-agent/paramrecovery_test.go
+++ b/cmd/rds-agent/paramrecovery_test.go
@@ -74,6 +74,133 @@ func TestPostgresEngine_ApplyParametersWithdrawsTheFirstRejectedSet(t *testing.T
 	}
 }
 
+type pendingAfterReloadRunner struct {
+	recordingRunner
+
+	pendingReads int
+}
+
+func (r *pendingAfterReloadRunner) run(ctx context.Context, c command) (string, error) {
+	if strings.Contains(c.Stdin, "pending_restart") {
+		r.pendingReads++
+		if r.pendingReads > 1 {
+			r.calls = append(r.calls, c)
+			return "shared_buffers\n", nil
+		}
+	}
+	return r.recordingRunner.run(ctx, c)
+}
+
+// A command can beat the first heartbeat. The apply must preserve the file the
+// current postmaster started with before installing a static replacement.
+func TestPostgresEngine_ApplyBeforeFirstHeartbeatSeedsLastKnownGood(t *testing.T) {
+	runner := &pendingAfterReloadRunner{}
+	engine := newTestEngine(t, runner.run)
+	first := []byte("shared_buffers = '32768'\n")
+	if err := os.WriteFile(engine.parametersPath(), first, 0o600); err != nil {
+		t.Fatalf("write serving parameter set: %v", err)
+	}
+
+	pending, err := engine.ApplyParameters(t.Context(), []handlers_rds.Parameter{{Name: "shared_buffers", Value: "65536"}})
+	if err != nil {
+		t.Fatalf("ApplyParameters: %v", err)
+	}
+	if !slices.Equal(pending, []string{"shared_buffers"}) {
+		t.Errorf("pending = %v, want shared_buffers", pending)
+	}
+	lastGood, err := os.ReadFile(engine.lastGoodPath())
+	if err != nil {
+		t.Fatalf("read last known good: %v", err)
+	}
+	if !slices.Equal(lastGood, first) {
+		t.Errorf("last known good = %q, want the pre-apply set %q", lastGood, first)
+	}
+}
+
+type blockingParameterRunner struct {
+	recordingRunner
+
+	checkStarted  chan struct{}
+	continueCheck chan struct{}
+	pendingReads  int
+}
+
+func (r *blockingParameterRunner) run(ctx context.Context, c command) (string, error) {
+	if slices.Contains(c.Args, "-C") {
+		r.calls = append(r.calls, c)
+		close(r.checkStarted)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-r.continueCheck:
+			return "", nil
+		}
+	}
+	if strings.Contains(c.Stdin, "pending_restart") {
+		r.pendingReads++
+		if r.pendingReads > 1 {
+			r.calls = append(r.calls, c)
+			return "shared_buffers\n", nil
+		}
+	}
+	return r.recordingRunner.run(ctx, c)
+}
+
+func TestPostgresEngine_ServingSnapshotWaitsForParameterApply(t *testing.T) {
+	runner := &blockingParameterRunner{
+		checkStarted:  make(chan struct{}),
+		continueCheck: make(chan struct{}),
+	}
+	engine := newTestEngine(t, runner.run)
+	first := []byte("shared_buffers = '32768'\n")
+	if err := os.WriteFile(engine.parametersPath(), first, 0o600); err != nil {
+		t.Fatalf("write serving parameter set: %v", err)
+	}
+	if err := os.WriteFile(engine.lastGoodPath(), first, 0o600); err != nil {
+		t.Fatalf("write last known good: %v", err)
+	}
+
+	applyDone := make(chan error, 1)
+	go func() {
+		_, err := engine.ApplyParameters(t.Context(), []handlers_rds.Parameter{{Name: "shared_buffers", Value: "65536"}})
+		applyDone <- err
+	}()
+	<-runner.checkStarted
+
+	recordDone := make(chan error, 1)
+	go func() {
+		recordDone <- engine.RecordServingParameters(t.Context())
+	}()
+	var earlyRecordErr error
+	recordedEarly := false
+	select {
+	case earlyRecordErr = <-recordDone:
+		recordedEarly = true
+	case <-time.After(10 * time.Millisecond):
+	}
+	close(runner.continueCheck)
+	if err := <-applyDone; err != nil {
+		t.Fatalf("ApplyParameters: %v", err)
+	}
+	if !recordedEarly {
+		earlyRecordErr = <-recordDone
+	}
+	if earlyRecordErr != nil {
+		t.Fatalf("RecordServingParameters: %v", earlyRecordErr)
+	}
+	if recordedEarly {
+		t.Error("serving snapshot completed while the parameter apply held its transaction")
+	}
+
+	lastGood, err := os.ReadFile(engine.lastGoodPath())
+	if err != nil {
+		t.Fatalf("read last known good: %v", err)
+	}
+	if !slices.Equal(lastGood, first) {
+		t.Errorf("last known good = %q, want the set served before the apply %q", lastGood, first)
+	}
+}
+
 // The rollback target moves only when a restart proves the installed static
 // values can serve, not when ApplyParameters merely reloads them.
 func TestPostgresEngine_LastKnownGoodTracksTheServingSet(t *testing.T) {
@@ -99,7 +226,7 @@ func TestPostgresEngine_LastKnownGoodTracksTheServingSet(t *testing.T) {
 	}
 
 	apply("4096")
-	if err := engine.RecordServingParameters(); err != nil {
+	if err := engine.RecordServingParameters(t.Context()); err != nil {
 		t.Fatalf("RecordServingParameters: %v", err)
 	}
 	apply("8192")
@@ -107,7 +234,7 @@ func TestPostgresEngine_LastKnownGoodTracksTheServingSet(t *testing.T) {
 
 	// Simulate the restart that adopts 8192, then another apply before the next
 	// restart. The target remains the set the postmaster actually started with.
-	if err := engine.RecordServingParameters(); err != nil {
+	if err := engine.RecordServingParameters(t.Context()); err != nil {
 		t.Fatalf("RecordServingParameters after restart: %v", err)
 	}
 	apply("16384")
@@ -118,12 +245,54 @@ func TestPostgresEngine_LastKnownGoodTracksTheServingSet(t *testing.T) {
 	}
 }
 
+func TestPostgresEngine_RecordServingParametersSkipsPendingRestart(t *testing.T) {
+	runner := &recordingRunner{}
+	engine := newTestEngine(t, runner.run)
+	first := []byte("shared_buffers = '32768'\n")
+	if err := os.WriteFile(engine.parametersPath(), first, 0o600); err != nil {
+		t.Fatalf("write first parameter set: %v", err)
+	}
+	if err := engine.RecordServingParameters(t.Context()); err != nil {
+		t.Fatalf("record first parameter set: %v", err)
+	}
+
+	second := []byte("shared_buffers = '65536'\n")
+	if err := os.WriteFile(engine.parametersPath(), second, 0o600); err != nil {
+		t.Fatalf("write pending parameter set: %v", err)
+	}
+	runner.out = "shared_buffers\n"
+	if err := engine.RecordServingParameters(t.Context()); err != nil {
+		t.Fatalf("record with a pending restart: %v", err)
+	}
+	lastGood, err := os.ReadFile(engine.lastGoodPath())
+	if err != nil {
+		t.Fatalf("read last known good: %v", err)
+	}
+	if !slices.Equal(lastGood, first) {
+		t.Errorf("last known good = %q, want the previously served set %q", lastGood, first)
+	}
+
+	// Once a restart has adopted the installed set, pending_restart clears and
+	// the same healthy-heartbeat path may advance the rollback target.
+	runner.out = ""
+	if err := engine.RecordServingParameters(t.Context()); err != nil {
+		t.Fatalf("record the restarted parameter set: %v", err)
+	}
+	lastGood, err = os.ReadFile(engine.lastGoodPath())
+	if err != nil {
+		t.Fatalf("read advanced last known good: %v", err)
+	}
+	if !slices.Equal(lastGood, second) {
+		t.Errorf("last known good = %q, want the restarted set %q", lastGood, second)
+	}
+}
+
 func TestPostgresEngine_RestoreLastKnownGoodParameters(t *testing.T) {
 	runner := &recordingRunner{}
 	engine := newTestEngine(t, runner.run)
 
 	// Nothing to restore before anything has ever been applied.
-	restored, err := engine.RestoreLastKnownGoodParameters()
+	restored, err := engine.RestoreLastKnownGoodParameters(t.Context())
 	if err != nil {
 		t.Fatalf("RestoreLastKnownGoodParameters: %v", err)
 	}
@@ -135,7 +304,7 @@ func TestPostgresEngine_RestoreLastKnownGoodParameters(t *testing.T) {
 		[]handlers_rds.Parameter{{Name: "work_mem", Value: "4096"}}); err != nil {
 		t.Fatalf("ApplyParameters(4096): %v", err)
 	}
-	if err := engine.RecordServingParameters(); err != nil {
+	if err := engine.RecordServingParameters(t.Context()); err != nil {
 		t.Fatalf("RecordServingParameters: %v", err)
 	}
 	if _, err := engine.ApplyParameters(context.Background(),
@@ -143,7 +312,18 @@ func TestPostgresEngine_RestoreLastKnownGoodParameters(t *testing.T) {
 		t.Fatalf("ApplyParameters(8192): %v", err)
 	}
 
-	restored, err = engine.RestoreLastKnownGoodParameters()
+	// A guard whose deadline expired while an apply restarted the engine must
+	// recheck health under the parameter lock rather than reverse that repair.
+	restored, err = engine.RestoreLastKnownGoodParameters(t.Context())
+	if err != nil {
+		t.Fatalf("RestoreLastKnownGoodParameters against serving engine: %v", err)
+	}
+	if restored {
+		t.Fatal("restored the old set while the engine was serving")
+	}
+
+	engine.probe = stubProbe(t, 2, nil)
+	restored, err = engine.RestoreLastKnownGoodParameters(t.Context())
 	if err != nil {
 		t.Fatalf("RestoreLastKnownGoodParameters: %v", err)
 	}
@@ -160,7 +340,7 @@ func TestPostgresEngine_RestoreLastKnownGoodParameters(t *testing.T) {
 
 	// Idempotent: the second call finds them already equal and does nothing, so a
 	// repeated rollback cannot churn a cluster that is failing for another reason.
-	restored, err = engine.RestoreLastKnownGoodParameters()
+	restored, err = engine.RestoreLastKnownGoodParameters(t.Context())
 	if err != nil {
 		t.Fatalf("RestoreLastKnownGoodParameters: %v", err)
 	}
@@ -177,7 +357,7 @@ type fakeRecovery struct {
 	restarts   int
 }
 
-func (f *fakeRecovery) RestoreLastKnownGoodParameters() (bool, error) {
+func (f *fakeRecovery) RestoreLastKnownGoodParameters(context.Context) (bool, error) {
 	return f.restored, f.restoreErr
 }
 

--- a/cmd/rds-agent/paramrecovery_test.go
+++ b/cmd/rds-agent/paramrecovery_test.go
@@ -74,29 +74,45 @@ func TestPostgresEngine_ApplyParametersWithdrawsTheFirstRejectedSet(t *testing.T
 	}
 }
 
-// The rollback target has to be a set the engine actually adopted, so a second
-// accepted apply leaves the first one as what a failed restart falls back to.
-func TestPostgresEngine_LastKnownGoodTracksTheAcceptedSet(t *testing.T) {
+// The rollback target moves only when a restart proves the installed static
+// values can serve, not when ApplyParameters merely reloads them.
+func TestPostgresEngine_LastKnownGoodTracksTheServingSet(t *testing.T) {
 	runner := &recordingRunner{}
 	engine := newTestEngine(t, runner.run)
 
-	for _, value := range []string{"4096", "8192"} {
+	apply := func(value string) {
+		t.Helper()
 		if _, err := engine.ApplyParameters(context.Background(),
 			[]handlers_rds.Parameter{{Name: "work_mem", Value: value}}); err != nil {
 			t.Fatalf("ApplyParameters(%s): %v", value, err)
 		}
 	}
-
-	lastGood, err := os.ReadFile(engine.lastGoodPath())
-	if err != nil {
-		t.Fatalf("read the last known good parameters: %v", err)
+	assertLastGood := func(value string) {
+		t.Helper()
+		lastGood, err := os.ReadFile(engine.lastGoodPath())
+		if err != nil {
+			t.Fatalf("read the last known good parameters: %v", err)
+		}
+		if !strings.Contains(string(lastGood), "work_mem = '"+value+"'") {
+			t.Errorf("last known good = %q, want work_mem %s", lastGood, value)
+		}
 	}
-	if !strings.Contains(string(lastGood), "work_mem = '4096'") {
-		t.Errorf("last known good = %q, want the set the engine ran before the latest apply", lastGood)
-	}
 
-	// include_dir globs *.conf, so the rollback copy must not read as a second
-	// set of settings alongside the live one.
+	apply("4096")
+	if err := engine.RecordServingParameters(); err != nil {
+		t.Fatalf("RecordServingParameters: %v", err)
+	}
+	apply("8192")
+	assertLastGood("4096")
+
+	// Simulate the restart that adopts 8192, then another apply before the next
+	// restart. The target remains the set the postmaster actually started with.
+	if err := engine.RecordServingParameters(); err != nil {
+		t.Fatalf("RecordServingParameters after restart: %v", err)
+	}
+	apply("16384")
+	assertLastGood("8192")
+
 	if strings.HasSuffix(engine.lastGoodPath(), ".conf") {
 		t.Errorf("the rollback copy at %s would be included by the engine", engine.lastGoodPath())
 	}
@@ -115,11 +131,16 @@ func TestPostgresEngine_RestoreLastKnownGoodParameters(t *testing.T) {
 		t.Error("restored a set with no last known good on disk")
 	}
 
-	for _, value := range []string{"4096", "8192"} {
-		if _, err := engine.ApplyParameters(context.Background(),
-			[]handlers_rds.Parameter{{Name: "work_mem", Value: value}}); err != nil {
-			t.Fatalf("ApplyParameters(%s): %v", value, err)
-		}
+	if _, err := engine.ApplyParameters(context.Background(),
+		[]handlers_rds.Parameter{{Name: "work_mem", Value: "4096"}}); err != nil {
+		t.Fatalf("ApplyParameters(4096): %v", err)
+	}
+	if err := engine.RecordServingParameters(); err != nil {
+		t.Fatalf("RecordServingParameters: %v", err)
+	}
+	if _, err := engine.ApplyParameters(context.Background(),
+		[]handlers_rds.Parameter{{Name: "work_mem", Value: "8192"}}); err != nil {
+		t.Fatalf("ApplyParameters(8192): %v", err)
 	}
 
 	restored, err = engine.RestoreLastKnownGoodParameters()
@@ -175,7 +196,7 @@ func stubProbe(t *testing.T, code int, err error) *engineProbe {
 }
 
 func newTestGuard(engine parameterRecovery, probe *engineProbe) *paramGuard {
-	g := newParamGuard(engine, probe)
+	g := newParamGuard(engine, probe, nil)
 	// Real budgets are minutes, which is the point of them; the behaviour under
 	// test is the decision, not the wait.
 	g.after, g.poll = 20*time.Millisecond, time.Millisecond
@@ -184,12 +205,23 @@ func newTestGuard(engine parameterRecovery, probe *engineProbe) *paramGuard {
 
 // pg_isready exit 2 is an engine that is not there at all, which after a
 // parameter change is the boot-loop shape this breaks.
-func TestParamGuard_RollsBackAndRestartsWhenTheEngineNeverComesUp(t *testing.T) {
+func TestParamGuard_RollsBackReportsAndRestartsWhenTheEngineNeverComesUp(t *testing.T) {
 	engine := &fakeRecovery{restored: true}
-	newTestGuard(engine, stubProbe(t, 2, nil)).Run(t.Context())
+	cp := newFakeControlPlane()
+	guard := newParamGuard(engine, stubProbe(t, 2, nil), cp)
+	guard.id = identity{DBInstanceIdentifier: "db-1"}
+	guard.after, guard.poll = 20*time.Millisecond, time.Millisecond
+	guard.Run(t.Context())
 
 	if engine.restarts != 1 {
 		t.Errorf("restarts = %d, want the engine restarted on the rolled-back set", engine.restarts)
+	}
+	states := cp.snapshotStates()
+	if len(states) != 1 {
+		t.Fatalf("submitted states = %d, want the rollback report", len(states))
+	}
+	if states[0].health != handlers_rds.EngineHealthUnhealthy || states[0].message != handlers_rds.ParameterRollbackMessage {
+		t.Errorf("rollback state = %+v, want the unhealthy rollback report", states[0])
 	}
 }
 

--- a/spinifex/handlers/rds/agent.go
+++ b/spinifex/handlers/rds/agent.go
@@ -103,6 +103,11 @@ type CommandReply struct {
 const (
 	CommandStatusSucceeded = "succeeded"
 	CommandStatusFailed    = "failed"
+
+	// ParameterRollbackMessage is sent before the guest restarts on the last
+	// serving parameter set. The control plane keeps the group out of in-sync
+	// until a later apply succeeds.
+	ParameterRollbackMessage = "engine did not start after a parameter change; rolled back to the last accepted set"
 )
 
 // Idempotent: re-registering is the normal case after an agent restart and
@@ -164,7 +169,8 @@ func (s *Service) SubmitDBStateChange(ctx context.Context, input *SubmitDBStateC
 			"unknown engine health %q", input.EngineHealth)
 	}
 
-	beat, persist := s.noteBeat(accountID, input.DBInstanceIdentifier, input.EngineHealth, input.Message, false)
+	parameterRollback := input.Message == ParameterRollbackMessage
+	beat, persist := s.noteBeat(accountID, input.DBInstanceIdentifier, input.EngineHealth, input.Message, parameterRollback)
 	out := &SubmitDBStateChangeOutput{
 		Acknowledged:             true,
 		HeartbeatIntervalSeconds: int64(HeartbeatInterval.Seconds()),
@@ -192,6 +198,10 @@ func (s *Service) SubmitDBStateChange(ctx context.Context, input *SubmitDBStateC
 	rec.Agent.InstanceID = input.InstanceID
 	rec.Agent.EngineHealth = input.EngineHealth
 	rec.Agent.Message = input.Message
+	newParameterRollback := parameterRollback && !rec.ParametersRolledBack
+	if parameterRollback {
+		rec.ParametersRolledBack = true
+	}
 	if input.EngineVersion != "" {
 		rec.Agent.EngineVersion = input.EngineVersion
 	}
@@ -205,6 +215,11 @@ func (s *Service) SubmitDBStateChange(ctx context.Context, input *SubmitDBStateC
 		return nil, err
 	}
 	out.Persisted = true
+	if newParameterRollback {
+		s.RecordEvent(ctx, accountID, EventSourceTypeDBInstance, rec.DBInstanceIdentifier,
+			"The database engine rejected its pending parameters and restarted on the last accepted set.",
+			EventCategoryConfigurationChange, EventCategoryFailure)
+	}
 	return out, nil
 }
 

--- a/spinifex/handlers/rds/agent_test.go
+++ b/spinifex/handlers/rds/agent_test.go
@@ -496,6 +496,38 @@ func TestSubmitDBStateChange_PersistsOnChangeAndOnFloor(t *testing.T) {
 	assert.NotNil(t, rec.Agent.LastSeen)
 }
 
+func TestSubmitDBStateChange_RecordsParameterRollback(t *testing.T) {
+	svc := newTestService(t)
+	rec := defaultRecord()
+	rec.DBParameterGroupName = "customer-params"
+	seedInstance(t, svc, rec)
+
+	out, err := svc.SubmitDBStateChange(t.Context(), &SubmitDBStateChangeInput{
+		DBInstanceIdentifier: testDBID,
+		InstanceID:           testInstance,
+		EngineHealth:         EngineHealthUnhealthy,
+		Message:              ParameterRollbackMessage,
+	}, testAccountID)
+	require.NoError(t, err)
+	assert.True(t, out.Persisted)
+
+	stored, _ := readRecord(t, svc)
+	assert.True(t, stored.ParametersRolledBack)
+	groups := projectParameterGroup(&stored)
+	require.Len(t, groups, 1)
+	assert.Equal(t, parameterApplyStatusFailed, *groups[0].ParameterApplyStatus)
+
+	kv, err := svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	var ring eventRing
+	found, err := getJSON(t.Context(), kv, EventRingKey(EventSourceTypeDBInstance, testDBID), &ring)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Len(t, ring.Events, 1)
+	assert.Contains(t, ring.Events[0].Categories, EventCategoryConfigurationChange)
+	assert.Contains(t, ring.Events[0].Categories, EventCategoryFailure)
+}
+
 // In-memory liveness is fresher than the record between persists, which is what
 // lets the reconciler judge staleness without reading KV every tick.
 func TestSubmitDBStateChange_LastSeenTracksUnpersistedBeats(t *testing.T) {

--- a/spinifex/handlers/rds/agent_test.go
+++ b/spinifex/handlers/rds/agent_test.go
@@ -515,7 +515,7 @@ func TestSubmitDBStateChange_RecordsParameterRollback(t *testing.T) {
 	assert.True(t, stored.ParametersRolledBack)
 	groups := projectParameterGroup(&stored)
 	require.Len(t, groups, 1)
-	assert.Equal(t, parameterApplyStatusFailed, *groups[0].ParameterApplyStatus)
+	assert.Equal(t, "failed-to-apply", *groups[0].ParameterApplyStatus)
 
 	kv, err := svc.bucket(t.Context(), testAccountID)
 	require.NoError(t, err)

--- a/spinifex/handlers/rds/commands.go
+++ b/spinifex/handlers/rds/commands.go
@@ -49,7 +49,7 @@ const (
 // which is bounded by the dirty set rather than by anything the caller knows.
 const (
 	setPasswordTimeout = 30 * time.Second
-	applyParamsTimeout = 60 * time.Second
+	applyParamsTimeout = 120 * time.Second
 	stopEngineTimeout  = 120 * time.Second
 	// growpart plus an online resize2fs/xfs_growfs. Both scale with the
 	// filesystem's metadata rather than with the volume, so this is generous

--- a/spinifex/handlers/rds/describe.go
+++ b/spinifex/handlers/rds/describe.go
@@ -241,8 +241,6 @@ func projectPendingModifiedValues(pending *PendingModifiedValues) *rds.PendingMo
 	return out
 }
 
-const parameterApplyStatusFailed = "failed-to-apply"
-
 // AWS reports a parameter group's state on the membership rather than in
 // PendingModifiedValues, and the Terraform provider reads it there: applying
 // while a modify is draining, pending-reboot while static settings await the
@@ -256,7 +254,7 @@ func projectParameterGroup(rec *DBInstanceRecord) []*rds.DBParameterGroupStatus 
 	case rec.PendingModifiedValues != nil && rec.PendingModifiedValues.DBParameterGroupName != "":
 		status = "applying"
 	case rec.ParametersRolledBack:
-		status = parameterApplyStatusFailed
+		status = "failed-to-apply"
 	case len(rec.PendingRebootParameters) > 0:
 		status = "pending-reboot"
 	}

--- a/spinifex/handlers/rds/describe.go
+++ b/spinifex/handlers/rds/describe.go
@@ -241,6 +241,8 @@ func projectPendingModifiedValues(pending *PendingModifiedValues) *rds.PendingMo
 	return out
 }
 
+const parameterApplyStatusFailed = "failed-to-apply"
+
 // AWS reports a parameter group's state on the membership rather than in
 // PendingModifiedValues, and the Terraform provider reads it there: applying
 // while a modify is draining, pending-reboot while static settings await the
@@ -253,6 +255,8 @@ func projectParameterGroup(rec *DBInstanceRecord) []*rds.DBParameterGroupStatus 
 	switch {
 	case rec.PendingModifiedValues != nil && rec.PendingModifiedValues.DBParameterGroupName != "":
 		status = "applying"
+	case rec.ParametersRolledBack:
+		status = parameterApplyStatusFailed
 	case len(rec.PendingRebootParameters) > 0:
 		status = "pending-reboot"
 	}

--- a/spinifex/handlers/rds/modify.go
+++ b/spinifex/handlers/rds/modify.go
@@ -205,17 +205,28 @@ func (s *Service) planModify(ctx context.Context, input *rds.ModifyDBInstanceInp
 		plan.InstanceClass, plan.InstanceType = class, instanceType
 	}
 
-	// Resolved against KV here rather than at apply time, so a group that does
-	// not exist is rejected before the instance is moved into modifying.
 	if group := aws.StringValue(input.DBParameterGroupName); group != "" && group != rec.DBParameterGroupName {
+		plan.ParameterGroup = group
+	}
+
+	// Resolve the complete target pair before anything is persisted. Apply-time
+	// resolution remains necessary because a deferred group's values can change.
+	if plan.InstanceClass != "" || plan.ParameterGroup != "" {
+		targetClass := rec.DBInstanceClass
+		if plan.InstanceClass != "" {
+			targetClass = plan.InstanceClass
+		}
+		targetGroup := rec.DBParameterGroupName
+		if plan.ParameterGroup != "" {
+			targetGroup = plan.ParameterGroup
+		}
 		kv, err := s.bucket(ctx, accountID)
 		if err != nil {
 			return nil, err
 		}
-		if _, _, err := getDBParameterGroup(ctx, kv, accountID, group); err != nil {
+		if _, err := s.resolveGroupParameters(ctx, kv, accountID, targetGroup, targetClass); err != nil {
 			return nil, err
 		}
-		plan.ParameterGroup = group
 	}
 
 	groups, err := s.planSecurityGroups(ctx, accountID, rec, aws.StringValueSlice(input.VpcSecurityGroupIds))

--- a/spinifex/handlers/rds/modify_test.go
+++ b/spinifex/handlers/rds/modify_test.go
@@ -111,6 +111,20 @@ func modifyInput() *rds.ModifyDBInstanceInput {
 	return &rds.ModifyDBInstanceInput{DBInstanceIdentifier: aws.String(testDBID)}
 }
 
+const largeMemoryParameterGroup = "large-memory"
+
+func createLargeMemoryParameterGroup(t *testing.T, h *modifyHarness) {
+	t.Helper()
+	_, err := h.svc.CreateDBParameterGroup(t.Context(), parameterGroupInput(largeMemoryParameterGroup), testAccountID)
+	require.NoError(t, err)
+	_, err = h.svc.ModifyDBParameterGroup(t.Context(), modifyParameters(largeMemoryParameterGroup, &rds.Parameter{
+		ParameterName:  aws.String("shared_buffers"),
+		ParameterValue: aws.String("500000"),
+		ApplyMethod:    aws.String(ApplyMethodPendingReboot),
+	}), testAccountID)
+	require.NoError(t, err)
+}
+
 // None of these interrupts service, so AWS applies them as soon as possible and
 // so does this — ApplyImmediately is not what gates them.
 func TestModifyDBInstance_AppliesTheNonDisruptiveSettingsAtOnce(t *testing.T) {
@@ -336,6 +350,66 @@ func TestModifyDBInstance_RejectsAnUnknownParameterGroup(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), awserrors.ErrorDBParameterGroupNotFound)
 	assert.Nil(t, h.record(t).PendingModifiedValues)
+}
+
+func TestModifyDBInstance_RejectsAnIncompatibleParameterGroupBeforeMutation(t *testing.T) {
+	h := newModifyHarness(t)
+	createLargeMemoryParameterGroup(t, h)
+	seedInstance(t, h.svc, modifiableRecord())
+
+	in := modifyInput()
+	in.DBParameterGroupName = aws.String(largeMemoryParameterGroup)
+	in.DeletionProtection = aws.Bool(true)
+	in.ApplyImmediately = aws.Bool(true)
+	_, err := h.svc.ModifyDBInstance(t.Context(), in, testAccountID)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+	stored := h.record(t)
+	assert.Equal(t, StatusAvailable, stored.Status)
+	assert.Equal(t, testDefaultGroup, stored.DBParameterGroupName)
+	assert.False(t, stored.DeletionProtection)
+	assert.Nil(t, stored.PendingModifiedValues)
+	assert.Empty(t, h.agent.received())
+}
+
+func TestModifyDBInstance_ValidatesClassChangeAgainstCurrentGroup(t *testing.T) {
+	h := newModifyHarness(t)
+	createLargeMemoryParameterGroup(t, h)
+	rec := modifiableRecord()
+	rec.DBInstanceClass = "db.m5.xlarge"
+	rec.DBParameterGroupName = largeMemoryParameterGroup
+	seedInstance(t, h.svc, rec)
+
+	in := modifyInput()
+	in.DBInstanceClass = aws.String("db.t3.medium")
+	in.DeletionProtection = aws.Bool(true)
+	_, err := h.svc.ModifyDBInstance(t.Context(), in, testAccountID)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), awserrors.ErrorInvalidParameterValue)
+	stored := h.record(t)
+	assert.Equal(t, StatusAvailable, stored.Status)
+	assert.Equal(t, "db.m5.xlarge", stored.DBInstanceClass)
+	assert.False(t, stored.DeletionProtection)
+	assert.Nil(t, stored.PendingModifiedValues)
+}
+
+func TestModifyDBInstance_ValidatesSimultaneousGroupAndClassAgainstTargets(t *testing.T) {
+	h := newModifyHarness(t)
+	createLargeMemoryParameterGroup(t, h)
+	seedInstance(t, h.svc, modifiableRecord())
+
+	in := modifyInput()
+	in.DBParameterGroupName = aws.String(largeMemoryParameterGroup)
+	in.DBInstanceClass = aws.String("db.m5.xlarge")
+	_, err := h.svc.ModifyDBInstance(t.Context(), in, testAccountID)
+
+	require.NoError(t, err)
+	stored := h.record(t)
+	require.NotNil(t, stored.PendingModifiedValues)
+	assert.Equal(t, largeMemoryParameterGroup, stored.PendingModifiedValues.DBParameterGroupName)
+	assert.Equal(t, "db.m5.xlarge", stored.PendingModifiedValues.DBInstanceClass)
 }
 
 // These fields are stored rather than acted on, but a value outside AWS's

--- a/spinifex/handlers/rds/paramcatalog.go
+++ b/spinifex/handlers/rds/paramcatalog.go
@@ -605,25 +605,63 @@ func validateParameterValue(name, value string) (ParameterSpec, error) {
 const maxStringParameterBytes = 1024
 
 func validateStringParameter(spec ParameterSpec, value, trimmed string) error {
-	if len(value) > maxStringParameterBytes {
+	if len(trimmed) > maxStringParameterBytes {
 		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
 			"parameter %s exceeds the maximum length of %d bytes", spec.Name, maxStringParameterBytes)
 	}
-	if strings.HasSuffix(value, `\`) {
+	if strings.HasSuffix(trimmed, `\`) {
 		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
 			"parameter %s cannot end with a backslash", spec.Name)
 	}
-	if strings.IndexFunc(value, unicode.IsControl) >= 0 {
+	if strings.IndexFunc(trimmed, unicode.IsControl) >= 0 {
 		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
 			"parameter %s cannot contain control characters", spec.Name)
 	}
-	if spec.Name == "timezone" {
+	switch spec.Name {
+	case "timezone":
+		if strings.EqualFold(trimmed, "Local") {
+			return invalidTimezone(value)
+		}
 		if _, err := time.LoadLocation(trimmed); err != nil {
+			return invalidTimezone(value)
+		}
+	case "datestyle":
+		if !validDateStyle(trimmed) {
 			return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
-				"parameter timezone does not accept %q; use an IANA time zone name such as UTC or Australia/Sydney", value)
+				"parameter datestyle does not accept %q; use one output style (ISO, SQL, Postgres, German) and one date order (MDY, DMY, YMD)", value)
 		}
 	}
 	return nil
+}
+
+func invalidTimezone(value string) error {
+	return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+		"parameter timezone does not accept %q; use an IANA time zone name such as UTC or Australia/Sydney", value)
+}
+
+func validDateStyle(value string) bool {
+	parts := strings.Split(value, ",")
+	if len(parts) == 0 || len(parts) > 2 {
+		return false
+	}
+	seenStyle, seenOrder := false, false
+	for _, part := range parts {
+		switch strings.ToLower(strings.TrimSpace(part)) {
+		case "iso", "sql", "postgres", "german":
+			if seenStyle {
+				return false
+			}
+			seenStyle = true
+		case "mdy", "dmy", "ymd":
+			if seenOrder {
+				return false
+			}
+			seenOrder = true
+		default:
+			return false
+		}
+	}
+	return seenStyle || seenOrder
 }
 
 // PostgreSQL's own boolean spellings, so a config a customer copied from the

--- a/spinifex/handlers/rds/paramcatalog.go
+++ b/spinifex/handlers/rds/paramcatalog.go
@@ -7,6 +7,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
+	_ "time/tzdata"
+	"unicode"
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/instancetypes"
@@ -64,6 +67,9 @@ type ParameterSpec struct {
 	// Evaluated against the class's memory. The result is a literal, so the
 	// customer-facing API never sees a formula.
 	DefaultFor func(memoryMiB int64) string
+	// The generous class-specific ceiling for a size-derived parameter. It
+	// prevents a large-class literal from making a smaller guest unbootable.
+	MaxFor func(memoryMiB int64) int64
 
 	// Inclusive bounds for integer and real parameters. Both zero means
 	// unbounded below and above.
@@ -87,6 +93,7 @@ var parameterCatalog = buildParameterCatalog(
 		Name: "max_connections", DataType: paramTypeInteger, ApplyType: ApplyTypeStatic,
 		IsModifiable: true, Min: 6, Max: 5000,
 		DefaultFor:  maxConnectionsFor,
+		MaxFor:      maxConnectionsCeilingFor,
 		Description: "Maximum number of concurrent connections to the database server.",
 	},
 	ParameterSpec{
@@ -121,12 +128,14 @@ var parameterCatalog = buildParameterCatalog(
 		Name: "shared_buffers", DataType: paramTypeInteger, ApplyType: ApplyTypeStatic,
 		IsModifiable: true, Min: 16, Max: 4194304, Unit: "8kB",
 		DefaultFor:  sharedBuffersFor,
+		MaxFor:      sharedBuffersCeilingFor,
 		Description: "Shared memory buffers the server uses, in 8 kB blocks.",
 	},
 	ParameterSpec{
 		Name: "effective_cache_size", DataType: paramTypeInteger, ApplyType: ApplyTypeDynamic,
 		IsModifiable: true, Min: 1, Max: 4194304, Unit: "8kB",
 		DefaultFor:  effectiveCacheSizeFor,
+		MaxFor:      effectiveCacheSizeCeilingFor,
 		Description: "Planner assumption about the disk cache available to one query, in 8 kB blocks.",
 	},
 	// Per sort or hash rather than per connection, so RDS leaves it a literal
@@ -141,6 +150,7 @@ var parameterCatalog = buildParameterCatalog(
 		Name: "maintenance_work_mem", DataType: paramTypeInteger, ApplyType: ApplyTypeDynamic,
 		IsModifiable: true, Min: 1024, Max: 2147483647, Unit: "kB",
 		DefaultFor:  maintenanceWorkMemFor,
+		MaxFor:      maintenanceWorkMemCeilingFor,
 		Description: "Memory a VACUUM, CREATE INDEX or ALTER TABLE ADD FOREIGN KEY may use, in kB.",
 	},
 	ParameterSpec{
@@ -183,19 +193,23 @@ var parameterCatalog = buildParameterCatalog(
 		IsModifiable: true, Enum: []string{"off", "local", "remote_write", "on", "remote_apply"}, Default: "on",
 		Description: "How much WAL processing must complete before a commit returns.",
 	},
+	// Alpine's PostgreSQL 18 package is built with both optional compression
+	// libraries, so every engine method is safe to expose.
 	ParameterSpec{
 		Name: "wal_compression", DataType: paramTypeEnum, ApplyType: ApplyTypeDynamic,
 		IsModifiable: true, Enum: []string{"off", "pglz", "lz4", "zstd", "on"}, Default: "off",
 		Description: "Compression method for full-page images written to the WAL.",
 	},
+	// The image uses PostgreSQL's 16 MiB WAL segments; both size settings must
+	// hold at least two segments or startup rejects the configuration.
 	ParameterSpec{
 		Name: "max_wal_size", DataType: paramTypeInteger, ApplyType: ApplyTypeDynamic,
-		IsModifiable: true, Min: 2, Max: 2097151, Default: "1024", Unit: "MB",
+		IsModifiable: true, Min: 32, Max: 2097151, Default: "1024", Unit: "MB",
 		Description: "WAL size that triggers a checkpoint, in MB.",
 	},
 	ParameterSpec{
 		Name: "min_wal_size", DataType: paramTypeInteger, ApplyType: ApplyTypeDynamic,
-		IsModifiable: true, Min: 2, Max: 2097151, Default: "80", Unit: "MB",
+		IsModifiable: true, Min: 32, Max: 2097151, Default: "80", Unit: "MB",
 		Description: "WAL size below which old segments are recycled rather than removed, in MB.",
 	},
 	ParameterSpec{
@@ -231,8 +245,10 @@ var parameterCatalog = buildParameterCatalog(
 		IsModifiable: true, Default: "on",
 		Description: "Whether the autovacuum launcher runs.",
 	},
+	// PostgreSQL 18 moved this setting to SIGHUP; worker slot allocation is now
+	// controlled separately by the postmaster-only autovacuum_worker_slots.
 	ParameterSpec{
-		Name: "autovacuum_max_workers", DataType: paramTypeInteger, ApplyType: ApplyTypeStatic,
+		Name: "autovacuum_max_workers", DataType: paramTypeInteger, ApplyType: ApplyTypeDynamic,
 		IsModifiable: true, Min: 1, Max: 262143, Default: "3",
 		Description: "Maximum autovacuum worker processes running at once.",
 	},
@@ -402,6 +418,26 @@ func maintenanceWorkMemFor(memoryMiB int64) string {
 	return strconv.FormatInt(clampInt64(memoryMiB*mibToBytes/63963136*1024, 16384, 2097152), 10)
 }
 
+// Class ceilings deliberately leave substantial headroom above the defaults.
+// They prevent obviously impossible large-class literals without prescribing
+// production tuning for values the guest can support.
+func sharedBuffersCeilingFor(memoryMiB int64) int64 {
+	return clampInt64(memoryMiB*1024/8*3/4, 16, 4194304)
+}
+
+func effectiveCacheSizeCeilingFor(memoryMiB int64) int64 {
+	return clampInt64(memoryMiB*1024/8, 1, 4194304)
+}
+
+func maxConnectionsCeilingFor(memoryMiB int64) int64 {
+	defaults := clampInt64(memoryMiB*mibToBytes/9531392, 20, 5000)
+	return clampInt64(defaults*4, 20, 5000)
+}
+
+func maintenanceWorkMemCeilingFor(memoryMiB int64) int64 {
+	return clampInt64(memoryMiB*1024/2, 16384, 2147483647)
+}
+
 func clampInt64(v, lo, hi int64) int64 {
 	return min(max(v, lo), hi)
 }
@@ -418,6 +454,8 @@ func buildParameterCatalog(specs ...ParameterSpec) map[string]ParameterSpec {
 			panic("rds: parameter catalog entry " + spec.Name + " has no default")
 		case spec.Default != "" && spec.DefaultFor != nil:
 			panic("rds: parameter catalog entry " + spec.Name + " has both a literal and a computed default")
+		case (spec.DefaultFor == nil) != (spec.MaxFor == nil):
+			panic("rds: parameter catalog entry " + spec.Name + " must pair its computed default and class ceiling")
 		}
 		if _, exists := out[spec.Name]; exists {
 			panic("rds: parameter catalog entry " + spec.Name + " is duplicated")
@@ -556,8 +594,36 @@ func validateParameterValue(name, value string) (ParameterSpec, error) {
 			return ParameterSpec{}, awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
 				"parameter %s does not accept %q; allowed values are %s", spec.Name, value, strings.Join(spec.Enum, ", "))
 		}
+	case paramTypeString:
+		if err := validateStringParameter(spec, value, trimmed); err != nil {
+			return ParameterSpec{}, err
+		}
 	}
 	return spec, nil
+}
+
+const maxStringParameterBytes = 1024
+
+func validateStringParameter(spec ParameterSpec, value, trimmed string) error {
+	if len(value) > maxStringParameterBytes {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"parameter %s exceeds the maximum length of %d bytes", spec.Name, maxStringParameterBytes)
+	}
+	if strings.HasSuffix(value, `\`) {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"parameter %s cannot end with a backslash", spec.Name)
+	}
+	if strings.IndexFunc(value, unicode.IsControl) >= 0 {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"parameter %s cannot contain control characters", spec.Name)
+	}
+	if spec.Name == "timezone" {
+		if _, err := time.LoadLocation(trimmed); err != nil {
+			return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+				"parameter timezone does not accept %q; use an IANA time zone name such as UTC or Australia/Sydney", value)
+		}
+	}
+	return nil
 }
 
 // PostgreSQL's own boolean spellings, so a config a customer copied from the
@@ -602,9 +668,93 @@ func ResolveEffectiveParameters(instanceClass string, overrides map[string]strin
 			if _, err := validateParameterValue(name, override); err != nil {
 				return nil, err
 			}
+			if err := validateClassParameterValue(instanceClass, memoryMiB, spec, override); err != nil {
+				return nil, err
+			}
 			value = override
 		}
 		resolved = append(resolved, Parameter{Name: name, Value: value})
 	}
+	if err := validateParameterCombinations(resolved); err != nil {
+		return nil, err
+	}
 	return resolved, nil
+}
+
+func validateClassParameterValue(instanceClass string, memoryMiB int64, spec ParameterSpec, value string) error {
+	if spec.MaxFor == nil {
+		return nil
+	}
+	requested, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil {
+		return typeError(spec, value, "an integer")
+	}
+	ceiling := spec.MaxFor(memoryMiB)
+	if requested > ceiling {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"the value %q of parameter %s is too large for DB instance class %s; the class ceiling is %d",
+			value, spec.Name, instanceClass, ceiling)
+	}
+	return nil
+}
+
+func validateParameterCombinations(params []Parameter) error {
+	values := make(map[string]string, len(params))
+	for _, param := range params {
+		values[param.Name] = strings.ToLower(strings.TrimSpace(param.Value))
+	}
+
+	maxWALSenders, err := resolvedInteger(values, "max_wal_senders")
+	if err != nil {
+		return err
+	}
+	maxReplicationSlots, err := resolvedInteger(values, "max_replication_slots")
+	if err != nil {
+		return err
+	}
+	if values["wal_level"] == "minimal" && (maxWALSenders != 0 || maxReplicationSlots != 0) {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"wal_level minimal requires max_wal_senders and max_replication_slots both to be 0")
+	}
+	maxConnections, err := resolvedInteger(values, "max_connections")
+	if err != nil {
+		return err
+	}
+	reservedConnections, err := resolvedInteger(values, "superuser_reserved_connections")
+	if err != nil {
+		return err
+	}
+	if reservedConnections >= maxConnections {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"superuser_reserved_connections must be less than max_connections")
+	}
+	maxWorkerProcesses, err := resolvedInteger(values, "max_worker_processes")
+	if err != nil {
+		return err
+	}
+	const (
+		postgres18MaxBackends           = 262143
+		postgres18AutovacuumWorkerSlots = 16
+		postgres18SpecialWorkerProcs    = 2
+	)
+	backends := maxConnections + postgres18AutovacuumWorkerSlots + maxWorkerProcesses + maxWALSenders + postgres18SpecialWorkerProcs
+	if backends > postgres18MaxBackends {
+		return awserrors.Errorf(awserrors.ErrorInvalidParameterValue,
+			"max_connections, max_worker_processes and max_wal_senders reserve too many server processes")
+	}
+	return nil
+}
+
+func resolvedInteger(values map[string]string, name string) (int64, error) {
+	value, ok := values[name]
+	if !ok {
+		return 0, awserrors.Errorf(awserrors.ErrorServerInternal,
+			"resolved parameter set is missing %s", name)
+	}
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, awserrors.Errorf(awserrors.ErrorServerInternal,
+			"resolved parameter %s has invalid integer value %q", name, value)
+	}
+	return n, nil
 }

--- a/spinifex/handlers/rds/paramcatalog_test.go
+++ b/spinifex/handlers/rds/paramcatalog_test.go
@@ -94,11 +94,16 @@ func TestValidateParameterValue_RejectsBadInput(t *testing.T) {
 		{"NotAnInteger", "max_connections", "many", "takes an integer"},
 		{"BelowRange", "max_connections", "1", "outside its allowed range"},
 		{"AboveRange", "max_connections", "500000", "outside its allowed range"},
+		{"WALBelowTwoSegments", "min_wal_size", "16", "outside its allowed range"},
 		{"NotAReal", "checkpoint_completion_target", "high", "takes a number"},
 		{"RealOutOfRange", "checkpoint_completion_target", "2", "outside its allowed range"},
 		{"NotABoolean", "autovacuum", "maybe", "takes a boolean"},
 		{"NotInEnum", "log_statement", "everything", "does not accept"},
 		{"Empty", "work_mem", "", "empty value"},
+		{"StringControlCharacter", "timezone", "UTC\nwork_mem", "control characters"},
+		{"StringTrailingBackslash", "datestyle", `ISO\`, "end with a backslash"},
+		{"StringTooLong", "datestyle", strings.Repeat("x", maxStringParameterBytes+1), "maximum length"},
+		{"UnknownTimezone", "timezone", "Not/A_Real_Zone", "does not accept"},
 		// AWS accepts these; passing one through would be a startup failure rather
 		// than an API error.
 		{"Formula", "shared_buffers", "{DBInstanceClassMemory/32768}", "is a formula"},
@@ -163,6 +168,81 @@ func TestResolveEffectiveParameters_RevalidatesStoredOverrides(t *testing.T) {
 	_, err := ResolveEffectiveParameters("db.t3.medium", map[string]string{"max_connections": "999999"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "max_connections")
+}
+
+func TestResolveEffectiveParameters_BoundsSizeDerivedOverridesToTheClass(t *testing.T) {
+	tests := []struct {
+		name, value string
+	}{
+		{name: "shared_buffers", value: "131072"},
+		{name: "effective_cache_size", value: "262144"},
+		{name: "max_connections", value: "1000"},
+		{name: "maintenance_work_mem", value: "1048576"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveEffectiveParameters("db.t3.micro", map[string]string{tt.name: tt.value})
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+			assert.Contains(t, err.Error(), "db.t3.micro")
+			assert.Contains(t, err.Error(), tt.value)
+			assert.Contains(t, err.Error(), "ceiling")
+
+			_, err = ResolveEffectiveParameters("db.m5.xlarge", map[string]string{tt.name: tt.value})
+			assert.NoError(t, err, "the same literal should fit the larger class")
+		})
+	}
+}
+
+func TestResolveEffectiveParameters_RejectsFatalCombinations(t *testing.T) {
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		want      string
+	}{
+		{
+			name:      "minimal WAL with senders",
+			overrides: map[string]string{"wal_level": "minimal"},
+			want:      "max_wal_senders and max_replication_slots",
+		},
+		{
+			name: "reserved connections consume every slot",
+			overrides: map[string]string{
+				"max_connections": "20", "superuser_reserved_connections": "20",
+			},
+			want: "must be less than max_connections",
+		},
+		{
+			name:      "too many server processes",
+			overrides: map[string]string{"max_worker_processes": "262143"},
+			want:      "too many server processes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ResolveEffectiveParameters("db.m5.xlarge", tt.overrides)
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestResolveEffectiveParameters_AcceptsMinimalWALWithoutReplication(t *testing.T) {
+	_, err := ResolveEffectiveParameters("db.t3.micro", map[string]string{
+		"wal_level": "minimal", "max_wal_senders": "0", "max_replication_slots": "0",
+	})
+	require.NoError(t, err)
+}
+
+func TestParameterCatalog_Postgres18ApplyTypesAndBuiltCompressionMethods(t *testing.T) {
+	autovacuumWorkers, _ := LookupParameter("autovacuum_max_workers")
+	assert.Equal(t, ApplyTypeDynamic, autovacuumWorkers.ApplyType)
+
+	walCompression, _ := LookupParameter("wal_compression")
+	assert.ElementsMatch(t, []string{"off", "pglz", "lz4", "zstd", "on"}, walCompression.Enum)
 }
 
 func TestResolveEffectiveParameters_RejectsAnUnknownClass(t *testing.T) {

--- a/spinifex/handlers/rds/paramcatalog_test.go
+++ b/spinifex/handlers/rds/paramcatalog_test.go
@@ -102,8 +102,16 @@ func TestValidateParameterValue_RejectsBadInput(t *testing.T) {
 		{"Empty", "work_mem", "", "empty value"},
 		{"StringControlCharacter", "timezone", "UTC\nwork_mem", "control characters"},
 		{"StringTrailingBackslash", "datestyle", `ISO\`, "end with a backslash"},
+		{"NormalizedTrailingBackslash", "datestyle", "ISO\\   ", "end with a backslash"},
 		{"StringTooLong", "datestyle", strings.Repeat("x", maxStringParameterBytes+1), "maximum length"},
 		{"UnknownTimezone", "timezone", "Not/A_Real_Zone", "does not accept"},
+		{"GoLocalTimezone", "timezone", "Local", "does not accept"},
+		{"CaseInsensitiveLocalTimezone", "timezone", "lOcAl", "does not accept"},
+		{"UnknownDateStyle", "datestyle", "garbage", "does not accept"},
+		{"DuplicateDateStyles", "datestyle", "ISO, SQL", "does not accept"},
+		{"DuplicateDateOrders", "datestyle", "MDY, DMY", "does not accept"},
+		{"EmptyDateStylePart", "datestyle", "ISO,", "does not accept"},
+		{"TooManyDateStyleParts", "datestyle", "ISO, MDY, DMY", "does not accept"},
 		// AWS accepts these; passing one through would be a startup failure rather
 		// than an API error.
 		{"Formula", "shared_buffers", "{DBInstanceClassMemory/32768}", "is a formula"},
@@ -117,6 +125,28 @@ func TestValidateParameterValue_RejectsBadInput(t *testing.T) {
 			assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err),
 				"the code has to survive resolution or the client sees a 500")
 			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestValidateParameterValue_AcceptsPostgresStringValues(t *testing.T) {
+	cases := []struct {
+		name, param, value string
+	}{
+		{"UTC", "timezone", "UTC"},
+		{"GMT", "timezone", "GMT"},
+		{"IANAZone", "timezone", "Australia/Sydney"},
+		{"DateStyleOnly", "datestyle", "ISO"},
+		{"DateOrderOnly", "datestyle", "YMD"},
+		{"StyleAndOrder", "datestyle", "ISO, MDY"},
+		{"CaseInsensitive", "datestyle", "gErMaN, dMy"},
+		{"NormalizedWhitespace", "datestyle", "  SQL, DMY  \n"},
+		{"NormalizedLength", "datestyle", strings.Repeat(" ", maxStringParameterBytes+1) + "ISO"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateParameterValue(tc.param, tc.value)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/spinifex/handlers/rds/pending.go
+++ b/spinifex/handlers/rds/pending.go
@@ -158,9 +158,11 @@ func (s *Service) applyParameterGroup(ctx context.Context, kv jetstream.KeyValue
 	// Kept in step so the caller decides on the set this apply produced rather
 	// than on the one the instance carried in.
 	rec.PendingRebootParameters = pendingReboot
+	rec.ParametersRolledBack = false
 	return s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
 		stored.Bootstrap.ResolvedParameters = resolved
 		stored.PendingRebootParameters = pendingReboot
+		stored.ParametersRolledBack = false
 	})
 }
 

--- a/spinifex/handlers/rds/pending_test.go
+++ b/spinifex/handlers/rds/pending_test.go
@@ -371,6 +371,7 @@ func TestApplyPendingModifications_ParameterGroupChangeRevertsTheOldGroupsValues
 	// What the old group had set, carried on the record as the engine's current
 	// values; the new group sets nothing.
 	rec.Bootstrap.ResolvedParameters = []Parameter{{Name: "work_mem", Value: "262144"}}
+	rec.ParametersRolledBack = true
 	seedInstance(t, h.svc, rec)
 
 	require.NoError(t, h.svc.applyPendingModifications(t.Context(), h.kv(t), testAccountID, &rec))
@@ -384,6 +385,7 @@ func TestApplyPendingModifications_ParameterGroupChangeRevertsTheOldGroupsValues
 	workMem, _ := LookupParameter("work_mem")
 	assert.Equal(t, workMem.Default, applied["work_mem"],
 		"the old group's value should have reverted to the catalog default")
+	assert.False(t, h.record(t).ParametersRolledBack, "a successful corrected apply clears the rollback state")
 }
 
 func parameterValue(params []Parameter, name string) string {

--- a/spinifex/handlers/rds/records.go
+++ b/spinifex/handlers/rds/records.go
@@ -131,6 +131,9 @@ type DBInstanceRecord struct {
 	// Static parameters written to the engine's config but not yet in effect.
 	// Cleared by the reboot that applies them.
 	PendingRebootParameters []string `json:"pendingRebootParameters,omitempty"`
+	// Set when the guest rolls back a parameter set that prevented startup.
+	// Cleared only after a corrected set installs successfully.
+	ParametersRolledBack bool `json:"parametersRolledBack,omitempty"`
 
 	// Inline rather than a separate key space, so the record delete that ends the
 	// instance also ends its tags.

--- a/tests/e2e/rds/groups_test.go
+++ b/tests/e2e/rds/groups_test.go
@@ -124,6 +124,32 @@ func TestSubnetAndParameterGroups(t *testing.T) {
 		})
 	})
 
+	t.Run("CreateRejectsAClassFatalOverride", func(t *testing.T) {
+		_, err := f.AWS.RDS.ModifyDBParameterGroup(&rds.ModifyDBParameterGroupInput{
+			DBParameterGroupName: aws.String(paramGroup),
+			Parameters: []*rds.Parameter{{
+				ParameterName:  aws.String("shared_buffers"),
+				ParameterValue: aws.String("131072"),
+			}},
+		})
+		require.NoError(t, err, "store the catalog-valid large-class value")
+
+		in := validCreateInput(id + "-unsafe")
+		in.DBSubnetGroupName = aws.String(subnetGroup)
+		in.DBParameterGroupName = aws.String(paramGroup)
+		expectCreateRefused(t, f, f.AWS, "InvalidParameterValue", in)
+
+		// Put the group back within the micro ceiling for the serving-path test.
+		_, err = f.AWS.RDS.ModifyDBParameterGroup(&rds.ModifyDBParameterGroupInput{
+			DBParameterGroupName: aws.String(paramGroup),
+			Parameters: []*rds.Parameter{{
+				ParameterName:  aws.String("shared_buffers"),
+				ParameterValue: aws.String("32768"),
+			}},
+		})
+		require.NoError(t, err, "restore the micro-sized shared_buffers value")
+	})
+
 	harness.Phase(t, "Creating DB instance %q against both groups", id)
 	created := createDBInstance(t, f, id, func(in *rds.CreateDBInstanceInput) {
 		in.DBSubnetGroupName = aws.String(subnetGroup)


### PR DESCRIPTION
## Summary

- bound size-derived parameter overrides to the selected instance class and reject PostgreSQL-fatal parameter combinations
- validate string parameters and align PostgreSQL 18 parameter metadata with the pinned Alpine build
- seed last-known-good parameters from serving transitions, retain corrected sets while the engine is down, and report rollbacks as failed-to-apply events
- add control-plane, agent, and E2E coverage for the repaired paths

## Testing

- `make preflight`