### PR TITLE
feat(bedrock): reclaim idle serving GPUs with a leader-elected reaper

### DIFF
--- a/spinifex/daemon/daemon.go
+++ b/spinifex/daemon/daemon.go
@@ -153,6 +153,7 @@ type Daemon struct {
 	rdsService            *handlers_rds.Service
 	rdsReconciler         *handlers_rds.Reconciler
 	bedrockService        *handlers_bedrock.Service
+	bedrockReaper         *handlers_bedrock.Reaper
 	acmService            *handlers_acm.ACMServiceImpl
 	acmRenewalWorker      *handlers_acm.Worker
 	ecrMetaService        *handlers_ecr.MetaServiceImpl
@@ -1691,11 +1692,23 @@ func (d *Daemon) startCluster() error {
 		d.rdsReconciler.Run(d.ctx)
 	})
 
-	// Bedrock serving-endpoint lifecycle: no reconciler yet (no idle-reclaim or
-	// health sweep), just the request-driven
-	// ensure/describe/list/delete surface RDS-style, constructed synchronously
-	// since it touches no JetStream KV until its first request.
+	// Bedrock serving-endpoint lifecycle: the request-driven
+	// ensure/describe/list/delete surface, constructed synchronously since it
+	// touches no JetStream KV until its first request.
 	d.bedrockService = handlers_bedrock.NewService(d.natsConn, d.buildBedrockServiceDeps())
+
+	// One leader across the cluster scrapes each serving endpoint's vLLM metrics
+	// and hands an idle GPU back; every node keeps serving the API. Without it a
+	// launched model owns its device until an operator deletes the endpoint.
+	d.bedrockReaper = handlers_bedrock.NewReaper(d.bedrockService, d.node, handlers_bedrock.ReaperDeps{})
+	d.shutdownWg.Go(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("Bedrock reaper goroutine panicked", "recover", r)
+			}
+		}()
+		d.bedrockReaper.Run(d.ctx)
+	})
 
 	// ACM certificates hold private keys, so unlike EKS/ECS's IAM dependency
 	// (which degrades to "feature disabled" without a master key) there is no

--- a/spinifex/handlers/bedrock/metrics.go
+++ b/spinifex/handlers/bedrock/metrics.go
@@ -1,0 +1,149 @@
+package handlers_bedrock
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// The three vLLM series idleness is derived from. The first two are gauges of
+// the scheduler's queues; the third is the monotonic count of completed
+// requests, which is what distinguishes "nothing running right now" from
+// "nothing has run since the last sweep".
+const (
+	metricRunning      = "vllm:num_requests_running"
+	metricWaiting      = "vllm:num_requests_waiting"
+	metricSuccessTotal = "vllm:request_success_total"
+)
+
+// metricsBodyLimit caps how much of /metrics is read. vLLM's exposition is a
+// few tens of KB; anything past this is a wedged or hostile endpoint, and the
+// scrape runs on the daemon, so it must not be able to exhaust its memory.
+const metricsBodyLimit = 4 << 20
+
+// endpointMetrics is one sample of a serving endpoint's load.
+type endpointMetrics struct {
+	running      float64
+	waiting      float64
+	successTotal float64
+}
+
+// idle reports whether this sample, compared against the previous sweep's
+// successTotal, means nothing is being served. All three conditions are
+// required: an empty queue alone would call a request that started and
+// finished entirely between two sweeps idle.
+func (m endpointMetrics) idle(prevSuccessTotal float64) bool {
+	return m.running == 0 && m.waiting == 0 && m.successTotal == prevSuccessTotal
+}
+
+// inFlight is the queue depth the scheduler reported, published so an
+// eviction decision on another replica can tell a quiet endpoint from a busy
+// one without scraping it itself.
+func (m endpointMetrics) inFlight() int {
+	return int(m.running + m.waiting)
+}
+
+// scrapeMetrics reads baseURL + "/metrics" and extracts the three series
+// idleness needs. Any failure is the caller's cue to treat the sample as
+// unknown — never as idle, since a wedged VM must not be mistaken for a quiet
+// one.
+func scrapeMetrics(ctx context.Context, client *http.Client, baseURL string) (endpointMetrics, error) {
+	url := baseURL + "/metrics"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return endpointMetrics{}, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return endpointMetrics{}, fmt.Errorf("bedrock: scrape %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return endpointMetrics{}, fmt.Errorf("bedrock: scrape %s: HTTP %d", url, resp.StatusCode)
+	}
+	m, err := parseVLLMMetrics(io.LimitReader(resp.Body, metricsBodyLimit))
+	if err != nil {
+		return endpointMetrics{}, fmt.Errorf("bedrock: scrape %s: %w", url, err)
+	}
+	return m, nil
+}
+
+// parseVLLMMetrics reads the Prometheus text exposition format and sums the
+// three series of interest. Summing rather than taking the last value matters
+// because each series is labelled per served model, and a server hosting more
+// than one emits a line for each: the endpoint is only idle when every one of
+// them is.
+//
+// A full Prometheus parser is deliberately not pulled in for three counters
+// whose format is stable and documented.
+func parseVLLMMetrics(r io.Reader) (endpointMetrics, error) {
+	var m endpointMetrics
+	var seen bool
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, value, ok := parseMetricLine(line)
+		if !ok {
+			continue
+		}
+		switch name {
+		case metricRunning:
+			m.running += value
+		case metricWaiting:
+			m.waiting += value
+		case metricSuccessTotal:
+			m.successTotal += value
+		default:
+			continue
+		}
+		seen = true
+	}
+	if err := scanner.Err(); err != nil {
+		return endpointMetrics{}, fmt.Errorf("read metrics: %w", err)
+	}
+	if !seen {
+		// A 200 carrying none of the three series is not an idle endpoint: it
+		// is something other than the vLLM server we expected to be there.
+		return endpointMetrics{}, fmt.Errorf("no %s series in response", metricRunning)
+	}
+	return m, nil
+}
+
+// parseMetricLine splits one exposition line into its series name (labels
+// stripped) and value. Returns ok=false for anything unparseable, which the
+// caller skips: one malformed line must not discard a whole scrape.
+func parseMetricLine(line string) (string, float64, bool) {
+	// Sample lines carry an optional trailing timestamp, so the value is the
+	// field after the name rather than the last field on the line.
+	sep := strings.IndexAny(line, "{ ")
+	if sep <= 0 {
+		return "", 0, false
+	}
+	name := line[:sep]
+	rest := line[sep:]
+	if strings.HasPrefix(rest, "{") {
+		end := strings.LastIndex(rest, "}")
+		if end < 0 {
+			return "", 0, false
+		}
+		rest = rest[end+1:]
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return "", 0, false
+	}
+	value, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return name, value, true
+}

--- a/spinifex/handlers/bedrock/metrics_test.go
+++ b/spinifex/handlers/bedrock/metrics_test.go
@@ -1,0 +1,111 @@
+package handlers_bedrock
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vLLM emits one line per served model, so a server hosting two models emits
+// two of every series. Idleness is a property of the whole endpoint, so the
+// parser must sum them rather than take the last one it saw.
+func TestParseVLLMMetrics_SumsAcrossLabelSets(t *testing.T) {
+	body := `# HELP vllm:num_requests_running Number of requests currently running.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model_name="a"} 2.0
+vllm:num_requests_running{model_name="b"} 3.0
+vllm:num_requests_waiting{model_name="a"} 1.0
+vllm:num_requests_waiting{model_name="b"} 0.0
+vllm:request_success_total{finished_reason="stop",model_name="a"} 7.0
+vllm:request_success_total{finished_reason="length",model_name="a"} 5.0
+`
+	m, err := parseVLLMMetrics(strings.NewReader(body))
+	require.NoError(t, err)
+	assert.InDelta(t, 5.0, m.running, 0)
+	assert.InDelta(t, 1.0, m.waiting, 0)
+	assert.InDelta(t, 12.0, m.successTotal, 0)
+	assert.Equal(t, 6, m.inFlight())
+}
+
+func TestParseVLLMMetrics_UnlabelledSeries(t *testing.T) {
+	body := "vllm:num_requests_running 0.0\nvllm:num_requests_waiting 0.0\nvllm:request_success_total 4\n"
+	m, err := parseVLLMMetrics(strings.NewReader(body))
+	require.NoError(t, err)
+	assert.Zero(t, m.inFlight())
+	assert.InDelta(t, 4.0, m.successTotal, 0)
+}
+
+// One unparseable line must not discard the rest of the scrape: the
+// alternative is that a single odd series makes a healthy endpoint look
+// unreachable and eventually gets it relaunched.
+func TestParseVLLMMetrics_SkipsUnparseableLines(t *testing.T) {
+	body := `# a comment
+
+vllm:num_requests_running{model_name="a" 1.0
+vllm:num_requests_waiting{model_name="a"} not-a-number
+python_gc_objects_collected_total{generation="0"} 143.0
+vllm:num_requests_running{model_name="b"} 4.0
+`
+	m, err := parseVLLMMetrics(strings.NewReader(body))
+	require.NoError(t, err)
+	assert.InDelta(t, 4.0, m.running, 0, "the well-formed line must still be counted")
+	assert.Zero(t, m.waiting)
+}
+
+// A 200 carrying none of the three series is something other than the vLLM
+// server we expected, which is a failed scrape, not an idle endpoint.
+func TestParseVLLMMetrics_NoKnownSeriesIsError(t *testing.T) {
+	_, err := parseVLLMMetrics(strings.NewReader("go_goroutines 12\n"))
+	require.Error(t, err)
+}
+
+func TestScrapeMetrics_ReadsLiveEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/metrics", r.URL.Path)
+		_, _ = w.Write([]byte("vllm:num_requests_running 1.0\nvllm:num_requests_waiting 2.0\nvllm:request_success_total 9\n"))
+	}))
+	defer srv.Close()
+
+	m, err := scrapeMetrics(t.Context(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, 3, m.inFlight())
+	assert.InDelta(t, 9.0, m.successTotal, 0)
+}
+
+func TestScrapeMetrics_Non200IsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := scrapeMetrics(t.Context(), srv.Client(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+}
+
+// The counter clause is the point of the definition: a request that started
+// and finished entirely between two sweeps leaves both queues at zero, and
+// only the advanced counter says it happened.
+func TestEndpointMetrics_Idle(t *testing.T) {
+	tests := []struct {
+		name    string
+		sample  endpointMetrics
+		prev    float64
+		wantIdl bool
+	}{
+		{"empty queues and unchanged counter", endpointMetrics{successTotal: 4}, 4, true},
+		{"counter advanced", endpointMetrics{successTotal: 5}, 4, false},
+		{"request running", endpointMetrics{running: 1, successTotal: 4}, 4, false},
+		{"request queued", endpointMetrics{waiting: 1, successTotal: 4}, 4, false},
+		{"first sweep of a never-used endpoint", endpointMetrics{}, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantIdl, tt.sample.idle(tt.prev))
+		})
+	}
+}

--- a/spinifex/handlers/bedrock/reaper.go
+++ b/spinifex/handlers/bedrock/reaper.go
@@ -1,0 +1,329 @@
+package handlers_bedrock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Sweep and lease timing. The holder refreshes well inside the bucket's TTL,
+// so a leader that dies is replaced within one TTL rather than one refresh.
+const (
+	defaultReaperInterval = 30 * time.Second
+	defaultLeaseRefresh   = 20 * time.Second
+
+	// How long an endpoint must have been idle before its GPU is taken back.
+	// Cold start was measured at 4m12s for the smallest model this platform
+	// serves, so a TTL of a few multiples of that is what keeps a quiet-but-used
+	// model from becoming a cold-start generator. Scale-to-zero is a cost
+	// optimisation; a latency-sensitive workload buys warmth by pinning.
+	defaultIdleTTL = 15 * time.Minute
+
+	// How many consecutive failed scrapes mean the serving process is wedged
+	// rather than briefly busy. Long enough that a GC pause or a dropped packet
+	// is not an outage, short enough that a dead VM does not hold a device for a
+	// whole idleTTL.
+	maxScrapeFailures = 5
+
+	// Per-scrape budget. Generous next to the sweep interval, because a slow
+	// answer is still an answer and a timeout here counts as a failure.
+	defaultScrapeTimeout = 5 * time.Second
+)
+
+// ReaperDeps are the reaper's overridable knobs. Every zero value takes the
+// constant above; they exist so a test does not wait out production cadence.
+type ReaperDeps struct {
+	Interval      time.Duration
+	IdleTTL       time.Duration
+	LeaseRefresh  time.Duration
+	ScrapeTimeout time.Duration
+}
+
+// Reaper is the leader-elected idle-reclaim loop. One node holds the lease and
+// does the scraping and reaping; every node keeps serving the API, so a
+// leaderless gap delays a reclaim rather than failing a request.
+//
+// It reads idleness from the serving process's own Prometheus /metrics rather
+// than from gateway-reported activity: that keeps the daemon the single writer
+// of endpoint state, survives a gateway node dying mid-call, and works
+// unchanged with any number of gateways.
+type Reaper struct {
+	svc    *Service
+	holder string
+	deps   ReaperDeps
+
+	mu     sync.Mutex
+	leader bool
+}
+
+// NewReaper builds the reaper for svc; holder identifies this daemon in the lease.
+func NewReaper(svc *Service, holder string, deps ReaperDeps) *Reaper {
+	return &Reaper{svc: svc, holder: holder, deps: deps}
+}
+
+func (r *Reaper) interval() time.Duration {
+	if r.deps.Interval > 0 {
+		return r.deps.Interval
+	}
+	return defaultReaperInterval
+}
+
+func (r *Reaper) idleTTL() time.Duration {
+	if r.deps.IdleTTL > 0 {
+		return r.deps.IdleTTL
+	}
+	return defaultIdleTTL
+}
+
+func (r *Reaper) leaseRefresh() time.Duration {
+	if r.deps.LeaseRefresh > 0 {
+		return r.deps.LeaseRefresh
+	}
+	return defaultLeaseRefresh
+}
+
+func (r *Reaper) scrapeTimeout() time.Duration {
+	if r.deps.ScrapeTimeout > 0 {
+		return r.deps.ScrapeTimeout
+	}
+	return defaultScrapeTimeout
+}
+
+// Run drives the leadership and sweep loop until ctx is cancelled. Intended as
+// a daemon-boot goroutine; panics are the caller's recover concern.
+func (r *Reaper) Run(ctx context.Context) {
+	leaseTicker := time.NewTicker(r.leaseRefresh())
+	sweepTicker := time.NewTicker(r.interval())
+	defer leaseTicker.Stop()
+	defer sweepTicker.Stop()
+
+	r.evaluateLeadership(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			r.relinquish()
+			return
+		case <-leaseTicker.C:
+			r.evaluateLeadership(ctx)
+		case <-sweepTicker.C:
+			if !r.IsLeader() {
+				continue
+			}
+			if err := r.sweepOnce(ctx); err != nil {
+				slog.ErrorContext(ctx, "bedrock reaper: sweep failed", "holder", r.holder, "err", err)
+			}
+		}
+	}
+}
+
+// IsLeader reports whether this node currently holds the reaper lease.
+func (r *Reaper) IsLeader() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.leader
+}
+
+func (r *Reaper) evaluateLeadership(ctx context.Context) {
+	won := r.acquireOrRefresh(ctx)
+	r.mu.Lock()
+	was := r.leader
+	r.leader = won
+	r.mu.Unlock()
+
+	switch {
+	case won && !was:
+		slog.Info("bedrock reaper: elected leader", "holder", r.holder)
+	case !won && was:
+		slog.Info("bedrock reaper: lost leadership", "holder", r.holder)
+	}
+}
+
+// acquireOrRefresh claims the lease, or refreshes it (resetting the TTL) when
+// this node already holds it.
+func (r *Reaper) acquireOrRefresh(ctx context.Context) bool {
+	kv, err := r.leaderBucket(ctx)
+	if err != nil {
+		return false
+	}
+	if _, err := kv.Create(ctx, leaderKey, []byte(r.holder)); err == nil {
+		return true
+	}
+	entry, err := kv.Get(ctx, leaderKey)
+	if err != nil {
+		return false
+	}
+	if string(entry.Value()) != r.holder {
+		return false
+	}
+	if _, err := kv.Put(ctx, leaderKey, []byte(r.holder)); err != nil {
+		return false
+	}
+	return true
+}
+
+// relinquish releases the lease on shutdown so the next leader is elected
+// immediately rather than after the TTL.
+func (r *Reaper) relinquish() {
+	// Run's ctx is already cancelled by the time this is called, so the release
+	// runs on its own — a cancelled ctx would fail the delete.
+	ctx := context.Background()
+	kv, err := r.leaderBucket(ctx)
+	if err != nil {
+		return
+	}
+	if entry, gerr := kv.Get(ctx, leaderKey); gerr == nil && string(entry.Value()) == r.holder {
+		if err := kv.Delete(ctx, leaderKey); err != nil {
+			slog.Debug("bedrock reaper: release lease failed", "holder", r.holder, "err", err)
+		}
+	}
+}
+
+func (r *Reaper) leaderBucket(ctx context.Context) (jetstream.KeyValue, error) {
+	js, err := r.svc.js()
+	if err != nil {
+		return nil, err
+	}
+	return GetOrCreateLeaderBucket(ctx, js)
+}
+
+// sweepOnce scrapes every READY endpoint once and acts on what it saw. One
+// endpoint's failure does not stop the pass: the others still need deciding.
+func (r *Reaper) sweepOnce(ctx context.Context) error {
+	kv, err := r.svc.bucket(ctx)
+	if err != nil {
+		return err
+	}
+	recs, err := ListEndpoints(ctx, kv, utils.GlobalAccountID)
+	if err != nil {
+		return err
+	}
+	var failures []error
+	for _, rec := range recs {
+		// STARTING and DRAINING belong to the launch goroutine and to Delete
+		// respectively; both are mid-transition and neither is ours to judge.
+		if rec.State != StateReady {
+			continue
+		}
+		if err := r.sweepEndpoint(ctx, kv, rec); err != nil {
+			failures = append(failures, fmt.Errorf("%s: %w", rec.ModelID, err))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// sweepEndpoint decides one endpoint's fate from a single scrape.
+func (r *Reaper) sweepEndpoint(ctx context.Context, kv jetstream.KeyValue, rec EndpointRecord) error {
+	scrapeCtx, cancel := context.WithTimeout(ctx, r.scrapeTimeout())
+	defer cancel()
+
+	sample, err := scrapeMetrics(scrapeCtx, r.svc.httpClient(), rec.BaseURL)
+	if err != nil {
+		return r.recordScrapeFailure(ctx, kv, rec, err)
+	}
+
+	now := time.Now().UTC()
+	updated := rec
+	updated.ScrapeFailures = 0
+	updated.InFlight = sample.inFlight()
+	updated.SuccessTotal = sample.successTotal
+	if !sample.idle(rec.SuccessTotal) {
+		updated.LastActiveAt = now
+	}
+
+	if r.shouldReap(updated, now) {
+		slog.InfoContext(ctx, "bedrock reaper: reclaiming an idle endpoint",
+			"model", rec.ModelID, "instanceId", rec.InstanceID,
+			"idleFor", now.Sub(lastActive(updated)).Round(time.Second))
+		if _, err := r.svc.Delete(ctx, &DeleteEndpointInput{ModelID: rec.ModelID}, utils.GlobalAccountID); err != nil {
+			return fmt.Errorf("reap idle endpoint: %w", err)
+		}
+		return nil
+	}
+	return r.persistObservation(ctx, kv, rec, updated)
+}
+
+// shouldReap applies the two rules an idle endpoint must clear before its GPU
+// is taken back: it must be idle for a full idleTTL, and it must have been
+// READY for one. The second is not implied by the first — without it an
+// endpoint could be reclaimed in the window between reaching READY and its
+// first request landing, which is exactly the request that launched it.
+func (r *Reaper) shouldReap(rec EndpointRecord, now time.Time) bool {
+	if rec.Pinned || rec.InFlight > 0 {
+		return false
+	}
+	ttl := r.idleTTL()
+	return now.Sub(lastActive(rec)) >= ttl && now.Sub(rec.ReadyAt) >= ttl
+}
+
+// recordScrapeFailure counts an unknown sample and escalates a persistently
+// unreachable endpoint to terminate-and-relaunch. Never treats the failure as
+// idleness: a wedged VM must not be mistaken for a quiet one.
+func (r *Reaper) recordScrapeFailure(ctx context.Context, kv jetstream.KeyValue, rec EndpointRecord, cause error) error {
+	updated := rec
+	updated.ScrapeFailures = rec.ScrapeFailures + 1
+	if updated.ScrapeFailures < maxScrapeFailures {
+		slog.WarnContext(ctx, "bedrock reaper: metrics scrape failed",
+			"model", rec.ModelID, "instanceId", rec.InstanceID,
+			"consecutiveFailures", updated.ScrapeFailures, "err", cause)
+		return r.persistObservation(ctx, kv, rec, updated)
+	}
+
+	slog.ErrorContext(ctx, "bedrock reaper: endpoint unreachable; terminating and relaunching",
+		"model", rec.ModelID, "instanceId", rec.InstanceID,
+		"consecutiveFailures", updated.ScrapeFailures, "err", cause)
+	if _, err := r.svc.Delete(ctx, &DeleteEndpointInput{ModelID: rec.ModelID}, utils.GlobalAccountID); err != nil {
+		return fmt.Errorf("terminate unreachable endpoint: %w", err)
+	}
+	// A relaunch that cannot be admitted (the device did not come back, or
+	// another model took it) is not a sweep failure: the endpoint is gone, which
+	// was the point, and the next invoke will ask for it again.
+	if _, err := r.svc.Ensure(ctx, &EnsureEndpointInput{ModelID: rec.ModelID}, utils.GlobalAccountID); err != nil {
+		slog.WarnContext(ctx, "bedrock reaper: relaunch of an unreachable endpoint was refused",
+			"model", rec.ModelID, "err", err)
+	}
+	return nil
+}
+
+// persistObservation CAS-writes the sweep's findings, and only when they
+// changed: a steady-state idle endpoint would otherwise cost a KV write per
+// tick per endpoint forever.
+func (r *Reaper) persistObservation(ctx context.Context, kv jetstream.KeyValue, prev, next EndpointRecord) error {
+	if prev.LastActiveAt.Equal(next.LastActiveAt) && prev.InFlight == next.InFlight &&
+		prev.SuccessTotal == next.SuccessTotal && prev.ScrapeFailures == next.ScrapeFailures {
+		return nil
+	}
+	key := EndpointKey(utils.GlobalAccountID, next.ModelID)
+	current, rev, found, err := getFullJSON(ctx, kv, key)
+	if err != nil {
+		return err
+	}
+	if !found || current.Generation != prev.Generation || current.State != StateReady {
+		// The record moved since this pass read it — a delete, or a relaunch that
+		// reused the key. The next sweep re-reads rather than clobbering it.
+		return nil
+	}
+	next.Generation = current.Generation + 1
+	if err := updateJSON(ctx, kv, key, rev, next); err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// lastActive is rec's LRU ordering key: the last sweep that saw it serving,
+// falling back to when it became READY. The fallback covers a record written
+// before its first sweep, which is a fresh endpoint, not a stale one.
+func lastActive(rec EndpointRecord) time.Time {
+	if !rec.LastActiveAt.IsZero() {
+		return rec.LastActiveAt
+	}
+	return rec.ReadyAt
+}

--- a/spinifex/handlers/bedrock/reaper_test.go
+++ b/spinifex/handlers/bedrock/reaper_test.go
@@ -1,0 +1,352 @@
+package handlers_bedrock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mulgadc/spinifex/spinifex/config"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/mulgadc/spinifex/spinifex/utils"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vllmTransport answers both halves of what a serving VM exposes: the
+// readiness probe on /v1/models and the reaper's scrape on /metrics. One
+// transport serves both because the Service uses one HTTP client for both.
+type vllmTransport struct {
+	mu      sync.Mutex
+	body    string
+	fail    bool
+	scrapes int
+}
+
+func (v *vllmTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if strings.HasSuffix(req.URL.Path, "/metrics") {
+		v.scrapes++
+		if v.fail {
+			return nil, errors.New("connection refused")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(v.body)),
+			Header:     make(http.Header),
+		}, nil
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+}
+
+// serve makes the next scrapes report these queue depths and completed count.
+func (v *vllmTransport) serve(running, waiting int, successTotal float64) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.fail = false
+	v.body = fmt.Sprintf("vllm:num_requests_running %d\nvllm:num_requests_waiting %d\nvllm:request_success_total %v\n",
+		running, waiting, successTotal)
+}
+
+func (v *vllmTransport) breakScrapes() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.fail = true
+}
+
+func (v *vllmTransport) scrapeCount() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.scrapes
+}
+
+// reaperFixture is a Service with a reaper bound to it and a scriptable
+// serving VM behind both.
+type reaperFixture struct {
+	svc       *Service
+	reaper    *Reaper
+	harness   *launchHarness
+	transport *vllmTransport
+	kv        jetstream.KeyValue
+}
+
+func newReaperFixture(t *testing.T, deps ReaperDeps) *reaperFixture {
+	t.Helper()
+	h := newLaunchHarness()
+	transport := &vllmTransport{}
+	transport.serve(0, 0, 0)
+
+	_, nc, _ := testutil.StartTestJetStream(t)
+	svc := NewService(nc, ServiceDeps{
+		Config:         &config.Config{Region: "us-east-1", AZ: "us-east-1a"},
+		Launch:         h.deps(),
+		GPU:            sufficientGPU(),
+		NodeID:         testNodeID,
+		StartupTimeout: 2 * time.Second,
+		HTTPClient:     &http.Client{Transport: transport},
+		PollInterval:   5 * time.Millisecond,
+		Replicas:       1,
+	})
+	kv, err := svc.bucket(t.Context())
+	require.NoError(t, err)
+
+	return &reaperFixture{
+		svc:       svc,
+		reaper:    NewReaper(svc, "node-a", deps),
+		harness:   h,
+		transport: transport,
+		kv:        kv,
+	}
+}
+
+// ready launches testModelID and waits for its record to reach READY.
+func (f *reaperFixture) ready(t *testing.T) EndpointRecord {
+	t.Helper()
+	_, err := f.svc.Ensure(t.Context(), &EnsureEndpointInput{ModelID: testModelID}, "")
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
+
+	desc, err := f.svc.Describe(t.Context(), &DescribeEndpointInput{ModelID: testModelID}, "")
+	require.NoError(t, err)
+	require.Equal(t, StateReady, desc.Endpoint.State)
+	return desc.Endpoint
+}
+
+// age rewrites the record's timestamps into the past, standing in for an
+// endpoint that has been up and quiet for a while.
+func (f *reaperFixture) age(t *testing.T, readyAgo, activeAgo time.Duration) EndpointRecord {
+	t.Helper()
+	key := EndpointKey(utils.GlobalAccountID, testModelID)
+	rec, rev, found, err := getFullJSON(t.Context(), f.kv, key)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	now := time.Now().UTC()
+	rec.ReadyAt = now.Add(-readyAgo)
+	if activeAgo > 0 {
+		rec.LastActiveAt = now.Add(-activeAgo)
+	}
+	require.NoError(t, updateJSON(t.Context(), f.kv, key, rev, rec))
+	return rec
+}
+
+func (f *reaperFixture) current(t *testing.T) (EndpointRecord, bool) {
+	t.Helper()
+	rec, _, found, err := getFullJSON(t.Context(), f.kv, EndpointKey(utils.GlobalAccountID, testModelID))
+	require.NoError(t, err)
+	return rec, found
+}
+
+func TestReaper_ReapsIdleEndpointPastTTL(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Minute})
+	rec := f.ready(t)
+	f.age(t, 10*time.Minute, 10*time.Minute)
+
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+
+	_, found := f.current(t)
+	assert.False(t, found, "a reaped endpoint's record must be purged, not left DRAINING")
+	assert.Contains(t, f.harness.launcher.terminated, rec.InstanceID, "the GPU is only released by tearing the VM down")
+}
+
+// The rule that is not implied by the idle clock: an endpoint must not be
+// reclaimed in the window between reaching READY and the request that
+// launched it arriving.
+func TestReaper_NeverReapsWithinIdleTTLOfReadyAt(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Hour})
+	f.ready(t)
+	// Idle for far longer than the TTL, but only just became READY.
+	f.age(t, time.Second, 24*time.Hour)
+
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+
+	_, found := f.current(t)
+	assert.True(t, found, "a freshly READY endpoint must survive its first sweep")
+	assert.Empty(t, f.harness.launcher.terminated)
+}
+
+func TestReaper_NeverReapsPinnedEndpoint(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Minute})
+	f.ready(t)
+	f.age(t, time.Hour, time.Hour)
+
+	key := EndpointKey(utils.GlobalAccountID, testModelID)
+	rec, rev, _, err := getFullJSON(t.Context(), f.kv, key)
+	require.NoError(t, err)
+	rec.Pinned = true
+	require.NoError(t, updateJSON(t.Context(), f.kv, key, rev, rec))
+
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+
+	got, found := f.current(t)
+	require.True(t, found)
+	assert.True(t, got.Pinned)
+	assert.Empty(t, f.harness.launcher.terminated)
+}
+
+// A busy endpoint's LastActiveAt is refreshed rather than left to age out,
+// which is both what stops the reap and what orders eviction later.
+func TestReaper_BusyEndpointStampsLastActive(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Minute})
+	f.ready(t)
+	f.age(t, time.Hour, time.Hour)
+	f.transport.serve(2, 1, 5)
+
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+
+	got, found := f.current(t)
+	require.True(t, found, "an endpoint serving traffic must never be reaped")
+	assert.WithinDuration(t, time.Now(), got.LastActiveAt, time.Minute)
+	assert.Equal(t, 3, got.InFlight)
+	assert.InDelta(t, 5.0, got.SuccessTotal, 0)
+}
+
+// Both queues empty but the counter advanced means a request landed and
+// completed between sweeps, which is activity, not idleness.
+func TestReaper_AdvancedCounterCountsAsActivity(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Minute})
+	f.ready(t)
+	f.age(t, time.Hour, time.Hour)
+	f.transport.serve(0, 0, 12)
+
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+
+	got, found := f.current(t)
+	require.True(t, found)
+	assert.WithinDuration(t, time.Now(), got.LastActiveAt, time.Minute)
+
+	// Once that activity has aged out, the same unchanged counter is what makes
+	// the next sweep read the endpoint as idle.
+	f.age(t, time.Hour, time.Hour)
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+	_, found = f.current(t)
+	assert.False(t, found)
+}
+
+func TestReaper_ScrapeFailuresEscalateToRelaunch(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Hour})
+	rec := f.ready(t)
+	f.transport.breakScrapes()
+
+	for range maxScrapeFailures - 1 {
+		require.NoError(t, f.reaper.sweepOnce(t.Context()))
+		got, found := f.current(t)
+		require.True(t, found, "an unreachable endpoint is unknown, never idle")
+		assert.Empty(t, f.harness.launcher.terminated)
+		assert.Positive(t, got.ScrapeFailures)
+	}
+
+	// The escalating sweep tears the wedged VM down and asks for it back.
+	f.transport.serve(0, 0, 0)
+	f.transport.breakScrapes()
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+	f.svc.WaitLaunches()
+
+	assert.Contains(t, f.harness.launcher.terminated, rec.InstanceID)
+	assert.EqualValues(t, 2, f.harness.launcher.launchCount.Load(), "the endpoint must be relaunched, not just removed")
+}
+
+func TestReaper_SuccessfulScrapeResetsFailureCount(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Hour})
+	f.ready(t)
+
+	f.transport.breakScrapes()
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+	got, _ := f.current(t)
+	require.Equal(t, 1, got.ScrapeFailures)
+
+	f.transport.serve(1, 0, 0)
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+	got, _ = f.current(t)
+	assert.Zero(t, got.ScrapeFailures)
+}
+
+// A steady-state idle endpoint is the common case and must cost a scrape per
+// tick and nothing else; a KV write per endpoint per tick forever is the
+// failure mode being guarded against.
+func TestReaper_UnchangedObservationWritesNothing(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Hour})
+	f.ready(t)
+
+	before, _ := f.current(t)
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+	after, found := f.current(t)
+
+	require.True(t, found)
+	assert.Equal(t, before.Generation, after.Generation, "an unchanged observation must not bump the record")
+	assert.Equal(t, 2, f.transport.scrapeCount(), "the endpoint is still scraped every tick")
+}
+
+// STARTING belongs to the launch goroutine and DRAINING to Delete; the reaper
+// scrapes neither, so a launch in progress cannot be torn down under it.
+func TestReaper_SkipsNonReadyRecords(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Nanosecond})
+	key := EndpointKey(utils.GlobalAccountID, testModelID)
+	_, err := createJSONRevision(t.Context(), f.kv, key, EndpointRecord{
+		AccountID: utils.GlobalAccountID, ModelID: testModelID, State: StateStarting, Generation: 1,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, f.reaper.sweepOnce(t.Context()))
+
+	_, found := f.current(t)
+	assert.True(t, found)
+	assert.Zero(t, f.transport.scrapeCount())
+}
+
+func TestReaper_LeaseAdmitsOneLeader(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{})
+	other := NewReaper(f.svc, "node-b", ReaperDeps{})
+
+	f.reaper.evaluateLeadership(t.Context())
+	other.evaluateLeadership(t.Context())
+
+	assert.True(t, f.reaper.IsLeader())
+	assert.False(t, other.IsLeader(), "two nodes must never sweep the same endpoints at once")
+
+	// A refresh by the holder keeps it, and does not hand it away.
+	f.reaper.evaluateLeadership(t.Context())
+	assert.True(t, f.reaper.IsLeader())
+}
+
+// Releasing on shutdown is what makes a rolling restart cost seconds rather
+// than a full lease TTL of no reclaim.
+func TestReaper_RelinquishFreesTheLeaseImmediately(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{})
+	other := NewReaper(f.svc, "node-b", ReaperDeps{})
+
+	f.reaper.evaluateLeadership(t.Context())
+	require.True(t, f.reaper.IsLeader())
+
+	f.reaper.relinquish()
+	other.evaluateLeadership(t.Context())
+	assert.True(t, other.IsLeader())
+}
+
+// A node that lost the election does no work at all, so a leaderless gap
+// delays a reclaim rather than duplicating one.
+func TestReaper_NonLeaderSweepsNothing(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{Interval: 5 * time.Millisecond, LeaseRefresh: time.Hour, IdleTTL: time.Nanosecond})
+	f.ready(t)
+	f.age(t, time.Hour, time.Hour)
+
+	holder := NewReaper(f.svc, "node-b", ReaperDeps{})
+	holder.evaluateLeadership(t.Context())
+	require.True(t, holder.IsLeader())
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Millisecond)
+	defer cancel()
+	f.reaper.Run(ctx)
+
+	_, found := f.current(t)
+	assert.True(t, found, "a non-leader must not reap")
+	assert.Zero(t, f.transport.scrapeCount())
+}

--- a/spinifex/handlers/bedrock/state.go
+++ b/spinifex/handlers/bedrock/state.go
@@ -74,8 +74,23 @@ type EndpointRecord struct {
 	CreatedAt time.Time `json:"created_at,omitzero"`
 	ReadyAt   time.Time `json:"ready_at,omitzero"`
 
-	// Pinned exempts this endpoint from the (not-yet-built) idle-reclaim sweep.
+	// Pinned exempts this endpoint from the idle-reclaim sweep and from eviction.
 	Pinned bool `json:"pinned,omitempty"`
+
+	// The reaper's last observation of this endpoint. Persisted rather than kept
+	// in the reaper's memory because an eviction decision runs on whichever
+	// replica the queue group picked, not necessarily the reaper's leader, and
+	// because a leader change must not reset the idle clock or the failure count.
+	//
+	// LastActiveAt is the last sweep at which the endpoint was observed serving,
+	// seeded from ReadyAt; it is the LRU ordering key. InFlight and SuccessTotal
+	// are the last successful scrape's queue depth and completed-request count,
+	// the latter being idleness's "unchanged since the previous tick" comparison
+	// point. ScrapeFailures counts consecutive failed scrapes.
+	LastActiveAt   time.Time `json:"last_active_at,omitzero"`
+	InFlight       int       `json:"in_flight,omitempty"`
+	SuccessTotal   float64   `json:"success_total,omitempty"`
+	ScrapeFailures int       `json:"scrape_failures,omitempty"`
 
 	// Generation increments on every write and is the CAS single-flight token:
 	// a concurrent Ensure that lost the local-mutex race re-reads the record and

--- a/spinifex/handlers/bedrock/store.go
+++ b/spinifex/handlers/bedrock/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
 	"github.com/nats-io/nats.go/jetstream"
@@ -22,6 +23,24 @@ const KVBucketEndpoints = "bedrock-endpoints"
 // KVBucketEndpointsHistory pins one revision per key: a superseded state is
 // not meaningful to retain, only the current one CAS-guards against races.
 const KVBucketEndpointsHistory = 1
+
+// KVBucketLeader holds the reaper's leader lease. Its TTL is what makes the
+// lease self-healing: a leader that dies without releasing it is replaced
+// within one TTL rather than never.
+const (
+	KVBucketLeader    = "bedrock-leader"
+	KVBucketLeaderTTL = 60 * time.Second
+	leaderKey         = "reaper"
+)
+
+// GetOrCreateLeaderBucket returns the reaper's TTL-backed leader bucket.
+func GetOrCreateLeaderBucket(ctx context.Context, js jetstream.JetStream) (jetstream.KeyValue, error) {
+	kv, err := kvutil.GetOrCreateBucketWithTTL(ctx, js, KVBucketLeader, 1, KVBucketLeaderTTL)
+	if err != nil {
+		return nil, fmt.Errorf("bedrock: create leader KV bucket: %w", err)
+	}
+	return kv, nil
+}
 
 // EndpointKey returns the KV key for accountID's modelID endpoint record.
 // Model IDs contain ':' (e.g. "meta.llama3-2-1b-instruct-v1:0"), which NATS


### PR DESCRIPTION
Part of `mulga-vmfng.7.7` (Ochre Phase 3 / D3). Plan: `docs/development/feature/ochre-scale-to-zero-reclaim.md` in mulga.

## Problem

After #742 a cold model launches on demand, but nothing ever gives the GPU back. On a single-GPU deployment the first model invoked owns the device until an operator runs `spx admin ochre endpoint delete` — every other model in the catalog is permanently unreachable, and the caller gets `ModelNotReadyException` forever with no path to recovery that does not involve a human.

## What this does

A leader-elected daemon loop scrapes each READY endpoint's vLLM Prometheus `/metrics` and hands an idle GPU back.

**Idle** = `vllm:num_requests_running` and `vllm:num_requests_waiting` both zero **and** `vllm:request_success_total` unchanged since the previous sweep. The counter clause is the point of the definition: a request that started and finished entirely between two sweeps leaves both queues at zero, and only the advanced counter says it happened.

Idleness is read from the serving process rather than reported by the gateway. That keeps the daemon the single writer of endpoint state, survives a gateway node dying mid-call, and works unchanged with any number of gateways.

Two rules bound the reclaim:

- **Never reaped within `idleTTL` of `readyAt`** — an endpoint cannot be taken back in the window between reaching READY and the request that launched it arriving.
- **A failed scrape is unknown, never idle.** Five consecutive failures escalate to terminate-and-relaunch, so a wedged VM is not mistaken for a quiet one and left holding a device.

Reaping is `Service.Delete`, not a bespoke teardown: it already does DRAINING → terminate → release → purge, holds the per-key mutex against a racing `Ensure`, and resumes a teardown that failed partway.

## Notable decisions

- **Observations are persisted on the record** (`LastActiveAt`, `InFlight`, `SuccessTotal`, `ScrapeFailures`) rather than kept in the reaper's memory. A leader change must not reset the idle clock or the failure count, and the LRU eviction that follows in the next PR runs on whichever replica the queue group picked — not necessarily the reaper's leader.
- **A sweep writes only when what it saw changed.** A steady-state idle endpoint is the common case; a KV write per endpoint per tick forever is the failure mode being avoided.
- **No Prometheus client dependency** for three counters with a stable documented text format. The parser sums across label sets, because vLLM emits one line per served model and the endpoint is only idle when every one of them is.
- **Lease follows `handlers/rds/reconciler.go`** — CAS `Create` on a 60s-TTL bucket, refresh by re-`Put` while held, `Delete` on shutdown so a rolling restart costs seconds rather than a full TTL of no reclaim.

`defaultIdleTTL` is 15m: cold start was measured at 4m12s on the smallest model this platform serves, so a TTL of a few multiples of that is what keeps a quiet-but-used model from becoming a cold-start generator.

## Testing

`make preflight` passes; diff coverage 76.3%.

New tests cover the parse (multi-label-set summing, unparseable lines skipped, no known series is an error, non-200), the idle truth table, the two reap rules, pinned exemption, failure escalation and reset, the no-op write guard, non-READY records being skipped, and the lease (one leader, release frees it immediately, a non-leader sweeps nothing).

Live verification on wattle is in the plan doc and comes with the eviction PR, since the two share one GPU-bound run.