### PR TITLE
fix: judge transitional-state heartbeats by the persist floor

### DIFF
--- a/spinifex/handlers/rds/lifecycle_test.go
+++ b/spinifex/handlers/rds/lifecycle_test.go
@@ -637,6 +637,21 @@ func TestReconciler_CompletesARestartOnAHeartbeatFromTheRestartedEngine(t *testi
 	}
 }
 
+// The beat that ends a restart usually reaches the leader through KV, where it
+// is at most a persist floor behind the engine. Judging it by the raw stale
+// window left a database that came back cleanly rebooting until it timed out.
+func TestReconciler_CompletesARestartOnAPersistedHeartbeatInsideTheFloor(t *testing.T) {
+	h := newLifecycleHarness(t, false)
+	// Older than the stale window, younger than the window plus the floor, and
+	// still after the transition it proves finished.
+	persisted := time.Now().UTC().Add(-HeartbeatStaleAfter - time.Minute)
+	seedInstance(t, h.svc, restartingRecord(StatusRebooting, persisted.Add(-time.Second), persisted))
+
+	require.NoError(t, NewReconciler(h.svc, "node-a").reconcileOnce(t.Context()))
+
+	assert.Equal(t, StatusAvailable, h.record(t).Status)
+}
+
 // The VM keeps its instance ID across a restart, so a beat sent before the
 // transition began would otherwise report the reboot as finished the instant it
 // started.

--- a/spinifex/handlers/rds/reconciler.go
+++ b/spinifex/handlers/rds/reconciler.go
@@ -654,43 +654,16 @@ func transitionStarted(rec *DBInstanceRecord) time.Time {
 	return rec.UpdatedAt
 }
 
-// Both halves must hold: a healthy heartbeat from the record's *current* VM,
-// and that VM actually running. A stale beat from a superseded VM would
-// otherwise report a replaced instance as ready. Beats at or before since are
-// ignored, which is how a restart is told from the engine it restarted.
+// Both halves must hold: a fresh healthy heartbeat from the record's *current*
+// VM, and that VM actually running. A stale beat from a superseded VM would
+// otherwise report a replaced instance as ready. The observation is the same one
+// the health classifier forms, so freshness is judged by one rule package-wide.
 func (r *Reconciler) engineReady(ctx context.Context, accountID string, rec *DBInstanceRecord, since time.Time) (bool, error) {
-	if rec.Agent.EngineHealth != EngineHealthHealthy || rec.InstanceID == "" ||
-		rec.Agent.InstanceID != rec.InstanceID {
+	obs := r.observeAgent(accountID, rec, since)
+	if !obs.engineHealthy || !obs.heartbeatFresh {
 		return false, nil
 	}
-	if !r.heartbeatFresh(accountID, rec, since) {
-		return false, nil
-	}
-	if r.svc.deps.InstanceState == nil {
-		return true, nil
-	}
-	state, err := r.svc.deps.InstanceState.InstanceState(ctx, rec.InstanceID, accountID)
-	if err != nil {
-		return false, fmt.Errorf("resolve VM state for %s: %w", rec.InstanceID, err)
-	}
-	return state == instanceStateRunning, nil
-}
-
-// The in-memory beat is fresher than the persisted one but only this node sees
-// it, so a leader that has seen no beat falls back to the record — which trails
-// the truth by at most the persist floor.
-func (r *Reconciler) heartbeatFresh(accountID string, rec *DBInstanceRecord, since time.Time) bool {
-	lastSeen, ok := r.svc.LastSeen(accountID, rec.DBInstanceIdentifier)
-	if !ok {
-		if rec.Agent.LastSeen == nil {
-			return false
-		}
-		lastSeen = *rec.Agent.LastSeen
-	}
-	if !since.IsZero() && !lastSeen.After(since) {
-		return false
-	}
-	return time.Since(lastSeen) <= HeartbeatStaleAfter
+	return r.vmRunning(ctx, accountID, rec)
 }
 
 // A CAS write, so a transition raced by an agent report or a lifecycle op is

--- a/spinifex/handlers/rds/reconciler.go
+++ b/spinifex/handlers/rds/reconciler.go
@@ -659,8 +659,13 @@ func transitionStarted(rec *DBInstanceRecord) time.Time {
 // otherwise report a replaced instance as ready. The observation is the same one
 // the health classifier forms, so freshness is judged by one rule package-wide.
 func (r *Reconciler) engineReady(ctx context.Context, accountID string, rec *DBInstanceRecord, since time.Time) (bool, error) {
-	obs := r.observeAgent(accountID, rec, since)
+	obs := r.observeAgent(accountID, rec)
 	if !obs.engineHealthy || !obs.heartbeatFresh {
+		return false, nil
+	}
+	// A beat at or before since came from the engine the restart replaced, so it
+	// says nothing about the one that took its place.
+	if !since.IsZero() && !obs.lastSeen.After(since) {
 		return false, nil
 	}
 	return r.vmRunning(ctx, accountID, rec)

--- a/spinifex/handlers/rds/reconciler_test.go
+++ b/spinifex/handlers/rds/reconciler_test.go
@@ -140,8 +140,10 @@ func TestReconciler_HoldsCreatingUntilTheEngineIsHealthy(t *testing.T) {
 		// A beat from a VM other than the record's current one is a superseded VM
 		// still running after a replace; it must not report the instance ready.
 		{"BeatFromASupersededVM", func(rec *DBInstanceRecord) { rec.Agent.InstanceID = "i-oldvm" }},
+		// Silent for longer than even the slack a persisted beat earns, so no
+		// source could have seen this agent recently.
 		{"StaleHeartbeat", func(rec *DBInstanceRecord) {
-			stale := time.Now().UTC().Add(-2 * HeartbeatStaleAfter)
+			stale := time.Now().UTC().Add(-2 * (HeartbeatStaleAfter + HeartbeatPersistFloor))
 			rec.Agent.LastSeen = &stale
 		}},
 	}
@@ -159,6 +161,26 @@ func TestReconciler_HoldsCreatingUntilTheEngineIsHealthy(t *testing.T) {
 			assert.Equal(t, StatusCreating, status)
 		})
 	}
+}
+
+// The transitional states judge freshness by the same rule as the health
+// classifier. A leader handling none of an instance's beats sees them only
+// through KV, which a healthy agent refreshes no more often than the persist
+// floor; judging that beat by the raw stale window failed a live database at the
+// transition timeout.
+func TestReconciler_CompletesACreateOnAPersistedHeartbeatInsideTheFloor(t *testing.T) {
+	h := newReconcileHarness(t)
+	rec := healthyRecord()
+	// Older than the stale window, younger than the window plus the floor: what a
+	// perfectly healthy instance looks like to a leader that has seen no beat.
+	persisted := time.Now().UTC().Add(-HeartbeatStaleAfter - time.Minute)
+	rec.Agent.LastSeen = &persisted
+	seedInstance(t, h.svc, rec)
+
+	require.NoError(t, h.rec.reconcileOnce(t.Context()))
+
+	status, _ := h.statusOf(t, testDBID)
+	assert.Equal(t, StatusAvailable, status)
 }
 
 // A create that never comes up has to end somewhere: the customer sees a broken

--- a/spinifex/handlers/rds/recovery.go
+++ b/spinifex/handlers/rds/recovery.go
@@ -74,7 +74,7 @@ func classifyHealth(obs healthObservation) healthVerdict {
 // Restart=on-failure and EC2's VM auto-restart provide underneath. v1.0 does no
 // repair of its own.
 func (r *Reconciler) reconcileHealth(ctx context.Context, kv jetstream.KeyValue, rev uint64, accountID string, rec *DBInstanceRecord) error {
-	obs := r.observeAgent(accountID, rec, time.Time{})
+	obs := r.observeAgent(accountID, rec)
 
 	// The VM lookup is a fleet-wide describe fan-out, so it is issued only where
 	// its answer could change something. A healthy instance with nothing recorded
@@ -172,18 +172,15 @@ func failureReason(obs healthObservation) string {
 		time.Since(obs.lastSeen).Round(time.Second))
 }
 
-// The agent half of the observation, read without touching the fleet. Beats at
-// or before since are not fresh, which is how a restart is told from the engine
-// it restarted; a zero since accepts any beat inside the staleness bound.
-func (r *Reconciler) observeAgent(accountID string, rec *DBInstanceRecord, since time.Time) healthObservation {
+// The agent half of the observation, read without touching the fleet.
+func (r *Reconciler) observeAgent(accountID string, rec *DBInstanceRecord) healthObservation {
 	lastSeen, bound := r.lastHeartbeat(accountID, rec)
 	return healthObservation{
 		status: rec.Status,
 		engineHealthy: rec.Agent.EngineHealth == EngineHealthHealthy && rec.InstanceID != "" &&
 			rec.Agent.InstanceID == rec.InstanceID,
-		heartbeatFresh: !lastSeen.IsZero() && time.Since(lastSeen) <= bound &&
-			(since.IsZero() || lastSeen.After(since)),
-		lastSeen: lastSeen,
+		heartbeatFresh: !lastSeen.IsZero() && time.Since(lastSeen) <= bound,
+		lastSeen:       lastSeen,
 	}
 }
 

--- a/spinifex/handlers/rds/recovery.go
+++ b/spinifex/handlers/rds/recovery.go
@@ -74,7 +74,7 @@ func classifyHealth(obs healthObservation) healthVerdict {
 // Restart=on-failure and EC2's VM auto-restart provide underneath. v1.0 does no
 // repair of its own.
 func (r *Reconciler) reconcileHealth(ctx context.Context, kv jetstream.KeyValue, rev uint64, accountID string, rec *DBInstanceRecord) error {
-	obs := r.observeAgent(accountID, rec)
+	obs := r.observeAgent(accountID, rec, time.Time{})
 
 	// The VM lookup is a fleet-wide describe fan-out, so it is issued only where
 	// its answer could change something. A healthy instance with nothing recorded
@@ -172,15 +172,18 @@ func failureReason(obs healthObservation) string {
 		time.Since(obs.lastSeen).Round(time.Second))
 }
 
-// The agent half of the observation, read without touching the fleet.
-func (r *Reconciler) observeAgent(accountID string, rec *DBInstanceRecord) healthObservation {
+// The agent half of the observation, read without touching the fleet. Beats at
+// or before since are not fresh, which is how a restart is told from the engine
+// it restarted; a zero since accepts any beat inside the staleness bound.
+func (r *Reconciler) observeAgent(accountID string, rec *DBInstanceRecord, since time.Time) healthObservation {
 	lastSeen, bound := r.lastHeartbeat(accountID, rec)
 	return healthObservation{
 		status: rec.Status,
 		engineHealthy: rec.Agent.EngineHealth == EngineHealthHealthy && rec.InstanceID != "" &&
 			rec.Agent.InstanceID == rec.InstanceID,
-		heartbeatFresh: !lastSeen.IsZero() && time.Since(lastSeen) <= bound,
-		lastSeen:       lastSeen,
+		heartbeatFresh: !lastSeen.IsZero() && time.Since(lastSeen) <= bound &&
+			(since.IsZero() || lastSeen.After(since)),
+		lastSeen: lastSeen,
 	}
 }
 


### PR DESCRIPTION
## Problem

The RDS package had two implementations of heartbeat freshness and they disagreed.

`Reconciler.lastHeartbeat` judges a beat that arrived through the record against `HeartbeatStaleAfter + HeartbeatPersistFloor`, because a healthy agent only persists an unchanged beat every fifth tick — judging it by the raw stale window reports a steady instance as stale for most of every persist cycle. `Reconciler.heartbeatFresh`, used by `engineReady`, applied the raw `HeartbeatStaleAfter` to both sources, and preferred the in-memory beat even when the record's was newer.

Beats are queue-group delivered, so in a multi-node cluster most land on a node other than the reconciler leader. A leader with no in-memory beat therefore never observed a healthy engine in `creating`, `restarting` or `modifying`, and failed the instance at `transitionTimeout` — a healthy database marked `failed` after ~10 minutes. Only the transitional states were affected; the health classifier next door goes through `observeAgent` and got it right.

## Changes

- `observeAgent` takes a `since time.Time` lower bound, so it can express the restart-vs-restarted distinction the transitional states need. `reconcileHealth` passes the zero time, which is what it meant already.
- `engineReady` is expressed over `observeAgent` and `vmRunning`, dropping its own copies of the engine-healthy and VM-state predicates.
- `heartbeatFresh` is deleted. `lastHeartbeat` is now the package's only freshness rule.

Two intended behaviour changes fall out: a record-sourced beat between `HeartbeatStaleAfter` and `HeartbeatStaleAfter + HeartbeatPersistFloor` now counts as fresh in the transitional states, and when both sources have a beat the newer one wins rather than the in-memory one unconditionally.

## Testing

- `TestReconciler_CompletesACreateOnAPersistedHeartbeatInsideTheFloor` and `TestReconciler_CompletesARestartOnAPersistedHeartbeatInsideTheFloor` cover a beat aged between the two bounds on a reconciler that has seen no in-memory beat.
- The existing `StaleHeartbeat` case in `TestReconciler_HoldsCreatingUntilTheEngineIsHealthy` used a 180s beat, which is stale only under the rule being removed; it now ages the beat past the widened bound.
- `TestReconciler_IgnoresAHeartbeatPredatingTheRestart` still passes, so the widened bound does not lose the restart-vs-restarted distinction.
- `make preflight` passes.