### PR TITLE
fix: authorize RDS data-volume formatting by exact volume identity

### DIFF
--- a/cmd/rds-agent/agent.go
+++ b/cmd/rds-agent/agent.go
@@ -228,9 +228,8 @@ func (a *Agent) Run(ctx context.Context) error {
 	// and authorize the volume. Commands and the parameter guard wait because
 	// their durable state belongs on that mount, never on the disposable boot disk.
 	if err := a.dataMountWaiter(ctx, a.cfg.MountsFile, a.cfg.DataMount); err != nil {
-		if ctx.Err() != nil {
-			return nil
-		}
+		// A shutdown cancels this wait; main treats the wrapped context.Canceled
+		// as a clean stop, exactly as it does for register and bootstrap above.
 		return fmt.Errorf("wait for data mount %s: %w", a.cfg.DataMount, err)
 	}
 

--- a/cmd/rds-agent/agent.go
+++ b/cmd/rds-agent/agent.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log/slog"
 	"net/url"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mulgadc/spinifex/internal/gwsign"
@@ -148,12 +151,13 @@ func setIfPresent(params url.Values, key, value string) {
 }
 
 type Agent struct {
-	cfg           config
-	id            identity
-	cp            controlPlane
-	probe         *engineProbe
-	engine        *postgresEngine
-	handoffWriter func(string, *handlers_rds.GetDBBootstrapConfigOutput) error
+	cfg             config
+	id              identity
+	cp              controlPlane
+	probe           *engineProbe
+	engine          *postgresEngine
+	handoffWriter   func(string, *handlers_rds.GetDBBootstrapConfigOutput) error
+	dataMountWaiter func(context.Context, string, string) error
 
 	hb    *heartbeater
 	cmd   *commander
@@ -163,12 +167,21 @@ type Agent struct {
 // Assembles from already-built parts, so tests can pass fakes; New builds the
 // production control plane and delegates here.
 func newAgent(cfg config, cp controlPlane, probe *engineProbe) *Agent {
+	if cfg.DataMount == "" {
+		cfg.DataMount = defaultDataMount
+	}
+	if cfg.MountsFile == "" {
+		cfg.MountsFile = defaultMountsFile
+	}
 	id := identity{
 		DBInstanceIdentifier: cfg.DBInstanceIdentifier,
 		AgentVersion:         version,
 		EngineVersion:        cfg.EngineVersion,
 	}
-	a := &Agent{cfg: cfg, id: id, cp: cp, probe: probe, handoffWriter: writeHandoff}
+	a := &Agent{
+		cfg: cfg, id: id, cp: cp, probe: probe,
+		handoffWriter: writeHandoff, dataMountWaiter: waitForDataMount,
+	}
 	a.engine = newPostgresEngine(cfg, execCommandRunner, execSessionRunner, probe)
 	a.hb = newHeartbeater(cp, probe, a.engine, handlers_rds.HeartbeatInterval)
 	a.cmd = newCommander(cp, newCommandRegistry(a.engine, newGuestStorage(cfg, execCommandRunner)), cfg.PollWait)
@@ -211,7 +224,17 @@ func (a *Agent) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Directives are only meaningful against a bootstrapped engine.
+	// The handoff must land before this wait: rds-datadir needs it to identify
+	// and authorize the volume. Commands and the parameter guard wait because
+	// their durable state belongs on that mount, never on the disposable boot disk.
+	if err := a.dataMountWaiter(ctx, a.cfg.MountsFile, a.cfg.DataMount); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("wait for data mount %s: %w", a.cfg.DataMount, err)
+	}
+
+	// Directives are only meaningful against a bootstrapped, mounted engine.
 	go a.cmd.Run(ctx)
 
 	// Started after the handoff, so the window it measures covers the engine's
@@ -220,6 +243,58 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	<-ctx.Done()
 	return nil
+}
+
+const dataMountPollInterval = time.Second
+
+// waitForDataMount blocks the stateful agent loops until the kernel reports the
+// configured data mount. Registration, heartbeat, and bootstrap run before it.
+func waitForDataMount(ctx context.Context, mountsFile, target string) error {
+	ticker := time.NewTicker(dataMountPollInterval)
+	defer ticker.Stop()
+
+	for {
+		mounted, err := mountTableContains(mountsFile, target)
+		if err != nil {
+			slog.WarnContext(ctx, "rds-agent: could not read mount table while waiting for data volume",
+				"mountsFile", mountsFile, "dataMount", target, "err", err)
+		} else if mounted {
+			slog.InfoContext(ctx, "rds-agent: data volume mount is ready", "dataMount", target)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func mountTableContains(path, target string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && unescapeMountField(fields[1]) == target {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// Linux mount tables encode whitespace and backslashes as octal escapes.
+func unescapeMountField(field string) string {
+	replacer := strings.NewReplacer(`\134`, `\`, `\040`, " ", `\011`, "\t", `\012`, "\n")
+	return replacer.Replace(field)
 }
 
 // Boot-retry bounds. Tight to start, since the usual cause is a control plane

--- a/cmd/rds-agent/agent_test.go
+++ b/cmd/rds-agent/agent_test.go
@@ -197,6 +197,11 @@ func runAgent(t *testing.T, a *Agent) error {
 	cancel()
 	select {
 	case err := <-done:
+		// The cancellation above is this helper's own, so Run reporting it is the
+		// expected clean stop rather than a failure, exactly as main treats it.
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
 		return err
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run did not exit after cancellation")

--- a/cmd/rds-agent/agent_test.go
+++ b/cmd/rds-agent/agent_test.go
@@ -18,6 +18,8 @@ import (
 	gateway_rds "github.com/mulgadc/spinifex/spinifex/gateway/rds"
 	handlers_rds "github.com/mulgadc/spinifex/spinifex/handlers/rds"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // fakeControlPlane is a scriptable controlPlane. Every call records what the
@@ -171,6 +173,9 @@ func bootstrapOutput(password *string) *handlers_rds.GetDBBootstrapConfigOutput 
 		MasterUsername:       "master",
 		MasterUserPassword:   password,
 		Port:                 5432,
+		DataVolumeID:         "vol-data-01",
+		DataVolumeSerial:     "voldata01",
+		VMGeneration:         1,
 	}
 }
 
@@ -329,6 +334,81 @@ func TestRun_SendsConfiguredIdentifier(t *testing.T) {
 	sent := cp.registerReqs[0]
 	if sent.DBInstanceIdentifier != "db-configured" || sent.EngineVersion != "18.1" {
 		t.Errorf("register sent %+v, want the configured identifier and engine version", sent)
+	}
+}
+
+func TestRun_WaitsForDataMountBeforePollingCommands(t *testing.T) {
+	cp := newFakeControlPlane()
+	cp.bootstrapOut = bootstrapOutput(nil)
+	cfg := testConfig(t)
+	a := newAgent(cfg, cp, newEngineProbe(cfg, staticProbe(2)))
+
+	waiting := make(chan struct{})
+	release := make(chan struct{})
+	a.dataMountWaiter = func(ctx context.Context, mountsFile, target string) error {
+		if mountsFile != defaultMountsFile || target != defaultDataMount {
+			t.Errorf("mount waiter got %q/%q, want configured defaults", mountsFile, target)
+		}
+		close(waiting)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-release:
+			return nil
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	select {
+	case <-waiting:
+	case <-ctx.Done():
+		t.Fatal("agent did not reach the data-mount wait after writing the handoff")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.HandoffDir, handoffEnvFile)); err != nil {
+		t.Fatalf("handoff was not present before mount wait: %v", err)
+	}
+	select {
+	case <-cp.polled:
+		t.Fatal("command poll started before the data volume was mounted")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-cp.polled:
+	case <-ctx.Done():
+		t.Fatal("command poll did not start after the data mount became ready")
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestMountTableContains(t *testing.T) {
+	mounts := filepath.Join(t.TempDir(), "mounts")
+	require.NoError(t, os.WriteFile(mounts, []byte(
+		"/dev/vda1 / ext4 rw 0 0\n/dev/vdb /var/lib/postgresql ext4 rw 0 0\n"+
+			"/dev/vdc /path\\040with\\040spaces xfs rw 0 0\nmalformed\n"), 0o600))
+
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{target: "/var/lib/postgresql", want: true},
+		{target: "/path with spaces", want: true},
+		{target: "/missing", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.target, func(t *testing.T) {
+			got, err := mountTableContains(mounts, tc.target)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
 	}
 }
 

--- a/cmd/rds-agent/bootstrap.go
+++ b/cmd/rds-agent/bootstrap.go
@@ -108,6 +108,10 @@ func renderBootstrapEnv(cfg *handlers_rds.GetDBBootstrapConfigOutput) string {
 	b.WriteString("# Written by rds-agent. Regenerated on every boot; edits are lost.\n")
 	writeEnvLine(&b, "RDS_MODE", cfg.Mode)
 	writeEnvLine(&b, "RDS_MASTER_USERNAME", cfg.MasterUsername)
+	writeEnvLine(&b, "RDS_DATA_VOLUME_ID", cfg.DataVolumeID)
+	writeEnvLine(&b, "RDS_DATA_VOLUME_SERIAL", cfg.DataVolumeSerial)
+	writeEnvLine(&b, "RDS_VM_GENERATION", strconv.FormatInt(cfg.VMGeneration, 10))
+	writeEnvLine(&b, "RDS_FORMAT_AUTHORIZED", strconv.FormatBool(cfg.FormatAuthorized))
 	// Present only in initialize mode: an attach fetch has no password to write
 	// and rds-init must not find a stale one.
 	if cfg.MasterUserPassword != nil {

--- a/cmd/rds-agent/bootstrap_test.go
+++ b/cmd/rds-agent/bootstrap_test.go
@@ -20,6 +20,10 @@ func TestWriteHandoff_WritesEveryFileRootOnly(t *testing.T) {
 		MasterUserPassword: &password,
 		DBName:             "appdb",
 		Port:               5433,
+		DataVolumeID:       "vol-data-01",
+		DataVolumeSerial:   "voldata01",
+		VMGeneration:       4,
+		FormatAuthorized:   true,
 		Parameters: []handlers_rds.Parameter{
 			{Name: "max_connections", Value: "200"},
 			{Name: "shared_buffers", Value: "256MB"},
@@ -38,6 +42,10 @@ func TestWriteHandoff_WritesEveryFileRootOnly(t *testing.T) {
 		"RDS_MASTER_PASSWORD='s3cret'",
 		"RDS_DB_NAME='appdb'",
 		"RDS_PORT='5433'",
+		"RDS_DATA_VOLUME_ID='vol-data-01'",
+		"RDS_DATA_VOLUME_SERIAL='voldata01'",
+		"RDS_VM_GENERATION='4'",
+		"RDS_FORMAT_AUTHORIZED='true'",
 	} {
 		if !strings.Contains(env, want) {
 			t.Errorf("handoff env missing %s:\n%s", want, env)
@@ -80,8 +88,19 @@ func TestWriteHandoff_AttachOmitsPassword(t *testing.T) {
 		t.Fatalf("writeHandoff: %v", err)
 	}
 
-	if env := readFile(t, filepath.Join(dir, handoffEnvFile)); strings.Contains(env, "RDS_MASTER_PASSWORD") {
+	env := readFile(t, filepath.Join(dir, handoffEnvFile))
+	if strings.Contains(env, "RDS_MASTER_PASSWORD") {
 		t.Errorf("handoff env = %q, want no RDS_MASTER_PASSWORD key", env)
+	}
+	for _, want := range []string{
+		"RDS_DATA_VOLUME_ID=''",
+		"RDS_DATA_VOLUME_SERIAL=''",
+		"RDS_VM_GENERATION='0'",
+		"RDS_FORMAT_AUTHORIZED='false'",
+	} {
+		if !strings.Contains(env, want) {
+			t.Errorf("handoff env missing fail-closed field %s: %q", want, env)
+		}
 	}
 }
 

--- a/internal/rdsgw/client_test.go
+++ b/internal/rdsgw/client_test.go
@@ -123,6 +123,10 @@ func TestCall_DecodesNestedListsAndOptionalFields(t *testing.T) {
 		MasterUsername:       "master",
 		MasterUserPassword:   &password,
 		Port:                 5432,
+		DataVolumeID:         "vol-data-01",
+		DataVolumeSerial:     "voldata01",
+		VMGeneration:         3,
+		FormatAuthorized:     true,
 		Parameters: []handlers_rds.Parameter{
 			{Name: "max_connections", Value: "100"},
 			{Name: "work_mem", Value: "4MB"},
@@ -150,6 +154,12 @@ func TestCall_DecodesNestedListsAndOptionalFields(t *testing.T) {
 	if got.ServingCertificate != want.ServingCertificate {
 		t.Errorf("ServingCertificate = %q, want the seeded PEM", got.ServingCertificate)
 	}
+	if got.DataVolumeID != want.DataVolumeID || got.DataVolumeSerial != want.DataVolumeSerial ||
+		got.VMGeneration != want.VMGeneration || got.FormatAuthorized != want.FormatAuthorized {
+		t.Errorf("volume contract = %q/%q/%d/%t, want %q/%q/%d/%t",
+			got.DataVolumeID, got.DataVolumeSerial, got.VMGeneration, got.FormatAuthorized,
+			want.DataVolumeID, want.DataVolumeSerial, want.VMGeneration, want.FormatAuthorized)
+	}
 }
 
 // An absent optional field must decode as nil, not as an empty value: attach
@@ -169,6 +179,9 @@ func TestCall_AbsentOptionalStaysNil(t *testing.T) {
 	}
 	if got.MasterUserPassword != nil {
 		t.Errorf("MasterUserPassword = %q, want nil in attach mode", *got.MasterUserPassword)
+	}
+	if got.DataVolumeID != "" || got.DataVolumeSerial != "" || got.VMGeneration != 0 || got.FormatAuthorized {
+		t.Errorf("absent volume contract decoded as %+v, want zero values", got)
 	}
 }
 

--- a/scripts/images/rds-postgres/manifest.conf
+++ b/scripts/images/rds-postgres/manifest.conf
@@ -44,6 +44,6 @@ SETUP_SCRIPT="scripts/images/rds-postgres/setup.sh"
 
 AMI_NAME="spinifex-rds-postgres"
 
-# managed-by=rds marks it a system AMI; engine/engine-version are what the
-# control plane resolves an EngineVersion request against.
-SYSTEM_TAG="spinifex:managed-by=rds engine=postgres engine-version=18"
+# The contract tag prevents the control plane from issuing a format grant to an
+# older image that still discovers generic vol* devices.
+SYSTEM_TAG="spinifex:managed-by=rds engine=postgres engine-version=18 rds-data-volume-contract=format-auth-v1"

--- a/scripts/images/rds-postgres/rds-agent.initd
+++ b/scripts/images/rds-postgres/rds-agent.initd
@@ -24,8 +24,8 @@ handoff_tail="${RDS_HANDOFF_TAIL:-20}"
 
 depend() {
     need net
-    before rds-init
     after localmount
+    before rds-datadir rds-init postgresql
 }
 
 start_pre() {
@@ -36,7 +36,7 @@ start_pre() {
         . "${AGENT_ENV}"
         export RDS_GATEWAY_URL RDS_GATEWAY_CA RDS_REGION RDS_DB_INSTANCE_IDENTIFIER \
             RDS_ENGINE_VERSION RDS_HANDOFF_DIR RDS_ENGINE_HOST RDS_ENGINE_PORT \
-            RDS_PG_ISREADY RDS_POLL_WAIT
+            RDS_PG_ISREADY RDS_POLL_WAIT RDS_DATA_MOUNT
     fi
 }
 

--- a/scripts/images/rds-postgres/rds-datadir
+++ b/scripts/images/rds-postgres/rds-datadir
@@ -41,14 +41,18 @@ mounted_source() {
     awk -v mnt="${DATA_MOUNT}" '$2 == mnt { print $1; found = 1; exit } END { exit !found }' "${MOUNTS_FILE}"
 }
 
-# Only an exact serial match is a candidate. Other vol* devices are unrelated
-# attachments and are deliberately ignored.
+# Only an exact serial match is a candidate; other vol* devices are unrelated
+# attachments and are deliberately ignored. The loop status must not depend on
+# the last device examined, or set -e would abort the caller's wait and report.
 data_disks() {
     for _p in "${SYS_BLOCK}"/*; do
         [ -r "${_p}/serial" ] || continue
         _serial=$(cat "${_p}/serial" 2>/dev/null || true)
-        [ "${_serial}" = "${RDS_DATA_VOLUME_SERIAL}" ] && basename "${_p}"
+        if [ "${_serial}" = "${RDS_DATA_VOLUME_SERIAL}" ]; then
+            basename "${_p}"
+        fi
     done
+    return 0
 }
 
 await_data_disk() {
@@ -121,6 +125,11 @@ main() {
     # be empty before it can be treated as a signature-free device.
     _probe_err="${HANDOFF_ENV}.blkid.$$"
     umask 077
+    # A redirection that cannot be created leaves blkid unrun and returns the
+    # shell's own status, which some shells report as the blank-device exit 2.
+    # `true` is a regular builtin, so the failure is catchable rather than fatal.
+    true > "${_probe_err}" ||
+        fail "could not create the probe error capture at ${_probe_err}; refusing to classify ${_dev}"
     if _probe=$(blkid -p -o export "${_dev}" 2>"${_probe_err}"); then
         _probe_rc=0
     else

--- a/scripts/images/rds-postgres/rds-datadir
+++ b/scripts/images/rds-postgres/rds-datadir
@@ -1,101 +1,78 @@
 #!/bin/sh
-# rds-datadir — prepare and mount the instance's data volume at the datadir
-# mount point, before rds-init bootstraps the cluster onto it.
-#
-# The volume is hot-plugged after launch, so it cannot be in /etc/fstab and the
-# guest has to discover it. Data volumes are attached as virtio-blk with
-# serial = volume-id, and the boot volume carries no serial — so a `vol*` serial
-# identifies the data volume and nothing else.
-#
-# This is the one place in the image that may format a block device, so every
-# branch that is not "an empty disk we just attached" refuses:
-#
-#   - a disk carrying a partition table or an existing filesystem is mounted as
-#     found, never re-made (a replaced VM comes back on its existing volume);
-#   - more than one candidate disk is an error, not a guess;
-#   - no candidate within the wait window is an error, and rds-init then fails
-#     on the missing mount rather than initialising on the boot volume.
+# rds-datadir — select, authorize, prepare, and mount the exact data volume
+# assigned by the control plane before rds-init touches the PostgreSQL datadir.
 set -eu
 
-# Mount point of the data volume. rds-init puts the datadir one level inside it.
 DATA_MOUNT="${RDS_DATA_MOUNT:-/var/lib/postgresql}"
-
 PG_USER="${RDS_PG_USER:-postgres}"
-
 SYS_BLOCK="${RDS_SYS_BLOCK:-/sys/block}"
 DEV_DIR="${RDS_DEV_DIR:-/dev}"
 MOUNTS_FILE="${RDS_MOUNTS_FILE:-/proc/mounts}"
-
-# How long to wait for the attach. The control plane hot-plugs the volume as
-# soon as the VM launches, so this covers the boot racing the attach, not an
-# attach that never happens.
 WAIT_SECS="${RDS_DATA_VOLUME_WAIT:-120}"
-
-# Filesystem label written at format time. Purely diagnostic: discovery is by
-# serial, so a volume whose label was changed out of band still mounts.
 FS_LABEL="${RDS_DATA_FS_LABEL:-rds-data}"
+HANDOFF_ENV="${RDS_HANDOFF_ENV:-${RDS_HANDOFF_DIR:-/run/spinifex-rds}/bootstrap.env}"
 
 log() { echo "[rds-datadir] $*"; }
 fail() { echo "[rds-datadir] ERROR: $*" >&2; exit 1; }
 
-# An already-mounted DATA_MOUNT makes the whole script a no-op; an OpenRC restart
-# must not try to mount twice.
-mounted() {
-    awk -v mnt="${DATA_MOUNT}" '$2 == mnt { found = 1 } END { exit !found }' "${MOUNTS_FILE}"
+load_handoff() {
+    [ -f "${HANDOFF_ENV}" ] || fail "no bootstrap handoff at ${HANDOFF_ENV}; refusing to discover or format a volume"
+    # Root-owned content written with shell-safe quoting by rds-agent.
+    # shellcheck disable=SC1090
+    . "${HANDOFF_ENV}"
+
+    RDS_DATA_VOLUME_ID="${RDS_DATA_VOLUME_ID:-}"
+    RDS_DATA_VOLUME_SERIAL="${RDS_DATA_VOLUME_SERIAL:-}"
+    RDS_VM_GENERATION="${RDS_VM_GENERATION:-}"
+    RDS_FORMAT_AUTHORIZED="${RDS_FORMAT_AUTHORIZED:-false}"
+
+    [ -n "${RDS_DATA_VOLUME_ID}" ] || fail "bootstrap handoff has no RDS_DATA_VOLUME_ID"
+    [ -n "${RDS_DATA_VOLUME_SERIAL}" ] || fail "bootstrap handoff has no RDS_DATA_VOLUME_SERIAL"
+    case "${RDS_VM_GENERATION}" in
+        ''|*[!0-9]*|0) fail "bootstrap handoff has invalid RDS_VM_GENERATION '${RDS_VM_GENERATION}'" ;;
+    esac
+    case "${RDS_FORMAT_AUTHORIZED}" in
+        true|false) ;;
+        *) fail "bootstrap handoff has invalid RDS_FORMAT_AUTHORIZED '${RDS_FORMAT_AUTHORIZED}'" ;;
+    esac
 }
 
-# The boot volume is attached with no serial and so never appears here.
+mounted_source() {
+    awk -v mnt="${DATA_MOUNT}" '$2 == mnt { print $1; found = 1; exit } END { exit !found }' "${MOUNTS_FILE}"
+}
+
+# Only an exact serial match is a candidate. Other vol* devices are unrelated
+# attachments and are deliberately ignored.
 data_disks() {
     for _p in "${SYS_BLOCK}"/*; do
         [ -r "${_p}/serial" ] || continue
-        case "$(cat "${_p}/serial" 2>/dev/null)" in
-            vol*) basename "${_p}" ;;
-        esac
+        _serial=$(cat "${_p}/serial" 2>/dev/null || true)
+        [ "${_serial}" = "${RDS_DATA_VOLUME_SERIAL}" ] && basename "${_p}"
     done
 }
 
-# Two disks is a configuration this image cannot resolve safely, so it fails
-# rather than picking one.
 await_data_disk() {
     _waited=0
     while :; do
         _found=$(data_disks)
         _count=$(printf '%s\n' "${_found}" | grep -c . || true)
         if [ "${_count}" -gt 1 ]; then
-            fail "found ${_count} attached data volumes ($(printf '%s\n' "${_found}" | tr '\n' ' ')); expected exactly one"
+            fail "found ${_count} devices with expected serial ${RDS_DATA_VOLUME_SERIAL}; refusing to choose one"
         fi
-        # The sysfs entry appears before the device node, and blkid on a missing
-        # node reports the same "no filesystem" a blank disk does — so the wait
-        # is not over until both exist.
+        # Sysfs appears before the device node. A probe cannot classify a node
+        # that is not present yet, so both must exist before the wait ends.
         if [ "${_count}" = "1" ] && [ -e "${DEV_DIR}/${_found}" ]; then
             printf '%s\n' "${_found}"
             return 0
         fi
         if [ "${_waited}" -ge "${WAIT_SECS}" ]; then
-            fail "no data volume attached after ${WAIT_SECS}s"
+            fail "volume ${RDS_DATA_VOLUME_ID} with serial ${RDS_DATA_VOLUME_SERIAL} was not attached after ${WAIT_SECS}s"
         fi
         sleep 1
         _waited=$((_waited + 1))
     done
 }
 
-# Prints the filesystem on dev, nothing if it holds none, and returns non-zero
-# when it could not find out: a blkid that is missing, errored or pointed at an
-# absent node prints exactly what a blank disk prints, so only the status decides.
-fstype_of() {
-    if _out=$(blkid -o value -s TYPE "$1" 2>/dev/null); then
-        _rc=0
-    else
-        _rc=$?
-    fi
-    # 0 is a signature found, 2 a clean probe that found none. Anything else
-    # means the probe did not run, which is not an answer.
-    [ "${_rc}" -eq 0 ] || [ "${_rc}" -eq 2 ] || return 1
-    printf '%s' "${_out}"
-}
-
-# Partitions appear as child directories of the disk in sysfs, which needs no
-# tool and no signature guessing.
 has_partitions() {
     for _part in "${SYS_BLOCK}/$1/$1"*; do
         [ -d "${_part}" ] && return 0
@@ -103,46 +80,101 @@ has_partitions() {
     return 1
 }
 
-main() {
-    if mounted; then
-        log "${DATA_MOUNT} is already a mount point; nothing to do"
-        return 0
+consume_format_authorization() {
+    [ "${RDS_FORMAT_AUTHORIZED}" = "true" ] || return 0
+    _tmp="${HANDOFF_ENV}.consume.$$"
+    if ! awk '!/^RDS_FORMAT_AUTHORIZED=/' "${HANDOFF_ENV}" > "${_tmp}"; then
+        rm -f "${_tmp}"
+        fail "could not remove the consumed format authorization from ${HANDOFF_ENV}"
     fi
+    chmod 0600 "${_tmp}" || {
+        rm -f "${_tmp}"
+        fail "could not secure the rewritten bootstrap handoff"
+    }
+    mv -f "${_tmp}" "${HANDOFF_ENV}" || {
+        rm -f "${_tmp}"
+        fail "could not install the bootstrap handoff without its consumed format authorization"
+    }
+    RDS_FORMAT_AUTHORIZED=false
+}
 
-    # Checked before anything else: without it the probe below cannot run, and a
-    # probe that cannot run looks identical to a blank disk.
+main() {
+    load_handoff
+
     command -v blkid >/dev/null 2>&1 ||
-        fail "blkid is not installed in this image; refusing to tell a blank volume from a customer's data without it"
+        fail "blkid is not installed; refusing to classify the expected volume"
 
     _disk=$(await_data_disk)
     _dev="${DEV_DIR}/${_disk}"
-    log "data volume attached as ${_dev} (serial $(cat "${SYS_BLOCK}/${_disk}/serial"))"
+    log "volume ${RDS_DATA_VOLUME_ID} generation ${RDS_VM_GENERATION} attached as ${_dev}"
 
-    if ! _fstype=$(fstype_of "${_dev}"); then
-        fail "could not probe ${_dev} for a filesystem; refusing to decide whether it is blank"
+    if _mounted=$(mounted_source 2>/dev/null); then
+        [ "${_mounted}" = "${_dev}" ] ||
+            fail "${DATA_MOUNT} is mounted from ${_mounted}, not expected device ${_dev}"
+        consume_format_authorization
+        log "${DATA_MOUNT} is already mounted from the expected device"
+        return 0
     fi
-    if [ -z "${_fstype}" ]; then
-        # A partition table with no whole-disk filesystem is somebody else's
-        # disk — a restored image, a mis-targeted attach — so formatting would
-        # destroy it.
-        if has_partitions "${_disk}"; then
-            fail "${_dev} carries a partition table but no filesystem; refusing to format it"
-        fi
-        log "formatting ${_dev} (ext4, label ${FS_LABEL})"
-        # -m 0: no reserved-for-root blocks. The customer paid for the whole
-        # volume and nothing but PostgreSQL writes to it.
-        mkfs.ext4 -q -L "${FS_LABEL}" -m 0 "${_dev}" ||
-            fail "mkfs.ext4 failed on ${_dev}"
-        _fstype=ext4
+
+    # Low-level probing exposes partition tables and returns a distinct failure
+    # for ambiguous signatures. Exit 2 also covers read failures, so stderr must
+    # be empty before it can be treated as a signature-free device.
+    _probe_err="${HANDOFF_ENV}.blkid.$$"
+    umask 077
+    if _probe=$(blkid -p -o export "${_dev}" 2>"${_probe_err}"); then
+        _probe_rc=0
     else
-        log "${_dev} already holds a ${_fstype} filesystem; mounting as found"
+        _probe_rc=$?
+    fi
+    _probe_stderr=$(cat "${_probe_err}" 2>/dev/null || true)
+    rm -f "${_probe_err}"
+    if [ "${_probe_rc}" -eq 2 ] && [ -n "${_probe_stderr}" ]; then
+        fail "could not read ${_dev} while probing it; refusing to classify it as blank"
     fi
 
-    mount "${_dev}" "${DATA_MOUNT}" || fail "could not mount ${_dev} at ${DATA_MOUNT}"
+    case "${_probe_rc}" in
+        0)
+            _pttype=$(printf '%s\n' "${_probe}" | awk -F= '$1 == "PTTYPE" { print $2 }')
+            _types=$(printf '%s\n' "${_probe}" | awk -F= '$1 == "TYPE" { print $2 }')
+            _type_count=$(printf '%s\n' "${_types}" | grep -c . || true)
+            if [ -n "${_pttype}" ] || has_partitions "${_disk}"; then
+                fail "${_dev} carries a partition table or partitions; refusing to mount or format it"
+            fi
+            [ "${_type_count}" = "1" ] ||
+                fail "${_dev} has conflicting or incomplete filesystem signatures; refusing to use it"
+            case "${_types}" in
+                ext4|xfs) _fstype="${_types}" ;;
+                *) fail "${_dev} holds unsupported filesystem ${_types}; refusing to use it" ;;
+            esac
+            # A grant left after mkfs but before local consumption must not
+            # survive once the newly recognizable filesystem is observed.
+            consume_format_authorization
+            log "${_dev} already holds a supported ${_fstype} filesystem"
+            ;;
+        2)
+            if has_partitions "${_disk}"; then
+                fail "${_dev} carries partitions but no supported whole-disk filesystem; refusing to format it"
+            fi
+            [ "${RDS_FORMAT_AUTHORIZED}" = "true" ] ||
+                fail "${_dev} has no recognizable filesystem and this boot has no matching format authorization"
+            log "formatting authorized volume ${RDS_DATA_VOLUME_ID} as ext4"
+            mkfs.ext4 -q -L "${FS_LABEL}" -m 0 "${_dev}" ||
+                fail "mkfs.ext4 failed on ${_dev}"
+            # Consume before mount. If mounting later fails, the next run sees
+            # ext4 and mounts it without receiving another chance to format.
+            consume_format_authorization
+            _fstype=ext4
+            ;;
+        8)
+            fail "${_dev} has ambiguous or conflicting signatures; refusing to use it"
+            ;;
+        *)
+            fail "could not probe ${_dev} (blkid exit ${_probe_rc}); refusing to classify it as blank"
+            ;;
+    esac
 
-    # The mount does not inherit the image mount point's ownership: a freshly
-    # formatted volume's root is root-owned 0755, which initdb (as postgres)
-    # cannot create the datadir under.
+    mount -t "${_fstype}" "${_dev}" "${DATA_MOUNT}" ||
+        fail "could not mount ${_dev} at ${DATA_MOUNT}"
     chown "${PG_USER}:${PG_USER}" "${DATA_MOUNT}" ||
         fail "could not set ${PG_USER} ownership on ${DATA_MOUNT}"
     chmod 0750 "${DATA_MOUNT}"

--- a/scripts/images/rds-postgres/rds-datadir.initd
+++ b/scripts/images/rds-postgres/rds-datadir.initd
@@ -1,14 +1,24 @@
 #!/sbin/openrc-run
 # rds-datadir — boot oneshot that discovers the hot-plugged data volume, formats
-# it if new, and mounts it at the datadir mount point. First of the three RDS
-# services, since rds-init's initdb targets a datadir this must mount. Ordered
-# with `before`, not a dependency, so a missing volume fails visibly.
+# it if authorized, and mounts it at the datadir mount point. It runs after the
+# agent has written the authenticated handoff and before anything can use the
+# PostgreSQL datadir. Soft ordering keeps a failed boot visible on the console.
 
 description="Spinifex RDS data volume mount"
 
+AGENT_ENV="/etc/spinifex-rds/agent.env"
+
 depend() {
-    before rds-agent rds-init postgresql
-    after localmount
+    after localmount rds-agent
+    before rds-init postgresql
+}
+
+start_pre() {
+    if [ -f "${AGENT_ENV}" ]; then
+        # shellcheck disable=SC1090
+        . "${AGENT_ENV}"
+        export RDS_HANDOFF_DIR RDS_DATA_MOUNT
+    fi
 }
 
 start() {

--- a/scripts/images/rds-postgres/rds-datadir_test.sh
+++ b/scripts/images/rds-postgres/rds-datadir_test.sh
@@ -123,12 +123,18 @@ run_ok() {
     return 1
 }
 
+# A refusal must be diagnosable on the serial console, so the expected reason is
+# asserted too: a non-zero exit alone also matches a script that died silently.
+# Always returns 0; a non-zero status here would abort the suite under set -e.
 run_fails() {
     if run > "${WORK}/out" 2>&1; then
         fail "$1: expected a non-zero exit"
-        return 1
+    elif ! grep -q "\[rds-datadir\] ERROR: .*$2" "${WORK}/out"; then
+        fail "$1: refused without reporting '$2': $(cat "${WORK}/out")"
+    else
+        pass "$1: refused with a reported reason"
     fi
-    pass "$1: refused"
+    return 0
 }
 
 nothing_formatted() {
@@ -150,20 +156,33 @@ if run_ok "authorized blank exact volume"; then
     if grep -q '^RDS_FORMAT_AUTHORIZED=' "${HANDOFF}"; then fail "authorized: grant retained"; else pass "authorized: grant consumed"; fi
 fi
 
-# A lone vol* disk with the wrong serial never becomes a fallback candidate.
+# A lone vol* disk with the wrong serial never becomes a fallback candidate, and
+# the absent expected volume is reported as an attach timeout.
 reset_state
 add_disk vda
 add_disk vdb volwrong
 write_handoff vol-expected volexpected 1 true
-run_fails "serial mismatch"
+run_fails "serial mismatch" "volume vol-expected with serial volexpected was not attached"
 nothing_formatted "serial mismatch"
+
+# Selection must not depend on sysfs enumeration order: the expected disk is
+# found even when an unrelated vol* disk sorts after it.
+reset_state
+add_disk vda
+add_disk vdb volexpected
+add_disk vdc volunrelated
+write_handoff vol-expected volexpected 1 true
+if run_ok "unrelated disk sorts last"; then
+    grep -q "mkfs.ext4 .*${DEV_DIR}/vdb" "${MKFS_CALLS}" && pass "sort order: expected disk formatted" || fail "sort order: expected disk not formatted"
+    grep -q "mount -t ext4 ${DEV_DIR}/vdb ${DATA_MOUNT}" "${MOUNT_CALLS}" && pass "sort order: mounted" || fail "sort order: not mounted"
+fi
 
 # Duplicate exact serials are ambiguous even if both name generic data disks.
 reset_state
 add_disk vdb volexpected
 add_disk vdc volexpected
 write_handoff vol-expected volexpected 1 true
-run_fails "duplicate expected serial"
+run_fails "duplicate expected serial" "refusing to choose one"
 nothing_formatted "duplicate expected serial"
 
 # Existing supported filesystems mount without any grant.
@@ -180,7 +199,7 @@ done
 # Blank restore/start/replacement volumes have no grant and fail closed.
 reset_state
 add_disk vdb volexpected
-run_fails "blank without grant"
+run_fails "blank without grant" "no recognizable filesystem and this boot has no matching format authorization"
 nothing_formatted "blank without grant"
 
 # Partition tables, visible partitions, unsupported filesystems, ambiguity, and
@@ -189,24 +208,49 @@ for kind in pttable fspt unsupported ambiguous unreadable error; do
     reset_state
     add_disk vdb volexpected
     case "${kind}" in
-        pttable) printf '%s pttable gpt\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
-        fspt) printf '%s fspt ext4\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
-        unsupported) printf '%s fs btrfs\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
-        ambiguous) printf '%s ambiguous x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
-        unreadable) printf '%s unreadable x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
-        error) printf '%s error x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
+        pttable)
+            printf '%s pttable gpt\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+            reason="carries a partition table or partitions" ;;
+        fspt)
+            printf '%s fspt ext4\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+            reason="carries a partition table or partitions" ;;
+        unsupported)
+            printf '%s fs btrfs\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+            reason="holds unsupported filesystem btrfs" ;;
+        ambiguous)
+            printf '%s ambiguous x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+            reason="ambiguous or conflicting signatures" ;;
+        unreadable)
+            printf '%s unreadable x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+            reason="refusing to classify it as blank" ;;
+        error)
+            printf '%s error x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+            reason="could not probe" ;;
     esac
     write_handoff vol-expected volexpected 1 true
-    run_fails "probe ${kind}"
+    run_fails "probe ${kind}" "${reason}"
     nothing_formatted "probe ${kind}"
 done
+
+# An uncreatable probe capture leaves blkid unrun, and some shells report that
+# as the blank-device exit 2. Root ignores the directory mode, so it cannot run
+# the case at all.
+if [ "$(id -u)" -ne 0 ]; then
+    reset_state
+    add_disk vdb volexpected
+    write_handoff vol-expected volexpected 1 true
+    chmod 0500 "$(dirname "${HANDOFF}")"
+    run_fails "unwritable probe capture" "could not create the probe error capture"
+    nothing_formatted "unwritable probe capture"
+    chmod 0700 "$(dirname "${HANDOFF}")"
+fi
 
 reset_state
 add_disk vdb volexpected
 add_partition vdb 1
 printf '%s fs ext4\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
 write_handoff vol-expected volexpected 1 true
-run_fails "sysfs partition plus filesystem"
+run_fails "sysfs partition plus filesystem" "carries a partition table or partitions"
 nothing_formatted "sysfs partition plus filesystem"
 
 # Missing identity and invalid generation cannot authorize even when true.
@@ -215,11 +259,17 @@ for field in id serial generation; do
     add_disk vdb volexpected
     write_handoff vol-expected volexpected 1 true
     case "${field}" in
-        id) sed -i "s/RDS_DATA_VOLUME_ID='vol-expected'/RDS_DATA_VOLUME_ID=''/" "${HANDOFF}" ;;
-        serial) sed -i "s/RDS_DATA_VOLUME_SERIAL='volexpected'/RDS_DATA_VOLUME_SERIAL=''/" "${HANDOFF}" ;;
-        generation) sed -i "s/RDS_VM_GENERATION='1'/RDS_VM_GENERATION='0'/" "${HANDOFF}" ;;
+        id)
+            sed -i "s/RDS_DATA_VOLUME_ID='vol-expected'/RDS_DATA_VOLUME_ID=''/" "${HANDOFF}"
+            reason="has no RDS_DATA_VOLUME_ID" ;;
+        serial)
+            sed -i "s/RDS_DATA_VOLUME_SERIAL='volexpected'/RDS_DATA_VOLUME_SERIAL=''/" "${HANDOFF}"
+            reason="has no RDS_DATA_VOLUME_SERIAL" ;;
+        generation)
+            sed -i "s/RDS_VM_GENERATION='1'/RDS_VM_GENERATION='0'/" "${HANDOFF}"
+            reason="invalid RDS_VM_GENERATION" ;;
     esac
-    run_fails "invalid ${field}"
+    run_fails "invalid ${field}" "${reason}"
     nothing_formatted "invalid ${field}"
 done
 
@@ -227,7 +277,7 @@ done
 reset_state
 add_disk vdb volexpected
 write_handoff vol-expected volexpected 1 true
-MKFS_FAIL=1 run_fails "mkfs failure"
+MKFS_FAIL=1 run_fails "mkfs failure" "mkfs.ext4 failed on"
 grep -q '^RDS_FORMAT_AUTHORIZED=' "${HANDOFF}" && pass "mkfs failure: grant retained" || fail "mkfs failure: grant lost"
 [ ! -s "${MOUNT_CALLS}" ] && pass "mkfs failure: not mounted" || fail "mkfs failure: mounted raw disk"
 
@@ -256,7 +306,7 @@ fi
 reset_state
 add_disk vdb volexpected
 printf '%s %s ext4 rw 0 0\n' "${DEV_DIR}/wrong" "${DATA_MOUNT}" >> "${MOUNTS}"
-run_fails "already mounted wrong device"
+run_fails "already mounted wrong device" "not expected device"
 nothing_formatted "already mounted wrong device"
 
 if [ "${FAILS}" -eq 0 ]; then

--- a/scripts/images/rds-postgres/rds-datadir_test.sh
+++ b/scripts/images/rds-postgres/rds-datadir_test.sh
@@ -1,61 +1,50 @@
 #!/bin/sh
-# Self-contained POSIX test for rds-datadir: discovery of the hot-plugged data
-# volume by virtio-blk serial, formatting a blank volume, mounting an existing
-# one as found, and the refusals — no volume, two volumes, a partition table.
-# No block devices and no root: a fake sysfs tree stands in for /sys/block, and
-# blkid, mkfs.ext4, mount and chown are stubbed on PATH.
-#
-# Run: sh scripts/images/rds-postgres/rds-datadir_test.sh
+# Self-contained POSIX tests for exact RDS data-volume selection and formatting
+# authorization. Fake sysfs and command stubs avoid root and block devices.
 set -eu
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 SCRIPT="${SCRIPT_DIR}/rds-datadir"
 WORK=$(mktemp -d)
 trap 'rm -rf "${WORK}"' EXIT
-
 STUBBIN="${WORK}/bin"
 mkdir -p "${STUBBIN}"
 
-# blkid stub: prints the requested filesystem type value for any device listed
-# in FS_TABLE as "<dev> <fstype>", and exits non-zero when none is present.
 cat > "${STUBBIN}/blkid" <<'EOF'
 #!/bin/sh
-# BLKID_RC simulates a probe that could not run at all — 127 is a blkid missing
-# from the image, 4 an internal error. Both print nothing, which is precisely
-# what a genuinely blank disk prints, so only the exit status separates them.
-[ "${BLKID_RC:-0}" = "0" ] || exit "${BLKID_RC}"
-[ "$1" = "-o" ] && [ "$2" = "value" ] && [ "$3" = "-s" ] && [ "$4" = "TYPE" ] || exit 4
-dev="$5"
-fstype=$(awk -v d="${dev}" '$1 == d { print $2 }' "${FS_TABLE}" 2>/dev/null)
-[ -n "${fstype}" ] || exit 2
-printf '%s\n' "${fstype}"
+[ "$1" = "-p" ] && [ "$2" = "-o" ] && [ "$3" = "export" ] || exit 4
+dev="$4"
+kind=$(awk -v d="${dev}" '$1 == d { print $2; exit }' "${PROBE_TABLE}" 2>/dev/null)
+value=$(awk -v d="${dev}" '$1 == d { print $3; exit }' "${PROBE_TABLE}" 2>/dev/null)
+case "${kind}" in
+    fs) printf 'DEVNAME=%s\nTYPE=%s\n' "${dev}" "${value}" ;;
+    pttable) printf 'DEVNAME=%s\nPTTYPE=%s\n' "${dev}" "${value:-gpt}" ;;
+    fspt) printf 'DEVNAME=%s\nTYPE=%s\nPTTYPE=gpt\n' "${dev}" "${value}" ;;
+    ambiguous) exit 8 ;;
+    unreadable) echo "read error" >&2; exit 2 ;;
+    error) exit 4 ;;
+    *) exit 2 ;;
+esac
 EOF
 
-# mkfs.ext4 stub: records the call and marks the device formatted, so a mount
-# in the same run sees the filesystem the format created.
 cat > "${STUBBIN}/mkfs.ext4" <<'EOF'
 #!/bin/sh
 echo "mkfs.ext4 $*" >> "${MKFS_CALLS}"
 [ "${MKFS_FAIL:-0}" = "1" ] && exit 1
 dev=""
-for a in "$@"; do dev="${a}"; done
-echo "${dev} ext4" >> "${FS_TABLE}"
-exit 0
+for arg in "$@"; do dev="${arg}"; done
+printf '%s fs ext4\n' "${dev}" >> "${PROBE_TABLE}"
 EOF
 
-# mount stub: records the call only. The script re-reads its mounts file rather
-# than the mount table, so nothing else has to be simulated.
 cat > "${STUBBIN}/mount" <<'EOF'
 #!/bin/sh
 echo "mount $*" >> "${MOUNT_CALLS}"
 exit "${MOUNT_RC:-0}"
 EOF
 
-# chown stub: file ownership is a no-op outside the guest.
 cat > "${STUBBIN}/chown" <<'EOF'
 #!/bin/sh
 echo "chown $*" >> "${CHOWN_CALLS}"
-exit 0
 EOF
 
 chmod +x "${STUBBIN}"/*
@@ -70,16 +59,13 @@ DATA_MOUNT="${WORK}/data"
 SYS_BLOCK="${WORK}/sys/block"
 DEV_DIR="${WORK}/dev"
 MOUNTS="${WORK}/mounts"
-
-FS_TABLE="${WORK}/fs.table"
+HANDOFF="${WORK}/handoff/bootstrap.env"
+PROBE_TABLE="${WORK}/probe.table"
 MKFS_CALLS="${WORK}/mkfs.calls"
 MOUNT_CALLS="${WORK}/mount.calls"
 CHOWN_CALLS="${WORK}/chown.calls"
-export FS_TABLE MKFS_CALLS MOUNT_CALLS CHOWN_CALLS
+export PROBE_TABLE MKFS_CALLS MOUNT_CALLS CHOWN_CALLS
 
-# add_disk <name> [serial]: materialise a block device in the fake sysfs. A disk
-# with no serial stands in for the boot volume, which Spinifex attaches without
-# one.
 add_disk() {
     mkdir -p "${SYS_BLOCK}/$1" "${DEV_DIR}"
     : > "${DEV_DIR}/$1"
@@ -87,137 +73,191 @@ add_disk() {
     return 0
 }
 
-# add_partition <disk> <n>: the sysfs child directory the kernel creates for a
-# partition, which is how the script detects a partition table.
 add_partition() { mkdir -p "${SYS_BLOCK}/$1/$1$2"; }
 
-# reset_state clears the fake sysfs, the filesystem table and the stub call logs.
-# The mounts file starts with the datadir unmounted, as it is at boot.
+write_handoff() {
+    mkdir -p "$(dirname "${HANDOFF}")"
+    cat > "${HANDOFF}" <<EOF
+RDS_MODE='initialize'
+RDS_MASTER_USERNAME='master'
+RDS_MASTER_PASSWORD='still-needed-by-rds-init'
+RDS_DATA_VOLUME_ID='${1:-vol-expected}'
+RDS_DATA_VOLUME_SERIAL='${2:-volexpected}'
+RDS_VM_GENERATION='${3:-1}'
+RDS_FORMAT_AUTHORIZED='${4:-false}'
+RDS_PORT='5432'
+EOF
+    chmod 0600 "${HANDOFF}"
+}
+
 reset_state() {
-    rm -rf "${WORK}/sys" "${DEV_DIR}" "${DATA_MOUNT}"
+    rm -rf "${WORK}/sys" "${DEV_DIR}" "${DATA_MOUNT}" "$(dirname "${HANDOFF}")"
     mkdir -p "${SYS_BLOCK}" "${DEV_DIR}" "${DATA_MOUNT}"
     printf '/dev/vda1 / ext4 rw,relatime 0 0\n' > "${MOUNTS}"
-    : > "${FS_TABLE}"
+    : > "${PROBE_TABLE}"
     : > "${MKFS_CALLS}"
     : > "${MOUNT_CALLS}"
     : > "${CHOWN_CALLS}"
-    unset MKFS_FAIL MOUNT_RC BLKID_RC || true
+    unset MKFS_FAIL MOUNT_RC || true
+    write_handoff vol-expected volexpected 1 false
 }
 
-# run: invoke rds-datadir against the fake sysfs and a wait short enough that
-# the "never attached" case does not stall the suite.
 run() {
     env RDS_DATA_MOUNT="${DATA_MOUNT}" \
         RDS_SYS_BLOCK="${SYS_BLOCK}" \
         RDS_DEV_DIR="${DEV_DIR}" \
         RDS_MOUNTS_FILE="${MOUNTS}" \
-        RDS_DATA_VOLUME_WAIT="${RDS_DATA_VOLUME_WAIT:-2}" \
+        RDS_HANDOFF_ENV="${HANDOFF}" \
+        RDS_DATA_VOLUME_WAIT=1 \
         MKFS_FAIL="${MKFS_FAIL:-0}" \
         MOUNT_RC="${MOUNT_RC:-0}" \
-        BLKID_RC="${BLKID_RC:-0}" \
         sh "${SCRIPT}" </dev/null
 }
 
-run_ok() { run > "${WORK}/out" 2>&1 || { fail "$1: non-zero exit: $(cat "${WORK}/out")"; return 1; }; }
-run_fails() { run > "${WORK}/out" 2>&1 && fail "$1: expected a non-zero exit" || pass "$1: refused"; }
+run_ok() {
+    if run > "${WORK}/out" 2>&1; then
+        pass "$1"
+        return 0
+    fi
+    fail "$1: non-zero exit: $(cat "${WORK}/out")"
+    return 1
+}
 
-# --- Case 1: a blank data volume is formatted and mounted ---
+run_fails() {
+    if run > "${WORK}/out" 2>&1; then
+        fail "$1: expected a non-zero exit"
+        return 1
+    fi
+    pass "$1: refused"
+}
+
+nothing_formatted() {
+    if grep -q . "${MKFS_CALLS}"; then fail "$1: unexpectedly ran mkfs"; else pass "$1: no mkfs"; fi
+}
+
+# A matching create grant formats only the exact disk and consumes only the
+# authorization line. An unrelated generic volume is ignored.
 reset_state
 add_disk vda
-add_disk vdb vol0123456789abcdef
-if run_ok "blank"; then
-    grep -q "mkfs.ext4 .*${DEV_DIR}/vdb" "${MKFS_CALLS}" \
-        && pass "blank: formatted the data volume" || fail "blank: no mkfs"
-    grep -q -- '-m 0' "${MKFS_CALLS}" \
-        && pass "blank: no reserved blocks" || fail "blank: reserved blocks left on"
-    grep -q "mount ${DEV_DIR}/vdb ${DATA_MOUNT}" "${MOUNT_CALLS}" \
-        && pass "blank: mounted at the datadir mount point" || fail "blank: not mounted"
-    grep -q "postgres:postgres ${DATA_MOUNT}" "${CHOWN_CALLS}" \
-        && pass "blank: mount point handed to postgres" || fail "blank: ownership not set"
+add_disk vdb volunrelated
+add_disk vdc volexpected
+write_handoff vol-expected volexpected 1 true
+if run_ok "authorized blank exact volume"; then
+    grep -q "mkfs.ext4 .*${DEV_DIR}/vdc" "${MKFS_CALLS}" && pass "authorized: exact disk formatted" || fail "authorized: exact disk not formatted"
+    grep -q -- '-m 0' "${MKFS_CALLS}" && pass "authorized: no reserved blocks" || fail "authorized: reserved blocks left on"
+    grep -q "mount -t ext4 ${DEV_DIR}/vdc ${DATA_MOUNT}" "${MOUNT_CALLS}" && pass "authorized: mounted" || fail "authorized: not mounted"
+    grep -q '^RDS_MASTER_PASSWORD=' "${HANDOFF}" && pass "authorized: bootstrap material preserved" || fail "authorized: bootstrap material removed"
+    if grep -q '^RDS_FORMAT_AUTHORIZED=' "${HANDOFF}"; then fail "authorized: grant retained"; else pass "authorized: grant consumed"; fi
 fi
 
-# --- Case 2: the boot volume is never a candidate ---
+# A lone vol* disk with the wrong serial never becomes a fallback candidate.
 reset_state
 add_disk vda
-if run_fails "boot-only"; then :; fi
-grep -q . "${MKFS_CALLS}" \
-    && fail "boot-only: formatted a disk with no volume serial" || pass "boot-only: nothing formatted"
+add_disk vdb volwrong
+write_handoff vol-expected volexpected 1 true
+run_fails "serial mismatch"
+nothing_formatted "serial mismatch"
 
-# --- Case 3: an existing volume is mounted as found, never re-made ---
+# Duplicate exact serials are ambiguous even if both name generic data disks.
 reset_state
-add_disk vda
-add_disk vdb vol0123456789abcdef
-echo "${DEV_DIR}/vdb ext4" > "${FS_TABLE}"
-if run_ok "existing"; then
-    grep -q . "${MKFS_CALLS}" \
-        && fail "existing: reformatted a volume that already held a filesystem" \
-        || pass "existing: not reformatted"
-    grep -q "mount ${DEV_DIR}/vdb ${DATA_MOUNT}" "${MOUNT_CALLS}" \
-        && pass "existing: mounted as found" || fail "existing: not mounted"
-fi
+add_disk vdb volexpected
+add_disk vdc volexpected
+write_handoff vol-expected volexpected 1 true
+run_fails "duplicate expected serial"
+nothing_formatted "duplicate expected serial"
 
-# --- Case 4: a partition table is somebody else's disk ---
-reset_state
-add_disk vda
-add_disk vdb vol0123456789abcdef
-add_partition vdb 1
-run_fails "partitioned"
-grep -q . "${MKFS_CALLS}" \
-    && fail "partitioned: formatted over a partition table" || pass "partitioned: nothing formatted"
-
-# --- Case 5: two data volumes is an error, not a guess ---
-reset_state
-add_disk vda
-add_disk vdb vol0123456789abcdef
-add_disk vdc vol0fedcba987654321
-run_fails "ambiguous"
-grep -q . "${MKFS_CALLS}" \
-    && fail "ambiguous: formatted one of two candidates" || pass "ambiguous: nothing formatted"
-
-# --- Case 6: an already-mounted datadir is a no-op, so a restart is safe ---
-reset_state
-add_disk vda
-add_disk vdb vol0123456789abcdef
-printf '%s %s ext4 rw,relatime 0 0\n' "${DEV_DIR}/vdb" "${DATA_MOUNT}" >> "${MOUNTS}"
-if run_ok "already-mounted"; then
-    grep -q . "${MOUNT_CALLS}" \
-        && fail "already-mounted: mounted over an existing mount" || pass "already-mounted: no-op"
-fi
-
-# --- Case 7: a failed format does not go on to mount a raw device ---
-reset_state
-add_disk vda
-add_disk vdb vol0123456789abcdef
-MKFS_FAIL=1 run_fails "mkfs-fail"
-grep -q . "${MOUNT_CALLS}" \
-    && fail "mkfs-fail: mounted after a failed format" || pass "mkfs-fail: not mounted"
-
-# --- Case 8: a probe that could not run is never read as a blank disk ---
-# The volume below holds a customer's filesystem. Deciding from blkid's empty
-# output rather than its exit status reformats it.
-for rc in 127 4; do
+# Existing supported filesystems mount without any grant.
+for fs in ext4 xfs; do
     reset_state
-    add_disk vda
-    add_disk vdb vol0123456789abcdef
-    echo "${DEV_DIR}/vdb ext4" > "${FS_TABLE}"
-    BLKID_RC="${rc}" run_fails "blkid-exit-${rc}"
-    grep -q . "${MKFS_CALLS}" \
-        && fail "blkid-exit-${rc}: formatted a volume it could not probe" \
-        || pass "blkid-exit-${rc}: nothing formatted"
-    grep -q . "${MOUNT_CALLS}" \
-        && fail "blkid-exit-${rc}: mounted a volume it could not probe" \
-        || pass "blkid-exit-${rc}: not mounted"
+    add_disk vdb volexpected
+    printf '%s fs %s\n' "${DEV_DIR}/vdb" "${fs}" > "${PROBE_TABLE}"
+    if run_ok "existing ${fs}"; then
+        nothing_formatted "existing ${fs}"
+        grep -q "mount -t ${fs} ${DEV_DIR}/vdb ${DATA_MOUNT}" "${MOUNT_CALLS}" && pass "existing ${fs}: mounted by type" || fail "existing ${fs}: not mounted"
+    fi
 done
 
-# --- Case 9: sysfs listing a disk before its device node exists is not blank ---
+# Blank restore/start/replacement volumes have no grant and fail closed.
 reset_state
-add_disk vda
-add_disk vdb vol0123456789abcdef
-rm -f "${DEV_DIR}/vdb"
-run_fails "no-device-node"
-grep -q . "${MKFS_CALLS}" \
-    && fail "no-device-node: formatted a device that does not exist yet" \
-    || pass "no-device-node: nothing formatted"
+add_disk vdb volexpected
+run_fails "blank without grant"
+nothing_formatted "blank without grant"
+
+# Partition tables, visible partitions, unsupported filesystems, ambiguity, and
+# operational probe errors all fail without formatting.
+for kind in pttable fspt unsupported ambiguous unreadable error; do
+    reset_state
+    add_disk vdb volexpected
+    case "${kind}" in
+        pttable) printf '%s pttable gpt\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
+        fspt) printf '%s fspt ext4\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
+        unsupported) printf '%s fs btrfs\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
+        ambiguous) printf '%s ambiguous x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
+        unreadable) printf '%s unreadable x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
+        error) printf '%s error x\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}" ;;
+    esac
+    write_handoff vol-expected volexpected 1 true
+    run_fails "probe ${kind}"
+    nothing_formatted "probe ${kind}"
+done
+
+reset_state
+add_disk vdb volexpected
+add_partition vdb 1
+printf '%s fs ext4\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+write_handoff vol-expected volexpected 1 true
+run_fails "sysfs partition plus filesystem"
+nothing_formatted "sysfs partition plus filesystem"
+
+# Missing identity and invalid generation cannot authorize even when true.
+for field in id serial generation; do
+    reset_state
+    add_disk vdb volexpected
+    write_handoff vol-expected volexpected 1 true
+    case "${field}" in
+        id) sed -i "s/RDS_DATA_VOLUME_ID='vol-expected'/RDS_DATA_VOLUME_ID=''/" "${HANDOFF}" ;;
+        serial) sed -i "s/RDS_DATA_VOLUME_SERIAL='volexpected'/RDS_DATA_VOLUME_SERIAL=''/" "${HANDOFF}" ;;
+        generation) sed -i "s/RDS_VM_GENERATION='1'/RDS_VM_GENERATION='0'/" "${HANDOFF}" ;;
+    esac
+    run_fails "invalid ${field}"
+    nothing_formatted "invalid ${field}"
+done
+
+# A failed format retains the one boot's grant for a legitimate retry.
+reset_state
+add_disk vdb volexpected
+write_handoff vol-expected volexpected 1 true
+MKFS_FAIL=1 run_fails "mkfs failure"
+grep -q '^RDS_FORMAT_AUTHORIZED=' "${HANDOFF}" && pass "mkfs failure: grant retained" || fail "mkfs failure: grant lost"
+[ ! -s "${MOUNT_CALLS}" ] && pass "mkfs failure: not mounted" || fail "mkfs failure: mounted raw disk"
+
+# If mkfs succeeded but the guest died before consuming the line, observing the
+# supported filesystem consumes it without formatting again.
+reset_state
+add_disk vdb volexpected
+printf '%s fs ext4\n' "${DEV_DIR}/vdb" > "${PROBE_TABLE}"
+write_handoff vol-expected volexpected 1 true
+if run_ok "lingering grant on filesystem"; then
+    nothing_formatted "lingering grant"
+    if grep -q '^RDS_FORMAT_AUTHORIZED=' "${HANDOFF}"; then fail "lingering grant: retained"; else pass "lingering grant: consumed"; fi
+fi
+
+# A service restart verifies the mounted source is the expected exact device and
+# removes any lingering authorization.
+reset_state
+add_disk vdb volexpected
+printf '%s %s ext4 rw 0 0\n' "${DEV_DIR}/vdb" "${DATA_MOUNT}" >> "${MOUNTS}"
+write_handoff vol-expected volexpected 1 true
+if run_ok "already mounted exact device"; then
+    [ ! -s "${MOUNT_CALLS}" ] && pass "already mounted: no duplicate mount" || fail "already mounted: mounted twice"
+    if grep -q '^RDS_FORMAT_AUTHORIZED=' "${HANDOFF}"; then fail "already mounted: grant retained"; else pass "already mounted: grant consumed"; fi
+fi
+
+reset_state
+add_disk vdb volexpected
+printf '%s %s ext4 rw 0 0\n' "${DEV_DIR}/wrong" "${DATA_MOUNT}" >> "${MOUNTS}"
+run_fails "already mounted wrong device"
+nothing_formatted "already mounted wrong device"
 
 if [ "${FAILS}" -eq 0 ]; then
     echo "PASS: all rds-datadir cases"

--- a/scripts/images/rds-postgres/rds-init
+++ b/scripts/images/rds-postgres/rds-init
@@ -13,6 +13,8 @@
 #       RDS_MASTER_PASSWORD=<present only when RDS_MODE=initialize>
 #       RDS_DB_NAME=<initial database; optional, as on AWS>
 #       RDS_PORT=<listen port; defaults to 5432>
+#       RDS_DATA_VOLUME_ID / RDS_DATA_VOLUME_SERIAL=<expected volume identity>
+#       RDS_VM_GENERATION / RDS_FORMAT_AUTHORIZED=<create-only format grant>
 #   /run/spinifex-rds/parameters.conf  0600  resolved parameter-group values in
 #                                            postgresql.conf syntax
 #   /run/spinifex-rds/server.crt       0600  serving cert, cluster-CA-signed

--- a/scripts/images/rds-postgres/rds-init.initd
+++ b/scripts/images/rds-postgres/rds-init.initd
@@ -9,10 +9,20 @@
 
 description="Spinifex RDS PostgreSQL bootstrap"
 
+AGENT_ENV="/etc/spinifex-rds/agent.env"
+
 depend() {
     need net
-    after rds-agent
+    after rds-agent rds-datadir
     before postgresql
+}
+
+start_pre() {
+    if [ -f "${AGENT_ENV}" ]; then
+        # shellcheck disable=SC1090
+        . "${AGENT_ENV}"
+        export RDS_HANDOFF_DIR RDS_DATA_MOUNT
+    fi
 }
 
 start() {

--- a/scripts/images/rds-postgres/rds-openrc_test.sh
+++ b/scripts/images/rds-postgres/rds-openrc_test.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "${WORK}"' EXIT
+
+capture_dependencies() {
+    _script=$1
+    (
+        need() { echo "need $*"; }
+        after() { echo "after $*"; }
+        before() { echo "before $*"; }
+        # shellcheck disable=SC1090
+        . "${SCRIPT_DIR}/${_script}"
+        depend
+    )
+}
+
+assert_line() {
+    _file=$1
+    _line=$2
+    grep -Fxq "${_line}" "${_file}" || {
+        echo "FAIL: ${_file} missing dependency: ${_line}" >&2
+        cat "${_file}" >&2
+        exit 1
+    }
+}
+
+capture_dependencies rds-agent.initd > "${WORK}/agent"
+capture_dependencies rds-datadir.initd > "${WORK}/datadir"
+capture_dependencies rds-init.initd > "${WORK}/init"
+
+assert_line "${WORK}/agent" "need net"
+assert_line "${WORK}/agent" "after localmount"
+assert_line "${WORK}/agent" "before rds-datadir rds-init postgresql"
+assert_line "${WORK}/datadir" "after localmount rds-agent"
+assert_line "${WORK}/datadir" "before rds-init postgresql"
+assert_line "${WORK}/init" "need net"
+assert_line "${WORK}/init" "after rds-agent rds-datadir"
+assert_line "${WORK}/init" "before postgresql"
+
+if grep -Fq "before rds-agent" "${WORK}/datadir"; then
+    echo "FAIL: rds-datadir still starts before the bootstrap handoff" >&2
+    exit 1
+fi
+
+echo "rds-openrc: dependency order tests passed"

--- a/spinifex/gateway/rds/agent.go
+++ b/spinifex/gateway/rds/agent.go
@@ -28,6 +28,7 @@ type agentIdentity struct {
 	AccountID            string
 	DBInstanceIdentifier string
 	InstanceID           string
+	VMGeneration         int64
 }
 
 // requestedID, from the request body, is only ever used to reject a mismatch —
@@ -63,6 +64,7 @@ func authorizeAgent(ctx context.Context, nc *nats.Conn, caller Caller, requested
 		AccountID:            entry.AccountID,
 		DBInstanceIdentifier: entry.DBInstanceIdentifier,
 		InstanceID:           caller.SessionName,
+		VMGeneration:         entry.VMGeneration,
 	}, nil
 }
 
@@ -153,6 +155,7 @@ func GetDBBootstrapConfig(ctx context.Context, input *GetDBBootstrapConfigInput,
 	return handlers_rds.NewNATSService(nc).GetDBBootstrapConfig(ctx, &handlers_rds.GetDBBootstrapConfigInput{
 		DBInstanceIdentifier: id.DBInstanceIdentifier,
 		InstanceID:           id.InstanceID,
+		VMGeneration:         id.VMGeneration,
 	}, id.AccountID)
 }
 

--- a/spinifex/gateway/rds/agent_test.go
+++ b/spinifex/gateway/rds/agent_test.go
@@ -53,6 +53,7 @@ func TestAuthorizeAgent_ResolvesInstanceFromIndex(t *testing.T) {
 	assert.Equal(t, testAccountID, id.AccountID, "the account comes from the index, not the caller")
 	assert.Equal(t, testDBID, id.DBInstanceIdentifier)
 	assert.Equal(t, testInstanceID, id.InstanceID)
+	assert.Equal(t, int64(1), id.VMGeneration)
 }
 
 // The agent's own credentials are minted under the system account, so the
@@ -269,6 +270,10 @@ func TestBootstrapConfigXML_OmitsPasswordOnAttach(t *testing.T) {
 		Engine:               "postgres",
 		MasterUsername:       "postgres",
 		Port:                 5432,
+		DataVolumeID:         "vol-data-01",
+		DataVolumeSerial:     "voldata01",
+		VMGeneration:         1,
+		FormatAuthorized:     true,
 		Parameters:           []handlers_rds.Parameter{{Name: "shared_buffers", Value: "128MB"}},
 	}
 
@@ -288,6 +293,10 @@ func TestBootstrapConfigXML_OmitsPasswordOnAttach(t *testing.T) {
 	// marshaller emits a struct's children in map order, so each element is
 	// asserted on its own rather than as an ordered pair.
 	assert.Contains(t, body, "<Port>5432</Port>")
+	assert.Contains(t, body, "<DataVolumeId>vol-data-01</DataVolumeId>")
+	assert.Contains(t, body, "<DataVolumeSerial>voldata01</DataVolumeSerial>")
+	assert.Contains(t, body, "<VMGeneration>1</VMGeneration>")
+	assert.Contains(t, body, "<FormatAuthorized>true</FormatAuthorized>")
 	assert.Contains(t, body, "<member>")
 	assert.Contains(t, body, "<Name>shared_buffers</Name>")
 	assert.Contains(t, body, "<Value>128MB</Value>")

--- a/spinifex/handlers/rds/agent.go
+++ b/spinifex/handlers/rds/agent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 )
 
 // Bootstrap modes returned by GetDBBootstrapConfig. Initialize is the first
@@ -60,6 +61,7 @@ type SubmitDBStateChangeOutput struct {
 type GetDBBootstrapConfigInput struct {
 	DBInstanceIdentifier string `json:"dbInstanceIdentifier"`
 	InstanceID           string `json:"instanceId"`
+	VMGeneration         int64  `json:"vmGeneration"`
 }
 
 // Everything rds-init needs to bootstrap or attach. The serving cert and key
@@ -73,6 +75,11 @@ type GetDBBootstrapConfigOutput struct {
 	MasterUsername       string  `json:"masterUsername" locationName:"MasterUsername"`
 	MasterUserPassword   *string `json:"masterUserPassword,omitempty" locationName:"MasterUserPassword"`
 	Port                 int64   `json:"port" locationName:"Port"`
+
+	DataVolumeID     string `json:"dataVolumeId,omitempty" locationName:"DataVolumeId" xml:"DataVolumeId"`
+	DataVolumeSerial string `json:"dataVolumeSerial,omitempty" locationName:"DataVolumeSerial" xml:"DataVolumeSerial"`
+	VMGeneration     int64  `json:"vmGeneration,omitempty" locationName:"VMGeneration" xml:"VMGeneration"`
+	FormatAuthorized bool   `json:"formatAuthorized" locationName:"FormatAuthorized" xml:"FormatAuthorized"`
 
 	Parameters []Parameter `json:"parameters,omitempty" locationName:"Parameters" locationNameList:"member" xml:"Parameters>member"`
 
@@ -284,6 +291,29 @@ func (s *Service) GetDBBootstrapConfig(ctx context.Context, input *GetDBBootstra
 		if !found {
 			return nil, errors.New(awserrors.ErrorDBInstanceNotFound)
 		}
+		if rec.InstanceID == "" || input.InstanceID != rec.InstanceID {
+			return nil, errors.New(awserrors.ErrorAccessDenied)
+		}
+
+		generationMatches := input.VMGeneration > 0 && input.VMGeneration == rec.VMGeneration
+		// An old gateway may omit the generation for an existing record. It may
+		// still serve attach material, but it must not consume or expose a live
+		// create grant until the caller is bound to the current generation.
+		if rec.FormatAuthorized && !generationMatches {
+			return nil, errors.New(awserrors.ErrorAccessDenied)
+		}
+		serial := rec.DataVolumeSerial
+		if serial == "" && rec.DataVolumeID != "" {
+			// Backward-compatible identity for records written before the serial
+			// field existed. Missing authorization remains false.
+			serial = vm.VolumeSerial(rec.DataVolumeID)
+		}
+		authoritativeSerial := vm.VolumeSerial(rec.DataVolumeID)
+		grantIdentityValid := generationMatches && rec.DataVolumeID != "" &&
+			rec.DataVolumeSerial != "" && rec.DataVolumeSerial == authoritativeSerial
+		if rec.FormatAuthorized && !grantIdentityValid {
+			return nil, errors.New(awserrors.ErrorAccessDenied)
+		}
 
 		out := &GetDBBootstrapConfigOutput{
 			Mode:                 BootstrapModeAttach,
@@ -293,6 +323,10 @@ func (s *Service) GetDBBootstrapConfig(ctx context.Context, input *GetDBBootstra
 			DBName:               rec.DBName,
 			MasterUsername:       rec.MasterUsername,
 			Port:                 rec.Port,
+			DataVolumeID:         rec.DataVolumeID,
+			DataVolumeSerial:     serial,
+			VMGeneration:         rec.VMGeneration,
+			FormatAuthorized:     rec.FormatAuthorized && grantIdentityValid,
 			Parameters:           rec.Bootstrap.ResolvedParameters,
 		}
 

--- a/spinifex/handlers/rds/agent_test.go
+++ b/spinifex/handlers/rds/agent_test.go
@@ -113,9 +113,13 @@ func readRecord(t *testing.T, svc *Service) (DBInstanceRecord, string) {
 
 func TestGetDBBootstrapConfig_InitializeThenAttach(t *testing.T) {
 	svc := newTestService(t)
-	seedInstance(t, svc, defaultRecord())
+	rec := defaultRecord()
+	rec.VMGeneration = 1
+	rec.DataVolumeID = "vol-data-01"
+	rec.DataVolumeSerial = "voldata01"
+	seedInstance(t, svc, rec)
 	ctx := context.Background()
-	in := &GetDBBootstrapConfigInput{DBInstanceIdentifier: testDBID, InstanceID: testInstance}
+	in := &GetDBBootstrapConfigInput{DBInstanceIdentifier: testDBID, InstanceID: testInstance, VMGeneration: 1}
 
 	first, err := svc.GetDBBootstrapConfig(ctx, in, testAccountID)
 	require.NoError(t, err)
@@ -128,6 +132,10 @@ func TestGetDBBootstrapConfig_InitializeThenAttach(t *testing.T) {
 	assert.Equal(t, int64(5432), first.Port)
 	assert.Equal(t, "orders", first.DBName)
 	assert.Equal(t, []Parameter{{Name: "shared_buffers", Value: "128MB"}}, first.Parameters)
+	assert.Equal(t, "vol-data-01", first.DataVolumeID)
+	assert.Equal(t, "voldata01", first.DataVolumeSerial)
+	assert.Equal(t, int64(1), first.VMGeneration)
+	assert.False(t, first.FormatAuthorized)
 
 	for i := range 3 {
 		next, err := svc.GetDBBootstrapConfig(ctx, in, testAccountID)
@@ -137,6 +145,55 @@ func TestGetDBBootstrapConfig_InitializeThenAttach(t *testing.T) {
 		assert.Equal(t, int64(5432), next.Port)
 		assert.Equal(t, "orders", next.DBName)
 		assert.Equal(t, first.Parameters, next.Parameters)
+	}
+}
+
+func TestGetDBBootstrapConfig_FormatGrantRequiresExactCurrentIdentity(t *testing.T) {
+	tests := []struct {
+		name       string
+		generation int64
+		mutate     func(*DBInstanceRecord)
+		wantGrant  bool
+		wantErr    bool
+	}{
+		{name: "matching current generation", generation: 1, wantGrant: true},
+		{name: "stale generation", generation: 2, wantErr: true},
+		{name: "generation omitted by old gateway", wantErr: true},
+		{name: "serial does not match volume", generation: 1, mutate: func(rec *DBInstanceRecord) {
+			rec.DataVolumeSerial = "volwrong"
+		}, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newTestService(t)
+			rec := defaultRecord()
+			rec.VMGeneration = 1
+			rec.DataVolumeID = "vol-data-01"
+			rec.DataVolumeSerial = "voldata01"
+			rec.FormatAuthorized = true
+			if tc.mutate != nil {
+				tc.mutate(&rec)
+			}
+			seedInstance(t, svc, rec)
+
+			out, err := svc.GetDBBootstrapConfig(t.Context(), &GetDBBootstrapConfigInput{
+				DBInstanceIdentifier: testDBID,
+				InstanceID:           testInstance,
+				VMGeneration:         tc.generation,
+			}, testAccountID)
+			if tc.wantErr {
+				require.Error(t, err)
+				stored, _ := readRecord(t, svc)
+				assert.False(t, stored.Bootstrap.Consumed, "a rejected caller must not consume the one-shot password")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantGrant, out.FormatAuthorized)
+			assert.Equal(t, rec.DataVolumeID, out.DataVolumeID)
+			assert.Equal(t, rec.DataVolumeSerial, out.DataVolumeSerial)
+			assert.Equal(t, rec.VMGeneration, out.VMGeneration)
+		})
 	}
 }
 

--- a/spinifex/handlers/rds/backup.go
+++ b/spinifex/handlers/rds/backup.go
@@ -364,6 +364,7 @@ func (s *Service) runMaintenanceWindow(ctx context.Context, kv jetstream.KeyValu
 
 	rec.LastMaintenanceWindowAt = &now
 	rec.TransitionStartedAt = &now
+	rec.FormatAuthorized = false
 	rec.Status = StatusModifying
 	rec.UpdatedAt = now
 	if err := updateJSON(ctx, kv, DBInstanceKey(rec.DBInstanceIdentifier), rev, rec); err != nil {

--- a/spinifex/handlers/rds/backup_test.go
+++ b/spinifex/handlers/rds/backup_test.go
@@ -593,6 +593,7 @@ func TestResolvedBackupWindow_DerivesAWindowForARecordWithoutOne(t *testing.T) {
 func TestRunMaintenanceWindow_OpensADeferredModify(t *testing.T) {
 	h := newSnapshotHarness(t, false)
 	rec := backupReadyRecord()
+	rec.FormatAuthorized = true
 	rec.PreferredMaintenanceWindow = openMaintenanceWindow(time.Now().UTC())
 	rec.PendingModifiedValues = &PendingModifiedValues{
 		DBInstanceClass: "db.t3.large",
@@ -604,6 +605,7 @@ func TestRunMaintenanceWindow_OpensADeferredModify(t *testing.T) {
 
 	stored := h.instance(t, testDBID)
 	assert.Equal(t, StatusModifying, stored.Status)
+	assert.False(t, stored.FormatAuthorized, "deferred replacement must revoke formatting before its boot")
 	require.NotNil(t, stored.LastMaintenanceWindowAt)
 	require.NotNil(t, stored.TransitionStartedAt)
 	require.NotNil(t, stored.PendingModifiedValues, "the values are drained by the reconciler, not here")

--- a/spinifex/handlers/rds/create.go
+++ b/spinifex/handlers/rds/create.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	handlers_dns "github.com/mulgadc/spinifex/spinifex/handlers/dns"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -104,7 +105,7 @@ func (s *Service) CreateDBInstance(ctx context.Context, input *rds.CreateDBInsta
 
 	// The launch already unwound everything on failure, so from here the resources
 	// exist and the record has to catch up with them.
-	stored, launchRev, err := s.recordLaunch(ctx, kv, key, accountID, rec.DbiResourceID, launched)
+	stored, launchRev, err := s.recordLaunch(ctx, kv, key, accountID, rec.DbiResourceID, launched, true)
 	if err != nil {
 		s.unwindLaunched(ctx, launched)
 		return nil, err
@@ -183,7 +184,7 @@ func newDBInstanceRecord(accountID string, req *validatedCreate, placement *endp
 // The endpoint is settled here because the ENI IP — and so the vanity name — is
 // only known now.
 func (s *Service) recordLaunch(ctx context.Context, kv jetstream.KeyValue, key, accountID,
-	expectedResourceID string, launched *LaunchOutput) (*DBInstanceRecord, uint64, error) {
+	expectedResourceID string, launched *LaunchOutput, initialCreate bool) (*DBInstanceRecord, uint64, error) {
 	var rec DBInstanceRecord
 	rev, found, err := getJSONRevision(ctx, kv, key, &rec)
 	if err != nil {
@@ -195,6 +196,10 @@ func (s *Service) recordLaunch(ctx context.Context, kv jetstream.KeyValue, key, 
 	if rec.DbiResourceID != expectedResourceID {
 		return nil, 0, fmt.Errorf("rds: DB instance reservation %s changed ownership during launch", key)
 	}
+	if launched.DataVolumeID == "" || launched.DataVolumeSerial == "" ||
+		launched.DataVolumeSerial != vm.VolumeSerial(launched.DataVolumeID) {
+		return nil, 0, fmt.Errorf("rds: DB instance launch %s returned invalid data volume identity", key)
+	}
 
 	rec.InstanceID = launched.InstanceID
 	rec.VMGeneration = firstVMGeneration
@@ -202,6 +207,11 @@ func (s *Service) recordLaunch(ctx context.Context, kv jetstream.KeyValue, key, 
 	rec.ENIID = launched.CustomerENIID
 	rec.ENIPrivateIP = launched.CustomerENIIP
 	rec.DataVolumeID = launched.DataVolumeID
+	rec.DataVolumeSerial = launched.DataVolumeSerial
+	// Formatting is a create-only grant bound to this launch's exact fresh
+	// volume and first VM generation. Restore and every existing-volume launch
+	// pass false and cannot infer permission from an empty filesystem.
+	rec.FormatAuthorized = initialCreate && launched.CreatedDataVolume && rec.VMGeneration == firstVMGeneration
 	// Only a launch that made the volume can report its encryption; a restore
 	// attaches one it created itself, whose encryption the record already carries.
 	if launched.CreatedDataVolume {

--- a/spinifex/handlers/rds/create_test.go
+++ b/spinifex/handlers/rds/create_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -248,6 +249,8 @@ func TestCreateDBInstance_ProvisionsAndRecordsTheInstance(t *testing.T) {
 	assert.NotEmpty(t, rec.ENIID)
 	assert.NotEqual(t, rec.SystemENIID, rec.ENIID, "the system and customer NICs are distinct")
 	assert.Equal(t, "vol-rdsdata01", rec.DataVolumeID)
+	assert.Equal(t, vm.VolumeSerial(rec.DataVolumeID), rec.DataVolumeSerial)
+	assert.True(t, rec.FormatAuthorized, "only the fresh initial-create volume may be formatted")
 	assert.True(t, rec.StorageEncrypted)
 	// The master password is staged for the one-shot bootstrap fetch, unconsumed.
 	assert.Equal(t, "Sup3rSecret!", rec.Bootstrap.MasterUserPassword)

--- a/spinifex/handlers/rds/launch.go
+++ b/spinifex/handlers/rds/launch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
 )
 
@@ -35,8 +36,10 @@ const (
 
 	// Stamped on the engine AMIs by their image manifest; an EngineVersion
 	// request resolves against these.
-	engineTagKey        = "engine"
-	engineVersionTagKey = "engine-version"
+	engineTagKey             = "engine"
+	engineVersionTagKey      = "engine-version"
+	dataVolumeContractTagKey = "rds-data-volume-contract"
+	dataVolumeContractV1     = "format-auth-v1"
 
 	attachRequestTimeout = 30 * time.Second
 
@@ -121,10 +124,11 @@ type LaunchOutput struct {
 	InstanceID string
 	// The system ENI is disposable — a replace makes a new one. The customer
 	// ENI is the stable endpoint: its IP is the DNS target and survives.
-	SystemENIID   string
-	CustomerENIID string
-	CustomerENIIP string
-	DataVolumeID  string
+	SystemENIID      string
+	CustomerENIID    string
+	CustomerENIIP    string
+	DataVolumeID     string
+	DataVolumeSerial string
 	// The volume's own reported state, not an echo of the request, so
 	// DescribeDBInstances reports encryption the way EC2 does. Meaningful only
 	// when this launch created the volume; a replace or restore attaches one
@@ -299,6 +303,7 @@ func LaunchDBInstanceVM(ctx context.Context, deps LaunchDeps, in LaunchInput) (o
 		CustomerENIID:       customerENI.id,
 		CustomerENIIP:       customerENI.ip,
 		DataVolumeID:        volumeID,
+		DataVolumeSerial:    vm.VolumeSerial(volumeID),
 		DataVolumeEncrypted: volumeEncrypted,
 		CreatedDataVolume:   in.ExistingDataVolume == "",
 		Unwind:              unwind,
@@ -422,6 +427,7 @@ func resolveEngineAMI(ctx context.Context, amiSvc launchAMIResolver, engine, ver
 	filters := []*ec2.Filter{
 		{Name: aws.String("tag:" + tags.ManagedByKey), Values: aws.StringSlice([]string{tags.ManagedByRDS})},
 		{Name: aws.String("tag:" + engineTagKey), Values: aws.StringSlice([]string{engine})},
+		{Name: aws.String("tag:" + dataVolumeContractTagKey), Values: aws.StringSlice([]string{dataVolumeContractV1})},
 	}
 	if version != "" {
 		filters = append(filters, &ec2.Filter{

--- a/spinifex/handlers/rds/launch_test.go
+++ b/spinifex/handlers/rds/launch_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -585,6 +586,22 @@ func TestLaunchDBInstanceVMAttachesTheDataVolume(t *testing.T) {
 	assert.Equal(t, utils.GlobalAccountID, h.attacher.accountID)
 
 	assert.Equal(t, "vol-rdsdata01", out.DataVolumeID)
+	assert.Equal(t, vm.VolumeSerial(out.DataVolumeID), out.DataVolumeSerial)
+	assert.True(t, out.CreatedDataVolume)
+}
+
+func TestLaunchDBInstanceVMReportsExistingVolumeIntentAndSerial(t *testing.T) {
+	h := newLaunchHarness()
+	in := testLaunchInput()
+	in.ExistingDataVolume = "vol-existing-01"
+
+	out, err := LaunchDBInstanceVM(t.Context(), h.deps(), in)
+	require.NoError(t, err)
+
+	assert.Equal(t, "vol-existing-01", out.DataVolumeID)
+	assert.Equal(t, vm.VolumeSerial(out.DataVolumeID), out.DataVolumeSerial)
+	assert.False(t, out.CreatedDataVolume)
+	assert.Empty(t, h.volumes.created, "an existing-volume launch must not create a blank replacement")
 }
 
 func TestLaunchDBInstanceVMRollsBackEverythingItCreated(t *testing.T) {
@@ -701,9 +718,10 @@ func TestResolveEngineAMIMatchesOnManifestTags(t *testing.T) {
 		got[aws.StringValue(f.Name)] = aws.StringValue(f.Values[0])
 	}
 	assert.Equal(t, map[string]string{
-		"tag:" + tags.ManagedByKey: tags.ManagedByRDS,
-		"tag:engine":               "postgres",
-		"tag:engine-version":       "18",
+		"tag:" + tags.ManagedByKey:        tags.ManagedByRDS,
+		"tag:engine":                      "postgres",
+		"tag:engine-version":              "18",
+		"tag:" + dataVolumeContractTagKey: dataVolumeContractV1,
 	}, got)
 }
 

--- a/spinifex/handlers/rds/lifecycle.go
+++ b/spinifex/handlers/rds/lifecycle.go
@@ -281,6 +281,10 @@ func (s *Service) beginTransition(ctx context.Context, accountID, id string, to 
 	// so a clock left over from an earlier outage cannot shorten the grace on a
 	// fault the customer has just acted on.
 	rec.UnhealthySince = nil
+	// No lifecycle operation is an initial create. Revoke before issuing a
+	// command that can boot the guest, so an unrecognized existing volume can
+	// never inherit the create-time format grant.
+	rec.FormatAuthorized = false
 	rec.TransitionStartedAt = &now
 	rec.UpdatedAt = now
 	if err := updateJSON(ctx, kv, DBInstanceKey(id), rev, rec); err != nil {

--- a/spinifex/handlers/rds/lifecycle_test.go
+++ b/spinifex/handlers/rds/lifecycle_test.go
@@ -310,7 +310,9 @@ func (h *lifecycleHarness) events(t *testing.T) []Event {
 // checkpointed cluster rather than a crash it has to replay.
 func TestRebootDBInstance_StopsTheEngineThenTheVM(t *testing.T) {
 	h := newLifecycleHarness(t, false)
-	seedInstance(t, h.svc, availableRecord())
+	rec := availableRecord()
+	rec.FormatAuthorized = true
+	seedInstance(t, h.svc, rec)
 
 	out, err := h.svc.RebootDBInstance(t.Context(),
 		&rds.RebootDBInstanceInput{DBInstanceIdentifier: aws.String(testDBID)}, testAccountID)
@@ -324,7 +326,9 @@ func TestRebootDBInstance_StopsTheEngineThenTheVM(t *testing.T) {
 	// Reported as rebooting, not available: the engine has to come back and say
 	// so before the reconciler calls it that.
 	assert.Equal(t, string(StatusRebooting), aws.StringValue(out.DBInstance.DBInstanceStatus))
-	assert.Equal(t, StatusRebooting, h.record(t).Status)
+	stored := h.record(t)
+	assert.Equal(t, StatusRebooting, stored.Status)
+	assert.False(t, stored.FormatAuthorized, "reboot must revoke create-time formatting")
 }
 
 // The static parameters are already in the engine's config, so the restart
@@ -470,7 +474,9 @@ func TestReconciler_DoesNotCallAStillRunningVMStopped(t *testing.T) {
 // so a start comes back on the same datadir at the same address.
 func TestStopDBInstance_RetainsTheEndpointAndTheVolume(t *testing.T) {
 	h := newLifecycleHarness(t, false)
-	seedInstance(t, h.svc, availableRecord())
+	seed := availableRecord()
+	seed.FormatAuthorized = true
+	seedInstance(t, h.svc, seed)
 
 	_, err := h.svc.StopDBInstance(t.Context(),
 		&rds.StopDBInstanceInput{DBInstanceIdentifier: aws.String(testDBID)}, testAccountID)
@@ -482,6 +488,7 @@ func TestStopDBInstance_RetainsTheEndpointAndTheVolume(t *testing.T) {
 	rec := h.record(t)
 	assert.Equal(t, "vol-rdsdata01", rec.DataVolumeID)
 	assert.Equal(t, "eni-cust01", rec.ENIID)
+	assert.False(t, rec.FormatAuthorized, "stop must leave no grant for a later start")
 }
 
 // A pre-stop snapshot is a later phase's. Accepting it here would report a
@@ -503,6 +510,7 @@ func TestStartDBInstance_StartsTheVMAndReportsStarting(t *testing.T) {
 	h := newLifecycleHarness(t, false)
 	rec := availableRecord()
 	rec.Status = StatusStopped
+	rec.FormatAuthorized = true
 	seedInstance(t, h.svc, rec)
 
 	out, err := h.svc.StartDBInstance(t.Context(),
@@ -511,7 +519,9 @@ func TestStartDBInstance_StartsTheVMAndReportsStarting(t *testing.T) {
 
 	assert.Equal(t, []string{"start:" + testInstance}, h.cmdr.calls)
 	assert.Equal(t, string(StatusStarting), aws.StringValue(out.DBInstance.DBInstanceStatus))
-	assert.Equal(t, StatusStarting, h.record(t).Status)
+	stored := h.record(t)
+	assert.Equal(t, StatusStarting, stored.Status)
+	assert.False(t, stored.FormatAuthorized, "start must never restore format permission")
 }
 
 // A node restart drops the VM from memory, so the start relaunches it from the

--- a/spinifex/handlers/rds/modify_test.go
+++ b/spinifex/handlers/rds/modify_test.go
@@ -560,7 +560,9 @@ func TestModifyDBInstance_AcceptsARetryFromFailed(t *testing.T) {
 // the in-guest filesystem grow still outstanding.
 func TestModifyDBInstance_AppliesAStorageGrowImmediately(t *testing.T) {
 	h := newModifyHarness(t)
-	seedInstance(t, h.svc, modifiableRecord())
+	seed := modifiableRecord()
+	seed.FormatAuthorized = true
+	seedInstance(t, h.svc, seed)
 
 	in := modifyInput()
 	in.AllocatedStorage = aws.Int64(50)
@@ -580,6 +582,7 @@ func TestModifyDBInstance_AppliesAStorageGrowImmediately(t *testing.T) {
 	rec := h.record(t)
 	assert.Equal(t, int64(50), rec.AllocatedStorage)
 	assert.Equal(t, testInstance, rec.InstanceID, "a grow restarts the VM rather than replacing it")
+	assert.False(t, rec.FormatAuthorized, "storage grow must not carry create-time formatting into the restart")
 	require.NotNil(t, rec.PendingModifiedValues)
 	assert.True(t, rec.PendingModifiedValues.FilesystemGrowPending)
 	assert.Nil(t, rec.PendingModifiedValues.AllocatedStorage, "the volume is at its new size")

--- a/spinifex/handlers/rds/reconciler.go
+++ b/spinifex/handlers/rds/reconciler.go
@@ -642,6 +642,12 @@ func (r *Reconciler) transition(ctx context.Context, kv jetstream.KeyValue, rev 
 	}
 	from := rec.Status
 	rec.Status = to
+	if from == StatusCreating {
+		// A healthy engine proves the initial format completed; a failed create
+		// is no longer an active initialization either. Never retain a reusable
+		// grant after leaving the create operation.
+		rec.FormatAuthorized = false
+	}
 	rec.FailureReason = reason
 	rec.UpdatedAt = time.Now().UTC()
 

--- a/spinifex/handlers/rds/reconciler_test.go
+++ b/spinifex/handlers/rds/reconciler_test.go
@@ -90,13 +90,20 @@ func (h *reconcileHarness) statusOf(t *testing.T, id string) (Status, string) {
 
 func TestReconciler_MarksAvailableOnHealthyHeartbeatFromARunningVM(t *testing.T) {
 	h := newReconcileHarness(t)
-	seedInstance(t, h.svc, healthyRecord())
+	rec := healthyRecord()
+	rec.FormatAuthorized = true
+	seedInstance(t, h.svc, rec)
 
 	require.NoError(t, h.rec.reconcileOnce(t.Context()))
 
 	status, reason := h.statusOf(t, testDBID)
 	assert.Equal(t, StatusAvailable, status)
 	assert.Empty(t, reason)
+	kv, err := h.svc.bucket(t.Context(), testAccountID)
+	require.NoError(t, err)
+	stored, _, err := h.svc.getDBInstance(t.Context(), kv, testDBID)
+	require.NoError(t, err)
+	assert.False(t, stored.FormatAuthorized, "a completed create must not retain a reusable grant")
 	assert.Equal(t, []string{testInstance}, h.state.calls)
 
 	events := describeEvents(t, h.svc, &rds.DescribeEventsInput{

--- a/spinifex/handlers/rds/records.go
+++ b/spinifex/handlers/rds/records.go
@@ -83,9 +83,13 @@ type DBInstanceRecord struct {
 	InstanceID string `json:"instanceId,omitempty"`
 	// Increments on every replace, so a superseded VM's agent is
 	// distinguishable from the current one.
-	VMGeneration int64  `json:"vmGeneration,omitempty"`
-	DataVolumeID string `json:"dataVolumeId,omitempty"`
-	ENIID        string `json:"eniId,omitempty"`
+	VMGeneration     int64  `json:"vmGeneration,omitempty"`
+	DataVolumeID     string `json:"dataVolumeId,omitempty"`
+	DataVolumeSerial string `json:"dataVolumeSerial,omitempty"`
+	// True only while the initial create may format its exact fresh volume.
+	// Every later boot path clears it before the guest can fetch a handoff.
+	FormatAuthorized bool   `json:"formatAuthorized,omitempty"`
+	ENIID            string `json:"eniId,omitempty"`
 	// Disposable: a replace mints a new one, unlike the customer ENI.
 	SystemENIID string `json:"systemEniId,omitempty"`
 	// Stable across VM replace, so it serves as both the fallback endpoint and

--- a/spinifex/handlers/rds/replace.go
+++ b/spinifex/handlers/rds/replace.go
@@ -59,6 +59,14 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 	if err != nil {
 		return err
 	}
+	if rec.FormatAuthorized {
+		if err := s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
+			stored.FormatAuthorized = false
+		}); err != nil {
+			return fmt.Errorf("revoke the data-volume format grant before replacing %s: %w", rec.DBInstanceIdentifier, err)
+		}
+		rec.FormatAuthorized = false
+	}
 
 	// Checkpointed first so the replacement boots on a clean datadir rather than
 	// one it has to replay a WAL over. A wedged agent degrades this rather than
@@ -118,7 +126,9 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 	if err := s.updateInstance(ctx, kv, rec.DBInstanceIdentifier, func(stored *DBInstanceRecord) {
 		stored.InstanceID = launched.InstanceID
 		stored.SystemENIID = launched.SystemENIID
+		stored.DataVolumeSerial = launched.DataVolumeSerial
 		stored.VMGeneration++
+		stored.FormatAuthorized = false
 		// The new VM has never reported, so the old VM's health must not read as
 		// this one's — the reconciler would call the replace finished at once.
 		stored.Agent = AgentState{}
@@ -129,7 +139,9 @@ func (s *Service) replaceInstanceVM(ctx context.Context, kv jetstream.KeyValue, 
 	// VM's identity on top of this one.
 	rec.InstanceID = launched.InstanceID
 	rec.SystemENIID = launched.SystemENIID
+	rec.DataVolumeSerial = launched.DataVolumeSerial
 	rec.VMGeneration++
+	rec.FormatAuthorized = false
 	rec.Agent = AgentState{}
 
 	slog.InfoContext(ctx, "rds: DB VM replaced",

--- a/spinifex/handlers/rds/replace_test.go
+++ b/spinifex/handlers/rds/replace_test.go
@@ -140,6 +140,7 @@ func TestReplaceInstanceVM_RewritesTheInstanceIndex(t *testing.T) {
 func TestReplaceInstanceVM_RecordsTheNewVMAndKeepsTheEndpoint(t *testing.T) {
 	h := newModifyHarness(t)
 	seed := modifiableRecord()
+	seed.FormatAuthorized = true
 	beat := time.Now().UTC()
 	seed.Agent = AgentState{InstanceID: testInstance, EngineHealth: EngineHealthHealthy, LastSeen: &beat}
 	rec := seedReplaceable(t, h, seed)
@@ -159,11 +160,14 @@ func TestReplaceInstanceVM_RecordsTheNewVMAndKeepsTheEndpoint(t *testing.T) {
 	assert.Equal(t, seed.ENIPrivateIP, stored.ENIPrivateIP)
 	assert.Equal(t, seed.DNSName, stored.DNSName)
 	assert.Equal(t, testDataVolume, stored.DataVolumeID)
+	assert.Equal(t, "volrdsdata01", stored.DataVolumeSerial)
+	assert.False(t, stored.FormatAuthorized, "replacement must revoke an initial-create grant")
 
 	// The caller's copy is kept in step, so its own record write cannot
 	// resurrect the old VM's identity on top of this one.
 	assert.Equal(t, testReplacementInstance, rec.InstanceID)
 	assert.Equal(t, int64(1), rec.VMGeneration)
+	assert.False(t, rec.FormatAuthorized)
 }
 
 // A grow riding a class change takes the only window in which nothing holds the

--- a/spinifex/handlers/rds/restore.go
+++ b/spinifex/handlers/rds/restore.go
@@ -132,7 +132,7 @@ func (s *Service) RestoreDBInstanceFromDBSnapshot(ctx context.Context, input *rd
 		return nil, err
 	}
 
-	stored, launchRev, err := s.recordLaunch(ctx, kv, key, accountID, rec.DbiResourceID, launched)
+	stored, launchRev, err := s.recordLaunch(ctx, kv, key, accountID, rec.DbiResourceID, launched, false)
 	if err != nil {
 		s.unwindLaunched(ctx, launched)
 		return nil, err

--- a/spinifex/handlers/rds/restore_test.go
+++ b/spinifex/handlers/rds/restore_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/mulgadc/spinifex/spinifex/vm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +60,8 @@ func TestRestoreDBInstanceFromDBSnapshot_BuildsANewInstanceOnTheSnapshotsData(t 
 
 	stored := h.instance(t, testRestoredID)
 	assert.Equal(t, "vol-rdsdata01", stored.DataVolumeID)
+	assert.Equal(t, vm.VolumeSerial(stored.DataVolumeID), stored.DataVolumeSerial)
+	assert.False(t, stored.FormatAuthorized, "snapshot-derived volumes must never receive a format grant")
 	assert.Equal(t, testSnapshotID, stored.RestoredFromDBSnapshot)
 	assert.True(t, stored.StorageEncrypted)
 

--- a/spinifex/utils/images.go
+++ b/spinifex/utils/images.go
@@ -507,7 +507,10 @@ var AvailableImages = map[string]Images{
 		Checksum:     "https://iso.mulgadc.com/system-ami/spinifex-rds-postgres-x86_64.qcow2.sha256",
 		ChecksumType: "sha256",
 		BootMode:     "bios",
-		Tags:         map[string]string{"spinifex:managed-by": "rds", "engine": "postgres", "engine-version": "18"},
+		Tags: map[string]string{
+			"spinifex:managed-by": "rds", "engine": "postgres", "engine-version": "18",
+			"rds-data-volume-contract": "format-auth-v1",
+		},
 	},
 }
 

--- a/spinifex/utils/utils_test.go
+++ b/spinifex/utils/utils_test.go
@@ -1687,6 +1687,8 @@ func TestAvailableImages_RDSPostgresEntry(t *testing.T) {
 	assert.Equal(t, "postgres", img.Tags["engine"])
 	assert.Equal(t, "18", img.Tags["engine-version"],
 		"the pinned PostgreSQL major version is what EngineVersion resolves against")
+	assert.Equal(t, "format-auth-v1", img.Tags["rds-data-volume-contract"],
+		"RDS launches must exclude images that still discover generic data disks")
 }
 
 // --- NormalizeXMLOutput / normalizeNilSlices ---

--- a/spinifex/vm/devices_test.go
+++ b/spinifex/vm/devices_test.go
@@ -6,6 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestVolumeSerial(t *testing.T) {
+	tests := []struct {
+		volumeID string
+		want     string
+	}{
+		{volumeID: "vol-0123456789abcdef0", want: "vol0123456789abcdef0"},
+		{volumeID: "vol-many-dashes-here", want: "volmanydasheshere"},
+		{volumeID: "", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.volumeID, func(t *testing.T) {
+			assert.Equal(t, tc.want, VolumeSerial(tc.volumeID))
+		})
+	}
+}
+
 func TestIsMMIO(t *testing.T) {
 	tests := []struct {
 		machineType string


### PR DESCRIPTION
## Summary

`rds-datadir` previously selected any single virtio disk whose serial started with `vol`, ran `blkid`, and formatted it when no filesystem was recognized. A damaged existing filesystem satisfied that test, so a subsequent boot could convert recoverable damage into irreversible loss of the datadir and WAL.

Formatting is now gated on an explicit control-plane grant bound to the exact volume identity, rather than inferred from `blkid` output.

- The launch record persists `DataVolumeID`, `DataVolumeSerial`, `VMGeneration`, and `FormatAuthorized`. The grant is set only on the initial create path, only when `LaunchDBInstanceVM` created the volume itself, and never for a snapshot-derived volume. Restore, start, reboot, class replacement, and storage replacement revoke it.
- The four non-secret fields reach the guest through `GetDBBootstrapConfigOutput`, `internal/rdsgw`, and the root-only handoff. The handler denies the fetch when the caller's VM generation or the record's volume identity does not match the grant.
- OpenRC now orders `network -> rds-agent bootstrap fetch -> rds-datadir -> rds-init -> postgresql`, and the agent's command loop waits for the data mount to appear in `/proc/mounts` so guest state cannot land on the disposable boot volume.
- `rds-datadir` selects only the device whose serial exactly matches, ignoring unrelated `vol*` disks, and fails closed on a mismatch, a duplicate serial, a partition table, conflicting signatures, a failed probe, or a missing grant.
- Engine AMI resolution requires the `rds-data-volume-contract=format-auth-v1` tag, so a new instance cannot boot an image that still does generic `vol*` discovery.

## Rollout

The AMI contract tag is a hard filter in `resolveEngineAMI`, and it gates every path that launches a VM — create, restore, stop/start, class change, storage grow, and maintenance replacement. **A retagged `rds-postgres` AMI must be built and registered before this merges into a running environment**, or those operations fail with `no AMI found for engine`. Steps 4 and 5 of the plan's rollout (live-cluster lifecycle validation, removing legacy generic `vol*` discovery) are still outstanding.