### PR TITLE
fix(gpu): treat an already-released GPU as success during teardown

### DIFF
--- a/spinifex/daemon/vm_adapters.go
+++ b/spinifex/daemon/vm_adapters.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/gpu"
 	handlers_ec2_placementgroup "github.com/mulgadc/spinifex/spinifex/handlers/ec2/placementgroup"
 	"github.com/mulgadc/spinifex/spinifex/network/topology"
 	"github.com/mulgadc/spinifex/spinifex/tags"
@@ -880,11 +881,21 @@ func (a *instanceCleanerAdapter) RemoveFromSpotRequest(instance *vm.VM) error {
 // ReleaseGPU unbinds the instance's GPU from vfio-pci and rebinds to its
 // original host driver. No-op for instances without a GPU allocation or
 // when GPU passthrough is disabled.
+//
+// Holding no device is success, not failure: teardown re-drives this until it
+// reports done, and a stop that already released leaves nothing for the later
+// terminate to do. Returning an error there wedges the record forever.
 func (a *instanceCleanerAdapter) ReleaseGPU(instance *vm.VM) error {
 	if a.d.gpuManager == nil || len(instance.GPUAttachments) == 0 {
 		return nil
 	}
-	if err := a.d.gpuManager.Release(instance.ID); err != nil {
+	err := a.d.gpuManager.Release(instance.ID)
+	switch {
+	case errors.Is(err, gpu.ErrNoGPUClaimed):
+		slog.Info("GPU already released, nothing to do",
+			"gpus", instance.GPUAttachments, "instanceId", instance.ID)
+		return nil
+	case err != nil:
 		slog.Error("Failed to release GPU on stop, device may need manual rebind",
 			"gpus", instance.GPUAttachments, "instanceId", instance.ID, "err", err)
 		return err

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -368,15 +368,22 @@ func TestReleaseGPU_NoAddresses_NoOp(t *testing.T) {
 	a.ReleaseGPU(instance)
 }
 
-// ReleaseGPU logs a warning when the manager returns an error (instance not claimed).
-func TestReleaseGPU_ManagerError_LogsWarning(t *testing.T) {
+// TestReleaseGPU_AlreadyReleased_IsSuccess pins the fix for a teardown record
+// that could never complete. A stop releases the GPU, so the later terminate
+// finds no claim; reporting that as failure left the gpu teardown mark stuck
+// short of done, so the record was never purged and the GC re-drove it every
+// two minutes indefinitely, failing identically each time.
+func TestReleaseGPU_AlreadyReleased_IsSuccess(t *testing.T) {
 	mgr := gpu.NewManager(nil)
 	d := &Daemon{gpuManager: mgr}
 	a := newInstanceCleanerAdapter(d)
-	// GPU address set but no claim registered — Release returns an error.
+	// GPU address set but no claim registered — the shape a re-driven release
+	// sees once the work is already done.
 	instance := &vm.VM{ID: "i-unclaimed", GPUAttachments: []gpu.GPUAttachment{{PCIAddress: "0000:03:00.0"}}}
-	// Must not panic; the error is logged as a warning.
-	a.ReleaseGPU(instance)
+
+	require.NoError(t, a.ReleaseGPU(instance), "an already-released GPU must not fail teardown")
+	// Idempotent under repetition, which is what the reaper does to it.
+	require.NoError(t, a.ReleaseGPU(instance))
 }
 
 // --- RemoveFromSpotRequest ---

--- a/spinifex/gpu/manager.go
+++ b/spinifex/gpu/manager.go
@@ -8,6 +8,11 @@ import (
 	"sync"
 )
 
+// ErrNoGPUClaimed reports that the instance held no device when Release ran.
+// Teardown re-drives releases and should read this as success, since the state
+// it wants already holds; a claim/release pair that hits it is out of step.
+var ErrNoGPUClaimed = errors.New("no GPU claimed by instance")
+
 type gpuEntry struct {
 	Device        GPUDevice
 	MIGInstance   *MIGInstance       // nil = whole-GPU passthrough; non-nil = MIG slice
@@ -213,6 +218,10 @@ func (m *Manager) Claim(instanceID, profileName string) (*GPUDevice, *MIGInstanc
 // (already vfio-pci before the daemon) are left bound; Claim-bound devices are
 // unbound and rebind to their original driver (failure marks them unavailable).
 // For dynamically carved MIG GPUs, the last release destroys all slices.
+//
+// Holding nothing yields ErrNoGPUClaimed, which is a distinct condition rather
+// than a fault: it says the desired state already holds. Callers that re-drive
+// releases decide for themselves whether that counts as success.
 func (m *Manager) Release(instanceID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -269,7 +278,7 @@ func (m *Manager) Release(instanceID string) error {
 	}
 
 	if !released {
-		return fmt.Errorf("no GPU claimed by instance %s", instanceID)
+		return fmt.Errorf("%w %s", ErrNoGPUClaimed, instanceID)
 	}
 
 	// For dynamically carved MIG GPUs: destroy all slices when the last instance

--- a/spinifex/gpu/manager_mig_test.go
+++ b/spinifex/gpu/manager_mig_test.go
@@ -153,6 +153,7 @@ func TestMIGRelease_UnknownInstance_ReturnsError(t *testing.T) {
 	m := NewManager(nil)
 	err := m.Release("i-never-claimed")
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoGPUClaimed)
 }
 
 // --- MarkMIGFailed ---

--- a/spinifex/gpu/manager_test.go
+++ b/spinifex/gpu/manager_test.go
@@ -1,8 +1,10 @@
 package gpu
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -151,7 +153,15 @@ func TestManagerRelease_UnknownInstance(t *testing.T) {
 
 	err := m.Release("i-does-not-exist")
 	if err == nil {
-		t.Error("want error releasing unknown instance, got nil")
+		t.Fatal("want error releasing unknown instance, got nil")
+	}
+	// Matchable rather than a bare message: teardown re-drives releases and has
+	// to tell "already released" from a rebind failure without reading text.
+	if !errors.Is(err, ErrNoGPUClaimed) {
+		t.Errorf("want ErrNoGPUClaimed, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "i-does-not-exist") {
+		t.Errorf("want the instance ID in the message, got %q", err)
 	}
 }
 
@@ -180,6 +190,12 @@ func TestManagerRelease_FailureMarksUnavailable(t *testing.T) {
 	err := m.Release("i-001")
 	if err == nil {
 		t.Error("want error when vfio-pci unbind fails, got nil")
+	}
+	// Must stay distinct from the benign already-released case, which callers
+	// are entitled to ignore. This one clears Available, the health signal the
+	// Bedrock capacity gate reads.
+	if errors.Is(err, ErrNoGPUClaimed) {
+		t.Errorf("a rebind failure must not report as ErrNoGPUClaimed, got %v", err)
 	}
 
 	// Pool entry must be marked unavailable so the broken GPU isn't re-offered.


### PR DESCRIPTION
Closes `mulga-0pbr4`.

## Problem

Two instances on wattle have been logging this every two minutes for days — 2251 and 640 times respectively:

```
level=ERROR msg="Failed to release GPU on stop, device may need manual rebind"
  gpus=[{"pci_address":"0000:5e:00.0","xvga_enabled":true}]
  instanceId=i-01a5e4a99ef00844c
  err="no GPU claimed by instance i-01a5e4a99ef00844c"
```

Both are long gone from the control plane. The obvious reading is accumulated state from repeated binary-swap deploys, but the timeline rules that out — each failure starts within seconds of a **successful** release, under the **same daemon pid**:

| instance | GPU released | first failure | pid |
| --- | --- | --- | --- |
| `i-209b4786b3d0511fe` | 17:08:09 | 17:08:09 | 2927548 |
| `i-01a5e4a99ef00844c` | 11:28:33 | 11:28:36 | 1735928 |

No restart, no deploy, no drift. The release works, and then the same process treats the completed work as a failure.

## Cause

Two paths release a GPU, and only the second records a teardown mark:

- `stopCleanup` (`vm/shutdown.go:387`) releases and logs a warning. Marks nothing.
- `terminateCleanup` (`vm/shutdown.go:417`) releases and calls `markTeardownResult(TeardownGPU, gpuErr)`.

Stop-then-terminate is ordinary, supported behaviour: the stop releases the GPU, and the later terminate finds nothing to release. `Release` returned an error for that, so the `gpu` mark never reached `done`, `TeardownComplete()` was never true, `TerminatedTeardownReaper.purge` never ran, and the record was re-driven every `GCInterval` forever.

It breaks the reaper's own documented contract, `vm/teardown_reaper.go:98`:

> The cleaner calls are idempotent (absent → success), so a successful re-drive confirms the Spinifex-side teardown.

Every other cleaner honours it. `ReleaseGPU` did not.

**The double call is not the bug.** Terminate must attempt a release, since the instance may have been running. Making terminate skip it would break terminating a running GPU instance, so `shutdown.go` is deliberately untouched.

## Change

`Release` returns a matchable `ErrNoGPUClaimed`; `instanceCleanerAdapter.ReleaseGPU` reads it as success and logs it at INFO without the rebind warning.

Kept as an error rather than `nil` on purpose. The launch-rollback path (`daemonGPUClaimer.Release`) hitting it means the claim/release pair is out of step, which is worth surfacing — only the teardown caller wants it treated as success, so only the teardown caller decides that. It also keeps the benign case distinct from a real vfio rebind failure, which sets `Available = false`, the health signal `checkCapacity` reads. Conflating those would mark a healthy GPU unavailable and fail every Ochre admission.

## Testing

`make preflight` passes. `TestReleaseGPU_AlreadyReleased_IsSuccess` fails without the adapter change:

```
--- FAIL: TestReleaseGPU_AlreadyReleased_IsSuccess (0.00s)
        Messages: an already-released GPU must not fail teardown
```

The existing rebind-failure test now also asserts it is **not** `ErrNoGPUClaimed`, so the two conditions cannot drift back together. Swallowing a real rebind failure would leave a device bound to vfio with nothing to reclaim it, which is the regression that matters here.

Live verification on wattle after merge: the two wedged records are the fixture. `TeardownGPU` should advance to `done` on the next sweep, `purge` should clear both once past `terminatedVisibilityWindow`, and the two-minute ERROR should stop.

Plan: `docs/development/bugs/gpu-release-idempotency.md`