### PR TITLE
feat(bedrock): add Llama 3.2 3B Instruct as a second self-host model

### DIFF
--- a/spinifex/gateway/bedrock/access_test.go
+++ b/spinifex/gateway/bedrock/access_test.go
@@ -16,8 +16,9 @@ import (
 // Naming them here keeps a catalog change to one edit per tier rather than one
 // per assertion.
 const (
-	selfHostTestModel  = "meta.llama3-2-1b-instruct-v1:0"
-	anthropicTestModel = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+	selfHostTestModel   = "meta.llama3-2-1b-instruct-v1:0"
+	selfHostTestModel3B = "meta.llama3-2-3b-instruct-v1:0"
+	anthropicTestModel  = "anthropic.claude-3-5-sonnet-20240620-v1:0"
 )
 
 // grantSet is an AccessResolver granting exactly the model IDs it contains.

--- a/spinifex/gateway/bedrock/catalog.go
+++ b/spinifex/gateway/bedrock/catalog.go
@@ -55,8 +55,12 @@ type catalogEntry struct {
 	PriceKnown                    bool     // provider entries only; self-host is always known-zero
 }
 
-// catalog is the static Phase-1 model set: one self-hosted open model and one
+// catalog is the static model set: two self-hosted open models and one
 // Anthropic-direct model. Later phases extend this list.
+//
+// Both self-host entries are Meta models on purpose: self-host InvokeModel
+// dispatch picks llamaInvokeAdapter for every self-host entry, so a model of
+// another family would be served with Llama's native request schema.
 var catalog = []catalogEntry{
 	{
 		ModelID:                    "meta.llama3-2-1b-instruct-v1:0",
@@ -73,6 +77,25 @@ var catalog = []catalogEntry{
 		MinVRAMMiB:   5120,
 		InstanceType: "g5.xlarge",
 		VLLMArgs:     []string{"--dtype=bfloat16", "--max-model-len=8192", "--gpu-memory-utilization=0.6"},
+	},
+	{
+		ModelID:                    "meta.llama3-2-3b-instruct-v1:0",
+		ModelName:                  "Llama 3.2 3B Instruct",
+		ProviderName:               "Meta",
+		Provider:                   tierSelfHost,
+		InputModalities:            []string{"TEXT"},
+		OutputModalities:           []string{"TEXT"},
+		ResponseStreamingSupported: false,
+		InferenceTypesSupported:    []string{"ON_DEMAND"},
+		// 3.21B params at bf16 is roughly 6124 MiB of weights, so on an 8188 MiB
+		// card the budget is tight: --enforce-eager skips CUDA graph capture to
+		// free several hundred MiB, and max-model-len is half the 1B entry's.
+		MinVRAMMiB:   7168,
+		InstanceType: "g5.xlarge",
+		VLLMArgs: []string{
+			"--dtype=bfloat16", "--max-model-len=4096", "--gpu-memory-utilization=0.92",
+			"--max-num-seqs=8", "--enforce-eager",
+		},
 	},
 	{
 		ModelID:                    "anthropic.claude-3-5-sonnet-20240620-v1:0",

--- a/spinifex/gateway/bedrock/catalog_test.go
+++ b/spinifex/gateway/bedrock/catalog_test.go
@@ -3,6 +3,7 @@ package gateway_bedrock
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/bedrock"
@@ -227,4 +228,44 @@ func TestLookupServingSpec_UnknownModel(t *testing.T) {
 	assert.False(t, found)
 	assert.False(t, selfHost)
 	assert.Zero(t, spec)
+}
+
+func TestLookupServingSpec_SelfHost3BEntry(t *testing.T) {
+	spec, found, selfHost := LookupServingSpec(selfHostTestModel3B)
+	require.True(t, found)
+	require.True(t, selfHost)
+	assert.Equal(t, selfHostTestModel3B, spec.ModelID)
+	assert.Equal(t, "g5.xlarge", spec.InstanceType)
+	assert.Equal(t, 7168, spec.MinVRAMMiB)
+	assert.Contains(t, spec.VLLMArgs, "--enforce-eager",
+		"CUDA graph capture does not fit alongside 3B of bf16 weights on an 8 GiB card")
+}
+
+// TestCatalog_SelfHostEntriesFitTheLlamaInvokeAdapter guards the assumption
+// baked into InvokeRouter: every self-host entry is dispatched to
+// llamaInvokeAdapter on tier alone, so a self-host model of another family
+// would be served with Llama's native request and response schema instead of
+// being refused. This fails the moment the catalog outgrows that dispatch.
+func TestCatalog_SelfHostEntriesFitTheLlamaInvokeAdapter(t *testing.T) {
+	for _, entry := range catalog {
+		if entry.Provider != tierSelfHost {
+			continue
+		}
+		assert.True(t, strings.HasPrefix(entry.ModelID, "meta.llama"),
+			"self-host entry %q is not a Llama model; InvokeRouter would serve it "+
+				"through llamaInvokeAdapter with the wrong native schema", entry.ModelID)
+	}
+}
+
+// TestListFoundationModels_SelfHostGatingIsPerEntry proves weights gating
+// filters one entry at a time rather than all-or-nothing. Only measurable now
+// that two self-host entries exist and can disagree.
+func TestListFoundationModels_SelfHostGatingIsPerEntry(t *testing.T) {
+	withWeightsResolver(t, stubWeightsResolver{ok: map[string]bool{selfHostTestModel3B: true}})
+	out, err := ListFoundationModels(context.Background(), "000000000001", stubResolver{ok: map[string]bool{}},
+		grantAll{}, &bedrock.ListFoundationModelsInput{})
+	require.NoError(t, err)
+	assert.Contains(t, modelIDs(out), selfHostTestModel3B)
+	assert.NotContains(t, modelIDs(out), selfHostTestModel,
+		"a staged model must not advertise an unstaged sibling")
 }


### PR DESCRIPTION
Closes the catalog side of `mulga-ic4tc`.

## Why

The catalog carried exactly one self-host entry, so two models could never contend for a GPU: an `Ensure` for the model already running returns the existing record before reaching the capacity check. The LRU eviction that landed in #745 was therefore built and unit-tested but unable to fire in production, and it is the one acceptance criterion of `mulga-vmfng.7.7` that live testing could not cover.

A second model is also a product requirement on its own. One 1B model is a thin offering at release.

## Why this model

**`meta.llama3-2-3b-instruct-v1:0` is a real AWS-published Bedrock model ID.** The catalog's stated contract is that model IDs mirror AWS exactly so existing SDK code and configs are drop-in. Inventing an ID for a model AWS does not serve would break that for the sake of a test.

**It stays inside the family the invoke path assumes.** `InvokeRouter` dispatches on tier, not family:

```go
case entry.Provider == tierSelfHost:
    a = newLlamaInvokeAdapter(rt.endpointResolver)
```

Every self-host entry is served through `llamaInvokeAdapter`, which translates the Bedrock-native *Llama* shape. A same-family model is correct under that dispatch by construction; a Mistral or Qwen entry would be silently mis-served. `TestCatalog_SelfHostEntriesFitTheLlamaInvokeAdapter` pins that assumption to the catalog so the next person to add a non-Meta model gets a failing test rather than a wrong answer at runtime. Raised as `mulga-kvxp5` to fix properly.

Rejected: `mistral.mistral-7b-instruct-v0:2` (real ID, but 14.5 GiB at bf16 does not fit; an AWQ build would need both a quantization path and the dispatch fix above); fp8 of anything larger (the A1000 is GA107, compute capability **8.6** — fp8 needs sm_89); Qwen/Gemma small variants (AWS publishes no Bedrock IDs for them, so the ID would be fabricated).

## Sizing

3.21B params at bf16 is roughly 6124 MiB of weights against the RTX A1000's 8188 MiB, so the budget is tight:

- `--gpu-memory-utilization=0.92` → ~7533 MiB, leaving ~1400 MiB for CUDA context, activations and KV cache.
- KV cache is 2 × 28 layers × 8 KV heads × 128 head_dim × 2 bytes = **112 KiB/token**, so ~1 GiB of KV is roughly 9K tokens — enough for `--max-model-len=4096` with real concurrency.
- `--enforce-eager` skips CUDA graph capture. It costs steady-state throughput but frees several hundred MiB and shortens cold start, both of which matter more on an 8 GiB card serving a scale-to-zero workload.
- `--max-model-len=4096` is half the 1B entry's 8192. The larger model buys quality at the cost of context on this hardware.

**These are estimates, not measurements.** `MinVRAMMiB: 7168` is an honest floor that admits on the A1000 and refuses a smaller card; live testing should correct it against a real reading.

## Note on contention

`checkCapacity` scans for a pool entry with `Available == true` and compares against that entry's **whole-device** `MemoryMiB`, not free VRAM on a partly-used device — passthrough hands the entire GPU to one guest. So on a single-GPU node *any* second self-host model contends, regardless of how the VRAM floors are set. The figures above decide whether the model boots and serves, not whether eviction triggers.

## Testing

Unit: serving-spec assertions for the new entry, the family invariant above, and a per-entry weights-gating case — one self-host model staged, its sibling not — which only became observable now that two self-host entries can disagree. `make preflight` passes.

**Not yet verified live.** The model's weights still need staging on wattle, and the eviction run itself (idle 1B evicted to make room for the 3B, plus the `minResidency` refusal case) is the remaining acceptance criterion on `mulga-ic4tc`. Plan: `docs/development/feature/ochre-second-self-host-model.md`.