### PR TITLE
fix: propagate RDS parameter group edits

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -900,12 +900,12 @@ Statuses: `creating`, `available`, `modifying`, `backing-up`, `rebooting`, `stop
 |---------|-------------------|---------------|--------|
 | `create-db-parameter-group` | `--db-parameter-group-name`, `--db-parameter-group-family` (postgres18), `--description`, `--tags` | — | **DONE** — names beginning with `default.` are reserved; the implicit group is `default.postgres18` |
 | `describe-db-parameter-groups` | `--db-parameter-group-name` | `--filters`, `--max-records`, `--marker` | **DONE** — the implicit default group is always listed |
-| `modify-db-parameter-group` | `--db-parameter-group-name`, `--parameters` (ParameterName, ParameterValue, ApplyMethod) | — | **DONE** — the whole batch is validated before anything is written; `immediate` on a static parameter is rejected, as AWS does |
+| `modify-db-parameter-group` | `--db-parameter-group-name`, `--parameters` (ParameterName, ParameterValue, ApplyMethod) | — | **DONE** — the whole batch is validated before anything is written and propagated to attached instances; `immediate` on a static parameter is rejected, as AWS does |
 | `describe-db-parameters` | `--db-parameter-group-name`, `--source` (user, engine-default) | `--filters`, `--max-records`, `--marker` | **DONE** — 51-parameter PostgreSQL 18 catalog; memory defaults are computed per instance class and reported as literals |
 | `delete-db-parameter-group` | `--db-parameter-group-name` | — | **DONE** — refused for a default group and while any instance references it |
 | `reset-db-parameter-group` | — | all | **NOT STARTED** (`InvalidAction`) |
 
-A group takes effect on an instance when `modify-db-instance --db-parameter-group-name` attaches it — immediately with `--apply-immediately`, otherwise at the next maintenance window. Dynamic parameters are written into the engine's config and reloaded live; static ones are recorded `pending-reboot` and applied by `reboot-db-instance`.
+A group takes effect on an instance when `modify-db-instance --db-parameter-group-name` attaches it — immediately with `--apply-immediately`, otherwise at the next maintenance window. Later group edits propagate to every attached instance. Dynamic parameters are written into the engine's config and reloaded live; static ones are recorded `pending-reboot` and applied by `reboot-db-instance`.
 
 ### RDS — Tags
 

--- a/spinifex/handlers/rds/parametergroup.go
+++ b/spinifex/handlers/rds/parametergroup.go
@@ -178,9 +178,42 @@ func (s *Service) ModifyDBParameterGroup(ctx context.Context, input *rds.ModifyD
 		}
 	}
 
+	if err := s.propagateParameterGroup(ctx, kv, accountID, name); err != nil {
+		return nil, err
+	}
+
 	slog.InfoContext(ctx, "rds: DB parameter group modified",
 		"dbParameterGroup", name, "accountId", accountID, "parameters", len(updates))
 	return &rds.DBParameterGroupNameMessage{DBParameterGroupName: aws.String(name)}, nil
+}
+
+// Applies the complete effective set to every instance currently attached to
+// the group. Each record is re-read before the command so a concurrent detach
+// or delete does not receive parameters for a group it no longer uses.
+func (s *Service) propagateParameterGroup(ctx context.Context, kv jetstream.KeyValue, accountID, name string) error {
+	ids, err := instancesUsingGroup(ctx, kv, func(rec *DBInstanceRecord) bool {
+		return rec.DBParameterGroupName == name
+	})
+	if err != nil {
+		return err
+	}
+
+	var failures []error
+	for _, id := range ids {
+		var rec DBInstanceRecord
+		found, err := getJSON(ctx, kv, DBInstanceKey(id), &rec)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("rds: read DB instance %s before propagating parameter group %s: %w", id, name, err))
+			continue
+		}
+		if !found || rec.DBParameterGroupName != name {
+			continue
+		}
+		if err := s.applyParameterGroup(ctx, kv, accountID, &rec, name, rec.DBInstanceClass); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
 }
 
 // Merges catalog defaults with the group's stored overrides. The defaults are

--- a/spinifex/handlers/rds/parametergroup_test.go
+++ b/spinifex/handlers/rds/parametergroup_test.go
@@ -38,6 +38,17 @@ func parameter(name, value, applyMethod string) *rds.Parameter {
 	return p
 }
 
+func storedDBInstance(t *testing.T, svc *Service, id string) DBInstanceRecord {
+	t.Helper()
+	kv, err := svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	var rec DBInstanceRecord
+	found, err := getJSON(t.Context(), kv, DBInstanceKey(id), &rec)
+	require.NoError(t, err)
+	require.True(t, found)
+	return rec
+}
+
 // The values of a described group, keyed by name, with the source each was
 // reported under.
 func describedParameters(t *testing.T, h *createHarness, group string) map[string]*rds.Parameter {
@@ -192,6 +203,105 @@ func TestModifyDBParameterGroup_StoresValidatedOverrides(t *testing.T) {
 	assert.Equal(t, ParameterSourceUser, aws.StringValue(params["shared_buffers"].Source))
 	// Untouched parameters stay engine defaults rather than becoming user values.
 	assert.Equal(t, ParameterSourceEngineDefault, aws.StringValue(params["autovacuum"].Source))
+}
+
+func TestModifyDBParameterGroup_PropagatesDynamicParametersToEveryAttachedInstance(t *testing.T) {
+	h := newModifyHarness(t)
+	_, err := h.svc.CreateDBParameterGroup(t.Context(), parameterGroupInput(testParameterGroup), testAccountID)
+	require.NoError(t, err)
+
+	first := modifiableRecord()
+	first.DBParameterGroupName = testParameterGroup
+	seedInstance(t, h.svc, first)
+
+	secondID := testDBID + "-second"
+	second := modifiableRecord()
+	second.DBInstanceIdentifier = secondID
+	second.DBParameterGroupName = testParameterGroup
+	seedInstance(t, h.svc, second)
+	secondAgent := newStubAgent(t, h.nc, testAccountID, secondID, false)
+
+	_, err = h.svc.ModifyDBParameterGroup(t.Context(), modifyParameters(testParameterGroup,
+		parameter("work_mem", "16384", ApplyMethodImmediate),
+	), testAccountID)
+	require.NoError(t, err)
+
+	for id, issued := range map[string][]Command{
+		testDBID: h.agent.received(),
+		secondID: secondAgent.received(),
+	} {
+		require.Len(t, issued, 1, "instance %s must receive the group update", id)
+		assert.Equal(t, CommandApplyParams, issued[0].Type)
+		assert.Contains(t, issued[0].Parameters, Parameter{Name: "work_mem", Value: "16384"})
+
+		stored := storedDBInstance(t, h.svc, id)
+		assert.Contains(t, stored.Bootstrap.ResolvedParameters, Parameter{Name: "work_mem", Value: "16384"})
+		assert.Empty(t, stored.PendingRebootParameters)
+		groups := projectParameterGroup(&stored)
+		require.Len(t, groups, 1)
+		assert.Equal(t, "in-sync", aws.StringValue(groups[0].ParameterApplyStatus))
+	}
+}
+
+func TestModifyDBParameterGroup_RecordsStaticParametersPendingReboot(t *testing.T) {
+	h := newModifyHarness(t)
+	h.agent.replyWith("max_connections")
+	_, err := h.svc.CreateDBParameterGroup(t.Context(), parameterGroupInput(testParameterGroup), testAccountID)
+	require.NoError(t, err)
+
+	rec := modifiableRecord()
+	rec.DBParameterGroupName = testParameterGroup
+	seedInstance(t, h.svc, rec)
+
+	_, err = h.svc.ModifyDBParameterGroup(t.Context(), modifyParameters(testParameterGroup,
+		parameter("max_connections", "137", ApplyMethodPendingReboot),
+	), testAccountID)
+	require.NoError(t, err)
+
+	stored := h.record(t)
+	assert.Equal(t, []string{"max_connections"}, stored.PendingRebootParameters)
+	groups := projectParameterGroup(&stored)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "pending-reboot", aws.StringValue(groups[0].ParameterApplyStatus))
+}
+
+func TestModifyDBParameterGroup_DoesNotPropagateToAPendingAttachment(t *testing.T) {
+	h := newModifyHarness(t)
+	_, err := h.svc.CreateDBParameterGroup(t.Context(), parameterGroupInput(testParameterGroup), testAccountID)
+	require.NoError(t, err)
+
+	rec := modifiableRecord()
+	rec.PendingModifiedValues = &PendingModifiedValues{DBParameterGroupName: testParameterGroup}
+	seedInstance(t, h.svc, rec)
+
+	_, err = h.svc.ModifyDBParameterGroup(t.Context(), modifyParameters(testParameterGroup,
+		parameter("work_mem", "16384", ApplyMethodImmediate),
+	), testAccountID)
+	require.NoError(t, err)
+	assert.Empty(t, h.agent.received(), "the latest values resolve when the pending attachment is applied")
+}
+
+func TestModifyDBParameterGroup_ReturnsAPropagationFailure(t *testing.T) {
+	h := newModifyHarnessWithAgent(t, true)
+	_, err := h.svc.CreateDBParameterGroup(t.Context(), parameterGroupInput(testParameterGroup), testAccountID)
+	require.NoError(t, err)
+
+	rec := modifiableRecord()
+	rec.DBParameterGroupName = testParameterGroup
+	seedInstance(t, h.svc, rec)
+
+	_, err = h.svc.ModifyDBParameterGroup(t.Context(), modifyParameters(testParameterGroup,
+		parameter("work_mem", "16384", ApplyMethodImmediate),
+	), testAccountID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testDBID)
+
+	overrides, listErr := ListDBParameterOverrides(t.Context(), h.kv(t), testParameterGroup)
+	require.NoError(t, listErr)
+	assert.Equal(t, "16384", overrides["work_mem"].Value,
+		"the durable group edit remains available for a retry")
+	assert.NotContains(t, h.record(t).Bootstrap.ResolvedParameters,
+		Parameter{Name: "work_mem", Value: "16384"}, "a failed apply must not advance the instance record")
 }
 
 // A batch with one bad value must leave the group exactly as it was: a

--- a/tests/e2e/rds/groups_test.go
+++ b/tests/e2e/rds/groups_test.go
@@ -22,7 +22,8 @@ const (
 	dbParameterGroupFamily = "postgres18"
 	// A dynamic parameter, so the engine adopts it on a reload and the assertion
 	// does not have to wait out a restart. Its default is 4096 kB.
-	workMemKiB = "8192"
+	workMemKiB        = "8192"
+	updatedWorkMemKiB = "12288"
 )
 
 // TestSubnetAndParameterGroups drives the customer-managed group path end to
@@ -176,6 +177,53 @@ func TestSubnetAndParameterGroups(t *testing.T) {
 		conn := harness.PSQLConnFor(t, instance, dbMasterUser, dbMasterPassword, dbName)
 		out := harness.PSQL(t, client, conn, "SHOW work_mem;")
 		assert.Equal(t, "8MB", strings.TrimSpace(out), "the engine is not running the group's work_mem")
+	})
+
+	t.Run("AttachedGroupEditsReachTheRunningEngine", func(t *testing.T) {
+		requireAvailable(t, instance)
+		client := rdsClient(t, f)
+		conn := harness.PSQLConnFor(t, instance, dbMasterUser, dbMasterPassword, dbName)
+
+		_, err := f.AWS.RDS.ModifyDBParameterGroup(&rds.ModifyDBParameterGroupInput{
+			DBParameterGroupName: aws.String(paramGroup),
+			Parameters: []*rds.Parameter{{
+				ParameterName:  aws.String("work_mem"),
+				ParameterValue: aws.String(updatedWorkMemKiB),
+				ApplyMethod:    aws.String("immediate"),
+			}},
+		})
+		require.NoError(t, err, "modify an attached group with a dynamic parameter")
+		out := harness.PSQL(t, client, conn, "SHOW work_mem;")
+		assert.Equal(t, "12MB", strings.TrimSpace(out),
+			"an immediate edit to an attached group must reload without a reboot")
+
+		before := showInteger(t, client, conn, staticParameterName)
+		require.NotEqual(t, staticParameterValue, before,
+			"the chosen static value must differ from the engine default")
+		_, err = f.AWS.RDS.ModifyDBParameterGroup(&rds.ModifyDBParameterGroupInput{
+			DBParameterGroupName: aws.String(paramGroup),
+			Parameters: []*rds.Parameter{{
+				ParameterName:  aws.String(staticParameterName),
+				ParameterValue: aws.String(staticParameterValue),
+				ApplyMethod:    aws.String("pending-reboot"),
+			}},
+		})
+		require.NoError(t, err, "modify an attached group with a static parameter")
+
+		pending, err := harness.DescribeDBInstance(f.AWS, id)
+		require.NoError(t, err, "describe the pending static parameter")
+		require.NotEmpty(t, pending.DBParameterGroups)
+		assert.Equal(t, "pending-reboot", aws.StringValue(pending.DBParameterGroups[0].ParameterApplyStatus))
+		assert.Equal(t, before, showInteger(t, client, conn, staticParameterName),
+			"a static edit must not take effect before a reboot")
+
+		_, err = f.AWS.RDS.RebootDBInstance(&rds.RebootDBInstanceInput{DBInstanceIdentifier: aws.String(id)})
+		require.NoError(t, err, "reboot-db-instance for the static parameter")
+		instance = waitForAvailable(t, f, id)
+		require.NotEmpty(t, instance.DBParameterGroups)
+		assert.Equal(t, "in-sync", aws.StringValue(instance.DBParameterGroups[0].ParameterApplyStatus))
+		assert.Equal(t, staticParameterValue, showInteger(t, client, conn, staticParameterName),
+			"the reboot must apply the attached group's static edit")
 	})
 
 	t.Run("GroupsInUseCannotBeDeleted", func(t *testing.T) {

--- a/tests/e2e/rds/lifecycle_test.go
+++ b/tests/e2e/rds/lifecycle_test.go
@@ -133,10 +133,9 @@ func TestLifecycle(t *testing.T) {
 		assert.NotEqual(t, before, after, "pg_postmaster_start_time() did not move, so the engine never restarted")
 	})
 
-	// A static parameter reaches a running instance only through a modify that
-	// moves the instance onto a group, not through a modify of the group it
-	// already holds: the group write pushes nothing at an instance.
-	t.Run("AStaticParameterWaitsForARebootAndThenApplies", func(t *testing.T) {
+	// A deferred attachment is drained by the maintenance window. The static
+	// parameter it installs then remains pending until a separate reboot.
+	t.Run("ADeferredGroupAttachmentWaitsForItsWindow", func(t *testing.T) {
 		createParameterGroupWithStatic(t, f, paramGroup)
 
 		harness.Step(t, "Moving %q onto %q, deferred to the maintenance window", id, paramGroup)


### PR DESCRIPTION
## Summary

Propagate `ModifyDBParameterGroup` changes to every DB instance currently attached to the modified group, so dynamic parameters reload immediately and static parameters report `pending-reboot` until restart.

## Changes

- Re-resolve and apply the complete effective parameter set to every attached instance.
- Continue propagation across instances and return aggregated failures.
- Add handler coverage for multiple attached instances, pending reboot state, pending attachments, and apply failures.
- Extend the RDS e2e scenario to modify an already-attached group and verify dynamic and static behavior.
- Update RDS command documentation and deferred attachment test wording.

## Testing

- `go test ./spinifex/handlers/rds -count=1`
- RDS e2e package compilation with the `e2e` build tag
- `make preflight`