### PR TITLE
feat: parameterise bedrock endpoint create/delete by account and pinned

### DIFF
--- a/cmd/spinifex/cmd/admin_ochre_endpoint.go
+++ b/cmd/spinifex/cmd/admin_ochre_endpoint.go
@@ -75,6 +75,7 @@ func init() {
 	_ = ochreEndpointEnsureCmd.MarkFlagRequired("model-id")
 
 	ochreEndpointDescribeCmd.Flags().String("model-id", "", "Model ID to describe (required)")
+	ochreEndpointDescribeCmd.Flags().String("account", "", "Account ID scoping the lookup (defaults to the shared platform account; set to see a pinned provisioned-throughput endpoint)")
 	_ = ochreEndpointDescribeCmd.MarkFlagRequired("model-id")
 
 	ochreEndpointDeleteCmd.Flags().String("model-id", "", "Model ID whose endpoint to tear down (required)")
@@ -145,7 +146,13 @@ func waitForEndpointReady(ctx context.Context, svc handlers_bedrock.EndpointServ
 func formatEndpointRecord(rec handlers_bedrock.EndpointRecord) string {
 	rows := [][2]string{
 		{"Model ID", rec.ModelID},
-		{"State", string(rec.State)},
+	}
+	if rec.AccountID != "" {
+		rows = append(rows, [2]string{"Account", rec.AccountID})
+	}
+	rows = append(rows, [2]string{"State", string(rec.State)})
+	if rec.Pinned {
+		rows = append(rows, [2]string{"Pinned", "yes"})
 	}
 	if rec.InstanceID != "" {
 		rows = append(rows, [2]string{"Instance ID", rec.InstanceID})
@@ -180,7 +187,8 @@ func formatEndpointRecord(rec handlers_bedrock.EndpointRecord) string {
 // reclaimRows renders what the daemon's idle sweep last observed, so an
 // operator asking why an endpoint was or was not reclaimed can see the inputs
 // rather than infer them. Only meaningful for a READY endpoint: no other state
-// is swept.
+// is swept. The Pinned flag itself is rendered unconditionally in
+// formatEndpointRecord, since it is meaningful regardless of state.
 //
 // "Idle for" is measured from the record's LastActive, which falls back to
 // ReadyAt, so an endpoint that has been quiet since launch reads as idle since
@@ -195,9 +203,6 @@ func reclaimRows(rec handlers_bedrock.EndpointRecord) [][2]string {
 			[2]string{"Last active", since.Format(time.RFC3339)},
 			[2]string{"Idle for", time.Since(since).Round(time.Second).String()})
 	}
-	if rec.Pinned {
-		rows = append(rows, [2]string{"Pinned", "yes (never reclaimed or evicted)"})
-	}
 	if rec.ScrapeFailures > 0 {
 		rows = append(rows, [2]string{"Scrape failures", strconv.Itoa(rec.ScrapeFailures)})
 	}
@@ -206,6 +211,9 @@ func reclaimRows(rec handlers_bedrock.EndpointRecord) [][2]string {
 
 // listEndpointsOutput renders 'ochre endpoint list'. Split from its Run
 // function so it is testable against a fake service with no NATS connection.
+// ACCOUNT and PINNED distinguish a pinned, account-scoped endpoint from a
+// shared platform one — List itself now returns every account's records, not
+// just the shared platform account's.
 func listEndpointsOutput(ctx context.Context, svc handlers_bedrock.EndpointService) (string, error) {
 	out, err := svc.List(ctx, &handlers_bedrock.ListEndpointsInput{}, utils.GlobalAccountID)
 	if err != nil {
@@ -215,9 +223,13 @@ func listEndpointsOutput(ctx context.Context, svc handlers_bedrock.EndpointServi
 		return "No serving endpoints.", nil
 	}
 
-	tableData := pterm.TableData{{"MODEL ID", "STATE", "INSTANCE ID", "BASE URL"}}
+	tableData := pterm.TableData{{"MODEL ID", "STATE", "ACCOUNT", "PINNED", "INSTANCE ID", "BASE URL"}}
 	for _, e := range out.Endpoints {
-		tableData = append(tableData, []string{e.ModelID, string(e.State), e.InstanceID, e.BaseURL})
+		pinned := ""
+		if e.Pinned {
+			pinned = "yes"
+		}
+		tableData = append(tableData, []string{e.ModelID, string(e.State), e.AccountID, pinned, e.InstanceID, e.BaseURL})
 	}
 	return pterm.DefaultTable.WithHasHeader().WithData(tableData).Srender()
 }
@@ -282,6 +294,7 @@ func runOchreEndpointEnsure(cmd *cobra.Command, _ []string) {
 
 func runOchreEndpointDescribe(cmd *cobra.Command, _ []string) {
 	modelID, _ := cmd.Flags().GetString("model-id")
+	accountID, _ := cmd.Flags().GetString("account")
 
 	svc, closeFn, err := endpointServiceFn()
 	if err != nil {
@@ -291,7 +304,7 @@ func runOchreEndpointDescribe(cmd *cobra.Command, _ []string) {
 	}
 	defer closeFn()
 
-	out, err := svc.Describe(context.Background(), &handlers_bedrock.DescribeEndpointInput{ModelID: modelID}, utils.GlobalAccountID)
+	out, err := svc.Describe(context.Background(), &handlers_bedrock.DescribeEndpointInput{ModelID: modelID, AccountID: accountID}, utils.GlobalAccountID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		ochreExit(1)

--- a/cmd/spinifex/cmd/admin_ochre_endpoint_test.go
+++ b/cmd/spinifex/cmd/admin_ochre_endpoint_test.go
@@ -22,8 +22,9 @@ type fakeEndpointService struct {
 	listErr     error
 	deleteErr   error
 
-	describeCalls int
-	deleteCalls   int
+	describeCalls  int
+	deleteCalls    int
+	describeInputs []*handlers_bedrock.DescribeEndpointInput
 }
 
 func (f *fakeEndpointService) Ensure(_ context.Context, _ *handlers_bedrock.EnsureEndpointInput, _ string) (*handlers_bedrock.EnsureEndpointOutput, error) {
@@ -33,7 +34,8 @@ func (f *fakeEndpointService) Ensure(_ context.Context, _ *handlers_bedrock.Ensu
 	return &handlers_bedrock.EnsureEndpointOutput{Endpoint: f.ensure}, nil
 }
 
-func (f *fakeEndpointService) Describe(_ context.Context, _ *handlers_bedrock.DescribeEndpointInput, _ string) (*handlers_bedrock.DescribeEndpointOutput, error) {
+func (f *fakeEndpointService) Describe(_ context.Context, in *handlers_bedrock.DescribeEndpointInput, _ string) (*handlers_bedrock.DescribeEndpointOutput, error) {
+	f.describeInputs = append(f.describeInputs, in)
 	if f.describeErr != nil {
 		return nil, f.describeErr
 	}
@@ -71,6 +73,10 @@ func fakeClock(now *time.Time) endpointWaitClock {
 }
 
 const testModelID = "meta.llama3-2-1b-instruct-v1:0"
+
+// testAccountID stands in for a caller's real (non-Global) account, mirroring
+// handlers_bedrock's own testAccountID.
+const testAccountID = "111111111111"
 
 func TestWaitForEndpointReady_ReachesReadyAndReportsElapsed(t *testing.T) {
 	svc := &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
@@ -215,6 +221,24 @@ func TestListEndpointsOutput_ListsEndpoints(t *testing.T) {
 	require.Contains(t, msg, "STARTING")
 }
 
+// TestListEndpointsOutput_ShowsAccountAndPinnedColumns is Bug 2's list seam:
+// a pinned, account-scoped endpoint must render its own account and a PINNED
+// indicator, while a bare GlobalAccountID endpoint keeps listing unchanged
+// (its ACCOUNT cell just reads GlobalAccountID, PINNED empty).
+func TestListEndpointsOutput_ShowsAccountAndPinnedColumns(t *testing.T) {
+	svc := &fakeEndpointService{list: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateReady, AccountID: "000000000001"},
+		{ModelID: "meta.llama3-2-3b-instruct-v1:0", State: handlers_bedrock.StateReady, AccountID: testAccountID, Pinned: true},
+	}}
+
+	msg, err := listEndpointsOutput(context.Background(), svc)
+	require.NoError(t, err)
+	require.Contains(t, msg, "ACCOUNT")
+	require.Contains(t, msg, "PINNED")
+	require.Contains(t, msg, "000000000001")
+	require.Contains(t, msg, testAccountID)
+}
+
 func TestListEndpointsOutput_ErrorSurfaces(t *testing.T) {
 	svc := &fakeEndpointService{listErr: errors.New("nats: no responders")}
 	_, err := listEndpointsOutput(context.Background(), svc)
@@ -308,6 +332,50 @@ func TestRunOchreEndpointDescribe_PrintsRecord(t *testing.T) {
 	})
 	require.Equal(t, -1, code)
 	require.Contains(t, out, "i-abc")
+}
+
+// TestRunOchreEndpointDescribe_DefaultAccountIsEmpty covers the regression
+// guard: a bare (GlobalAccountID) describe, with no --account flag set, must
+// still send an empty AccountID — resolveAccountID's own GlobalAccountID
+// fallback, unchanged from before --account existed.
+func TestRunOchreEndpointDescribe_DefaultAccountIsEmpty(t *testing.T) {
+	svc := &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateReady},
+	}}
+	withEndpointService(t, svc, nil)
+
+	cmd := *ochreEndpointDescribeCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+
+	withOchreExitCapture(t, func() {
+		captureStdout(t, func() { runOchreEndpointDescribe(&cmd, nil) })
+	})
+	require.Len(t, svc.describeInputs, 1)
+	require.Empty(t, svc.describeInputs[0].AccountID)
+}
+
+// TestRunOchreEndpointDescribe_AccountFlagScopesLookup is Bug 2's describe
+// seam: --account must reach DescribeEndpointInput.AccountID, which is how an
+// operator sees a pinned, account-scoped endpoint the GlobalAccountID lookup
+// would otherwise report ABSENT.
+func TestRunOchreEndpointDescribe_AccountFlagScopesLookup(t *testing.T) {
+	svc := &fakeEndpointService{describes: []handlers_bedrock.EndpointRecord{
+		{ModelID: testModelID, State: handlers_bedrock.StateReady, AccountID: testAccountID, Pinned: true},
+	}}
+	withEndpointService(t, svc, nil)
+
+	cmd := *ochreEndpointDescribeCmd
+	require.NoError(t, cmd.Flags().Set("model-id", testModelID))
+	require.NoError(t, cmd.Flags().Set("account", testAccountID))
+
+	var out string
+	withOchreExitCapture(t, func() {
+		out = captureStdout(t, func() { runOchreEndpointDescribe(&cmd, nil) })
+	})
+	require.Len(t, svc.describeInputs, 1)
+	require.Equal(t, testAccountID, svc.describeInputs[0].AccountID)
+	require.Contains(t, out, testAccountID)
+	require.Contains(t, out, "Pinned")
 }
 
 func TestRunOchreEndpointDescribe_ErrorExits1(t *testing.T) {

--- a/spinifex/gateway/bedrock.go
+++ b/spinifex/gateway/bedrock.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrock"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
@@ -28,23 +29,23 @@ type bedrockRoute struct {
 // is gw.bedrockResolver(): the configured credential store, or a no-op
 // fallback. loggingStore is gw.bedrockLoggingConfigStore(). access is
 // gw.bedrockAccessResolver(): the configured grant store, or a deny-all
-// fallback.
-type bedrockRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, loggingStore *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver) (any, error)
+// fallback. provisioned is gw.bedrockProvisionedStore().
+type bedrockRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, loggingStore *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error)
 
 // bedrockRoutes is the dispatch table. More-specific paths must precede
 // less-specific ones with the same prefix so the regex matcher picks the
 // deeper route first.
 var bedrockRoutes = []bedrockRoute{
 	{"GET", regexp.MustCompile(`^/foundation-models$`), "ListFoundationModels",
-		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
 			return gateway_bedrock.ListFoundationModels(ctx, acct, resolver, access, new(bedrock.ListFoundationModelsInput))
 		}},
 	{"GET", regexp.MustCompile(`^/foundation-models/([^/]+)$`), "GetFoundationModel",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
 			return gateway_bedrock.GetFoundationModel(ctx, acct, p[0], access)
 		}},
 	{"PUT", regexp.MustCompile(`^/logging/modelinvocations$`), "PutModelInvocationLoggingConfiguration",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
 			input := new(bedrock.PutModelInvocationLoggingConfigurationInput)
 			if len(b) > 0 {
 				if err := json.Unmarshal(b, input); err != nil {
@@ -54,12 +55,45 @@ var bedrockRoutes = []bedrockRoute{
 			return gateway_bedrock.PutModelInvocationLoggingConfiguration(ctx, acct, store, input)
 		}},
 	{"GET", regexp.MustCompile(`^/logging/modelinvocations$`), "GetModelInvocationLoggingConfiguration",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
 			return gateway_bedrock.GetModelInvocationLoggingConfiguration(ctx, acct, store, new(bedrock.GetModelInvocationLoggingConfigurationInput))
 		}},
 	{"DELETE", regexp.MustCompile(`^/logging/modelinvocations$`), "DeleteModelInvocationLoggingConfiguration",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
 			return gateway_bedrock.DeleteModelInvocationLoggingConfiguration(ctx, acct, store, new(bedrock.DeleteModelInvocationLoggingConfigurationInput))
+		}},
+	{"POST", regexp.MustCompile(`^/provisioned-model-throughput$`), "CreateProvisionedModelThroughput",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+			input := new(bedrock.CreateProvisionedModelThroughputInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			return gateway_bedrock.CreateProvisionedModelThroughput(ctx, acct, provisioned, input)
+		}},
+	{"GET", regexp.MustCompile(`^/provisioned-model-throughput/([^/]+)$`), "GetProvisionedModelThroughput",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+			return gateway_bedrock.GetProvisionedModelThroughput(ctx, acct, provisioned, &bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String(p[0])})
+		}},
+	{"GET", regexp.MustCompile(`^/provisioned-model-throughputs$`), "ListProvisionedModelThroughputs",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+			return gateway_bedrock.ListProvisionedModelThroughputs(ctx, acct, provisioned, new(bedrock.ListProvisionedModelThroughputsInput))
+		}},
+	{"PATCH", regexp.MustCompile(`^/provisioned-model-throughput/([^/]+)$`), "UpdateProvisionedModelThroughput",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+			input := new(bedrock.UpdateProvisionedModelThroughputInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.ProvisionedModelId = aws.String(p[0])
+			return gateway_bedrock.UpdateProvisionedModelThroughput(ctx, acct, provisioned, input)
+		}},
+	{"DELETE", regexp.MustCompile(`^/provisioned-model-throughput/([^/]+)$`), "DeleteProvisionedModelThroughput",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+			return gateway_bedrock.DeleteProvisionedModelThroughput(ctx, acct, provisioned, &bedrock.DeleteProvisionedModelThroughputInput{ProvisionedModelId: aws.String(p[0])})
 		}},
 }
 
@@ -123,7 +157,7 @@ func (gw *GatewayConfig) Bedrock_Request(w http.ResponseWriter, r *http.Request)
 		return errors.New(awserrors.ErrorInvalidParameterValue)
 	}
 
-	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockLoggingConfigStore(), gw.bedrockAccessResolver())
+	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockLoggingConfigStore(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
 	if err != nil {
 		return err
 	}
@@ -171,6 +205,18 @@ func (gw *GatewayConfig) bedrockAccessResolver() gateway_bedrock.AccessResolver 
 		return gw.BedrockAccess
 	}
 	return gateway_bedrock.DenyAllAccessResolver
+}
+
+// bedrockProvisionedStore returns gw.BedrockProvisioned, or a store backed by
+// no JetStream client when unconfigured. Reads/writes then fail with an error
+// (no JetStream to open a KV bucket against) rather than panicking, which is
+// acceptable for unit tests of unrelated routes that never reach a
+// provisioned-throughput handler.
+func (gw *GatewayConfig) bedrockProvisionedStore() *gateway_bedrock.ProvisionedStore {
+	if gw.BedrockProvisioned != nil {
+		return gw.BedrockProvisioned
+	}
+	return gateway_bedrock.NewProvisionedStore(nil, 1, gw.Region, nil)
 }
 
 // bedrockEndpointResolver returns the registry-backed resolver when one is

--- a/spinifex/gateway/bedrock/arn.go
+++ b/spinifex/gateway/bedrock/arn.go
@@ -1,0 +1,77 @@
+package gateway_bedrock
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// provisionedModelResourceType is the ARN resource-type segment for a
+// provisioned-throughput commitment. Bedrock ARNs are slash-separated
+// (unlike RDS's colon-separated ones), so the type and id share one segment.
+const provisionedModelResourceType = "provisioned-model"
+
+// FormatProvisionedModelARN builds the ARN a CreateProvisionedModelThroughput
+// call returns and every other PT op accepts back in place of a raw id.
+func FormatProvisionedModelARN(region, accountID, id string) string {
+	return fmt.Sprintf("arn:aws:bedrock:%s:%s:%s/%s", region, accountID, provisionedModelResourceType, id)
+}
+
+// ParsedProvisionedModelARN is a PT ARN split into the parts a caller acts on.
+// Partition and service are validated rather than returned: only
+// "arn:aws:bedrock" is ever accepted.
+type ParsedProvisionedModelARN struct {
+	Region    string
+	AccountID string
+	ID        string
+}
+
+// provisionedModelARNSegmentCount is the number of colon-separated segments in
+// arn:aws:bedrock:{region}:{accountID}:provisioned-model/{id}.
+const provisionedModelARNSegmentCount = 6
+
+// ParseProvisionedModelARN parses a PT ARN and validates it belongs to the
+// caller: wrong partition/service/resource-type, a foreign region or account,
+// or a malformed id are all rejected here, so a foreign-account ARN never
+// reaches a store lookup at all, mirroring handlers_rds.ParseARN.
+func ParseProvisionedModelARN(arn, region, accountID string) (ParsedProvisionedModelARN, error) {
+	parts := strings.SplitN(arn, ":", provisionedModelARNSegmentCount)
+	if len(parts) != provisionedModelARNSegmentCount {
+		return ParsedProvisionedModelARN{}, ptARNError(arn, "expected the form arn:aws:bedrock:{region}:{account}:provisioned-model/{id}")
+	}
+	if parts[0] != "arn" || parts[1] != "aws" || parts[2] != "bedrock" {
+		return ParsedProvisionedModelARN{}, ptARNError(arn, "only arn:aws:bedrock resources are addressable here")
+	}
+	if parts[3] != region {
+		return ParsedProvisionedModelARN{}, ptARNError(arn, fmt.Sprintf("region %q does not match this endpoint's region %q", parts[3], region))
+	}
+	if parts[4] != accountID {
+		return ParsedProvisionedModelARN{}, ptARNError(arn, "the resource belongs to another account")
+	}
+
+	resourceType, id, ok := strings.Cut(parts[5], "/")
+	if !ok || resourceType != provisionedModelResourceType || id == "" || strings.ContainsAny(id, ":/") {
+		return ParsedProvisionedModelARN{}, ptARNError(arn, "the resource name is empty or malformed")
+	}
+
+	return ParsedProvisionedModelARN{Region: parts[3], AccountID: parts[4], ID: id}, nil
+}
+
+// resolveProvisionedModelID accepts either a bare id or a full ARN (the shape
+// every PT op's ProvisionedModelId field allows) and returns the bare id,
+// validating region/account ownership when an ARN is given.
+func resolveProvisionedModelID(idOrARN, region, accountID string) (string, error) {
+	if !strings.HasPrefix(idOrARN, "arn:") {
+		return idOrARN, nil
+	}
+	parsed, err := ParseProvisionedModelARN(idOrARN, region, accountID)
+	if err != nil {
+		return "", err
+	}
+	return parsed.ID, nil
+}
+
+func ptARNError(arn, why string) error {
+	return awserrors.Errorf(awserrors.ErrorInvalidParameterValue, "%q is not a valid provisioned-model ARN: %s", arn, why)
+}

--- a/spinifex/gateway/bedrock/arn.go
+++ b/spinifex/gateway/bedrock/arn.go
@@ -1,6 +1,8 @@
 package gateway_bedrock
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -74,4 +76,57 @@ func resolveProvisionedModelID(idOrARN, region, accountID string) (string, error
 
 func ptARNError(arn, why string) error {
 	return awserrors.Errorf(awserrors.ErrorInvalidParameterValue, "%q is not a valid provisioned-model ARN: %s", arn, why)
+}
+
+// looksLikeProvisionedModelARN is the cheap shape guard the inference path
+// uses to decide whether a modelId needs the (heavier) parse-and-load
+// translation at all: a bare modelId or a foundation-model ARN
+// ("arn:aws:bedrock:*::foundation-model/...") must fall straight through to
+// the existing GlobalAccountID-shorthand path unchanged.
+func looksLikeProvisionedModelARN(modelID string) bool {
+	return strings.HasPrefix(modelID, "arn:") && strings.Contains(modelID, ":"+provisionedModelResourceType+"/")
+}
+
+// resolveInferenceTarget translates modelID into the (accountID, modelID)
+// pair the rest of the inference path — catalog lookup, access grant, and
+// endpoint resolution — must act on. A bare modelId (or any ARN that is not
+// shaped like a provisioned-model one) passes through unchanged with an
+// empty target account, meaning "resolve via the GlobalAccountID shorthand".
+// A PT ARN is parsed, its commitment loaded from store, and the
+// commitment's own (AccountID, ModelID) is returned instead, so inference
+// against a PT ARN reaches the pinned endpoint for that specific commitment
+// rather than the shared platform one.
+//
+// Any failure to resolve a PT ARN — malformed, wrong region, foreign
+// account, or an unknown commitment — reports ResourceNotFoundException: to
+// an inference caller a PT ARN it cannot use is indistinguishable from one
+// that was never a valid model identifier at all. On failure targetModelID
+// is the original modelID unchanged, so a caller logging the attempt still
+// records what was actually requested.
+func resolveInferenceTarget(ctx context.Context, accountID, modelID string, store *ProvisionedStore) (targetAccountID, targetModelID string, err error) {
+	if !looksLikeProvisionedModelARN(modelID) {
+		return "", modelID, nil
+	}
+	if store == nil {
+		return "", modelID, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	parsed, parseErr := ParseProvisionedModelARN(modelID, store.region, accountID)
+	if parseErr != nil {
+		return "", modelID, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return "", modelID, err
+	}
+	rec, found, err := getProvisionedRecord(ctx, kv, parsed.AccountID, parsed.ID)
+	if err != nil {
+		return "", modelID, err
+	}
+	if !found || rec.AccountID != accountID {
+		return "", modelID, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	return rec.AccountID, rec.ModelID, nil
 }

--- a/spinifex/gateway/bedrock/arn_test.go
+++ b/spinifex/gateway/bedrock/arn_test.go
@@ -1,0 +1,84 @@
+package gateway_bedrock
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ptTestRegion   = "us-east-1"
+	ptTestAccount  = "000000000001"
+	ptOtherAccount = "000000000002"
+	ptTestID       = "9f8b3c1e4a5d"
+)
+
+func TestFormatProvisionedModelARN(t *testing.T) {
+	arn := FormatProvisionedModelARN(ptTestRegion, ptTestAccount, ptTestID)
+	assert.Equal(t, "arn:aws:bedrock:us-east-1:000000000001:provisioned-model/9f8b3c1e4a5d", arn)
+}
+
+// TestParseProvisionedModelARN_RoundTrip proves a formatted ARN parses back
+// to the same region/account/id it was built from.
+func TestParseProvisionedModelARN_RoundTrip(t *testing.T) {
+	arn := FormatProvisionedModelARN(ptTestRegion, ptTestAccount, ptTestID)
+	parsed, err := ParseProvisionedModelARN(arn, ptTestRegion, ptTestAccount)
+	require.NoError(t, err)
+	assert.Equal(t, ptTestRegion, parsed.Region)
+	assert.Equal(t, ptTestAccount, parsed.AccountID)
+	assert.Equal(t, ptTestID, parsed.ID)
+}
+
+// TestParseProvisionedModelARN_RejectsForeignAccount guards the exact
+// invariant the plan calls out: a caller must never resolve another tenant's
+// commitment by presenting its ARN with their own credentials.
+func TestParseProvisionedModelARN_RejectsForeignAccount(t *testing.T) {
+	arn := FormatProvisionedModelARN(ptTestRegion, ptOtherAccount, ptTestID)
+	_, err := ParseProvisionedModelARN(arn, ptTestRegion, ptTestAccount)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+}
+
+func TestParseProvisionedModelARN_RejectsForeignRegion(t *testing.T) {
+	arn := FormatProvisionedModelARN("us-west-2", ptTestAccount, ptTestID)
+	_, err := ParseProvisionedModelARN(arn, ptTestRegion, ptTestAccount)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+}
+
+func TestParseProvisionedModelARN_RejectsMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"not-an-arn",
+		"arn:aws:rds:us-east-1:000000000001:provisioned-model/abc",
+		"arn:aws:bedrock:us-east-1:000000000001:custom-model/abc",
+		"arn:aws:bedrock:us-east-1:000000000001:provisioned-model/",
+		"arn:aws:bedrock:us-east-1:000000000001:provisioned-model",
+	}
+	for _, arn := range cases {
+		t.Run(arn, func(t *testing.T) {
+			_, err := ParseProvisionedModelARN(arn, ptTestRegion, ptTestAccount)
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+		})
+	}
+}
+
+// TestResolveProvisionedModelID_AcceptsRawIDOrARN covers the shape every PT
+// op's ProvisionedModelId field allows: a bare id or a full ARN.
+func TestResolveProvisionedModelID_AcceptsRawIDOrARN(t *testing.T) {
+	id, err := resolveProvisionedModelID(ptTestID, ptTestRegion, ptTestAccount)
+	require.NoError(t, err)
+	assert.Equal(t, ptTestID, id)
+
+	arn := FormatProvisionedModelARN(ptTestRegion, ptTestAccount, ptTestID)
+	id, err = resolveProvisionedModelID(arn, ptTestRegion, ptTestAccount)
+	require.NoError(t, err)
+	assert.Equal(t, ptTestID, id)
+
+	foreignARN := FormatProvisionedModelARN(ptTestRegion, ptOtherAccount, ptTestID)
+	_, err = resolveProvisionedModelID(foreignARN, ptTestRegion, ptTestAccount)
+	require.Error(t, err)
+}

--- a/spinifex/gateway/bedrock/contract_test.go
+++ b/spinifex/gateway/bedrock/contract_test.go
@@ -56,7 +56,7 @@ func TestContract_ConverseStream_SelfHost_RealSDKConsumerDecodesFrames(t *testin
 		if !assert.NoError(t, err) {
 			return
 		}
-		err = ConverseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, nil, grantAll{})
+		err = ConverseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, nil, grantAll{}, nil)
 		assert.NoError(t, err)
 	})
 
@@ -200,7 +200,7 @@ func TestContract_InvokeModelWithResponseStream_SelfHost_RealSDKConsumerDecodesF
 		if !assert.NoError(t, err) {
 			return
 		}
-		err = InvokeModelWithResponseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, r.Header.Get("Content-Type"), nil, grantAll{})
+		err = InvokeModelWithResponseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, r.Header.Get("Content-Type"), nil, grantAll{}, nil)
 		assert.NoError(t, err)
 	})
 

--- a/spinifex/gateway/bedrock/converse_stream.go
+++ b/spinifex/gateway/bedrock/converse_stream.go
@@ -116,7 +116,10 @@ func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, model
 
 	entry, _ := lookupCatalogEntry(modelID) // Router.ConverseStream below re-validates; only its Provider tag is needed here.
 
-	src, err := NewRouter(resolver, endpointResolver, recorder, access).ConverseStream(ctx, accountID, modelID, input)
+	// ConverseStream does not accept a PT ARN (out of scope for this stage);
+	// a nil provisioned store means Router treats one as unresolvable, same
+	// as any other unknown modelId.
+	src, err := NewRouter(resolver, endpointResolver, recorder, access, nil).ConverseStream(ctx, accountID, modelID, input)
 	if err != nil {
 		return err
 	}

--- a/spinifex/gateway/bedrock/converse_stream.go
+++ b/spinifex/gateway/bedrock/converse_stream.go
@@ -99,8 +99,9 @@ type converseStreamSource interface {
 // credential, upstream connect error) returns an awserrors code for the normal
 // ErrorHandler envelope. Once the first frame is written it always returns
 // nil — any later failure is an in-band exception event, since the HTTP
-// status can no longer change.
-func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver) error {
+// status can no longer change. provisioned may be nil, disabling PT ARN
+// acceptance (any PT ARN then reads as an unknown modelId).
+func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) error {
 	if recorder == nil {
 		recorder = NoopRecorder
 	}
@@ -114,12 +115,13 @@ func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, model
 		}
 	}
 
-	entry, _ := lookupCatalogEntry(modelID) // Router.ConverseStream below re-validates; only its Provider tag is needed here.
+	// Resolved here too (Router.ConverseStream below resolves it again for
+	// routing) purely so entry's Provider tag reflects a PT ARN's target
+	// model, not the raw ARN, for the InvocationRecord's Backend field.
+	_, recordModelID, _ := resolveInferenceTarget(ctx, accountID, modelID, provisioned)
+	entry, _ := lookupCatalogEntry(recordModelID) // Router.ConverseStream below re-validates; only its Provider tag is needed here.
 
-	// ConverseStream does not accept a PT ARN (out of scope for this stage);
-	// a nil provisioned store means Router treats one as unresolvable, same
-	// as any other unknown modelId.
-	src, err := NewRouter(resolver, endpointResolver, recorder, access, nil).ConverseStream(ctx, accountID, modelID, input)
+	src, err := NewRouter(resolver, endpointResolver, recorder, access, provisioned).ConverseStream(ctx, accountID, modelID, input)
 	if err != nil {
 		return err
 	}

--- a/spinifex/gateway/bedrock/converse_stream_test.go
+++ b/spinifex/gateway/bedrock/converse_stream_test.go
@@ -154,7 +154,7 @@ func TestConverseStream_UnknownModelReturnsResourceNotFoundPreHeader(t *testing.
 	rec := httptest.NewRecorder()
 	body := []byte(`{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`)
 
-	err := ConverseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", body, nil, nil, nil, grantAll{})
+	err := ConverseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", body, nil, nil, nil, grantAll{}, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 	// A pre-stream failure must not have written anything: the gateway's
@@ -164,7 +164,7 @@ func TestConverseStream_UnknownModelReturnsResourceNotFoundPreHeader(t *testing.
 
 func TestConverseStream_MalformedBodyReturnsValidationException(t *testing.T) {
 	rec := httptest.NewRecorder()
-	err := ConverseStream(context.Background(), rec, "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte("{not-json"), nil, nil, nil, grantAll{})
+	err := ConverseStream(context.Background(), rec, "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte("{not-json"), nil, nil, nil, grantAll{}, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
 }
@@ -186,7 +186,7 @@ func TestConverseStream_SelfHostHappyPath_WritesFramedTaxonomy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = ConverseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+	err = ConverseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -301,7 +301,7 @@ func TestConverseStream_ClientDisconnectAbortsUpstreamRequest(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = ConverseStream(ctx, rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+		_ = ConverseStream(ctx, rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 	}()
 
 	select {
@@ -337,7 +337,7 @@ func TestConverseStream_NonFlusherWriter_ReturnsPreHeaderError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = ConverseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+	err = ConverseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
 	assert.False(t, w.wroteHeader)

--- a/spinifex/gateway/bedrock/invoke.go
+++ b/spinifex/gateway/bedrock/invoke.go
@@ -157,13 +157,18 @@ type InvokeStreamRouter struct {
 	resolver         CredentialResolver
 	endpointResolver EndpointResolver
 	access           AccessResolver
+	// provisioned resolves a provisioned-throughput ARN's commitment. Nil
+	// means InvokeModelWithResponseStream rejects any PT ARN as
+	// ResourceNotFoundException, mirroring InvokeRouter.
+	provisioned *ProvisionedStore
 }
 
 // NewInvokeStreamRouter constructs an InvokeStreamRouter. A nil resolver or
 // endpointResolver falls back to a resolver/resolver that finds nothing, and a
 // nil access falls back to denying every model, so an InvokeStreamRouter is
-// always safe to use even before the real stores are wired in.
-func NewInvokeStreamRouter(resolver CredentialResolver, endpointResolver EndpointResolver, access AccessResolver) *InvokeStreamRouter {
+// always safe to use even before the real stores are wired in. A nil
+// provisioned disables PT ARN acceptance.
+func NewInvokeStreamRouter(resolver CredentialResolver, endpointResolver EndpointResolver, access AccessResolver, provisioned *ProvisionedStore) *InvokeStreamRouter {
 	if resolver == nil {
 		resolver = NoopCredentialResolver
 	}
@@ -173,13 +178,20 @@ func NewInvokeStreamRouter(resolver CredentialResolver, endpointResolver Endpoin
 	if access == nil {
 		access = DenyAllAccessResolver
 	}
-	return &InvokeStreamRouter{resolver: resolver, endpointResolver: endpointResolver, access: access}
+	return &InvokeStreamRouter{resolver: resolver, endpointResolver: endpointResolver, access: access, provisioned: provisioned}
 }
 
 // InvokeModelWithResponseStream routes modelID to its family adapter via the
-// catalog, exactly like InvokeRouter.InvokeModel, then requires the resolved
-// adapter to also implement InvokeStreamAdapter.
+// catalog, exactly like InvokeRouter.InvokeModel — including the same
+// translate-before-resolve treatment of a PT ARN via rt.provisioned — then
+// requires the resolved adapter to also implement InvokeStreamAdapter.
 func (rt *InvokeStreamRouter) InvokeModelWithResponseStream(ctx context.Context, accountID, modelID string, body []byte) (invokeStreamSource, error) {
+	// Translate before resolve, exactly like InvokeRouter.InvokeModel.
+	ptAccountID, modelID, err := resolveInferenceTarget(ctx, accountID, modelID, rt.provisioned)
+	if err != nil {
+		return nil, err
+	}
+
 	entry, err := grantedCatalogEntry(ctx, accountID, modelID, rt.access)
 	if err != nil {
 		return nil, err
@@ -188,7 +200,11 @@ func (rt *InvokeStreamRouter) InvokeModelWithResponseStream(ctx context.Context,
 	var a InvokeAdapter
 	switch {
 	case entry.Provider == tierSelfHost:
-		a = newLlamaInvokeAdapter(rt.endpointResolver)
+		if ptAccountID != "" {
+			a = newLlamaInvokeAdapterForAccount(rt.endpointResolver, ptAccountID)
+		} else {
+			a = newLlamaInvokeAdapter(rt.endpointResolver)
+		}
 	case strings.HasPrefix(entry.Provider, providerPrefix):
 		switch strings.TrimPrefix(entry.Provider, providerPrefix) {
 		case vendorAnthropic:

--- a/spinifex/gateway/bedrock/invoke.go
+++ b/spinifex/gateway/bedrock/invoke.go
@@ -26,13 +26,17 @@ type InvokeRouter struct {
 	endpointResolver EndpointResolver
 	recorder         Recorder
 	access           AccessResolver
+	// provisioned resolves a provisioned-throughput ARN's commitment. Nil
+	// means InvokeModel rejects any PT ARN as ResourceNotFoundException
+	// rather than a bare modelId's usual denial.
+	provisioned *ProvisionedStore
 }
 
 // NewInvokeRouter constructs an InvokeRouter. A nil resolver, endpointResolver,
 // or recorder falls back to a no-op implementation, and a nil access falls back
 // to denying every model, so an InvokeRouter is always safe to use even before
-// the real stores are wired in.
-func NewInvokeRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver) *InvokeRouter {
+// the real stores are wired in. A nil provisioned disables PT ARN acceptance.
+func NewInvokeRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) *InvokeRouter {
 	if resolver == nil {
 		resolver = NoopCredentialResolver
 	}
@@ -45,7 +49,7 @@ func NewInvokeRouter(resolver CredentialResolver, endpointResolver EndpointResol
 	if access == nil {
 		access = DenyAllAccessResolver
 	}
-	return &InvokeRouter{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access}
+	return &InvokeRouter{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access, provisioned: provisioned}
 }
 
 // InvokeModel routes modelID to its family adapter via the catalog. Unknown
@@ -76,6 +80,17 @@ func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID stri
 		})
 	}()
 
+	// Translate before resolve: a PT ARN is swapped for the commitment's own
+	// (account, foundation model) here, before catalog lookup, access grant,
+	// and endpoint resolution all act on it. Assigns the named err, so the
+	// deferred closure records a rejected PT ARN the same as any other
+	// failed invocation.
+	var ptAccountID string
+	ptAccountID, modelID, err = resolveInferenceTarget(ctx, accountID, modelID, rt.provisioned)
+	if err != nil {
+		return nil, "", err
+	}
+
 	// Assigns the named err, so the deferred closure records a denied
 	// invocation the same as any other failed one.
 	entry, err := grantedCatalogEntry(ctx, accountID, modelID, rt.access)
@@ -87,7 +102,11 @@ func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID stri
 	var a InvokeAdapter
 	switch {
 	case entry.Provider == tierSelfHost:
-		a = newLlamaInvokeAdapter(rt.endpointResolver)
+		if ptAccountID != "" {
+			a = newLlamaInvokeAdapterForAccount(rt.endpointResolver, ptAccountID)
+		} else {
+			a = newLlamaInvokeAdapter(rt.endpointResolver)
+		}
 	case strings.HasPrefix(entry.Provider, providerPrefix):
 		switch strings.TrimPrefix(entry.Provider, providerPrefix) {
 		case vendorAnthropic:
@@ -116,10 +135,11 @@ func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID stri
 }
 
 // InvokeModel is the bedrock-runtime InvokeModel entry point used by the
-// gateway route table. resolver, endpointResolver, recorder and access may be
-// nil; NewInvokeRouter supplies no-op (and, for access, deny-all) fallbacks.
-func InvokeModel(ctx context.Context, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver) ([]byte, string, error) {
-	return NewInvokeRouter(resolver, endpointResolver, recorder, access).InvokeModel(ctx, accountID, modelID, body)
+// gateway route table. resolver, endpointResolver, recorder, access and
+// provisioned may be nil; NewInvokeRouter supplies no-op (and, for access,
+// deny-all; for provisioned, PT-ARN-rejecting) fallbacks.
+func InvokeModel(ctx context.Context, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) ([]byte, string, error) {
+	return NewInvokeRouter(resolver, endpointResolver, recorder, access, provisioned).InvokeModel(ctx, accountID, modelID, body)
 }
 
 // InvokeStreamAdapter is the optional streaming capability an InvokeAdapter

--- a/spinifex/gateway/bedrock/invoke_llama.go
+++ b/spinifex/gateway/bedrock/invoke_llama.go
@@ -116,6 +116,10 @@ func mapLlamaStopReason(reason string) string {
 type llamaInvokeAdapter struct {
 	endpointResolver EndpointResolver
 	httpClient       *http.Client
+	// account scopes endpoint resolution to a provisioned-throughput
+	// commitment's own account instead of the GlobalAccountID shorthand.
+	// Empty (newLlamaInvokeAdapter's default) keeps the shorthand.
+	account string
 }
 
 var _ InvokeAdapter = (*llamaInvokeAdapter)(nil)
@@ -127,11 +131,32 @@ func newLlamaInvokeAdapter(endpointResolver EndpointResolver) *llamaInvokeAdapte
 	}
 }
 
+// newLlamaInvokeAdapterForAccount returns a llamaInvokeAdapter that resolves
+// a modelID's endpoint scoped to account — a provisioned-throughput ARN's
+// pinned endpoint — instead of the GlobalAccountID shorthand
+// newLlamaInvokeAdapter uses.
+func newLlamaInvokeAdapterForAccount(endpointResolver EndpointResolver, account string) *llamaInvokeAdapter {
+	return &llamaInvokeAdapter{
+		endpointResolver: endpointResolver,
+		httpClient:       &http.Client{Timeout: providerHTTPTimeout},
+		account:          account,
+	}
+}
+
+// resolveEndpoint resolves modelID's base URL: scoped to a.account when set
+// (a PT ARN's pinned endpoint), or the GlobalAccountID shorthand otherwise.
+func (a *llamaInvokeAdapter) resolveEndpoint(ctx context.Context, modelID string) (string, bool, error) {
+	if a.account != "" {
+		return a.endpointResolver.EndpointForAccount(ctx, a.account, modelID)
+	}
+	return a.endpointResolver.Endpoint(ctx, modelID)
+}
+
 // InvokeModel resolves modelID's endpoint, translates the Bedrock-native
 // Llama request to an OpenAI completions request, calls the endpoint, and
 // translates the response back to the Bedrock Llama shape.
 func (a *llamaInvokeAdapter) InvokeModel(ctx context.Context, modelID string, body []byte) ([]byte, string, error) {
-	baseURL, ok, err := a.endpointResolver.Endpoint(ctx, modelID)
+	baseURL, ok, err := a.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("llama invoke: endpoint resolution failed", "model", modelID, "err", err)
 		return nil, "", errors.New(awserrors.ErrorServiceUnavailableException)
@@ -215,7 +240,7 @@ var _ InvokeStreamAdapter = (*llamaInvokeAdapter)(nil)
 // source that translates each chunk to the Bedrock-native Llama streaming
 // shape.
 func (a *llamaInvokeAdapter) InvokeModelWithResponseStream(ctx context.Context, modelID string, body []byte) (invokeStreamSource, error) {
-	baseURL, ok, err := a.endpointResolver.Endpoint(ctx, modelID)
+	baseURL, ok, err := a.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("llama invoke-stream: endpoint resolution failed", "model", modelID, "err", err)
 		return nil, errors.New(awserrors.ErrorServiceUnavailableException)

--- a/spinifex/gateway/bedrock/invoke_stream.go
+++ b/spinifex/gateway/bedrock/invoke_stream.go
@@ -30,17 +30,22 @@ type invokeStreamSource interface {
 // requestContentType is the client's declared Content-Type, logged only.
 // resolver, endpointResolver, recorder and access may be nil;
 // NewInvokeStreamRouter and the internal NoopRecorder fallback keep this call
-// safe either way.
-func InvokeModelWithResponseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, requestContentType string, recorder Recorder, access AccessResolver) error {
+// safe either way. provisioned may be nil, disabling PT ARN acceptance (any
+// PT ARN then reads as an unknown modelId).
+func InvokeModelWithResponseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, requestContentType string, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) error {
 	if recorder == nil {
 		recorder = NoopRecorder
 	}
 	requestID := uuid.NewString()
 	start := time.Now()
 
-	entry, _ := lookupCatalogEntry(modelID) // InvokeStreamRouter below re-validates; only its Provider tag is needed here.
+	// Resolved here too (InvokeStreamRouter below resolves it again for
+	// routing) purely so entry's Provider tag reflects a PT ARN's target
+	// model, not the raw ARN, for the InvocationRecord's Backend field.
+	_, recordModelID, _ := resolveInferenceTarget(ctx, accountID, modelID, provisioned)
+	entry, _ := lookupCatalogEntry(recordModelID) // InvokeStreamRouter below re-validates; only its Provider tag is needed here.
 
-	src, err := NewInvokeStreamRouter(resolver, endpointResolver, access).InvokeModelWithResponseStream(ctx, accountID, modelID, body)
+	src, err := NewInvokeStreamRouter(resolver, endpointResolver, access, provisioned).InvokeModelWithResponseStream(ctx, accountID, modelID, body)
 	if err != nil {
 		return err
 	}

--- a/spinifex/gateway/bedrock/invoke_stream_test.go
+++ b/spinifex/gateway/bedrock/invoke_stream_test.go
@@ -119,7 +119,7 @@ func TestPumpInvokeStream_RecordsInvocationOnUpstreamFault(t *testing.T) {
 
 func TestInvokeModelWithResponseStream_UnknownModelReturnsResourceNotFoundPreHeader(t *testing.T) {
 	rec := httptest.NewRecorder()
-	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, "application/json", nil, grantAll{})
+	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, "application/json", nil, grantAll{}, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 	assert.Equal(t, 0, rec.Body.Len())
@@ -137,7 +137,7 @@ func TestInvokeModelWithResponseStream_SelfHostHappyPath_WritesChunkFrames(t *te
 	rec := httptest.NewRecorder()
 	body := []byte(`{"prompt":"hello","max_gen_len":128}`)
 
-	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{})
+	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -162,7 +162,7 @@ func TestInvokeModelWithResponseStream_NonFlusherWriter_ReturnsPreHeaderError(t 
 	w := &nonFlusherWriter{}
 	body := []byte(`{"prompt":"hello"}`)
 
-	err := InvokeModelWithResponseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{})
+	err := InvokeModelWithResponseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{}, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
 	assert.False(t, w.wroteHeader)

--- a/spinifex/gateway/bedrock/invoke_test.go
+++ b/spinifex/gateway/bedrock/invoke_test.go
@@ -24,7 +24,7 @@ func TestInvokeRouter_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 
 	respBody, contentType, err := rt.InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`))
 	require.NoError(t, err)
@@ -36,21 +36,21 @@ func TestInvokeRouter_SelfHostSuccess(t *testing.T) {
 }
 
 func TestInvokeRouter_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewInvokeRouter(nil, nil, nil, grantAll{})
+	rt := NewInvokeRouter(nil, nil, nil, grantAll{}, nil)
 	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestInvokeRouter_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewInvokeRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{})
+	rt := NewInvokeRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil)
 	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", []byte(`{}`))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
 }
 
 func TestInvokeRouter_SelfHostNoEndpointReturnsModelNotReady(t *testing.T) {
-	rt := NewInvokeRouter(nil, nil, nil, grantAll{})
+	rt := NewInvokeRouter(nil, nil, nil, grantAll{}, nil)
 	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
@@ -68,7 +68,7 @@ func TestInvokeModel_PackageEntryPoint_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	respBody, contentType, err := InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+	respBody, contentType, err := InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "application/json", contentType)
 
@@ -78,7 +78,7 @@ func TestInvokeModel_PackageEntryPoint_SelfHostSuccess(t *testing.T) {
 }
 
 func TestInvokeModel_PackageEntryPoint_UnknownModel(t *testing.T) {
-	_, _, err := InvokeModel(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, nil, grantAll{})
+	_, _, err := InvokeModel(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, nil, grantAll{}, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }

--- a/spinifex/gateway/bedrock/invoke_test.go
+++ b/spinifex/gateway/bedrock/invoke_test.go
@@ -92,7 +92,7 @@ func TestInvokeStreamRouter_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{})
+	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil)
 
 	src, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`))
 	require.NoError(t, err)
@@ -103,21 +103,21 @@ func TestInvokeStreamRouter_SelfHostSuccess(t *testing.T) {
 }
 
 func TestInvokeStreamRouter_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewInvokeStreamRouter(nil, nil, grantAll{})
+	rt := NewInvokeStreamRouter(nil, nil, grantAll{}, nil)
 	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestInvokeStreamRouter_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewInvokeStreamRouter(stubCredentialResolver{ok: false}, nil, grantAll{})
+	rt := NewInvokeStreamRouter(stubCredentialResolver{ok: false}, nil, grantAll{}, nil)
 	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", []byte(`{}`))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
 }
 
 func TestInvokeStreamRouter_SelfHostNoEndpointReturnsModelNotReady(t *testing.T) {
-	rt := NewInvokeStreamRouter(nil, nil, grantAll{})
+	rt := NewInvokeStreamRouter(nil, nil, grantAll{}, nil)
 	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())

--- a/spinifex/gateway/bedrock/provider.go
+++ b/spinifex/gateway/bedrock/provider.go
@@ -35,13 +35,17 @@ type Router struct {
 	endpointResolver EndpointResolver
 	recorder         Recorder
 	access           AccessResolver
+	// provisioned resolves a provisioned-throughput ARN's commitment.
+	// Nil (a Router built without one) means Converse rejects any PT ARN as
+	// ResourceNotFoundException rather than a bare modelId's usual denial.
+	provisioned *ProvisionedStore
 }
 
 // NewRouter constructs a Router. A nil resolver, endpointResolver, or recorder
 // falls back to a no-op implementation, and a nil access falls back to denying
 // every model, so a Router is always safe to use even before the real stores
-// are wired in.
-func NewRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver) *Router {
+// are wired in. A nil provisioned disables PT ARN acceptance.
+func NewRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) *Router {
 	if resolver == nil {
 		resolver = NoopCredentialResolver
 	}
@@ -54,7 +58,7 @@ func NewRouter(resolver CredentialResolver, endpointResolver EndpointResolver, r
 	if access == nil {
 		access = DenyAllAccessResolver
 	}
-	return &Router{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access}
+	return &Router{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access, provisioned: provisioned}
 }
 
 // Converse routes modelID to its provider via the catalog. Unknown modelIds
@@ -102,6 +106,17 @@ func (rt *Router) Converse(ctx context.Context, accountID, modelID string, input
 		})
 	}()
 
+	// Translate before resolve: a PT ARN is swapped for the commitment's own
+	// (account, foundation model) here, before catalog lookup, access grant,
+	// and endpoint resolution all act on it. Assigns the named err, so the
+	// deferred closure records a rejected PT ARN the same as any other
+	// failed invocation.
+	var ptAccountID string
+	ptAccountID, modelID, err = resolveInferenceTarget(ctx, accountID, modelID, rt.provisioned)
+	if err != nil {
+		return nil, err
+	}
+
 	// Assigns the named err, so the deferred closure records a denied
 	// invocation the same as any other failed one.
 	entry, err := grantedCatalogEntry(ctx, accountID, modelID, rt.access)
@@ -113,7 +128,11 @@ func (rt *Router) Converse(ctx context.Context, accountID, modelID string, input
 	var p Provider
 	switch {
 	case entry.Provider == tierSelfHost:
-		p = newVLLMProvider(rt.endpointResolver)
+		if ptAccountID != "" {
+			p = newVLLMProviderForAccount(rt.endpointResolver, ptAccountID)
+		} else {
+			p = newVLLMProvider(rt.endpointResolver)
+		}
 	case strings.HasPrefix(entry.Provider, providerPrefix):
 		switch strings.TrimPrefix(entry.Provider, providerPrefix) {
 		case vendorAnthropic:
@@ -142,10 +161,11 @@ func (rt *Router) Converse(ctx context.Context, accountID, modelID string, input
 }
 
 // Converse is the bedrock-runtime Converse entry point used by the gateway
-// route table. resolver, endpointResolver, recorder and access may be nil;
-// NewRouter supplies no-op (and, for access, deny-all) fallbacks.
-func Converse(ctx context.Context, accountID, modelID string, input *bedrockruntime.ConverseInput, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver) (*bedrockruntime.ConverseOutput, error) {
-	return NewRouter(resolver, endpointResolver, recorder, access).Converse(ctx, accountID, modelID, input)
+// route table. resolver, endpointResolver, recorder, access and provisioned
+// may be nil; NewRouter supplies no-op (and, for access, deny-all; for
+// provisioned, PT-ARN-rejecting) fallbacks.
+func Converse(ctx context.Context, accountID, modelID string, input *bedrockruntime.ConverseInput, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) (*bedrockruntime.ConverseOutput, error) {
+	return NewRouter(resolver, endpointResolver, recorder, access, provisioned).Converse(ctx, accountID, modelID, input)
 }
 
 // ConverseStreamProvider is the optional streaming capability a Provider may

--- a/spinifex/gateway/bedrock/provider.go
+++ b/spinifex/gateway/bedrock/provider.go
@@ -190,9 +190,18 @@ func converseStreamToConverseInput(input *bedrockruntime.ConverseStreamInput) *b
 }
 
 // ConverseStream routes modelID to its provider via the catalog, exactly like
-// Converse, then requires the resolved provider to also implement
-// ConverseStreamProvider.
+// Converse — including the same translate-before-resolve treatment of a PT
+// ARN via rt.provisioned — then requires the resolved provider to also
+// implement ConverseStreamProvider.
 func (rt *Router) ConverseStream(ctx context.Context, accountID, modelID string, input *bedrockruntime.ConverseStreamInput) (converseStreamSource, error) {
+	// Translate before resolve, exactly like Converse: a PT ARN is swapped
+	// for the commitment's own (account, foundation model) before catalog
+	// lookup and endpoint resolution act on it.
+	ptAccountID, modelID, err := resolveInferenceTarget(ctx, accountID, modelID, rt.provisioned)
+	if err != nil {
+		return nil, err
+	}
+
 	entry, err := grantedCatalogEntry(ctx, accountID, modelID, rt.access)
 	if err != nil {
 		return nil, err
@@ -201,7 +210,11 @@ func (rt *Router) ConverseStream(ctx context.Context, accountID, modelID string,
 	var p Provider
 	switch {
 	case entry.Provider == tierSelfHost:
-		p = newVLLMProvider(rt.endpointResolver)
+		if ptAccountID != "" {
+			p = newVLLMProviderForAccount(rt.endpointResolver, ptAccountID)
+		} else {
+			p = newVLLMProvider(rt.endpointResolver)
+		}
 	case strings.HasPrefix(entry.Provider, providerPrefix):
 		switch strings.TrimPrefix(entry.Provider, providerPrefix) {
 		case vendorAnthropic:

--- a/spinifex/gateway/bedrock/provisioned.go
+++ b/spinifex/gateway/bedrock/provisioned.go
@@ -1,0 +1,417 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/google/uuid"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// EndpointProvisioner is the narrow surface the provisioned-throughput ops
+// need from the daemon's endpoint lifecycle (handlers_bedrock.EndpointService):
+// launch a pinned endpoint, read its state, and tear it down. It is declared
+// here with primitive-typed methods rather than that package's input/output
+// structs because handlers_bedrock already imports this package
+// (LookupServingSpec), so importing it back here would cycle. See
+// handlers_bedrock.ProvisionedEndpointAdapter for the real implementation
+// over EndpointService; tests in this package use a stub instead.
+type EndpointProvisioner interface {
+	// EnsurePinned requests a pinned, account-scoped endpoint for modelID.
+	EnsurePinned(ctx context.Context, accountID, modelID string) error
+	// EndpointState reports (accountID, modelID)'s current endpoint state:
+	// one of the endpointState* constants below, mirroring
+	// handlers_bedrock.EndpointState's string values.
+	EndpointState(ctx context.Context, accountID, modelID string) (state string, err error)
+	// DeletePinned tears down (accountID, modelID)'s pinned endpoint.
+	// Idempotent: an already-absent endpoint is a success.
+	DeletePinned(ctx context.Context, accountID, modelID string) error
+}
+
+// Endpoint state strings EndpointProvisioner.EndpointState returns, mirroring
+// handlers_bedrock.EndpointState's string values without importing that
+// package back.
+const (
+	endpointStateStarting = "STARTING"
+	endpointStateReady    = "READY"
+)
+
+// bedrockProvisionedBucket is the cluster-replicated KV bucket holding
+// provisioned-throughput commitment records.
+const bedrockProvisionedBucket = "bedrock-provisioned"
+
+// bedrockProvisionedHistory keeps one revision per key: a commitment is
+// mutated in place (Update, and Status as observed), not a series.
+const bedrockProvisionedHistory = 1
+
+// ProvisionedModelRecord is the gateway control-plane state for one
+// commitment. The VM it pins is daemon-owned (handlers_bedrock.EndpointRecord);
+// this record is the AWS-shaped metadata layered on top of it.
+type ProvisionedModelRecord struct {
+	ARN                  string `json:"arn"`
+	ProvisionedModelName string `json:"provisioned_model_name"`
+	ModelID              string `json:"model_id"`
+	AccountID            string `json:"account_id"`
+	ModelUnits           int64  `json:"model_units"`
+	CommitmentDuration   string `json:"commitment_duration,omitempty"`
+	// Status is the value written at Create/Update time (always "Creating"
+	// initially). Get derives the live value from the pinned endpoint's
+	// current state instead of trusting this field, which List does not.
+	Status           string    `json:"status"`
+	CreationTime     time.Time `json:"creation_time"`
+	LastModifiedTime time.Time `json:"last_modified_time"`
+}
+
+// ProvisionedStore persists ProvisionedModelRecords in the bedrock-provisioned
+// JetStream KV bucket and drives the daemon endpoint lifecycle underneath
+// each commitment, mirroring the LoggingConfigStore/ModelAccessStore
+// gateway-direct-KV pattern.
+type ProvisionedStore struct {
+	js       jetstream.JetStream
+	replicas int
+	// region is baked in at construction (the gateway's own region never
+	// changes at runtime) so ARN building/parsing needs no extra parameter
+	// threaded through the fixed-arity route table.
+	region   string
+	endpoint EndpointProvisioner
+
+	mu sync.Mutex
+	kv jetstream.KeyValue
+}
+
+// NewProvisionedStore constructs a ProvisionedStore over js, replicated
+// across replicas nodes, driving endpoint launches/teardowns through
+// endpoint.
+func NewProvisionedStore(js jetstream.JetStream, replicas int, region string, endpoint EndpointProvisioner) *ProvisionedStore {
+	return &ProvisionedStore{js: js, replicas: replicas, region: region, endpoint: endpoint}
+}
+
+// bucket lazily opens (or creates) the bedrock-provisioned KV bucket, caching
+// the handle, mirroring LoggingConfigStore.bucket.
+func (s *ProvisionedStore) bucket(ctx context.Context) (jetstream.KeyValue, error) {
+	if s.js == nil {
+		return nil, errors.New("bedrock: provisioned store has no JetStream client configured")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.kv != nil {
+		return s.kv, nil
+	}
+	kv, err := kvutil.GetOrCreateBucketWithReplicas(ctx, s.js, bedrockProvisionedBucket, bedrockProvisionedHistory, s.replicas)
+	if err != nil {
+		return nil, err
+	}
+	s.kv = kv
+	return kv, nil
+}
+
+// provisionedKey scopes every stored record to its owning account, so List's
+// prefix scan is the only thing that ever needs to see across ids, and a
+// foreign account's raw-id guess can never collide with another tenant's key.
+func provisionedKey(accountID, id string) string {
+	return accountID + "/" + id
+}
+
+// getProvisionedRecord reads accountID's record for id, or (zero, false, nil)
+// if it does not exist.
+func getProvisionedRecord(ctx context.Context, kv jetstream.KeyValue, accountID, id string) (ProvisionedModelRecord, bool, error) {
+	rec, _, found, err := getProvisionedRecordRevision(ctx, kv, provisionedKey(accountID, id))
+	return rec, found, err
+}
+
+// getProvisionedRecordRevision is getProvisionedRecord with the KV revision
+// surfaced too, for Update's CAS write.
+func getProvisionedRecordRevision(ctx context.Context, kv jetstream.KeyValue, key string) (ProvisionedModelRecord, uint64, bool, error) {
+	entry, err := kv.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return ProvisionedModelRecord{}, 0, false, nil
+		}
+		return ProvisionedModelRecord{}, 0, false, fmt.Errorf("kv get %s: %w", key, err)
+	}
+	var rec ProvisionedModelRecord
+	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+		return ProvisionedModelRecord{}, 0, false, fmt.Errorf("decode %s: %w", key, err)
+	}
+	return rec, entry.Revision(), true, nil
+}
+
+// deriveStatus reports the AWS-shaped status for (accountID, modelID)'s
+// pinned endpoint. Anything other than STARTING/READY — including an absent
+// endpoint, DRAINING (only ever transient during this package's own Delete),
+// or a launch that reverted to ABSENT on failure — reads as Failed: there is
+// no persisted FAILED state in the daemon's own state machine to distinguish
+// "never launched" from "launch failed", and both are equally not-serving.
+func deriveStatus(ctx context.Context, endpoint EndpointProvisioner, accountID, modelID string) (string, error) {
+	state, err := endpoint.EndpointState(ctx, accountID, modelID)
+	if err != nil {
+		return "", err
+	}
+	switch state {
+	case endpointStateStarting:
+		return bedrock.ProvisionedModelStatusCreating, nil
+	case endpointStateReady:
+		return bedrock.ProvisionedModelStatusInService, nil
+	default:
+		return bedrock.ProvisionedModelStatusFailed, nil
+	}
+}
+
+// nonEmptyStringPtr returns nil for an empty string, so an optional
+// AWS-shaped field is omitted rather than rendered as an empty string.
+func nonEmptyStringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return aws.String(s)
+}
+
+// CreateProvisionedModelThroughput commits a pinned, account-scoped endpoint
+// for input.ModelId. Self-host only: a provider-hosted model has nothing to
+// provision capacity for. Creation is async, mirroring AWS: the record is
+// written Status:Creating and a caller polls Get for InService.
+//
+// The launch request and the KV write are not atomic — a crash between them
+// leaves a pinned endpoint with no commitment record — but the daemon's own
+// Ensure is idempotent, so a retried Create converges on the same endpoint
+// rather than doubling up.
+func CreateProvisionedModelThroughput(ctx context.Context, accountID string, store *ProvisionedStore, input *bedrock.CreateProvisionedModelThroughputInput) (*bedrock.CreateProvisionedModelThroughputOutput, error) {
+	if input == nil || aws.StringValue(input.ModelId) == "" || aws.StringValue(input.ProvisionedModelName) == "" || input.ModelUnits == nil {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	modelID := aws.StringValue(input.ModelId)
+
+	if _, found, selfHost := LookupServingSpec(modelID); !found || !selfHost {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	id := uuid.NewString()
+	arn := FormatProvisionedModelARN(store.region, accountID, id)
+
+	if err := store.endpoint.EnsurePinned(ctx, accountID, modelID); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	rec := ProvisionedModelRecord{
+		ARN:                  arn,
+		ProvisionedModelName: aws.StringValue(input.ProvisionedModelName),
+		ModelID:              modelID,
+		AccountID:            accountID,
+		ModelUnits:           aws.Int64Value(input.ModelUnits),
+		CommitmentDuration:   aws.StringValue(input.CommitmentDuration),
+		Status:               bedrock.ProvisionedModelStatusCreating,
+		CreationTime:         now,
+		LastModifiedTime:     now,
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return nil, fmt.Errorf("encode provisioned model %s: %w", id, err)
+	}
+	if _, err := kv.Put(ctx, provisionedKey(accountID, id), data); err != nil {
+		return nil, fmt.Errorf("kv put provisioned model %s: %w", id, err)
+	}
+
+	return &bedrock.CreateProvisionedModelThroughputOutput{ProvisionedModelArn: aws.String(arn)}, nil
+}
+
+// GetProvisionedModelThroughput returns input.ProvisionedModelId's commitment,
+// with Status reflecting the pinned endpoint's live state rather than the
+// value last written to the record.
+func GetProvisionedModelThroughput(ctx context.Context, accountID string, store *ProvisionedStore, input *bedrock.GetProvisionedModelThroughputInput) (*bedrock.GetProvisionedModelThroughputOutput, error) {
+	if input == nil || aws.StringValue(input.ProvisionedModelId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveProvisionedModelID(aws.StringValue(input.ProvisionedModelId), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, found, err := getProvisionedRecord(ctx, kv, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	status, err := deriveStatus(ctx, store.endpoint, accountID, rec.ModelID)
+	if err != nil {
+		return nil, err
+	}
+
+	fmArn := modelARN(rec.ModelID)
+	return &bedrock.GetProvisionedModelThroughputOutput{
+		CommitmentDuration:   nonEmptyStringPtr(rec.CommitmentDuration),
+		CreationTime:         aws.Time(rec.CreationTime),
+		DesiredModelArn:      aws.String(fmArn),
+		DesiredModelUnits:    aws.Int64(rec.ModelUnits),
+		FoundationModelArn:   aws.String(fmArn),
+		LastModifiedTime:     aws.Time(rec.LastModifiedTime),
+		ModelArn:             aws.String(fmArn),
+		ModelUnits:           aws.Int64(rec.ModelUnits),
+		ProvisionedModelArn:  aws.String(rec.ARN),
+		ProvisionedModelName: aws.String(rec.ProvisionedModelName),
+		Status:               aws.String(status),
+	}, nil
+}
+
+// ListProvisionedModelThroughputs returns accountID's own commitments only,
+// sorted by creation time, so one tenant never sees another's. Status is the
+// last value written to each record (Create's Creating, unchanged by
+// Update), not live-derived — unlike Get, a list scan does not pay for one
+// endpoint describe per commitment.
+func ListProvisionedModelThroughputs(ctx context.Context, accountID string, store *ProvisionedStore, _ *bedrock.ListProvisionedModelThroughputsInput) (*bedrock.ListProvisionedModelThroughputsOutput, error) {
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := kv.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return &bedrock.ListProvisionedModelThroughputsOutput{}, nil
+		}
+		return nil, fmt.Errorf("kv keys for provisioned models: %w", err)
+	}
+
+	prefix := accountID + "/"
+	var recs []ProvisionedModelRecord
+	for _, key := range keys {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		entry, err := kv.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("kv get %s: %w", key, err)
+		}
+		var rec ProvisionedModelRecord
+		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+			continue
+		}
+		recs = append(recs, rec)
+	}
+
+	slices.SortFunc(recs, func(a, b ProvisionedModelRecord) int {
+		return a.CreationTime.Compare(b.CreationTime)
+	})
+
+	summaries := make([]*bedrock.ProvisionedModelSummary, 0, len(recs))
+	for _, rec := range recs {
+		fmArn := modelARN(rec.ModelID)
+		summaries = append(summaries, &bedrock.ProvisionedModelSummary{
+			CommitmentDuration:   nonEmptyStringPtr(rec.CommitmentDuration),
+			CreationTime:         aws.Time(rec.CreationTime),
+			DesiredModelArn:      aws.String(fmArn),
+			DesiredModelUnits:    aws.Int64(rec.ModelUnits),
+			FoundationModelArn:   aws.String(fmArn),
+			LastModifiedTime:     aws.Time(rec.LastModifiedTime),
+			ModelArn:             aws.String(fmArn),
+			ModelUnits:           aws.Int64(rec.ModelUnits),
+			ProvisionedModelArn:  aws.String(rec.ARN),
+			ProvisionedModelName: aws.String(rec.ProvisionedModelName),
+			Status:               aws.String(rec.Status),
+		})
+	}
+	return &bedrock.ListProvisionedModelThroughputsOutput{ProvisionedModelSummaries: summaries}, nil
+}
+
+// UpdateProvisionedModelThroughput honours name changes only. AWS allows a
+// limited desired-model swap within a custom model's family; this platform
+// has no custom models, so any attempt to change the served model — as
+// opposed to re-stating the model it already serves — is rejected outright.
+func UpdateProvisionedModelThroughput(ctx context.Context, accountID string, store *ProvisionedStore, input *bedrock.UpdateProvisionedModelThroughputInput) (*bedrock.UpdateProvisionedModelThroughputOutput, error) {
+	if input == nil || aws.StringValue(input.ProvisionedModelId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveProvisionedModelID(aws.StringValue(input.ProvisionedModelId), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := provisionedKey(accountID, id)
+	rec, rev, found, err := getProvisionedRecordRevision(ctx, kv, key)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	if desired := aws.StringValue(input.DesiredModelId); desired != "" && desired != rec.ModelID && desired != modelARN(rec.ModelID) {
+		return nil, awserrors.Errorf(awserrors.ErrorValidationException,
+			"bedrock: provisioned throughput %s cannot change its served model", id)
+	}
+	if name := aws.StringValue(input.DesiredProvisionedModelName); name != "" {
+		rec.ProvisionedModelName = name
+	}
+	rec.LastModifiedTime = time.Now().UTC()
+
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return nil, fmt.Errorf("encode provisioned model %s: %w", id, err)
+	}
+	if _, err := kv.Update(ctx, key, data, rev); err != nil {
+		return nil, fmt.Errorf("kv update provisioned model %s: %w", id, err)
+	}
+	return &bedrock.UpdateProvisionedModelThroughputOutput{}, nil
+}
+
+// DeleteProvisionedModelThroughput tears down the pinned endpoint for
+// input.ProvisionedModelId's model, then removes the record. An already-absent
+// commitment is a no-op success, matching handlers_bedrock.Service.Delete's
+// own idempotence.
+func DeleteProvisionedModelThroughput(ctx context.Context, accountID string, store *ProvisionedStore, input *bedrock.DeleteProvisionedModelThroughputInput) (*bedrock.DeleteProvisionedModelThroughputOutput, error) {
+	if input == nil || aws.StringValue(input.ProvisionedModelId) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveProvisionedModelID(aws.StringValue(input.ProvisionedModelId), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, found, err := getProvisionedRecord(ctx, kv, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return &bedrock.DeleteProvisionedModelThroughputOutput{}, nil
+	}
+
+	if err := store.endpoint.DeletePinned(ctx, accountID, rec.ModelID); err != nil {
+		return nil, err
+	}
+	if err := kv.Delete(ctx, provisionedKey(accountID, id)); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return nil, fmt.Errorf("kv delete provisioned model %s: %w", id, err)
+	}
+	return &bedrock.DeleteProvisionedModelThroughputOutput{}, nil
+}

--- a/spinifex/gateway/bedrock/provisioned_inference_test.go
+++ b/spinifex/gateway/bedrock/provisioned_inference_test.go
@@ -1,0 +1,208 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// endpointForAccountCall is one recorded EndpointForAccount invocation.
+type endpointForAccountCall struct {
+	accountID string
+	modelID   string
+}
+
+// spyEndpointResolver records every Endpoint/EndpointForAccount call so a
+// test can assert which resolve path the PT-ARN translation actually drove
+// — the whole point of decision (A) — while answering a fixed base URL
+// either way.
+type spyEndpointResolver struct {
+	mu      sync.Mutex
+	baseURL string
+
+	endpointCalls           []string
+	endpointForAccountCalls []endpointForAccountCall
+}
+
+var _ EndpointResolver = (*spyEndpointResolver)(nil)
+
+func (s *spyEndpointResolver) Endpoint(_ context.Context, modelID string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.endpointCalls = append(s.endpointCalls, modelID)
+	return s.baseURL, s.baseURL != "", nil
+}
+
+func (s *spyEndpointResolver) EndpointForAccount(_ context.Context, accountID, modelID string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.endpointForAccountCalls = append(s.endpointForAccountCalls, endpointForAccountCall{accountID: accountID, modelID: modelID})
+	return s.baseURL, s.baseURL != "", nil
+}
+
+// vllmChatFixture is a minimal successful OpenAI chat-completions response,
+// used by every PT-ARN Converse test below: the point of these tests is
+// which endpoint got resolved, not the response translation itself.
+const vllmChatFixture = `{
+	"choices": [{"message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+	"usage": {"prompt_tokens": 1, "completion_tokens": 1}
+}`
+
+func vllmTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vllmChatFixture))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// createPTCommitment creates a self-host PT commitment for accountID and
+// returns its ARN, standing in for a prior CreateProvisionedModelThroughput
+// call the inference path only ever consumes.
+func createPTCommitment(t *testing.T, store *ProvisionedStore, accountID string) string {
+	t.Helper()
+	out, err := CreateProvisionedModelThroughput(context.Background(), accountID, store,
+		createInput(selfHostTestModel, "my-pt", 1))
+	require.NoError(t, err)
+	return aws.StringValue(out.ProvisionedModelArn)
+}
+
+// TestRouter_Converse_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount
+// is decision (A)'s core assertion: a PT ARN on the inference path must
+// reach the account-aware resolve keyed on the commitment's own account, not
+// the GlobalAccountID shorthand every bare-modelId caller uses.
+func TestRouter_Converse_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount(t *testing.T) {
+	ts := vllmTestServer(t)
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := createPTCommitment(t, store, ptCallerAccount)
+
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+
+	out, err := rt.Converse(context.Background(), ptCallerAccount, arn, converseInput())
+	require.NoError(t, err)
+	require.NotNil(t, out.Output.Message)
+	assert.Equal(t, "hi", *out.Output.Message.Content[0].Text)
+
+	require.Len(t, spy.endpointForAccountCalls, 1)
+	assert.Equal(t, ptCallerAccount, spy.endpointForAccountCalls[0].accountID,
+		"the PT ARN's own account, not GlobalAccountID, must drive the resolve")
+	assert.Equal(t, selfHostTestModel, spy.endpointForAccountCalls[0].modelID)
+	assert.Empty(t, spy.endpointCalls, "a PT ARN must never fall back to the GlobalAccountID shorthand")
+}
+
+// TestRouter_Converse_BareModelID_StillUsesGlobalShorthand is the regression
+// guard: a bare modelId, even with a provisioned store configured, must keep
+// resolving through the untouched Endpoint shorthand.
+func TestRouter_Converse_BareModelID_StillUsesGlobalShorthand(t *testing.T) {
+	ts := vllmTestServer(t)
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+
+	_, err := rt.Converse(context.Background(), ptCallerAccount, selfHostTestModel, converseInput())
+	require.NoError(t, err)
+
+	require.Len(t, spy.endpointCalls, 1)
+	assert.Equal(t, selfHostTestModel, spy.endpointCalls[0])
+	assert.Empty(t, spy.endpointForAccountCalls, "a bare modelId must never reach the account-aware resolve")
+}
+
+// TestRouter_Converse_ProvisionedThroughputARN_UnknownCommitment covers a
+// well-formed ARN whose commitment was never created (or was already
+// deleted): it must read exactly like any other unresolvable model
+// identifier, not a distinct error shape.
+func TestRouter_Converse_ProvisionedThroughputARN_UnknownCommitment(t *testing.T) {
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := FormatProvisionedModelARN(ptTestRegion, ptCallerAccount, "does-not-exist")
+
+	rt := NewRouter(nil, &spyEndpointResolver{}, nil, grantAll{}, store)
+	_, err := rt.Converse(context.Background(), ptCallerAccount, arn, converseInput())
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestRouter_Converse_ProvisionedThroughputARN_ForeignAccount is the
+// cross-tenant isolation guard: a caller presenting another account's PT ARN
+// must not resolve it, even though the commitment itself exists.
+func TestRouter_Converse_ProvisionedThroughputARN_ForeignAccount(t *testing.T) {
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := createPTCommitment(t, store, ptCallerAccount)
+
+	spy := &spyEndpointResolver{baseURL: "http://unused:8000"}
+	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+
+	_, err := rt.Converse(context.Background(), ptOtherCaller, arn, converseInput())
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.Empty(t, spy.endpointForAccountCalls, "a foreign-account ARN must never reach endpoint resolution")
+}
+
+// TestInvokeRouter_InvokeModel_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount
+// mirrors the Converse coverage above for InvokeModel's own resolve path
+// (llamaInvokeAdapter in invoke_llama.go), confirming both entry points
+// share the same translate-before-resolve behaviour.
+func TestInvokeRouter_InvokeModel_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"choices": [{"text": "hi", "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1}
+		}`))
+	}))
+	defer ts.Close()
+
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := createPTCommitment(t, store, ptCallerAccount)
+
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewInvokeRouter(nil, spy, nil, grantAll{}, store)
+
+	respBody, contentType, err := rt.InvokeModel(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", contentType)
+
+	var out llamaInvokeResponse
+	require.NoError(t, json.Unmarshal(respBody, &out))
+	assert.Equal(t, "hi", out.Generation)
+
+	require.Len(t, spy.endpointForAccountCalls, 1)
+	assert.Equal(t, ptCallerAccount, spy.endpointForAccountCalls[0].accountID)
+	assert.Equal(t, selfHostTestModel, spy.endpointForAccountCalls[0].modelID)
+	assert.Empty(t, spy.endpointCalls)
+}
+
+// TestInvokeRouter_InvokeModel_BareModelID_StillUsesGlobalShorthand is
+// InvokeModel's regression guard, mirroring the Converse one.
+func TestInvokeRouter_InvokeModel_BareModelID_StillUsesGlobalShorthand(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices": [{"text": "hi", "finish_reason": "stop"}], "usage": {"prompt_tokens": 1, "completion_tokens": 1}}`))
+	}))
+	defer ts.Close()
+
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewInvokeRouter(nil, spy, nil, grantAll{}, store)
+
+	_, _, err := rt.InvokeModel(context.Background(), ptCallerAccount, selfHostTestModel, []byte(`{"prompt":"hello"}`))
+	require.NoError(t, err)
+
+	require.Len(t, spy.endpointCalls, 1)
+	assert.Equal(t, selfHostTestModel, spy.endpointCalls[0])
+	assert.Empty(t, spy.endpointForAccountCalls)
+}

--- a/spinifex/gateway/bedrock/provisioned_stream_inference_test.go
+++ b/spinifex/gateway/bedrock/provisioned_stream_inference_test.go
@@ -1,0 +1,183 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// vllmStreamTestServer answers the vLLM (OpenAI chat-completions) SSE wire
+// with vllmStreamFixture, standing in for a pinned self-host endpoint.
+func vllmStreamTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vllmStreamFixture))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// llamaStreamTestServer answers the Llama (OpenAI completions) SSE wire with
+// llamaCompletionsStreamFixture, standing in for a pinned self-host endpoint.
+func llamaStreamTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(llamaCompletionsStreamFixture))
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestRouter_ConverseStream_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount
+// is ConverseStream's counterpart to
+// TestRouter_Converse_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount:
+// a PT ARN on the streaming path must reach the same account-aware resolve a
+// non-stream Converse call does, not silently fall through unresolved.
+func TestRouter_ConverseStream_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount(t *testing.T) {
+	ts := vllmStreamTestServer(t)
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := createPTCommitment(t, store, ptCallerAccount)
+
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+
+	src, err := rt.ConverseStream(context.Background(), ptCallerAccount, arn, converseStreamInput())
+	require.NoError(t, err)
+	events := drainConverseStream(t, src)
+	assert.NotEmpty(t, events)
+
+	require.Len(t, spy.endpointForAccountCalls, 1)
+	assert.Equal(t, ptCallerAccount, spy.endpointForAccountCalls[0].accountID,
+		"the PT ARN's own account, not GlobalAccountID, must drive the resolve")
+	assert.Equal(t, selfHostTestModel, spy.endpointForAccountCalls[0].modelID)
+	assert.Empty(t, spy.endpointCalls, "a PT ARN must never fall back to the GlobalAccountID shorthand")
+}
+
+// TestRouter_ConverseStream_BareModelID_StillUsesGlobalShorthand is the
+// regression guard: a bare modelId on the streaming path, even with a
+// provisioned store configured, must keep resolving through the untouched
+// Endpoint shorthand.
+func TestRouter_ConverseStream_BareModelID_StillUsesGlobalShorthand(t *testing.T) {
+	ts := vllmStreamTestServer(t)
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+
+	src, err := rt.ConverseStream(context.Background(), ptCallerAccount, selfHostTestModel, converseStreamInput())
+	require.NoError(t, err)
+	drainConverseStream(t, src)
+
+	require.Len(t, spy.endpointCalls, 1)
+	assert.Equal(t, selfHostTestModel, spy.endpointCalls[0])
+	assert.Empty(t, spy.endpointForAccountCalls, "a bare modelId must never reach the account-aware resolve")
+}
+
+// TestRouter_ConverseStream_ProvisionedThroughputARN_UnknownCommitment covers
+// a well-formed ARN whose commitment was never created (or was already
+// deleted) on the streaming path.
+func TestRouter_ConverseStream_ProvisionedThroughputARN_UnknownCommitment(t *testing.T) {
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := FormatProvisionedModelARN(ptTestRegion, ptCallerAccount, "does-not-exist")
+
+	rt := NewRouter(nil, &spyEndpointResolver{}, nil, grantAll{}, store)
+	_, err := rt.ConverseStream(context.Background(), ptCallerAccount, arn, converseStreamInput())
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestRouter_ConverseStream_ProvisionedThroughputARN_ForeignAccount is the
+// cross-tenant isolation guard on the streaming path: a caller presenting
+// another account's PT ARN must not resolve it, even though the commitment
+// itself exists.
+func TestRouter_ConverseStream_ProvisionedThroughputARN_ForeignAccount(t *testing.T) {
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := createPTCommitment(t, store, ptCallerAccount)
+
+	spy := &spyEndpointResolver{baseURL: "http://unused:8000"}
+	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+
+	_, err := rt.ConverseStream(context.Background(), ptOtherCaller, arn, converseStreamInput())
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.Empty(t, spy.endpointForAccountCalls, "a foreign-account ARN must never reach endpoint resolution")
+}
+
+// TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount
+// mirrors the ConverseStream coverage above for InvokeModelWithResponseStream's
+// own resolve path (llamaInvokeAdapter's streaming side in invoke_llama.go).
+func TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecordAccount(t *testing.T) {
+	ts := llamaStreamTestServer(t)
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := createPTCommitment(t, store, ptCallerAccount)
+
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store)
+
+	src, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`))
+	require.NoError(t, err)
+	chunks := drainInvokeStream(t, src)
+	assert.NotEmpty(t, chunks)
+
+	require.Len(t, spy.endpointForAccountCalls, 1)
+	assert.Equal(t, ptCallerAccount, spy.endpointForAccountCalls[0].accountID)
+	assert.Equal(t, selfHostTestModel, spy.endpointForAccountCalls[0].modelID)
+	assert.Empty(t, spy.endpointCalls)
+}
+
+// TestInvokeStreamRouter_InvokeModelWithResponseStream_BareModelID_StillUsesGlobalShorthand
+// is InvokeModelWithResponseStream's regression guard, mirroring the
+// ConverseStream one.
+func TestInvokeStreamRouter_InvokeModelWithResponseStream_BareModelID_StillUsesGlobalShorthand(t *testing.T) {
+	ts := llamaStreamTestServer(t)
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+
+	spy := &spyEndpointResolver{baseURL: ts.URL}
+	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store)
+
+	src, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, selfHostTestModel, []byte(`{"prompt":"hello"}`))
+	require.NoError(t, err)
+	drainInvokeStream(t, src)
+
+	require.Len(t, spy.endpointCalls, 1)
+	assert.Equal(t, selfHostTestModel, spy.endpointCalls[0])
+	assert.Empty(t, spy.endpointForAccountCalls)
+}
+
+// TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputARN_UnknownCommitment
+// covers a well-formed ARN whose commitment was never created, on the
+// InvokeModelWithResponseStream path.
+func TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputARN_UnknownCommitment(t *testing.T) {
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := FormatProvisionedModelARN(ptTestRegion, ptCallerAccount, "does-not-exist")
+
+	rt := NewInvokeStreamRouter(nil, &spyEndpointResolver{}, grantAll{}, store)
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputARN_ForeignAccount
+// is the cross-tenant isolation guard for InvokeModelWithResponseStream: a
+// caller presenting another account's PT ARN must not resolve it.
+func TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputARN_ForeignAccount(t *testing.T) {
+	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
+	arn := createPTCommitment(t, store, ptCallerAccount)
+
+	spy := &spyEndpointResolver{baseURL: "http://unused:8000"}
+	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store)
+
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), ptOtherCaller, arn, []byte(`{"prompt":"hello"}`))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.Empty(t, spy.endpointForAccountCalls, "a foreign-account ARN must never reach endpoint resolution")
+}

--- a/spinifex/gateway/bedrock/provisioned_test.go
+++ b/spinifex/gateway/bedrock/provisioned_test.go
@@ -1,0 +1,343 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubEndpointProvisioner is an in-memory EndpointProvisioner: it records
+// every call so a test can assert how the PT ops drove it, and its state per
+// (accountID, modelID) is a plain map a test seeds directly rather than a
+// real endpoint lifecycle, standing in for the daemon.
+type stubEndpointProvisioner struct {
+	mu sync.Mutex
+
+	ensured []provisionerCall
+	deleted []provisionerCall
+
+	// state maps "accountID/modelID" to the endpoint state EndpointState
+	// reports; an absent entry reports "" (ABSENT), matching
+	// handlers_bedrock.StateAbsent's zero-value shape.
+	state map[string]string
+
+	ensureErr error
+	deleteErr error
+}
+
+type provisionerCall struct {
+	accountID string
+	modelID   string
+}
+
+func newStubEndpointProvisioner() *stubEndpointProvisioner {
+	return &stubEndpointProvisioner{state: map[string]string{}}
+}
+
+func provisionerStateKey(accountID, modelID string) string {
+	return accountID + "/" + modelID
+}
+
+func (s *stubEndpointProvisioner) setState(accountID, modelID, state string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.state[provisionerStateKey(accountID, modelID)] = state
+}
+
+func (s *stubEndpointProvisioner) EnsurePinned(_ context.Context, accountID, modelID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ensured = append(s.ensured, provisionerCall{accountID: accountID, modelID: modelID})
+	if s.ensureErr != nil {
+		return s.ensureErr
+	}
+	if _, ok := s.state[provisionerStateKey(accountID, modelID)]; !ok {
+		s.state[provisionerStateKey(accountID, modelID)] = endpointStateStarting
+	}
+	return nil
+}
+
+func (s *stubEndpointProvisioner) EndpointState(_ context.Context, accountID, modelID string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state[provisionerStateKey(accountID, modelID)], nil
+}
+
+func (s *stubEndpointProvisioner) DeletePinned(_ context.Context, accountID, modelID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleted = append(s.deleted, provisionerCall{accountID: accountID, modelID: modelID})
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	delete(s.state, provisionerStateKey(accountID, modelID))
+	return nil
+}
+
+func (s *stubEndpointProvisioner) ensureCalls() []provisionerCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]provisionerCall(nil), s.ensured...)
+}
+
+func (s *stubEndpointProvisioner) deleteCalls() []provisionerCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]provisionerCall(nil), s.deleted...)
+}
+
+var _ EndpointProvisioner = (*stubEndpointProvisioner)(nil)
+
+const (
+	ptCallerAccount = "000000000001"
+	ptOtherCaller   = "000000000002"
+)
+
+func newProvisionedTestStore(t *testing.T, endpoint EndpointProvisioner) *ProvisionedStore {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	return NewProvisionedStore(js, 1, ptTestRegion, endpoint)
+}
+
+func createInput(modelID, name string, units int64) *bedrock.CreateProvisionedModelThroughputInput {
+	return &bedrock.CreateProvisionedModelThroughputInput{
+		ModelId:              aws.String(modelID),
+		ProvisionedModelName: aws.String(name),
+		ModelUnits:           aws.Int64(units),
+	}
+}
+
+// TestCreateProvisionedModelThroughput_RejectsProviderHostedModel guards the
+// bead's core constraint: provisioning capacity only makes sense for a model
+// this platform actually launches VMs for.
+func TestCreateProvisionedModelThroughput_RejectsProviderHostedModel(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+
+	_, err := CreateProvisionedModelThroughput(context.Background(), ptCallerAccount, store,
+		createInput(anthropicTestModel, "my-pt", 1))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.Empty(t, stub.ensureCalls(), "a rejected create must never touch the endpoint lifecycle")
+}
+
+// TestCreateProvisionedModelThroughput_RejectsUnknownModel covers the other
+// LookupServingSpec refusal: a model absent from the catalog entirely.
+func TestCreateProvisionedModelThroughput_RejectsUnknownModel(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+
+	_, err := CreateProvisionedModelThroughput(context.Background(), ptCallerAccount, store,
+		createInput("not-a-real-model", "my-pt", 1))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestCreateProvisionedModelThroughput_SelfHostSucceeds is the happy path:
+// Ensure is called for the caller's own account, the record is written
+// Creating, and a well-formed, parseable ARN comes back.
+func TestCreateProvisionedModelThroughput_SelfHostSucceeds(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+	ctx := context.Background()
+
+	out, err := CreateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		createInput(selfHostTestModel, "my-pt", 2))
+	require.NoError(t, err)
+	require.NotNil(t, out.ProvisionedModelArn)
+
+	arn := aws.StringValue(out.ProvisionedModelArn)
+	parsed, err := ParseProvisionedModelARN(arn, ptTestRegion, ptCallerAccount)
+	require.NoError(t, err, "Create must return a well-formed, self-parseable ARN")
+	assert.NotEmpty(t, parsed.ID)
+
+	calls := stub.ensureCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, ptCallerAccount, calls[0].accountID, "Ensure must be keyed on the caller's account, not the shared platform account")
+	assert.Equal(t, selfHostTestModel, calls[0].modelID)
+
+	getOut, err := GetProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		&bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String(parsed.ID)})
+	require.NoError(t, err)
+	assert.Equal(t, bedrock.ProvisionedModelStatusCreating, aws.StringValue(getOut.Status),
+		"a just-created commitment reads Creating because the stub endpoint starts STARTING")
+	assert.Equal(t, "my-pt", aws.StringValue(getOut.ProvisionedModelName))
+	assert.Equal(t, int64(2), aws.Int64Value(getOut.ModelUnits))
+}
+
+// TestGetProvisionedModelThroughput_StatusDerivation pins the exact mapping
+// the plan specifies: STARTING->Creating, READY->InService, absent->Failed.
+func TestGetProvisionedModelThroughput_StatusDerivation(t *testing.T) {
+	cases := []struct {
+		name       string
+		state      string
+		wantStatus string
+	}{
+		{"starting", endpointStateStarting, bedrock.ProvisionedModelStatusCreating},
+		{"ready", endpointStateReady, bedrock.ProvisionedModelStatusInService},
+		{"absent", "", bedrock.ProvisionedModelStatusFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := newStubEndpointProvisioner()
+			store := newProvisionedTestStore(t, stub)
+			ctx := context.Background()
+
+			out, err := CreateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+				createInput(selfHostTestModel, "my-pt", 1))
+			require.NoError(t, err)
+			parsed, err := ParseProvisionedModelARN(aws.StringValue(out.ProvisionedModelArn), ptTestRegion, ptCallerAccount)
+			require.NoError(t, err)
+
+			stub.setState(ptCallerAccount, selfHostTestModel, tc.state)
+
+			getOut, err := GetProvisionedModelThroughput(ctx, ptCallerAccount, store,
+				&bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String(parsed.ID)})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStatus, aws.StringValue(getOut.Status))
+		})
+	}
+}
+
+// TestGetProvisionedModelThroughput_NotFound covers both a bare id that was
+// never created and a foreign account presenting its own accountID: both
+// must read as not-found, never leaking whether the id exists elsewhere.
+func TestGetProvisionedModelThroughput_NotFound(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+	ctx := context.Background()
+
+	out, err := CreateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		createInput(selfHostTestModel, "my-pt", 1))
+	require.NoError(t, err)
+	parsed, err := ParseProvisionedModelARN(aws.StringValue(out.ProvisionedModelArn), ptTestRegion, ptCallerAccount)
+	require.NoError(t, err)
+
+	_, err = GetProvisionedModelThroughput(ctx, ptOtherCaller, store,
+		&bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String(parsed.ID)})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	_, err = GetProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		&bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String("does-not-exist")})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestListProvisionedModelThroughputs_AccountScoped is the plan's explicit
+// isolation requirement: account B never sees account A's commitment.
+func TestListProvisionedModelThroughputs_AccountScoped(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+	ctx := context.Background()
+
+	_, err := CreateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		createInput(selfHostTestModel, "acct-a-pt", 1))
+	require.NoError(t, err)
+
+	listA, err := ListProvisionedModelThroughputs(ctx, ptCallerAccount, store, nil)
+	require.NoError(t, err)
+	require.Len(t, listA.ProvisionedModelSummaries, 1)
+	assert.Equal(t, "acct-a-pt", aws.StringValue(listA.ProvisionedModelSummaries[0].ProvisionedModelName))
+
+	listB, err := ListProvisionedModelThroughputs(ctx, ptOtherCaller, store, nil)
+	require.NoError(t, err)
+	assert.Empty(t, listB.ProvisionedModelSummaries, "account B must not see account A's commitment")
+}
+
+// TestUpdateProvisionedModelThroughput_RejectsModelSwap pins the resolved
+// decision: Update honours name/tags only, never a served-model change.
+func TestUpdateProvisionedModelThroughput_RejectsModelSwap(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+	ctx := context.Background()
+
+	out, err := CreateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		createInput(selfHostTestModel, "my-pt", 1))
+	require.NoError(t, err)
+	parsed, err := ParseProvisionedModelARN(aws.StringValue(out.ProvisionedModelArn), ptTestRegion, ptCallerAccount)
+	require.NoError(t, err)
+
+	_, err = UpdateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		&bedrock.UpdateProvisionedModelThroughputInput{
+			ProvisionedModelId: aws.String(parsed.ID),
+			DesiredModelId:     aws.String(selfHostTestModel3B),
+		})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, awserrors.ValidErrorCodeFromError(err))
+}
+
+// TestUpdateProvisionedModelThroughput_AcceptsNameChange covers the mutable
+// side of the same op: a rename must succeed and persist.
+func TestUpdateProvisionedModelThroughput_AcceptsNameChange(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+	ctx := context.Background()
+
+	out, err := CreateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		createInput(selfHostTestModel, "old-name", 1))
+	require.NoError(t, err)
+	parsed, err := ParseProvisionedModelARN(aws.StringValue(out.ProvisionedModelArn), ptTestRegion, ptCallerAccount)
+	require.NoError(t, err)
+
+	_, err = UpdateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		&bedrock.UpdateProvisionedModelThroughputInput{
+			ProvisionedModelId:          aws.String(parsed.ID),
+			DesiredProvisionedModelName: aws.String("new-name"),
+		})
+	require.NoError(t, err)
+
+	getOut, err := GetProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		&bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String(parsed.ID)})
+	require.NoError(t, err)
+	assert.Equal(t, "new-name", aws.StringValue(getOut.ProvisionedModelName))
+}
+
+// TestDeleteProvisionedModelThroughput_RemovesEndpointAndRecord covers both
+// halves of Delete: the daemon call for the right account+model, and the KV
+// record actually going away (a subsequent Get reads not-found).
+func TestDeleteProvisionedModelThroughput_RemovesEndpointAndRecord(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+	ctx := context.Background()
+
+	out, err := CreateProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		createInput(selfHostTestModel, "my-pt", 1))
+	require.NoError(t, err)
+	parsed, err := ParseProvisionedModelARN(aws.StringValue(out.ProvisionedModelArn), ptTestRegion, ptCallerAccount)
+	require.NoError(t, err)
+
+	_, err = DeleteProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		&bedrock.DeleteProvisionedModelThroughputInput{ProvisionedModelId: aws.String(parsed.ID)})
+	require.NoError(t, err)
+
+	deletes := stub.deleteCalls()
+	require.Len(t, deletes, 1)
+	assert.Equal(t, ptCallerAccount, deletes[0].accountID)
+	assert.Equal(t, selfHostTestModel, deletes[0].modelID)
+
+	_, err = GetProvisionedModelThroughput(ctx, ptCallerAccount, store,
+		&bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String(parsed.ID)})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestDeleteProvisionedModelThroughput_AbsentIsNoop mirrors
+// handlers_bedrock.Service.Delete's own idempotence: deleting an
+// already-absent commitment must succeed, not error.
+func TestDeleteProvisionedModelThroughput_AbsentIsNoop(t *testing.T) {
+	stub := newStubEndpointProvisioner()
+	store := newProvisionedTestStore(t, stub)
+
+	_, err := DeleteProvisionedModelThroughput(context.Background(), ptCallerAccount, store,
+		&bedrock.DeleteProvisionedModelThroughputInput{ProvisionedModelId: aws.String("never-created")})
+	require.NoError(t, err)
+	assert.Empty(t, stub.deleteCalls(), "an absent record must never reach the endpoint lifecycle")
+}

--- a/spinifex/gateway/bedrock/router_test.go
+++ b/spinifex/gateway/bedrock/router_test.go
@@ -46,7 +46,7 @@ func TestRouter_Converse_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 
 	out, err := rt.Converse(context.Background(), "000000000001", modelID, converseInput())
 	require.NoError(t, err)
@@ -55,14 +55,14 @@ func TestRouter_Converse_SelfHostSuccess(t *testing.T) {
 }
 
 func TestRouter_Converse_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{})
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
 	_, err := rt.Converse(context.Background(), "000000000001", "does.not-exist-v1:0", converseInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestRouter_Converse_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{})
+	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil)
 	_, err := rt.Converse(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", converseInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
@@ -80,14 +80,14 @@ func TestConverse_PackageEntryPoint_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	out, err := Converse(context.Background(), "000000000001", modelID, converseInput(), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+	out, err := Converse(context.Background(), "000000000001", modelID, converseInput(), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, out.Output.Message)
 	assert.Equal(t, "via package Converse", *out.Output.Message.Content[0].Text)
 }
 
 func TestConverse_PackageEntryPoint_UnknownModel(t *testing.T) {
-	_, err := Converse(context.Background(), "000000000001", "does.not-exist-v1:0", converseInput(), nil, nil, nil, grantAll{})
+	_, err := Converse(context.Background(), "000000000001", "does.not-exist-v1:0", converseInput(), nil, nil, nil, grantAll{}, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
@@ -109,7 +109,7 @@ func TestRouter_ConverseStream_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{})
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
 
 	src, err := rt.ConverseStream(context.Background(), "000000000001", modelID, converseStreamInput())
 	require.NoError(t, err)
@@ -120,28 +120,28 @@ func TestRouter_ConverseStream_SelfHostSuccess(t *testing.T) {
 }
 
 func TestRouter_ConverseStream_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{})
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
 	_, err := rt.ConverseStream(context.Background(), "000000000001", "does.not-exist-v1:0", converseStreamInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestRouter_ConverseStream_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{})
+	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil)
 	_, err := rt.ConverseStream(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", converseStreamInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
 }
 
 func TestRouter_ConverseStream_SelfHostNoEndpointReturnsModelNotReady(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{})
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
 	_, err := rt.ConverseStream(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", converseStreamInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
 }
 
 func TestNewRouter_NilArgumentsFallBackToNoops(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{})
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
 	require.NotNil(t, rt)
 
 	// Self-host model with no endpoint resolver configured resolves nothing,

--- a/spinifex/gateway/bedrock/vllm.go
+++ b/spinifex/gateway/bedrock/vllm.go
@@ -23,6 +23,11 @@ const vllmChatCompletionsPath = "/v1/chat/completions"
 // A later task backs this with the daemon's endpoint registry.
 type EndpointResolver interface {
 	Endpoint(ctx context.Context, modelID string) (baseURL string, ok bool, err error)
+	// EndpointForAccount resolves modelID's base URL scoped to accountID
+	// rather than the GlobalAccountID shorthand Endpoint uses. It is the
+	// provisioned-throughput path: a PT ARN's pinned endpoint is keyed to
+	// the commitment's own account, not the shared platform account.
+	EndpointForAccount(ctx context.Context, accountID, modelID string) (baseURL string, ok bool, err error)
 }
 
 // staticEndpointResolver is a fixed modelID->baseURL map, for tests and
@@ -40,6 +45,12 @@ func NewStaticEndpointResolver(endpoints map[string]string) EndpointResolver {
 func (s staticEndpointResolver) Endpoint(_ context.Context, modelID string) (string, bool, error) {
 	baseURL, ok := s[modelID]
 	return baseURL, ok, nil
+}
+
+// EndpointForAccount ignores accountID: a fixed config-driven map has no
+// per-account entries to scope against, so it answers exactly like Endpoint.
+func (s staticEndpointResolver) EndpointForAccount(ctx context.Context, _, modelID string) (string, bool, error) {
+	return s.Endpoint(ctx, modelID)
 }
 
 type vllmMessage struct {
@@ -110,6 +121,10 @@ func mapVLLMFinishReason(reason string) string {
 type vllmProvider struct {
 	endpointResolver EndpointResolver
 	httpClient       *http.Client
+	// account scopes endpoint resolution to a provisioned-throughput
+	// commitment's own account instead of the GlobalAccountID shorthand.
+	// Empty (newVLLMProvider's default) keeps the shorthand.
+	account string
 }
 
 var _ Provider = (*vllmProvider)(nil)
@@ -121,11 +136,31 @@ func newVLLMProvider(endpointResolver EndpointResolver) *vllmProvider {
 	}
 }
 
+// newVLLMProviderForAccount returns a vllmProvider that resolves a modelID's
+// endpoint scoped to account — a provisioned-throughput ARN's pinned
+// endpoint — instead of the GlobalAccountID shorthand newVLLMProvider uses.
+func newVLLMProviderForAccount(endpointResolver EndpointResolver, account string) *vllmProvider {
+	return &vllmProvider{
+		endpointResolver: endpointResolver,
+		httpClient:       &http.Client{Timeout: providerHTTPTimeout},
+		account:          account,
+	}
+}
+
+// resolveEndpoint resolves modelID's base URL: scoped to p.account when set
+// (a PT ARN's pinned endpoint), or the GlobalAccountID shorthand otherwise.
+func (p *vllmProvider) resolveEndpoint(ctx context.Context, modelID string) (string, bool, error) {
+	if p.account != "" {
+		return p.endpointResolver.EndpointForAccount(ctx, p.account, modelID)
+	}
+	return p.endpointResolver.Endpoint(ctx, modelID)
+}
+
 // Converse resolves modelID's endpoint, translates input to an OpenAI
 // chat-completions request, calls the endpoint, and translates the response
 // back to a Bedrock ConverseOutput.
 func (p *vllmProvider) Converse(ctx context.Context, modelID string, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {
-	baseURL, ok, err := p.endpointResolver.Endpoint(ctx, modelID)
+	baseURL, ok, err := p.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("vllm: endpoint resolution failed", "model", modelID, "err", err)
 		return nil, errors.New(awserrors.ErrorServiceUnavailableException)
@@ -250,7 +285,7 @@ var _ ConverseStreamProvider = (*vllmProvider)(nil)
 // the trailing usage chunk), and returns a converseStreamSource that
 // reframes the SSE into the normalized Bedrock ConverseStream taxonomy.
 func (p *vllmProvider) ConverseStream(ctx context.Context, modelID string, input *bedrockruntime.ConverseStreamInput) (converseStreamSource, error) {
-	baseURL, ok, err := p.endpointResolver.Endpoint(ctx, modelID)
+	baseURL, ok, err := p.resolveEndpoint(ctx, modelID)
 	if err != nil {
 		slog.Error("vllm stream: endpoint resolution failed", "model", modelID, "err", err)
 		return nil, errors.New(awserrors.ErrorServiceUnavailableException)

--- a/spinifex/gateway/bedrock_test.go
+++ b/spinifex/gateway/bedrock_test.go
@@ -60,6 +60,10 @@ func (s stubEndpointResolver) Endpoint(context.Context, string) (string, bool, e
 	return s.baseURL, s.baseURL != "", nil
 }
 
+func (s stubEndpointResolver) EndpointForAccount(ctx context.Context, _, modelID string) (string, bool, error) {
+	return s.Endpoint(ctx, modelID)
+}
+
 // TestBedrockEndpointResolver_PrefersDynamic pins the wiring the whole
 // dynamic-resolution change hangs off: with a registry resolver configured the
 // gateway must use it, since it is the only path that can request a launch.

--- a/spinifex/gateway/bedrockruntime.go
+++ b/spinifex/gateway/bedrockruntime.go
@@ -28,22 +28,23 @@ type bedrockRuntimeRoute struct {
 // resolver is gw.bedrockResolver() (credential store or no-op); endpoints is
 // gw.bedrockEndpointResolver() over the configured pinned self-host
 // endpoints; recorder is gw.bedrockRecorder() (invocation recorder or no-op);
-// access is gw.bedrockAccessResolver() (grant store or deny-all).
-type bedrockRuntimeRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver) (any, error)
+// access is gw.bedrockAccessResolver() (grant store or deny-all); provisioned
+// is gw.bedrockProvisionedStore(), consulted when modelId is a PT ARN.
+type bedrockRuntimeRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error)
 
 // bedrockRuntimeRoutes is the dispatch table. InvokeModel has no handler
 // function here: BedrockRuntime_Request special-cases its action to bypass
 // the JSON-marshaling dispatch below, since its response is raw bytes.
 var bedrockRuntimeRoutes = []bedrockRuntimeRoute{
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/converse$`), "Converse",
-		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
 			input := new(bedrockruntime.ConverseInput)
 			if len(b) > 0 {
 				if err := json.Unmarshal(b, input); err != nil {
 					return nil, errors.New(awserrors.ErrorValidationException)
 				}
 			}
-			return gateway_bedrock.Converse(ctx, acct, p[0], input, resolver, endpoints, recorder, access)
+			return gateway_bedrock.Converse(ctx, acct, p[0], input, resolver, endpoints, recorder, access, provisioned)
 		}},
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/invoke$`), "InvokeModel", nil},
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/converse-stream$`), "ConverseStream", nil},
@@ -124,7 +125,7 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 	// InvokeModel returns provider-native bytes, not a struct WriteJSONResponse
 	// could marshal, so it writes its own response body directly.
 	if action == "InvokeModel" {
-		respBody, contentType, err := gateway_bedrock.InvokeModel(r.Context(), accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver())
+		respBody, contentType, err := gateway_bedrock.InvokeModel(r.Context(), accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
 		if err != nil {
 			return err
 		}
@@ -145,7 +146,7 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 		return gateway_bedrock.InvokeModelWithResponseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), r.Header.Get("Content-Type"), gw.bedrockRecorder(), gw.bedrockAccessResolver())
 	}
 
-	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver())
+	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
 	if err != nil {
 		return err
 	}

--- a/spinifex/gateway/bedrockruntime.go
+++ b/spinifex/gateway/bedrockruntime.go
@@ -140,10 +140,10 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 	// (-> ErrorHandler); once streaming starts they always return nil,
 	// surfacing any further failure as an in-band exception event.
 	if action == "ConverseStream" {
-		return gateway_bedrock.ConverseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver())
+		return gateway_bedrock.ConverseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
 	}
 	if action == "InvokeModelWithResponseStream" {
-		return gateway_bedrock.InvokeModelWithResponseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), r.Header.Get("Content-Type"), gw.bedrockRecorder(), gw.bedrockAccessResolver())
+		return gateway_bedrock.InvokeModelWithResponseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), r.Header.Get("Content-Type"), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
 	}
 
 	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -147,6 +147,10 @@ type GatewayConfig struct {
 	// the spinifex admin actions. Nil disables grant administration, which is
 	// how a gateway with an injected read-only resolver behaves.
 	BedrockAccessAdmin *gateway_bedrock.ModelAccessStore
+	// BedrockProvisioned persists provisioned-throughput commitments and
+	// drives the pinned endpoint underneath each one. Nil falls back to an
+	// unconfigured store, under which reads/writes error rather than panic.
+	BedrockProvisioned *gateway_bedrock.ProvisionedStore
 }
 
 var supportedServices = map[string]bool{

--- a/spinifex/handlers/bedrock/eviction_test.go
+++ b/spinifex/handlers/bedrock/eviction_test.go
@@ -1,6 +1,7 @@
 package handlers_bedrock
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -171,6 +172,41 @@ func TestEvictForCapacity_NeverEvictsTheRequester(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, s.evictForCapacity(t.Context(), kv, testModelID, 5120))
 	assert.Empty(t, h.launcher.terminations())
+}
+
+// TestSelectEvictable_SkipsRecordCreatedPinnedViaEnsure is .7.7's exemption
+// guarded against a regression from the new pinned-create path: a record
+// Ensure actually wrote with Pinned:true (not just hand-set on a struct) must
+// still be invisible to selectEvictable, while an identical unpinned one is
+// picked.
+func TestSelectEvictable_SkipsRecordCreatedPinnedViaEnsure(t *testing.T) {
+	h := newLaunchHarness()
+	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())
+
+	_, err := s.Ensure(t.Context(), &EnsureEndpointInput{
+		ModelID: testModelID, AccountID: testAccountID, Pinned: true,
+	}, "")
+	require.NoError(t, err)
+	s.WaitLaunches()
+
+	desc, err := s.Describe(t.Context(), &DescribeEndpointInput{ModelID: testModelID, AccountID: testAccountID}, "")
+	require.NoError(t, err)
+	pinned := desc.Endpoint
+	require.True(t, pinned.Pinned)
+
+	now := time.Now().UTC()
+	stale := now.Add(-time.Hour)
+	pinned.ReadyAt = stale.Add(-time.Hour)
+	pinned.LastActiveAt = stale
+
+	unpinned := pinned
+	unpinned.ModelID = "other.model-v1:0"
+	unpinned.Pinned = false
+
+	victim, found := selectEvictable([]EndpointRecord{pinned, unpinned}, s.deps.NodeID, 5*time.Minute, now)
+
+	require.True(t, found)
+	assert.Equal(t, unpinned.ModelID, victim.ModelID, "the endpoint Ensure created pinned must never be the victim")
 }
 
 // seedReadyEndpoint writes a READY record directly, which is the only way to

--- a/spinifex/handlers/bedrock/provisioned_adapter.go
+++ b/spinifex/handlers/bedrock/provisioned_adapter.go
@@ -1,0 +1,48 @@
+package handlers_bedrock
+
+import (
+	"context"
+
+	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
+)
+
+// ProvisionedEndpointAdapter adapts EndpointService to gateway_bedrock's
+// EndpointProvisioner, the narrow surface the provisioned-throughput ops
+// need. It exists because gateway_bedrock cannot import this package back
+// (handlers_bedrock already imports gateway_bedrock for LookupServingSpec),
+// so EndpointProvisioner is declared there with primitive-typed methods and
+// this adapter is what actually calls EndpointService underneath.
+type ProvisionedEndpointAdapter struct {
+	svc EndpointService
+}
+
+var _ gateway_bedrock.EndpointProvisioner = (*ProvisionedEndpointAdapter)(nil)
+
+// NewProvisionedEndpointAdapter constructs an adapter over svc.
+func NewProvisionedEndpointAdapter(svc EndpointService) *ProvisionedEndpointAdapter {
+	return &ProvisionedEndpointAdapter{svc: svc}
+}
+
+// EnsurePinned requests a pinned, account-scoped endpoint for modelID.
+func (a *ProvisionedEndpointAdapter) EnsurePinned(ctx context.Context, accountID, modelID string) error {
+	_, err := a.svc.Ensure(ctx, &EnsureEndpointInput{ModelID: modelID, AccountID: accountID, Pinned: true}, accountID)
+	return err
+}
+
+// EndpointState reports (accountID, modelID)'s current endpoint state
+// ("STARTING", "READY", "DRAINING", or "ABSENT"). Never an error for a model
+// with no endpoint at all: Describe already treats that as a normal answer.
+func (a *ProvisionedEndpointAdapter) EndpointState(ctx context.Context, accountID, modelID string) (string, error) {
+	out, err := a.svc.Describe(ctx, &DescribeEndpointInput{ModelID: modelID, AccountID: accountID}, accountID)
+	if err != nil {
+		return "", err
+	}
+	return string(out.Endpoint.State), nil
+}
+
+// DeletePinned tears down (accountID, modelID)'s pinned endpoint. Idempotent:
+// an already-absent endpoint is a success.
+func (a *ProvisionedEndpointAdapter) DeletePinned(ctx context.Context, accountID, modelID string) error {
+	_, err := a.svc.Delete(ctx, &DeleteEndpointInput{ModelID: modelID, AccountID: accountID}, accountID)
+	return err
+}

--- a/spinifex/handlers/bedrock/provisioned_adapter_test.go
+++ b/spinifex/handlers/bedrock/provisioned_adapter_test.go
@@ -1,0 +1,124 @@
+package handlers_bedrock
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingEndpointService is an EndpointService that captures the exact
+// input of its last Ensure/Describe/Delete call, so the adapter test can
+// assert the translation to EndpointProvisioner's primitive-typed methods
+// carries AccountID/Pinned through unchanged rather than just that some call
+// happened.
+type recordingEndpointService struct {
+	lastEnsure   *EnsureEndpointInput
+	lastDescribe *DescribeEndpointInput
+	lastDelete   *DeleteEndpointInput
+
+	describeOut EndpointRecord
+	ensureErr   error
+	describeErr error
+	deleteErr   error
+}
+
+var _ EndpointService = (*recordingEndpointService)(nil)
+
+func (r *recordingEndpointService) Ensure(_ context.Context, in *EnsureEndpointInput, _ string) (*EnsureEndpointOutput, error) {
+	r.lastEnsure = in
+	if r.ensureErr != nil {
+		return nil, r.ensureErr
+	}
+	return &EnsureEndpointOutput{}, nil
+}
+
+func (r *recordingEndpointService) Describe(_ context.Context, in *DescribeEndpointInput, _ string) (*DescribeEndpointOutput, error) {
+	r.lastDescribe = in
+	if r.describeErr != nil {
+		return nil, r.describeErr
+	}
+	return &DescribeEndpointOutput{Endpoint: r.describeOut}, nil
+}
+
+func (r *recordingEndpointService) List(context.Context, *ListEndpointsInput, string) (*ListEndpointsOutput, error) {
+	return &ListEndpointsOutput{}, nil
+}
+
+func (r *recordingEndpointService) Delete(_ context.Context, in *DeleteEndpointInput, _ string) (*DeleteEndpointOutput, error) {
+	r.lastDelete = in
+	if r.deleteErr != nil {
+		return nil, r.deleteErr
+	}
+	return &DeleteEndpointOutput{}, nil
+}
+
+const adapterTestModel = "meta.llama3-2-1b-instruct-v1:0"
+const adapterTestAccount = "000000000001"
+
+// TestProvisionedEndpointAdapter_EnsurePinned_AlwaysPinsAndScopesAccount
+// guards the one thing the whole PT feature depends on: every endpoint it
+// launches is pinned (exempt from idle reaping/eviction) and keyed to the
+// caller's real account, never the shared platform account.
+func TestProvisionedEndpointAdapter_EnsurePinned_AlwaysPinsAndScopesAccount(t *testing.T) {
+	svc := &recordingEndpointService{}
+	adapter := NewProvisionedEndpointAdapter(svc)
+
+	require.NoError(t, adapter.EnsurePinned(context.Background(), adapterTestAccount, adapterTestModel))
+
+	require.NotNil(t, svc.lastEnsure)
+	assert.Equal(t, adapterTestModel, svc.lastEnsure.ModelID)
+	assert.Equal(t, adapterTestAccount, svc.lastEnsure.AccountID)
+	assert.True(t, svc.lastEnsure.Pinned, "every PT-launched endpoint must be pinned")
+}
+
+func TestProvisionedEndpointAdapter_EnsurePinned_PropagatesError(t *testing.T) {
+	svc := &recordingEndpointService{ensureErr: errors.New("no capacity")}
+	adapter := NewProvisionedEndpointAdapter(svc)
+
+	err := adapter.EnsurePinned(context.Background(), adapterTestAccount, adapterTestModel)
+	require.Error(t, err)
+	assert.Equal(t, "no capacity", err.Error())
+}
+
+// TestProvisionedEndpointAdapter_EndpointState_MapsRecordState covers the
+// state values Get's status derivation switches on, plus the absent case
+// (ABSENT is the zero value of EndpointState's own type).
+func TestProvisionedEndpointAdapter_EndpointState_MapsRecordState(t *testing.T) {
+	cases := []struct {
+		name  string
+		state EndpointState
+		want  string
+	}{
+		{"starting", StateStarting, "STARTING"},
+		{"ready", StateReady, "READY"},
+		{"draining", StateDraining, "DRAINING"},
+		{"absent", StateAbsent, "ABSENT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &recordingEndpointService{describeOut: EndpointRecord{ModelID: adapterTestModel, State: tc.state}}
+			adapter := NewProvisionedEndpointAdapter(svc)
+
+			state, err := adapter.EndpointState(context.Background(), adapterTestAccount, adapterTestModel)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, state)
+
+			require.NotNil(t, svc.lastDescribe)
+			assert.Equal(t, adapterTestAccount, svc.lastDescribe.AccountID, "the describe must be scoped to the caller's account")
+		})
+	}
+}
+
+func TestProvisionedEndpointAdapter_DeletePinned_ScopesAccount(t *testing.T) {
+	svc := &recordingEndpointService{}
+	adapter := NewProvisionedEndpointAdapter(svc)
+
+	require.NoError(t, adapter.DeletePinned(context.Background(), adapterTestAccount, adapterTestModel))
+
+	require.NotNil(t, svc.lastDelete)
+	assert.Equal(t, adapterTestModel, svc.lastDelete.ModelID)
+	assert.Equal(t, adapterTestAccount, svc.lastDelete.AccountID)
+}

--- a/spinifex/handlers/bedrock/reaper_test.go
+++ b/spinifex/handlers/bedrock/reaper_test.go
@@ -191,6 +191,36 @@ func TestReaper_NeverReapsPinnedEndpoint(t *testing.T) {
 	assert.Empty(t, f.harness.launcher.terminated)
 }
 
+// TestReaper_ShouldReap_SkipsRecordCreatedPinnedViaEnsure is .7.7's exemption
+// guarded against a regression from the new pinned-create path: a record
+// Ensure actually wrote with Pinned:true (not just hand-set on a struct) must
+// still fail shouldReap once idle past the TTL, while an identical unpinned
+// one is reapable.
+func TestReaper_ShouldReap_SkipsRecordCreatedPinnedViaEnsure(t *testing.T) {
+	f := newReaperFixture(t, ReaperDeps{IdleTTL: time.Minute})
+
+	_, err := f.svc.Ensure(t.Context(), &EnsureEndpointInput{
+		ModelID: testModelID, AccountID: testAccountID, Pinned: true,
+	}, "")
+	require.NoError(t, err)
+	f.svc.WaitLaunches()
+
+	desc, err := f.svc.Describe(t.Context(), &DescribeEndpointInput{ModelID: testModelID, AccountID: testAccountID}, "")
+	require.NoError(t, err)
+	pinned := desc.Endpoint
+	require.True(t, pinned.Pinned)
+
+	now := time.Now().UTC()
+	pinned.ReadyAt = now.Add(-time.Hour)
+	pinned.LastActiveAt = now.Add(-time.Hour)
+
+	unpinned := pinned
+	unpinned.Pinned = false
+
+	assert.False(t, f.reaper.shouldReap(pinned, now), "the endpoint Ensure created pinned must never be reaped")
+	assert.True(t, f.reaper.shouldReap(unpinned, now), "an identical unpinned record must still be reapable")
+}
+
 // A busy endpoint's LastActiveAt is refreshed rather than left to age out,
 // which is both what stops the reap and what orders eviction later.
 func TestReaper_BusyEndpointStampsLastActive(t *testing.T) {

--- a/spinifex/handlers/bedrock/resolver.go
+++ b/spinifex/handlers/bedrock/resolver.go
@@ -113,7 +113,38 @@ func (r *DynamicEndpointResolver) Endpoint(ctx context.Context, modelID string) 
 // empty base URL means "not resolved", which is the only outcome a cold model
 // can have: the launch outlives this request by design.
 func (r *DynamicEndpointResolver) resolve(ctx context.Context, modelID string) (string, error) {
-	out, err := r.svc.Describe(ctx, &DescribeEndpointInput{ModelID: modelID}, utils.GlobalAccountID)
+	baseURL, err := r.describeAndEnsure(ctx, utils.GlobalAccountID, modelID, false)
+	if err != nil || baseURL == "" {
+		return baseURL, err
+	}
+	r.storeCache(modelID, baseURL)
+	return baseURL, nil
+}
+
+// EndpointForAccount resolves modelID's base URL scoped to accountID rather
+// than the GlobalAccountID shorthand Endpoint/resolve use — the
+// provisioned-throughput path, where the pinned endpoint is keyed to the
+// commitment's own account. It bypasses the static map and TTL cache
+// entirely: both are keyed by modelID alone for the shared shorthand, and
+// caching an account-scoped answer under that same key would leak a pinned
+// endpoint's address to (or steal a shared one from) an unrelated account.
+// A re-Ensure here keeps Pinned:true, mirroring how the commitment was
+// created.
+func (r *DynamicEndpointResolver) EndpointForAccount(ctx context.Context, accountID, modelID string) (string, bool, error) {
+	baseURL, err := r.describeAndEnsure(ctx, accountID, modelID, true)
+	if err != nil {
+		return "", false, err
+	}
+	return baseURL, baseURL != "", nil
+}
+
+// describeAndEnsure describes (accountID, modelID) and, when it is not
+// currently serving, requests one (pinned when pinned is true), then waits
+// up to coldStartWait for readiness. Shared by the GlobalAccountID shorthand
+// (resolve, which caches its own answer) and the account-aware PT path
+// (EndpointForAccount, which does not).
+func (r *DynamicEndpointResolver) describeAndEnsure(ctx context.Context, accountID, modelID string, pinned bool) (string, error) {
+	out, err := r.svc.Describe(ctx, &DescribeEndpointInput{ModelID: modelID, AccountID: accountID}, accountID)
 	if err != nil {
 		return "", err
 	}
@@ -123,30 +154,31 @@ func (r *DynamicEndpointResolver) resolve(ctx context.Context, modelID string) (
 		if out.Endpoint.BaseURL == "" {
 			return "", nil
 		}
-		r.storeCache(modelID, out.Endpoint.BaseURL)
 		return out.Endpoint.BaseURL, nil
 	case StateStarting:
 		// A launch is already in flight, so asking for another changes nothing.
 		// Waiting on it is still worth doing when the deployment asked for that.
-		return r.awaitReady(ctx, modelID)
+		return r.awaitReady(ctx, accountID, modelID)
 	case StateDraining:
 		// A teardown is in flight and nothing will relaunch on its own, so
 		// there is no readiness to wait for.
 		return "", nil
 	}
 
-	if _, err := r.svc.Ensure(ctx, &EnsureEndpointInput{ModelID: modelID}, utils.GlobalAccountID); err != nil {
+	if _, err := r.svc.Ensure(ctx, &EnsureEndpointInput{ModelID: modelID, AccountID: accountID, Pinned: pinned}, accountID); err != nil {
 		return "", err
 	}
-	return r.awaitReady(ctx, modelID)
+	return r.awaitReady(ctx, accountID, modelID)
 }
 
 // awaitReady holds the caller for up to coldStartWait waiting on a launch,
 // and returns "" (not ready) the moment the budget runs out. At the default
 // of zero it does nothing at all, so the fail-fast path costs no extra
-// describe. It runs inside the singleflight, so a burst of concurrent callers
-// for one cold model shares a single wait rather than one describe loop each.
-func (r *DynamicEndpointResolver) awaitReady(ctx context.Context, modelID string) (string, error) {
+// describe. For the GlobalAccountID shorthand it runs inside the
+// singleflight, so a burst of concurrent callers for one cold model shares a
+// single wait rather than one describe loop each; the account-aware path has
+// no such burst protection, matching describeAndEnsure's no-cache stance.
+func (r *DynamicEndpointResolver) awaitReady(ctx context.Context, accountID, modelID string) (string, error) {
 	if r.coldStartWait <= 0 {
 		return "", nil
 	}
@@ -162,12 +194,11 @@ func (r *DynamicEndpointResolver) awaitReady(ctx context.Context, modelID string
 			return "", nil
 		case <-ticker.C:
 		}
-		out, err := r.svc.Describe(ctx, &DescribeEndpointInput{ModelID: modelID}, utils.GlobalAccountID)
+		out, err := r.svc.Describe(ctx, &DescribeEndpointInput{ModelID: modelID, AccountID: accountID}, accountID)
 		if err != nil {
 			return "", err
 		}
 		if out.Endpoint.State == StateReady && out.Endpoint.BaseURL != "" {
-			r.storeCache(modelID, out.Endpoint.BaseURL)
 			return out.Endpoint.BaseURL, nil
 		}
 		if time.Now().After(deadline) {

--- a/spinifex/handlers/bedrock/resolver_test.go
+++ b/spinifex/handlers/bedrock/resolver_test.go
@@ -28,6 +28,15 @@ type fakeEndpointService struct {
 	describeCalls atomic.Int64
 	ensureCalls   atomic.Int64
 
+	// lastDescribeAccount/lastEnsureAccount/lastEnsurePinned capture the last
+	// call's account (the third EndpointService parameter, mirroring how
+	// ProvisionedEndpointAdapter threads it) and, for Ensure, whether it
+	// asked for a pinned endpoint — what the account-aware resolve path
+	// tests assert against.
+	lastDescribeAccount string
+	lastEnsureAccount   string
+	lastEnsurePinned    bool
+
 	// beforeDescribe runs inside Describe, so a test can hold every caller at
 	// the same point to exercise the concurrent path.
 	beforeDescribe func()
@@ -35,11 +44,14 @@ type fakeEndpointService struct {
 
 var _ EndpointService = (*fakeEndpointService)(nil)
 
-func (f *fakeEndpointService) Describe(_ context.Context, _ *DescribeEndpointInput, _ string) (*DescribeEndpointOutput, error) {
+func (f *fakeEndpointService) Describe(_ context.Context, _ *DescribeEndpointInput, accountID string) (*DescribeEndpointOutput, error) {
 	f.describeCalls.Add(1)
 	if f.beforeDescribe != nil {
 		f.beforeDescribe()
 	}
+	f.mu.Lock()
+	f.lastDescribeAccount = accountID
+	f.mu.Unlock()
 	if f.describeErr != nil {
 		return nil, f.describeErr
 	}
@@ -50,8 +62,12 @@ func (f *fakeEndpointService) Describe(_ context.Context, _ *DescribeEndpointInp
 
 // Ensure records the request and moves the fake to STARTING, mirroring the
 // daemon: the reply is immediate and the launch outlives it.
-func (f *fakeEndpointService) Ensure(_ context.Context, in *EnsureEndpointInput, _ string) (*EnsureEndpointOutput, error) {
+func (f *fakeEndpointService) Ensure(_ context.Context, in *EnsureEndpointInput, accountID string) (*EnsureEndpointOutput, error) {
 	f.ensureCalls.Add(1)
+	f.mu.Lock()
+	f.lastEnsureAccount = accountID
+	f.lastEnsurePinned = in.Pinned
+	f.mu.Unlock()
 	if f.ensureErr != nil {
 		return nil, f.ensureErr
 	}
@@ -73,6 +89,24 @@ func (f *fakeEndpointService) setRecord(rec EndpointRecord) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.record = rec
+}
+
+func (f *fakeEndpointService) describeAccount() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastDescribeAccount
+}
+
+func (f *fakeEndpointService) ensureAccount() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastEnsureAccount
+}
+
+func (f *fakeEndpointService) ensurePinned() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastEnsurePinned
 }
 
 func readyRecord(baseURL string) EndpointRecord {
@@ -343,4 +377,57 @@ func TestDynamicEndpointResolver_ColdStartWaitSkipsDraining(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 	assert.Less(t, time.Since(started), time.Second)
+}
+
+const ptResolverAccount = "000000000001"
+
+// TestDynamicEndpointResolver_EndpointForAccount_KeysOnPassedAccount is the
+// account-aware path's whole point: a ready PT endpoint must be described
+// under the caller-supplied account, not the GlobalAccountID shorthand
+// Endpoint uses.
+func TestDynamicEndpointResolver_EndpointForAccount_KeysOnPassedAccount(t *testing.T) {
+	svc := &fakeEndpointService{record: readyRecord("http://10.0.0.9:9000")}
+	r := NewDynamicEndpointResolver(svc, nil, time.Minute)
+
+	baseURL, ok, err := r.EndpointForAccount(context.Background(), ptResolverAccount, resolverTestModel)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "http://10.0.0.9:9000", baseURL)
+	assert.Equal(t, ptResolverAccount, svc.describeAccount())
+}
+
+// TestDynamicEndpointResolver_EndpointForAccount_AbsentEnsuresPinned covers
+// the launch path: an absent PT endpoint is (re-)requested under the passed
+// account with Pinned:true, mirroring how the commitment was created —
+// not the GlobalAccountID/Pinned:false shape Endpoint's own Ensure uses.
+func TestDynamicEndpointResolver_EndpointForAccount_AbsentEnsuresPinned(t *testing.T) {
+	svc := &fakeEndpointService{record: EndpointRecord{ModelID: resolverTestModel, State: StateAbsent}}
+	r := NewDynamicEndpointResolver(svc, nil, 0)
+
+	_, ok, err := r.EndpointForAccount(context.Background(), ptResolverAccount, resolverTestModel)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, int64(1), svc.ensureCalls.Load())
+	assert.Equal(t, ptResolverAccount, svc.ensureAccount())
+	assert.True(t, svc.ensurePinned(), "a PT (re-)ensure must stay pinned")
+}
+
+// TestDynamicEndpointResolver_EndpointForAccount_DoesNotShareTheGlobalCache
+// guards against the cross-account leak the account-aware path exists to
+// avoid: caching its answer under Endpoint's shared, modelID-only cache would
+// serve a pinned endpoint's address to an unrelated bare-modelId caller.
+func TestDynamicEndpointResolver_EndpointForAccount_DoesNotShareTheGlobalCache(t *testing.T) {
+	svc := &fakeEndpointService{record: readyRecord("http://10.0.0.9:9000")}
+	r := NewDynamicEndpointResolver(svc, nil, time.Minute)
+
+	_, ok, err := r.EndpointForAccount(context.Background(), ptResolverAccount, resolverTestModel)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	baseURL, ok, err := r.Endpoint(context.Background(), resolverTestModel)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "http://10.0.0.9:9000", baseURL)
+	assert.Equal(t, int64(2), svc.describeCalls.Load(),
+		"the account-scoped resolve must not have pre-populated Endpoint's cache")
 }

--- a/spinifex/handlers/bedrock/service.go
+++ b/spinifex/handlers/bedrock/service.go
@@ -387,13 +387,15 @@ func (s *Service) Describe(ctx context.Context, in *DescribeEndpointInput, _ str
 	return &DescribeEndpointOutput{Endpoint: rec}, nil
 }
 
-// List returns every endpoint record in the shared endpoints bucket.
+// List returns every endpoint record in the shared endpoints bucket, across
+// every account: an operator listing must see a pinned, account-scoped
+// endpoint alongside the shared platform ones, not just the latter.
 func (s *Service) List(ctx context.Context, _ *ListEndpointsInput, _ string) (*ListEndpointsOutput, error) {
 	kv, err := s.bucket(ctx)
 	if err != nil {
 		return nil, err
 	}
-	recs, err := ListEndpoints(ctx, kv, utils.GlobalAccountID)
+	recs, err := ListAllEndpoints(ctx, kv)
 	if err != nil {
 		return nil, err
 	}

--- a/spinifex/handlers/bedrock/service.go
+++ b/spinifex/handlers/bedrock/service.go
@@ -127,6 +127,16 @@ func (s *Service) httpClient() *http.Client {
 	return &http.Client{}
 }
 
+// resolveAccountID returns accountID, or utils.GlobalAccountID for the zero
+// value, so every existing Ensure/Describe/Delete caller that leaves the
+// input's AccountID unset keeps resolving to the shared platform endpoint.
+func resolveAccountID(accountID string) string {
+	if accountID == "" {
+		return utils.GlobalAccountID
+	}
+	return accountID
+}
+
 // Ensure idempotently guarantees modelID has a running or starting endpoint.
 // A model with no serving spec (unknown, or a provider entry) is rejected
 // before any KV touch. Capacity is admission-checked before the claim so a
@@ -140,11 +150,11 @@ func (s *Service) Ensure(ctx context.Context, in *EnsureEndpointInput, _ string)
 		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
 	}
 
-	// Serving endpoints are shared platform infra today, not per-tenant: every
-	// account's Ensure for the same model converges on one shared VM, stored
-	// under the system account. The {accountID}/{modelID} key shape stays
-	// ready for per-tenant serving pools without a schema change later.
-	storeAccountID := utils.GlobalAccountID
+	// Serving endpoints are shared platform infra by default: an Ensure with
+	// no AccountID converges on one shared VM stored under the system
+	// account. A caller that supplies its own AccountID (a pinned,
+	// account-scoped endpoint) gets a distinct key instead.
+	storeAccountID := resolveAccountID(in.AccountID)
 	key := EndpointKey(storeAccountID, in.ModelID)
 
 	unlock := s.ensureMu.lock(key)
@@ -192,6 +202,7 @@ func (s *Service) Ensure(ctx context.Context, in *EnsureEndpointInput, _ string)
 		NodeID:     s.deps.NodeID,
 		CreatedAt:  time.Now().UTC(),
 		Generation: 1,
+		Pinned:     in.Pinned,
 	}
 	if _, err := createJSONRevision(ctx, kv, key, rec); err != nil {
 		if errors.Is(err, jetstream.ErrKeyExists) {
@@ -360,7 +371,7 @@ func (s *Service) Describe(ctx context.Context, in *DescribeEndpointInput, _ str
 	if in == nil || in.ModelID == "" {
 		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
 	}
-	storeAccountID := utils.GlobalAccountID
+	storeAccountID := resolveAccountID(in.AccountID)
 	kv, err := s.bucket(ctx)
 	if err != nil {
 		return nil, err
@@ -399,7 +410,7 @@ func (s *Service) Delete(ctx context.Context, in *DeleteEndpointInput, _ string)
 	if in == nil || in.ModelID == "" {
 		return nil, errors.New(awserrors.ErrorInvalidParameterValue)
 	}
-	storeAccountID := utils.GlobalAccountID
+	storeAccountID := resolveAccountID(in.AccountID)
 	key := EndpointKey(storeAccountID, in.ModelID)
 
 	unlock := s.ensureMu.lock(key)

--- a/spinifex/handlers/bedrock/service_test.go
+++ b/spinifex/handlers/bedrock/service_test.go
@@ -350,3 +350,40 @@ func TestList_ReturnsAllEnsuredEndpoints(t *testing.T) {
 	require.Len(t, out.Endpoints, 1)
 	assert.Equal(t, testModelID, out.Endpoints[0].ModelID)
 }
+
+// TestList_ReturnsEndpointsAcrossAllAccountsIncludingPinned is Bug 2's core
+// regression guard: a pinned, account-scoped endpoint must appear in List
+// alongside the shared GlobalAccountID one, carrying its own AccountID and
+// Pinned — an operator listing must not key on GlobalAccountID only.
+func TestList_ReturnsEndpointsAcrossAllAccountsIncludingPinned(t *testing.T) {
+	h := newLaunchHarness()
+	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())
+
+	_, err := s.Ensure(t.Context(), &EnsureEndpointInput{ModelID: testModelID}, "")
+	require.NoError(t, err)
+
+	pinnedModelID := "meta.llama3-2-3b-instruct-v1:0"
+	_, err = s.Ensure(t.Context(), &EnsureEndpointInput{
+		ModelID: pinnedModelID, AccountID: testAccountID, Pinned: true,
+	}, "")
+	require.NoError(t, err)
+	s.WaitLaunches()
+
+	out, err := s.List(t.Context(), &ListEndpointsInput{}, "")
+	require.NoError(t, err)
+	require.Len(t, out.Endpoints, 2)
+
+	byModel := map[string]EndpointRecord{}
+	for _, e := range out.Endpoints {
+		byModel[e.ModelID] = e
+	}
+	global, ok := byModel[testModelID]
+	require.True(t, ok, "the shared GlobalAccountID endpoint must still list unchanged")
+	assert.Equal(t, utils.GlobalAccountID, global.AccountID)
+	assert.False(t, global.Pinned)
+
+	pinned, ok := byModel[pinnedModelID]
+	require.True(t, ok, "a pinned, account-scoped endpoint must appear in List")
+	assert.Equal(t, testAccountID, pinned.AccountID)
+	assert.True(t, pinned.Pinned)
+}

--- a/spinifex/handlers/bedrock/service_test.go
+++ b/spinifex/handlers/bedrock/service_test.go
@@ -247,6 +247,96 @@ func TestDelete_ResumesFromDraining(t *testing.T) {
 	assert.Contains(t, h.launcher.terminated, "i-stranded", "the resume must still tear the VM down")
 }
 
+// testAccountID is a non-Global account, distinct from utils.GlobalAccountID,
+// standing in for a real tenant across the account-scoping tests below.
+const testAccountID = "111111111111"
+
+// TestEnsure_EmptyAccountIDKeysGlobalAndUnpinned pins down existing-caller
+// behaviour under the widened input: an Ensure that leaves AccountID and
+// Pinned at their zero values must still land under GlobalAccountID,
+// unpinned, exactly as every pre-existing caller relies on.
+func TestEnsure_EmptyAccountIDKeysGlobalAndUnpinned(t *testing.T) {
+	h := newLaunchHarness()
+	s, nc := newTestService(t, h, http.StatusOK, sufficientGPU())
+
+	out, err := s.Ensure(t.Context(), &EnsureEndpointInput{ModelID: testModelID}, "")
+	require.NoError(t, err)
+	assert.Equal(t, utils.GlobalAccountID, out.Endpoint.AccountID)
+	assert.False(t, out.Endpoint.Pinned)
+	s.WaitLaunches()
+
+	js := testutil.NewJetStream(t, nc)
+	kv, err := GetOrCreateEndpointsBucket(t.Context(), js, 1)
+	require.NoError(t, err)
+	var rec EndpointRecord
+	found, err := getJSON(t.Context(), kv, EndpointKey(utils.GlobalAccountID, testModelID), &rec)
+	require.NoError(t, err)
+	require.True(t, found, "an empty AccountID must key the record under GlobalAccountID")
+	assert.False(t, rec.Pinned)
+}
+
+// TestEnsure_RealAccountIDKeysUnderAccountAndPersistsPinned is the PT shape:
+// a real AccountID plus Pinned:true must key the record away from the shared
+// GlobalAccountID endpoint and persist Pinned on it.
+func TestEnsure_RealAccountIDKeysUnderAccountAndPersistsPinned(t *testing.T) {
+	h := newLaunchHarness()
+	s, nc := newTestService(t, h, http.StatusOK, sufficientGPU())
+
+	out, err := s.Ensure(t.Context(), &EnsureEndpointInput{
+		ModelID: testModelID, AccountID: testAccountID, Pinned: true,
+	}, "")
+	require.NoError(t, err)
+	assert.Equal(t, testAccountID, out.Endpoint.AccountID)
+	assert.True(t, out.Endpoint.Pinned)
+	s.WaitLaunches()
+
+	js := testutil.NewJetStream(t, nc)
+	kv, err := GetOrCreateEndpointsBucket(t.Context(), js, 1)
+	require.NoError(t, err)
+	var rec EndpointRecord
+	found, err := getJSON(t.Context(), kv, EndpointKey(testAccountID, testModelID), &rec)
+	require.NoError(t, err)
+	require.True(t, found, "a real AccountID must key the record under that account, not Global")
+	assert.True(t, rec.Pinned)
+
+	// Nothing must have landed under the shared Global key.
+	var globalRec EndpointRecord
+	foundGlobal, err := getJSON(t.Context(), kv, EndpointKey(utils.GlobalAccountID, testModelID), &globalRec)
+	require.NoError(t, err)
+	assert.False(t, foundGlobal)
+}
+
+// TestDescribeDelete_AccountScopedRoundTrip covers Describe/Delete resolving
+// the same account-scoped key an account-scoped Ensure wrote.
+func TestDescribeDelete_AccountScopedRoundTrip(t *testing.T) {
+	h := newLaunchHarness()
+	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())
+
+	_, err := s.Ensure(t.Context(), &EnsureEndpointInput{
+		ModelID: testModelID, AccountID: testAccountID, Pinned: true,
+	}, "")
+	require.NoError(t, err)
+	s.WaitLaunches()
+
+	desc, err := s.Describe(t.Context(), &DescribeEndpointInput{ModelID: testModelID, AccountID: testAccountID}, "")
+	require.NoError(t, err)
+	assert.Equal(t, StateReady, desc.Endpoint.State)
+	assert.Equal(t, testAccountID, desc.Endpoint.AccountID)
+	assert.True(t, desc.Endpoint.Pinned)
+
+	// The Global account never had an endpoint created, so it must read ABSENT.
+	globalDesc, err := s.Describe(t.Context(), &DescribeEndpointInput{ModelID: testModelID}, "")
+	require.NoError(t, err)
+	assert.Equal(t, StateAbsent, globalDesc.Endpoint.State)
+
+	_, err = s.Delete(t.Context(), &DeleteEndpointInput{ModelID: testModelID, AccountID: testAccountID}, "")
+	require.NoError(t, err)
+
+	desc, err = s.Describe(t.Context(), &DescribeEndpointInput{ModelID: testModelID, AccountID: testAccountID}, "")
+	require.NoError(t, err)
+	assert.Equal(t, StateAbsent, desc.Endpoint.State)
+}
+
 func TestList_ReturnsAllEnsuredEndpoints(t *testing.T) {
 	h := newLaunchHarness()
 	s, _ := newTestService(t, h, http.StatusOK, sufficientGPU())

--- a/spinifex/handlers/bedrock/store.go
+++ b/spinifex/handlers/bedrock/store.go
@@ -136,7 +136,27 @@ func deleteJSON(ctx context.Context, kv jetstream.KeyValue, key string) error {
 }
 
 // ListEndpoints returns every endpoint record under accountID's key prefix.
+// Used by the reaper and eviction candidate search, both of which only ever
+// act on the shared platform account's endpoints; ListAllEndpoints is the
+// cross-account view an operator listing needs instead.
 func ListEndpoints(ctx context.Context, kv jetstream.KeyValue, accountID string) ([]EndpointRecord, error) {
+	prefix := endpointsPrefix(accountID)
+	return listEndpointRecords(ctx, kv, func(key string) bool {
+		return strings.HasPrefix(key, prefix)
+	})
+}
+
+// ListAllEndpoints returns every endpoint record in the bucket regardless of
+// which account it is keyed under, so an operator listing sees a pinned,
+// account-scoped endpoint alongside the shared platform ones.
+func ListAllEndpoints(ctx context.Context, kv jetstream.KeyValue) ([]EndpointRecord, error) {
+	return listEndpointRecords(ctx, kv, func(string) bool { return true })
+}
+
+// listEndpointRecords reads every KV key that satisfies keep, decoding each
+// into an EndpointRecord, and is the shared body of ListEndpoints and
+// ListAllEndpoints.
+func listEndpointRecords(ctx context.Context, kv jetstream.KeyValue, keep func(key string) bool) ([]EndpointRecord, error) {
 	keys, err := kvutil.Keys(ctx, kv)
 	if err != nil {
 		// An empty bucket is the normal state before any endpoint has ever
@@ -146,10 +166,9 @@ func ListEndpoints(ctx context.Context, kv jetstream.KeyValue, accountID string)
 		}
 		return nil, fmt.Errorf("bedrock: list endpoint keys: %w", err)
 	}
-	prefix := endpointsPrefix(accountID)
 	out := make([]EndpointRecord, 0, len(keys))
 	for _, key := range keys {
-		if !strings.HasPrefix(key, prefix) {
+		if !keep(key) {
 			continue
 		}
 		var rec EndpointRecord

--- a/spinifex/handlers/bedrock/store_test.go
+++ b/spinifex/handlers/bedrock/store_test.go
@@ -104,3 +104,42 @@ func TestListEndpoints_EmptyBucketIsNotAnError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, recs)
 }
+
+// TestListAllEndpoints_ReturnsAcrossAccounts is ListEndpoints' single-account
+// prefix filter's counterpart: ListAllEndpoints must return every account's
+// records in one pass, which is what an operator listing needs to see a
+// pinned endpoint alongside the shared platform ones.
+func TestListAllEndpoints_ReturnsAcrossAccounts(t *testing.T) {
+	kv := newTestBucket(t)
+
+	seed := func(accountID, modelID string, state EndpointState, pinned bool) {
+		rec := EndpointRecord{AccountID: accountID, ModelID: modelID, State: state, Pinned: pinned, Generation: 1}
+		_, err := createJSONRevision(t.Context(), kv, EndpointKey(accountID, modelID), rec)
+		require.NoError(t, err)
+	}
+	seed("000000000000", "model-a", StateReady, false)
+	seed("111111111111", "model-c", StateReady, true)
+
+	recs, err := ListAllEndpoints(t.Context(), kv)
+	require.NoError(t, err)
+	require.Len(t, recs, 2)
+
+	byModel := map[string]EndpointRecord{}
+	for _, rec := range recs {
+		byModel[rec.ModelID] = rec
+	}
+	assert.Equal(t, "000000000000", byModel["model-a"].AccountID)
+	assert.False(t, byModel["model-a"].Pinned)
+	assert.Equal(t, "111111111111", byModel["model-c"].AccountID)
+	assert.True(t, byModel["model-c"].Pinned)
+}
+
+// TestListAllEndpoints_EmptyBucketIsNotAnError mirrors ListEndpoints' own
+// empty-bucket guard.
+func TestListAllEndpoints_EmptyBucketIsNotAnError(t *testing.T) {
+	kv := newTestBucket(t)
+
+	recs, err := ListAllEndpoints(t.Context(), kv)
+	require.NoError(t, err)
+	assert.Empty(t, recs)
+}

--- a/spinifex/handlers/bedrock/types.go
+++ b/spinifex/handlers/bedrock/types.go
@@ -13,8 +13,15 @@ const (
 // EnsureEndpointInput requests that modelID have a running (or starting)
 // serving endpoint. Idempotent: a model already STARTING or READY returns its
 // current record without launching a second VM.
+//
+// AccountID scopes the endpoint to a tenant; empty resolves to
+// utils.GlobalAccountID, the shared platform endpoint every caller used
+// before per-account endpoints existed. Pinned marks a created endpoint
+// exempt from idle reaping and eviction.
 type EnsureEndpointInput struct {
-	ModelID string `json:"model_id"`
+	ModelID   string `json:"model_id"`
+	AccountID string `json:"account_id,omitempty"`
+	Pinned    bool   `json:"pinned,omitempty"`
 }
 
 type EnsureEndpointOutput struct {
@@ -22,8 +29,10 @@ type EnsureEndpointOutput struct {
 }
 
 // DescribeEndpointInput looks up modelID's current endpoint record.
+// AccountID scopes the lookup; empty resolves to utils.GlobalAccountID.
 type DescribeEndpointInput struct {
-	ModelID string `json:"model_id"`
+	ModelID   string `json:"model_id"`
+	AccountID string `json:"account_id,omitempty"`
 }
 
 type DescribeEndpointOutput struct {
@@ -40,8 +49,10 @@ type ListEndpointsOutput struct {
 
 // DeleteEndpointInput requests a READY endpoint move to DRAINING and its VM
 // be torn down. Idempotent: an already-ABSENT endpoint returns success.
+// AccountID scopes the target; empty resolves to utils.GlobalAccountID.
 type DeleteEndpointInput struct {
-	ModelID string `json:"model_id"`
+	ModelID   string `json:"model_id"`
+	AccountID string `json:"account_id,omitempty"`
 }
 
 type DeleteEndpointOutput struct{}

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -335,9 +335,20 @@ func launchService(config *config.ClusterConfig) error {
 	// returning ModelNotReadyException at once. Unset (the default) keeps the
 	// fail-fast contract: cold start is minutes, which no client retry spans.
 	bedrockEndpoints := parseBedrockEndpoints(os.Getenv("OCHRE_VLLM_ENDPOINTS"))
+	bedrockEndpointSvc := handlers_bedrock.NewNATSEndpointService(natsConn)
 	bedrockEndpointResolver := handlers_bedrock.NewDynamicEndpointResolver(
-		handlers_bedrock.NewNATSEndpointService(natsConn), bedrockEndpoints, 0,
+		bedrockEndpointSvc, bedrockEndpoints, 0,
 		handlers_bedrock.WithColdStartWait(parseColdStartWait(os.Getenv("OCHRE_COLD_START_WAIT"))))
+
+	// Bedrock provisioned throughput: commitment metadata lives in the
+	// bedrock-provisioned KV bucket (gateway control plane), while the pinned
+	// endpoint it commits to is requested through the same NATS endpoint
+	// service the dynamic resolver above uses, via an adapter satisfying
+	// gateway_bedrock's narrow EndpointProvisioner (see provisioned_adapter.go
+	// for why the adapter, not handlers_bedrock.EndpointService, is what
+	// gateway_bedrock depends on).
+	bedrockProvisioned := gateway_bedrock.NewProvisionedStore(js, len(config.Nodes), nodeConfig.Region,
+		handlers_bedrock.NewProvisionedEndpointAdapter(bedrockEndpointSvc))
 
 	// Bedrock invocation records: every Converse/InvokeModel call (streaming
 	// or not) is published to the invocation stream, then fanned out by
@@ -393,6 +404,7 @@ func launchService(config *config.ClusterConfig) error {
 		BedrockRecorder:         bedrockRecorder,
 		BedrockAccess:           bedrockAccess,
 		BedrockAccessAdmin:      bedrockAccess,
+		BedrockProvisioned:      bedrockProvisioned,
 	}
 
 	// Rotate the ECR signing key on a 30-day cadence, retaining the previous keys


### PR DESCRIPTION
## Summary

Stage 1 of Ochre provisioned throughput (`mulga-vmfng.7.8`): daemon-side account+pinned parameterisation only, per the [plan](../mulga/docs/development/feature/ochre-provisioned-throughput.md) §1. No PT CRUD, ARN, or inference changes in this PR — those land in later stages under the same bead.

- `EnsureEndpointInput` gains `AccountID string` and `Pinned bool`.
- `DescribeEndpointInput`/`DeleteEndpointInput` gain `AccountID string`.
- `Service.Ensure`/`Describe`/`Delete` resolve the effective account via a new `resolveAccountID` helper (empty → `utils.GlobalAccountID`) and key `EndpointKey` on it. `Ensure` persists `Pinned` on the `EndpointRecord` it writes.
- Nothing else about the launch/capacity/readiness/CAS single-flight logic changed.

**Existing callers are unchanged.** The resolver, reaper, `evictForCapacity`, the NATS gateway client, and the `admin_ochre_endpoint` CLI all construct these inputs with `AccountID` and `Pinned` left at their zero values, which resolve to `GlobalAccountID` and `Pinned=false` — identical to today's hardcoded behaviour. `.7.7`'s eviction/reap exemption for `Pinned` records was already wired in `selectEvictable`/`shouldReap`; this PR is what lets a caller actually set it via the normal `Ensure` path.

## Test plan
- [x] Added `TestEnsure_EmptyAccountIDKeysGlobalAndUnpinned` — confirms existing-caller behaviour is unchanged.
- [x] Added `TestEnsure_RealAccountIDKeysUnderAccountAndPersistsPinned` — a real `AccountID` + `Pinned:true` keys the record under that account and persists `Pinned`.
- [x] Added `TestDescribeDelete_AccountScopedRoundTrip` — Ensure(acct, pinned) → Describe(acct) → Delete(acct) round-trips on the account-scoped key.
- [x] Added `TestSelectEvictable_SkipsRecordCreatedPinnedViaEnsure` and `TestReaper_ShouldReap_SkipsRecordCreatedPinnedViaEnsure` — regression guards tying `.7.7`'s exemption to a record actually created via the new pinned `Ensure` path, contrasted against an identical unpinned record.
- [x] `make preflight` passes (build, manifest-lint, golangci-lint, govulncheck, coverage, e2e harness unit tests).