### PR TITLE
feat(bedrock): guardrail CRUD store and ARN

### DIFF
--- a/spinifex/gateway/bedrock.go
+++ b/spinifex/gateway/bedrock.go
@@ -29,23 +29,24 @@ type bedrockRoute struct {
 // is gw.bedrockResolver(): the configured credential store, or a no-op
 // fallback. loggingStore is gw.bedrockLoggingConfigStore(). access is
 // gw.bedrockAccessResolver(): the configured grant store, or a deny-all
-// fallback. provisioned is gw.bedrockProvisionedStore().
-type bedrockRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, loggingStore *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error)
+// fallback. provisioned is gw.bedrockProvisionedStore(). guardrails is
+// gw.bedrockGuardrailStore().
+type bedrockRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, loggingStore *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error)
 
 // bedrockRoutes is the dispatch table. More-specific paths must precede
 // less-specific ones with the same prefix so the regex matcher picks the
 // deeper route first.
 var bedrockRoutes = []bedrockRoute{
 	{"GET", regexp.MustCompile(`^/foundation-models$`), "ListFoundationModels",
-		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			return gateway_bedrock.ListFoundationModels(ctx, acct, resolver, access, new(bedrock.ListFoundationModelsInput))
 		}},
 	{"GET", regexp.MustCompile(`^/foundation-models/([^/]+)$`), "GetFoundationModel",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, access gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			return gateway_bedrock.GetFoundationModel(ctx, acct, p[0], access)
 		}},
 	{"PUT", regexp.MustCompile(`^/logging/modelinvocations$`), "PutModelInvocationLoggingConfiguration",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			input := new(bedrock.PutModelInvocationLoggingConfigurationInput)
 			if len(b) > 0 {
 				if err := json.Unmarshal(b, input); err != nil {
@@ -55,15 +56,15 @@ var bedrockRoutes = []bedrockRoute{
 			return gateway_bedrock.PutModelInvocationLoggingConfiguration(ctx, acct, store, input)
 		}},
 	{"GET", regexp.MustCompile(`^/logging/modelinvocations$`), "GetModelInvocationLoggingConfiguration",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			return gateway_bedrock.GetModelInvocationLoggingConfiguration(ctx, acct, store, new(bedrock.GetModelInvocationLoggingConfigurationInput))
 		}},
 	{"DELETE", regexp.MustCompile(`^/logging/modelinvocations$`), "DeleteModelInvocationLoggingConfiguration",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, store *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			return gateway_bedrock.DeleteModelInvocationLoggingConfiguration(ctx, acct, store, new(bedrock.DeleteModelInvocationLoggingConfigurationInput))
 		}},
 	{"POST", regexp.MustCompile(`^/provisioned-model-throughput$`), "CreateProvisionedModelThroughput",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			input := new(bedrock.CreateProvisionedModelThroughputInput)
 			if len(b) > 0 {
 				if err := json.Unmarshal(b, input); err != nil {
@@ -73,15 +74,15 @@ var bedrockRoutes = []bedrockRoute{
 			return gateway_bedrock.CreateProvisionedModelThroughput(ctx, acct, provisioned, input)
 		}},
 	{"GET", regexp.MustCompile(`^/provisioned-model-throughput/([^/]+)$`), "GetProvisionedModelThroughput",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			return gateway_bedrock.GetProvisionedModelThroughput(ctx, acct, provisioned, &bedrock.GetProvisionedModelThroughputInput{ProvisionedModelId: aws.String(p[0])})
 		}},
 	{"GET", regexp.MustCompile(`^/provisioned-model-throughputs$`), "ListProvisionedModelThroughputs",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			return gateway_bedrock.ListProvisionedModelThroughputs(ctx, acct, provisioned, new(bedrock.ListProvisionedModelThroughputsInput))
 		}},
 	{"PATCH", regexp.MustCompile(`^/provisioned-model-throughput/([^/]+)$`), "UpdateProvisionedModelThroughput",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			input := new(bedrock.UpdateProvisionedModelThroughputInput)
 			if len(b) > 0 {
 				if err := json.Unmarshal(b, input); err != nil {
@@ -92,8 +93,66 @@ var bedrockRoutes = []bedrockRoute{
 			return gateway_bedrock.UpdateProvisionedModelThroughput(ctx, acct, provisioned, input)
 		}},
 	{"DELETE", regexp.MustCompile(`^/provisioned-model-throughput/([^/]+)$`), "DeleteProvisionedModelThroughput",
-		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			return gateway_bedrock.DeleteProvisionedModelThroughput(ctx, acct, provisioned, &bedrock.DeleteProvisionedModelThroughputInput{ProvisionedModelId: aws.String(p[0])})
+		}},
+	{"POST", regexp.MustCompile(`^/guardrails$`), "CreateGuardrail",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
+			input := new(bedrock.CreateGuardrailInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			return gateway_bedrock.CreateGuardrail(ctx, acct, guardrails, input)
+		}},
+	{"GET", regexp.MustCompile(`^/guardrails/([^/]+)$`), "GetGuardrail",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
+			input := new(bedrock.GetGuardrailInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.GuardrailIdentifier = aws.String(p[0])
+			return gateway_bedrock.GetGuardrail(ctx, acct, guardrails, input)
+		}},
+	{"GET", regexp.MustCompile(`^/guardrails$`), "ListGuardrails",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
+			return gateway_bedrock.ListGuardrails(ctx, acct, guardrails, new(bedrock.ListGuardrailsInput))
+		}},
+	{"PUT", regexp.MustCompile(`^/guardrails/([^/]+)$`), "UpdateGuardrail",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
+			input := new(bedrock.UpdateGuardrailInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.GuardrailIdentifier = aws.String(p[0])
+			return gateway_bedrock.UpdateGuardrail(ctx, acct, guardrails, input)
+		}},
+	{"DELETE", regexp.MustCompile(`^/guardrails/([^/]+)$`), "DeleteGuardrail",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
+			input := new(bedrock.DeleteGuardrailInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.GuardrailIdentifier = aws.String(p[0])
+			return gateway_bedrock.DeleteGuardrail(ctx, acct, guardrails, input)
+		}},
+	{"POST", regexp.MustCompile(`^/guardrails/([^/]+)$`), "CreateGuardrailVersion",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ *gateway_bedrock.LoggingConfigStore, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
+			input := new(bedrock.CreateGuardrailVersionInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.GuardrailIdentifier = aws.String(p[0])
+			return gateway_bedrock.CreateGuardrailVersion(ctx, acct, guardrails, input)
 		}},
 }
 
@@ -157,7 +216,26 @@ func (gw *GatewayConfig) Bedrock_Request(w http.ResponseWriter, r *http.Request)
 		return errors.New(awserrors.ErrorInvalidParameterValue)
 	}
 
-	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockLoggingConfigStore(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
+	// Some REST-JSON actions carry their non-path inputs as singular query
+	// params with an empty body (e.g. GetGuardrail's guardrailVersion arrives
+	// as GET /guardrails/{id}?guardrailVersion=1). Only folds when the body is
+	// empty so it never shadows a real payload, mirroring lookupEKSAction's
+	// own query fold for its (repeated-value) tagKeys case.
+	if len(body) == 0 {
+		if q := r.URL.Query(); len(q) > 0 {
+			flat := make(map[string]string, len(q))
+			for k, v := range q {
+				if len(v) > 0 {
+					flat[k] = v[0]
+				}
+			}
+			if qb, err := json.Marshal(flat); err == nil {
+				body = qb
+			}
+		}
+	}
+
+	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockLoggingConfigStore(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), gw.bedrockGuardrailStore())
 	if err != nil {
 		return err
 	}
@@ -217,6 +295,18 @@ func (gw *GatewayConfig) bedrockProvisionedStore() *gateway_bedrock.ProvisionedS
 		return gw.BedrockProvisioned
 	}
 	return gateway_bedrock.NewProvisionedStore(nil, 1, gw.Region, nil)
+}
+
+// bedrockGuardrailStore returns gw.BedrockGuardrails, or a store backed by no
+// JetStream client when unconfigured. Reads/writes then fail with an error
+// (no JetStream to open a KV bucket against) rather than panicking, which is
+// acceptable for unit tests of unrelated routes that never reach a guardrail
+// handler.
+func (gw *GatewayConfig) bedrockGuardrailStore() *gateway_bedrock.GuardrailStore {
+	if gw.BedrockGuardrails != nil {
+		return gw.BedrockGuardrails
+	}
+	return gateway_bedrock.NewGuardrailStore(nil, 1, gw.Region)
 }
 
 // bedrockEndpointResolver returns the registry-backed resolver when one is

--- a/spinifex/gateway/bedrock/arn.go
+++ b/spinifex/gateway/bedrock/arn.go
@@ -87,6 +87,70 @@ func looksLikeProvisionedModelARN(modelID string) bool {
 	return strings.HasPrefix(modelID, "arn:") && strings.Contains(modelID, ":"+provisionedModelResourceType+"/")
 }
 
+// guardrailResourceType is the ARN resource-type segment for a guardrail.
+const guardrailResourceType = "guardrail"
+
+// FormatGuardrailARN builds the ARN a CreateGuardrail call returns and every
+// other guardrail op accepts back in place of a raw id.
+func FormatGuardrailARN(region, accountID, id string) string {
+	return fmt.Sprintf("arn:aws:bedrock:%s:%s:%s/%s", region, accountID, guardrailResourceType, id)
+}
+
+// ParsedGuardrailARN is a guardrail ARN split into the parts a caller acts on.
+type ParsedGuardrailARN struct {
+	Region    string
+	AccountID string
+	ID        string
+}
+
+// guardrailARNSegmentCount is the number of colon-separated segments in
+// arn:aws:bedrock:{region}:{accountID}:guardrail/{id}.
+const guardrailARNSegmentCount = 6
+
+// ParseGuardrailARN parses a guardrail ARN and validates it belongs to the
+// caller: wrong partition/service/resource-type, a foreign region or account,
+// or a malformed id are all rejected here, mirroring ParseProvisionedModelARN.
+func ParseGuardrailARN(arn, region, accountID string) (ParsedGuardrailARN, error) {
+	parts := strings.SplitN(arn, ":", guardrailARNSegmentCount)
+	if len(parts) != guardrailARNSegmentCount {
+		return ParsedGuardrailARN{}, guardrailARNError(arn, "expected the form arn:aws:bedrock:{region}:{account}:guardrail/{id}")
+	}
+	if parts[0] != "arn" || parts[1] != "aws" || parts[2] != "bedrock" {
+		return ParsedGuardrailARN{}, guardrailARNError(arn, "only arn:aws:bedrock resources are addressable here")
+	}
+	if parts[3] != region {
+		return ParsedGuardrailARN{}, guardrailARNError(arn, fmt.Sprintf("region %q does not match this endpoint's region %q", parts[3], region))
+	}
+	if parts[4] != accountID {
+		return ParsedGuardrailARN{}, guardrailARNError(arn, "the resource belongs to another account")
+	}
+
+	resourceType, id, ok := strings.Cut(parts[5], "/")
+	if !ok || resourceType != guardrailResourceType || id == "" || strings.ContainsAny(id, ":/") {
+		return ParsedGuardrailARN{}, guardrailARNError(arn, "the resource name is empty or malformed")
+	}
+
+	return ParsedGuardrailARN{Region: parts[3], AccountID: parts[4], ID: id}, nil
+}
+
+// resolveGuardrailID accepts either a bare id or a full ARN (the shape every
+// guardrail op's GuardrailIdentifier field allows) and returns the bare id,
+// validating region/account ownership when an ARN is given.
+func resolveGuardrailID(idOrARN, region, accountID string) (string, error) {
+	if !strings.HasPrefix(idOrARN, "arn:") {
+		return idOrARN, nil
+	}
+	parsed, err := ParseGuardrailARN(idOrARN, region, accountID)
+	if err != nil {
+		return "", err
+	}
+	return parsed.ID, nil
+}
+
+func guardrailARNError(arn, why string) error {
+	return awserrors.Errorf(awserrors.ErrorInvalidParameterValue, "%q is not a valid guardrail ARN: %s", arn, why)
+}
+
 // resolveInferenceTarget translates modelID into the (accountID, modelID)
 // pair the rest of the inference path — catalog lookup, access grant, and
 // endpoint resolution — must act on. A bare modelId (or any ARN that is not

--- a/spinifex/gateway/bedrock/arn_test.go
+++ b/spinifex/gateway/bedrock/arn_test.go
@@ -82,3 +82,71 @@ func TestResolveProvisionedModelID_AcceptsRawIDOrARN(t *testing.T) {
 	_, err = resolveProvisionedModelID(foreignARN, ptTestRegion, ptTestAccount)
 	require.Error(t, err)
 }
+
+func TestFormatGuardrailARN(t *testing.T) {
+	arn := FormatGuardrailARN(ptTestRegion, ptTestAccount, ptTestID)
+	assert.Equal(t, "arn:aws:bedrock:us-east-1:000000000001:guardrail/9f8b3c1e4a5d", arn)
+}
+
+// TestParseGuardrailARN_RoundTrip proves a formatted ARN parses back to the
+// same region/account/id it was built from.
+func TestParseGuardrailARN_RoundTrip(t *testing.T) {
+	arn := FormatGuardrailARN(ptTestRegion, ptTestAccount, ptTestID)
+	parsed, err := ParseGuardrailARN(arn, ptTestRegion, ptTestAccount)
+	require.NoError(t, err)
+	assert.Equal(t, ptTestRegion, parsed.Region)
+	assert.Equal(t, ptTestAccount, parsed.AccountID)
+	assert.Equal(t, ptTestID, parsed.ID)
+}
+
+// TestParseGuardrailARN_RejectsForeignAccount guards the exact invariant the
+// plan calls out: a caller must never resolve another tenant's guardrail by
+// presenting its ARN with their own credentials.
+func TestParseGuardrailARN_RejectsForeignAccount(t *testing.T) {
+	arn := FormatGuardrailARN(ptTestRegion, ptOtherAccount, ptTestID)
+	_, err := ParseGuardrailARN(arn, ptTestRegion, ptTestAccount)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+}
+
+func TestParseGuardrailARN_RejectsForeignRegion(t *testing.T) {
+	arn := FormatGuardrailARN("us-west-2", ptTestAccount, ptTestID)
+	_, err := ParseGuardrailARN(arn, ptTestRegion, ptTestAccount)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+}
+
+func TestParseGuardrailARN_RejectsMalformed(t *testing.T) {
+	cases := []string{
+		"",
+		"not-an-arn",
+		"arn:aws:rds:us-east-1:000000000001:guardrail/abc",
+		"arn:aws:bedrock:us-east-1:000000000001:provisioned-model/abc",
+		"arn:aws:bedrock:us-east-1:000000000001:guardrail/",
+		"arn:aws:bedrock:us-east-1:000000000001:guardrail",
+	}
+	for _, arn := range cases {
+		t.Run(arn, func(t *testing.T) {
+			_, err := ParseGuardrailARN(arn, ptTestRegion, ptTestAccount)
+			require.Error(t, err)
+			assert.Equal(t, awserrors.ErrorInvalidParameterValue, awserrors.ValidErrorCodeFromError(err))
+		})
+	}
+}
+
+// TestResolveGuardrailID_AcceptsRawIDOrARN covers the shape every guardrail
+// op's GuardrailIdentifier field allows: a bare id or a full ARN.
+func TestResolveGuardrailID_AcceptsRawIDOrARN(t *testing.T) {
+	id, err := resolveGuardrailID(ptTestID, ptTestRegion, ptTestAccount)
+	require.NoError(t, err)
+	assert.Equal(t, ptTestID, id)
+
+	arn := FormatGuardrailARN(ptTestRegion, ptTestAccount, ptTestID)
+	id, err = resolveGuardrailID(arn, ptTestRegion, ptTestAccount)
+	require.NoError(t, err)
+	assert.Equal(t, ptTestID, id)
+
+	foreignARN := FormatGuardrailARN(ptTestRegion, ptOtherAccount, ptTestID)
+	_, err = resolveGuardrailID(foreignARN, ptTestRegion, ptTestAccount)
+	require.Error(t, err)
+}

--- a/spinifex/gateway/bedrock/contract_test.go
+++ b/spinifex/gateway/bedrock/contract_test.go
@@ -200,7 +200,7 @@ func TestContract_InvokeModelWithResponseStream_SelfHost_RealSDKConsumerDecodesF
 		if !assert.NoError(t, err) {
 			return
 		}
-		err = InvokeModelWithResponseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, r.Header.Get("Content-Type"), nil, grantAll{}, nil)
+		err = InvokeModelWithResponseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, r.Header.Get("Content-Type"), nil, grantAll{}, nil, "", "", nil)
 		assert.NoError(t, err)
 	})
 

--- a/spinifex/gateway/bedrock/contract_test.go
+++ b/spinifex/gateway/bedrock/contract_test.go
@@ -56,7 +56,7 @@ func TestContract_ConverseStream_SelfHost_RealSDKConsumerDecodesFrames(t *testin
 		if !assert.NoError(t, err) {
 			return
 		}
-		err = ConverseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, nil, grantAll{}, nil)
+		err = ConverseStream(r.Context(), w, "000000000001", m[1], body, nil, endpoints, nil, grantAll{}, nil, nil)
 		assert.NoError(t, err)
 	})
 

--- a/spinifex/gateway/bedrock/converse_stream.go
+++ b/spinifex/gateway/bedrock/converse_stream.go
@@ -95,13 +95,13 @@ type converseStreamSource interface {
 
 // ConverseStream is the bedrock-runtime ConverseStream entry point used by
 // the gateway route table. Unlike the JSON-dispatch handlers it owns w
-// directly: a pre-stream failure (unknown model, ungranted model, unresolved
-// credential, upstream connect error) returns an awserrors code for the normal
-// ErrorHandler envelope. Once the first frame is written it always returns
-// nil — any later failure is an in-band exception event, since the HTTP
-// status can no longer change. provisioned may be nil, disabling PT ARN
-// acceptance (any PT ARN then reads as an unknown modelId).
-func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) error {
+// directly: a pre-stream failure (unknown/ungranted model, unresolved
+// credential, upstream connect error, unresolvable GuardrailConfig) returns
+// an awserrors code for the normal ErrorHandler envelope; once the first
+// frame is written it always returns nil, surfacing later failures as an
+// in-band exception event instead. provisioned and guardrails may be nil,
+// which fails closed on a PT ARN or GuardrailConfig respectively.
+func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore, guardrails *GuardrailStore) error {
 	if recorder == nil {
 		recorder = NoopRecorder
 	}
@@ -121,7 +121,40 @@ func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, model
 	_, recordModelID, _ := resolveInferenceTarget(ctx, accountID, modelID, provisioned)
 	entry, _ := lookupCatalogEntry(recordModelID) // Router.ConverseStream below re-validates; only its Provider tag is needed here.
 
-	src, err := NewRouter(resolver, endpointResolver, recorder, access, provisioned).ConverseStream(ctx, accountID, modelID, input)
+	inputJSON, jerr := json.Marshal(input)
+	if jerr != nil {
+		slog.Error("converse-stream: failed to marshal input for recording", "model", modelID, "err", jerr)
+	}
+	rc := streamRecordCtx{
+		recorder:  recorder,
+		requestID: requestID,
+		accountID: accountID,
+		backend:   entry.Provider,
+		operation: OperationConverseStream,
+		start:     start,
+		inputText: string(inputJSON),
+	}
+
+	// Guardrail INPUT check happens before the router ever resolves a
+	// backend: a request naming a guardrail that blocks the input must never
+	// open a connection to the model, self-host or Anthropic alike.
+	gc := input.GuardrailConfig
+	var inputAssessments []*bedrockruntime.GuardrailAssessment
+	traceEnabled := gc != nil && aws.StringValue(gc.Trace) == bedrockruntime.GuardrailTraceEnabled
+	if gc != nil {
+		ident, version := aws.StringValue(gc.GuardrailIdentifier), aws.StringValue(gc.GuardrailVersion)
+		blocked, message, _, assessments, err := enforceGuardrail(ctx, guardrails, accountID, ident, version,
+			bedrockruntime.GuardrailContentSourceInput, streamGuardrailTexts(input))
+		if err != nil {
+			return err
+		}
+		inputAssessments = assessments
+		if blocked {
+			return writeBlockedConverseStream(ctx, w, modelID, rc, message, traceEnabled, ident, assessments)
+		}
+	}
+
+	src, err := NewRouter(resolver, endpointResolver, recorder, access, provisioned, guardrails).ConverseStream(ctx, accountID, modelID, input)
 	if err != nil {
 		return err
 	}
@@ -131,24 +164,20 @@ func ConverseStream(ctx context.Context, w http.ResponseWriter, accountID, model
 		}
 	}()
 
+	// OUTPUT enforcement is buffered/SYNC: guardrailStreamSource holds every
+	// delta until its block closes rather than letting pumpConverseStream
+	// forward unassessed model text.
+	if gc != nil {
+		ident, version := aws.StringValue(gc.GuardrailIdentifier), aws.StringValue(gc.GuardrailVersion)
+		src = newGuardrailStreamSource(src, guardrails, accountID, ident, version, traceEnabled, inputAssessments)
+	}
+
 	fw, err := newFrameWriter(w)
 	if err != nil {
 		return err
 	}
 
-	inputJSON, jerr := json.Marshal(input)
-	if jerr != nil {
-		slog.Error("converse-stream: failed to marshal input for recording", "model", modelID, "err", jerr)
-	}
-	pumpConverseStream(ctx, fw, src, modelID, streamRecordCtx{
-		recorder:  recorder,
-		requestID: requestID,
-		accountID: accountID,
-		backend:   entry.Provider,
-		operation: OperationConverseStream,
-		start:     start,
-		inputText: string(inputJSON),
-	})
+	pumpConverseStream(ctx, fw, src, modelID, rc)
 	return nil
 }
 

--- a/spinifex/gateway/bedrock/converse_stream_test.go
+++ b/spinifex/gateway/bedrock/converse_stream_test.go
@@ -154,7 +154,7 @@ func TestConverseStream_UnknownModelReturnsResourceNotFoundPreHeader(t *testing.
 	rec := httptest.NewRecorder()
 	body := []byte(`{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`)
 
-	err := ConverseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", body, nil, nil, nil, grantAll{}, nil)
+	err := ConverseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", body, nil, nil, nil, grantAll{}, nil, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 	// A pre-stream failure must not have written anything: the gateway's
@@ -164,7 +164,7 @@ func TestConverseStream_UnknownModelReturnsResourceNotFoundPreHeader(t *testing.
 
 func TestConverseStream_MalformedBodyReturnsValidationException(t *testing.T) {
 	rec := httptest.NewRecorder()
-	err := ConverseStream(context.Background(), rec, "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte("{not-json"), nil, nil, nil, grantAll{}, nil)
+	err := ConverseStream(context.Background(), rec, "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte("{not-json"), nil, nil, nil, grantAll{}, nil, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorValidationException, err.Error())
 }
@@ -186,7 +186,7 @@ func TestConverseStream_SelfHostHappyPath_WritesFramedTaxonomy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = ConverseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+	err = ConverseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -301,7 +301,7 @@ func TestConverseStream_ClientDisconnectAbortsUpstreamRequest(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		_ = ConverseStream(ctx, rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+		_ = ConverseStream(ctx, rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
 	}()
 
 	select {
@@ -337,7 +337,7 @@ func TestConverseStream_NonFlusherWriter_ReturnsPreHeaderError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = ConverseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+	err = ConverseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
 	assert.False(t, w.wroteHeader)

--- a/spinifex/gateway/bedrock/guardrail.go
+++ b/spinifex/gateway/bedrock/guardrail.go
@@ -1,0 +1,599 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/google/uuid"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/kvutil"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// bedrockGuardrailBucket is the cluster-replicated KV bucket holding
+// guardrail control-plane records.
+const bedrockGuardrailBucket = "bedrock-guardrails"
+
+// bedrockGuardrailHistory keeps one revision per key: a guardrail (DRAFT plus
+// its numbered snapshots) is one JSON document mutated in place, not a series.
+const bedrockGuardrailHistory = 1
+
+// guardrailDraftVersion is the literal AWS uses for the mutable working copy
+// of a guardrail, as opposed to an immutable numbered snapshot ("1", "2", ...).
+const guardrailDraftVersion = "DRAFT"
+
+// guardrailView is the configured shape shared by the mutable DRAFT and every
+// immutable numbered snapshot: everything that came from a Create/Update
+// call, as opposed to the identity/status fields that live only on the
+// top-level record.
+type guardrailView struct {
+	Name                       string                                             `json:"name"`
+	Description                string                                             `json:"description,omitempty"`
+	BlockedInputMessaging      string                                             `json:"blockedInputMessaging"`
+	BlockedOutputsMessaging    string                                             `json:"blockedOutputsMessaging"`
+	WordPolicy                 *bedrock.GuardrailWordPolicyConfig                 `json:"wordPolicy,omitempty"`
+	SensitiveInformationPolicy *bedrock.GuardrailSensitiveInformationPolicyConfig `json:"sensitiveInformationPolicy,omitempty"`
+	ContentPolicy              *bedrock.GuardrailContentPolicyConfig              `json:"contentPolicy,omitempty"`
+	TopicPolicy                *bedrock.GuardrailTopicPolicyConfig                `json:"topicPolicy,omitempty"`
+	ContextualGroundingPolicy  *bedrock.GuardrailContextualGroundingPolicyConfig  `json:"contextualGroundingPolicy,omitempty"`
+	CreatedAt                  time.Time                                          `json:"createdAt"`
+	UpdatedAt                  time.Time                                          `json:"updatedAt"`
+}
+
+// GuardrailVersionSnapshot is one immutable numbered version, frozen from the
+// DRAFT at the moment CreateGuardrailVersion was called. Later mutation of the
+// DRAFT never reaches an already-created snapshot.
+type GuardrailVersionSnapshot struct {
+	guardrailView
+
+	Version string `json:"version"`
+}
+
+// GuardrailRecord is the gateway control-plane state for one guardrail: the
+// mutable DRAFT (guardrailView) plus every immutable numbered version taken
+// from it. Policy configs are stored verbatim from the create/update input so
+// the filter engine and inference enforcement (later stages) can read them
+// back unchanged.
+type GuardrailRecord struct {
+	guardrailView
+
+	ARN         string `json:"arn"`
+	GuardrailID string `json:"guardrailId"`
+	AccountID   string `json:"accountId"`
+	// Status is READY as soon as Create succeeds: v1's policies are all
+	// deterministic (string/regex match), so there is no async compile step
+	// the way a classifier-backed guardrail would need.
+	Status string `json:"status"`
+	// Versions maps a numbered version string ("1", "2", ...) to its frozen
+	// snapshot. NextVersion is the last version number minted, so a retried
+	// CreateGuardrailVersion after a partial failure still advances.
+	Versions    map[string]GuardrailVersionSnapshot `json:"versions,omitempty"`
+	NextVersion int                                 `json:"nextVersion"`
+}
+
+// GuardrailStore persists GuardrailRecords in the bedrock-guardrails
+// JetStream KV bucket, mirroring the ProvisionedStore/LoggingConfigStore
+// gateway-direct-KV pattern.
+type GuardrailStore struct {
+	js       jetstream.JetStream
+	replicas int
+	// region is baked in at construction, like ProvisionedStore.region, so
+	// ARN building/parsing needs no extra parameter threaded through the
+	// fixed-arity route table.
+	region string
+
+	mu sync.Mutex
+	kv jetstream.KeyValue
+}
+
+// NewGuardrailStore constructs a GuardrailStore over js, replicated across
+// replicas nodes, minting ARNs for region.
+func NewGuardrailStore(js jetstream.JetStream, replicas int, region string) *GuardrailStore {
+	return &GuardrailStore{js: js, replicas: replicas, region: region}
+}
+
+// bucket lazily opens (or creates) the bedrock-guardrails KV bucket, caching
+// the handle, mirroring ProvisionedStore.bucket.
+func (s *GuardrailStore) bucket(ctx context.Context) (jetstream.KeyValue, error) {
+	if s.js == nil {
+		return nil, errors.New("bedrock: guardrail store has no JetStream client configured")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.kv != nil {
+		return s.kv, nil
+	}
+	kv, err := kvutil.GetOrCreateBucketWithReplicas(ctx, s.js, bedrockGuardrailBucket, bedrockGuardrailHistory, s.replicas)
+	if err != nil {
+		return nil, err
+	}
+	s.kv = kv
+	return kv, nil
+}
+
+// guardrailKey scopes every stored record to its owning account, so List's
+// prefix scan is the only thing that ever needs to see across ids, and a
+// foreign account's raw-id guess can never collide with another tenant's key.
+func guardrailKey(accountID, id string) string {
+	return accountID + "/" + id
+}
+
+// getGuardrailRecord reads accountID's record for id, or (zero, false, nil)
+// if it does not exist.
+func getGuardrailRecord(ctx context.Context, kv jetstream.KeyValue, accountID, id string) (GuardrailRecord, bool, error) {
+	rec, _, found, err := getGuardrailRecordRevision(ctx, kv, guardrailKey(accountID, id))
+	return rec, found, err
+}
+
+// getGuardrailRecordRevision is getGuardrailRecord with the KV revision
+// surfaced too, for a CAS write.
+func getGuardrailRecordRevision(ctx context.Context, kv jetstream.KeyValue, key string) (GuardrailRecord, uint64, bool, error) {
+	entry, err := kv.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return GuardrailRecord{}, 0, false, nil
+		}
+		return GuardrailRecord{}, 0, false, fmt.Errorf("kv get %s: %w", key, err)
+	}
+	var rec GuardrailRecord
+	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+		return GuardrailRecord{}, 0, false, fmt.Errorf("decode %s: %w", key, err)
+	}
+	return rec, entry.Revision(), true, nil
+}
+
+// putGuardrailRecord writes rec as a brand-new key (Create only).
+func putGuardrailRecord(ctx context.Context, kv jetstream.KeyValue, rec GuardrailRecord) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("encode guardrail %s: %w", rec.GuardrailID, err)
+	}
+	if _, err := kv.Put(ctx, guardrailKey(rec.AccountID, rec.GuardrailID), data); err != nil {
+		return fmt.Errorf("kv put guardrail %s: %w", rec.GuardrailID, err)
+	}
+	return nil
+}
+
+// updateGuardrailRecord CAS-writes rec back over rev, the revision it was
+// read at, so two concurrent mutations of the same guardrail never silently
+// clobber one another.
+func updateGuardrailRecord(ctx context.Context, kv jetstream.KeyValue, key string, rec GuardrailRecord, rev uint64) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("encode guardrail %s: %w", rec.GuardrailID, err)
+	}
+	if _, err := kv.Update(ctx, key, data, rev); err != nil {
+		return fmt.Errorf("kv update guardrail %s: %w", rec.GuardrailID, err)
+	}
+	return nil
+}
+
+// contentPolicyToSDK translates the stored *Config shape back to the
+// AWS-parity *GuardrailContentPolicy GetGuardrail returns. The two shapes are
+// field-for-field identical; only the Go type names differ between the
+// create/update input and the read-back output.
+func contentPolicyToSDK(cfg *bedrock.GuardrailContentPolicyConfig) *bedrock.GuardrailContentPolicy {
+	if cfg == nil {
+		return nil
+	}
+	filters := make([]*bedrock.GuardrailContentFilter, 0, len(cfg.FiltersConfig))
+	for _, f := range cfg.FiltersConfig {
+		if f == nil {
+			continue
+		}
+		filters = append(filters, &bedrock.GuardrailContentFilter{
+			InputStrength:  f.InputStrength,
+			OutputStrength: f.OutputStrength,
+			Type:           f.Type,
+		})
+	}
+	return &bedrock.GuardrailContentPolicy{Filters: filters}
+}
+
+// contextualGroundingPolicyToSDK is contentPolicyToSDK's sibling for the
+// contextual-grounding policy.
+func contextualGroundingPolicyToSDK(cfg *bedrock.GuardrailContextualGroundingPolicyConfig) *bedrock.GuardrailContextualGroundingPolicy {
+	if cfg == nil {
+		return nil
+	}
+	filters := make([]*bedrock.GuardrailContextualGroundingFilter, 0, len(cfg.FiltersConfig))
+	for _, f := range cfg.FiltersConfig {
+		if f == nil {
+			continue
+		}
+		filters = append(filters, &bedrock.GuardrailContextualGroundingFilter{
+			Threshold: f.Threshold,
+			Type:      f.Type,
+		})
+	}
+	return &bedrock.GuardrailContextualGroundingPolicy{Filters: filters}
+}
+
+// sensitiveInformationPolicyToSDK is contentPolicyToSDK's sibling for the PII
+// and custom-regex policy.
+func sensitiveInformationPolicyToSDK(cfg *bedrock.GuardrailSensitiveInformationPolicyConfig) *bedrock.GuardrailSensitiveInformationPolicy {
+	if cfg == nil {
+		return nil
+	}
+	pii := make([]*bedrock.GuardrailPiiEntity, 0, len(cfg.PiiEntitiesConfig))
+	for _, e := range cfg.PiiEntitiesConfig {
+		if e == nil {
+			continue
+		}
+		pii = append(pii, &bedrock.GuardrailPiiEntity{Action: e.Action, Type: e.Type})
+	}
+	regexes := make([]*bedrock.GuardrailRegex, 0, len(cfg.RegexesConfig))
+	for _, r := range cfg.RegexesConfig {
+		if r == nil {
+			continue
+		}
+		regexes = append(regexes, &bedrock.GuardrailRegex{
+			Action:      r.Action,
+			Description: r.Description,
+			Name:        r.Name,
+			Pattern:     r.Pattern,
+		})
+	}
+	return &bedrock.GuardrailSensitiveInformationPolicy{PiiEntities: pii, Regexes: regexes}
+}
+
+// topicPolicyToSDK is contentPolicyToSDK's sibling for the denied-topics
+// policy.
+func topicPolicyToSDK(cfg *bedrock.GuardrailTopicPolicyConfig) *bedrock.GuardrailTopicPolicy {
+	if cfg == nil {
+		return nil
+	}
+	topics := make([]*bedrock.GuardrailTopic, 0, len(cfg.TopicsConfig))
+	for _, t := range cfg.TopicsConfig {
+		if t == nil {
+			continue
+		}
+		topics = append(topics, &bedrock.GuardrailTopic{
+			Definition: t.Definition,
+			Examples:   t.Examples,
+			Name:       t.Name,
+			Type:       t.Type,
+		})
+	}
+	return &bedrock.GuardrailTopicPolicy{Topics: topics}
+}
+
+// wordPolicyToSDK is contentPolicyToSDK's sibling for the word/phrase
+// blocklist and managed profanity list.
+func wordPolicyToSDK(cfg *bedrock.GuardrailWordPolicyConfig) *bedrock.GuardrailWordPolicy {
+	if cfg == nil {
+		return nil
+	}
+	managed := make([]*bedrock.GuardrailManagedWords, 0, len(cfg.ManagedWordListsConfig))
+	for _, m := range cfg.ManagedWordListsConfig {
+		if m == nil {
+			continue
+		}
+		managed = append(managed, &bedrock.GuardrailManagedWords{Type: m.Type})
+	}
+	words := make([]*bedrock.GuardrailWord, 0, len(cfg.WordsConfig))
+	for _, w := range cfg.WordsConfig {
+		if w == nil {
+			continue
+		}
+		words = append(words, &bedrock.GuardrailWord{Text: w.Text})
+	}
+	return &bedrock.GuardrailWordPolicy{ManagedWordLists: managed, Words: words}
+}
+
+// guardrailViewToGetOutput builds a GetGuardrailOutput for either the DRAFT
+// (status is the record's live Status) or a numbered snapshot (status is
+// always READY: it was only ever taken from a DRAFT that had already
+// compiled).
+func guardrailViewToGetOutput(arn, id, status, version string, view guardrailView) *bedrock.GetGuardrailOutput {
+	return &bedrock.GetGuardrailOutput{
+		BlockedInputMessaging:      aws.String(view.BlockedInputMessaging),
+		BlockedOutputsMessaging:    aws.String(view.BlockedOutputsMessaging),
+		ContentPolicy:              contentPolicyToSDK(view.ContentPolicy),
+		ContextualGroundingPolicy:  contextualGroundingPolicyToSDK(view.ContextualGroundingPolicy),
+		CreatedAt:                  aws.Time(view.CreatedAt),
+		Description:                nonEmptyStringPtr(view.Description),
+		GuardrailArn:               aws.String(arn),
+		GuardrailId:                aws.String(id),
+		Name:                       aws.String(view.Name),
+		SensitiveInformationPolicy: sensitiveInformationPolicyToSDK(view.SensitiveInformationPolicy),
+		Status:                     aws.String(status),
+		TopicPolicy:                topicPolicyToSDK(view.TopicPolicy),
+		UpdatedAt:                  aws.Time(view.UpdatedAt),
+		Version:                    aws.String(version),
+		WordPolicy:                 wordPolicyToSDK(view.WordPolicy),
+	}
+}
+
+// CreateGuardrail validates the required messaging/name fields, mints a
+// GuardrailID + ARN, and writes the DRAFT with Status READY: v1's policies
+// (word/PII deterministic, content/topic/contextual-grounding scaffolded) all
+// compile synchronously, so there is no Creating->InService async transition
+// the way provisioned throughput has.
+func CreateGuardrail(ctx context.Context, accountID string, store *GuardrailStore, input *bedrock.CreateGuardrailInput) (*bedrock.CreateGuardrailOutput, error) {
+	if input == nil || aws.StringValue(input.Name) == "" ||
+		aws.StringValue(input.BlockedInputMessaging) == "" || aws.StringValue(input.BlockedOutputsMessaging) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	id := uuid.NewString()
+	arn := FormatGuardrailARN(store.region, accountID, id)
+	now := time.Now().UTC()
+
+	rec := GuardrailRecord{
+		ARN:         arn,
+		GuardrailID: id,
+		AccountID:   accountID,
+		Status:      bedrock.GuardrailStatusReady,
+		guardrailView: guardrailView{
+			Name:                       aws.StringValue(input.Name),
+			Description:                aws.StringValue(input.Description),
+			BlockedInputMessaging:      aws.StringValue(input.BlockedInputMessaging),
+			BlockedOutputsMessaging:    aws.StringValue(input.BlockedOutputsMessaging),
+			WordPolicy:                 input.WordPolicyConfig,
+			SensitiveInformationPolicy: input.SensitiveInformationPolicyConfig,
+			ContentPolicy:              input.ContentPolicyConfig,
+			TopicPolicy:                input.TopicPolicyConfig,
+			ContextualGroundingPolicy:  input.ContextualGroundingPolicyConfig,
+			CreatedAt:                  now,
+			UpdatedAt:                  now,
+		},
+	}
+
+	if err := putGuardrailRecord(ctx, kv, rec); err != nil {
+		return nil, err
+	}
+
+	return &bedrock.CreateGuardrailOutput{
+		CreatedAt:    aws.Time(now),
+		GuardrailArn: aws.String(arn),
+		GuardrailId:  aws.String(id),
+		Version:      aws.String(guardrailDraftVersion),
+	}, nil
+}
+
+// GetGuardrail honours input.GuardrailVersion (DRAFT when empty): a numbered
+// version returns its frozen snapshot, never the current DRAFT. A foreign
+// account or an unknown id/version both report ResourceNotFoundException, so
+// a caller cannot distinguish "not yours" from "does not exist".
+func GetGuardrail(ctx context.Context, accountID string, store *GuardrailStore, input *bedrock.GetGuardrailInput) (*bedrock.GetGuardrailOutput, error) {
+	if input == nil || aws.StringValue(input.GuardrailIdentifier) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveGuardrailID(aws.StringValue(input.GuardrailIdentifier), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, found, err := getGuardrailRecord(ctx, kv, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	version := aws.StringValue(input.GuardrailVersion)
+	if version == "" || version == guardrailDraftVersion {
+		return guardrailViewToGetOutput(rec.ARN, id, rec.Status, guardrailDraftVersion, rec.guardrailView), nil
+	}
+
+	snap, ok := rec.Versions[version]
+	if !ok {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+	return guardrailViewToGetOutput(rec.ARN, id, bedrock.GuardrailStatusReady, snap.Version, snap.guardrailView), nil
+}
+
+// ListGuardrails returns the caller account's own guardrails, sorted by
+// creation time (id as a deterministic tie-breaker), so one tenant never sees
+// another's and repeated calls return a stable order.
+func ListGuardrails(ctx context.Context, accountID string, store *GuardrailStore, _ *bedrock.ListGuardrailsInput) (*bedrock.ListGuardrailsOutput, error) {
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := kv.Keys(ctx)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return &bedrock.ListGuardrailsOutput{}, nil
+		}
+		return nil, fmt.Errorf("kv keys for guardrails: %w", err)
+	}
+
+	prefix := accountID + "/"
+	var recs []GuardrailRecord
+	for _, key := range keys {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		entry, err := kv.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("kv get %s: %w", key, err)
+		}
+		var rec GuardrailRecord
+		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+			continue
+		}
+		recs = append(recs, rec)
+	}
+
+	slices.SortFunc(recs, func(a, b GuardrailRecord) int {
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
+		}
+		return strings.Compare(a.GuardrailID, b.GuardrailID)
+	})
+
+	summaries := make([]*bedrock.GuardrailSummary, 0, len(recs))
+	for _, rec := range recs {
+		summaries = append(summaries, &bedrock.GuardrailSummary{
+			Arn:         aws.String(rec.ARN),
+			CreatedAt:   aws.Time(rec.CreatedAt),
+			Description: nonEmptyStringPtr(rec.Description),
+			Id:          aws.String(rec.GuardrailID),
+			Name:        aws.String(rec.Name),
+			Status:      aws.String(rec.Status),
+			UpdatedAt:   aws.Time(rec.UpdatedAt),
+			Version:     aws.String(guardrailDraftVersion),
+		})
+	}
+	return &bedrock.ListGuardrailsOutput{Guardrails: summaries}, nil
+}
+
+// UpdateGuardrail mutates the DRAFT only. AWS's own UpdateGuardrailInput
+// carries no GuardrailVersion field at all — there is structurally no way to
+// address a numbered version through this op, which is how AWS enforces
+// "only DRAFT mutates" without a runtime check.
+func UpdateGuardrail(ctx context.Context, accountID string, store *GuardrailStore, input *bedrock.UpdateGuardrailInput) (*bedrock.UpdateGuardrailOutput, error) {
+	if input == nil || aws.StringValue(input.GuardrailIdentifier) == "" || aws.StringValue(input.Name) == "" ||
+		aws.StringValue(input.BlockedInputMessaging) == "" || aws.StringValue(input.BlockedOutputsMessaging) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveGuardrailID(aws.StringValue(input.GuardrailIdentifier), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := guardrailKey(accountID, id)
+	rec, rev, found, err := getGuardrailRecordRevision(ctx, kv, key)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	rec.Name = aws.StringValue(input.Name)
+	rec.Description = aws.StringValue(input.Description)
+	rec.BlockedInputMessaging = aws.StringValue(input.BlockedInputMessaging)
+	rec.BlockedOutputsMessaging = aws.StringValue(input.BlockedOutputsMessaging)
+	rec.WordPolicy = input.WordPolicyConfig
+	rec.SensitiveInformationPolicy = input.SensitiveInformationPolicyConfig
+	rec.ContentPolicy = input.ContentPolicyConfig
+	rec.TopicPolicy = input.TopicPolicyConfig
+	rec.ContextualGroundingPolicy = input.ContextualGroundingPolicyConfig
+	rec.UpdatedAt = time.Now().UTC()
+
+	if err := updateGuardrailRecord(ctx, kv, key, rec, rev); err != nil {
+		return nil, err
+	}
+
+	return &bedrock.UpdateGuardrailOutput{
+		GuardrailArn: aws.String(rec.ARN),
+		GuardrailId:  aws.String(id),
+		UpdatedAt:    aws.Time(rec.UpdatedAt),
+		Version:      aws.String(guardrailDraftVersion),
+	}, nil
+}
+
+// DeleteGuardrail is version-aware: a specific numbered GuardrailVersion
+// deletes only that snapshot; an absent version deletes the whole guardrail
+// (DRAFT and every snapshot). Both directions are idempotent: deleting an
+// already-absent guardrail or an already-absent version is a no-op success.
+func DeleteGuardrail(ctx context.Context, accountID string, store *GuardrailStore, input *bedrock.DeleteGuardrailInput) (*bedrock.DeleteGuardrailOutput, error) {
+	if input == nil || aws.StringValue(input.GuardrailIdentifier) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveGuardrailID(aws.StringValue(input.GuardrailIdentifier), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := guardrailKey(accountID, id)
+	version := aws.StringValue(input.GuardrailVersion)
+
+	if version == "" {
+		if err := kv.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, fmt.Errorf("kv delete guardrail %s: %w", id, err)
+		}
+		return &bedrock.DeleteGuardrailOutput{}, nil
+	}
+
+	rec, rev, found, err := getGuardrailRecordRevision(ctx, kv, key)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return &bedrock.DeleteGuardrailOutput{}, nil
+	}
+	if version == guardrailDraftVersion {
+		return nil, awserrors.Errorf(awserrors.ErrorValidationException,
+			"bedrock: guardrail %s DRAFT cannot be deleted by version; omit guardrailVersion to delete the whole guardrail", id)
+	}
+
+	delete(rec.Versions, version)
+	if err := updateGuardrailRecord(ctx, kv, key, rec, rev); err != nil {
+		return nil, err
+	}
+	return &bedrock.DeleteGuardrailOutput{}, nil
+}
+
+// CreateGuardrailVersion snapshots the current DRAFT into the next
+// immutable numbered version and returns that version number. NextVersion is
+// a monotonic counter on the record itself, not len(Versions), so a version
+// deleted later never gets its number reused.
+func CreateGuardrailVersion(ctx context.Context, accountID string, store *GuardrailStore, input *bedrock.CreateGuardrailVersionInput) (*bedrock.CreateGuardrailVersionOutput, error) {
+	if input == nil || aws.StringValue(input.GuardrailIdentifier) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveGuardrailID(aws.StringValue(input.GuardrailIdentifier), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := guardrailKey(accountID, id)
+	rec, rev, found, err := getGuardrailRecordRevision(ctx, kv, key)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	rec.NextVersion++
+	version := strconv.Itoa(rec.NextVersion)
+	if rec.Versions == nil {
+		rec.Versions = map[string]GuardrailVersionSnapshot{}
+	}
+	rec.Versions[version] = GuardrailVersionSnapshot{Version: version, guardrailView: rec.guardrailView}
+
+	if err := updateGuardrailRecord(ctx, kv, key, rec, rev); err != nil {
+		return nil, err
+	}
+
+	return &bedrock.CreateGuardrailVersionOutput{GuardrailId: aws.String(id), Version: aws.String(version)}, nil
+}

--- a/spinifex/gateway/bedrock/guardrail.go
+++ b/spinifex/gateway/bedrock/guardrail.go
@@ -135,6 +135,16 @@ func getGuardrailRecord(ctx context.Context, kv jetstream.KeyValue, accountID, i
 	return rec, found, err
 }
 
+// errGuardrailNotFound reports a guardrail-specific ResourceNotFoundException.
+// awserrors' default wording for that code ("could not resolve the foundation
+// model") is misleading when the missing resource is a guardrail, not a model.
+func errGuardrailNotFound(id, version string) error {
+	if version == "" {
+		return awserrors.Errorf(awserrors.ErrorResourceNotFoundException, "guardrail %q not found", id)
+	}
+	return awserrors.Errorf(awserrors.ErrorResourceNotFoundException, "guardrail %q version %q not found", id, version)
+}
+
 // getGuardrailRecordRevision is getGuardrailRecord with the KV revision
 // surfaced too, for a CAS write.
 func getGuardrailRecordRevision(ctx context.Context, kv jetstream.KeyValue, key string) (GuardrailRecord, uint64, bool, error) {
@@ -389,7 +399,7 @@ func GetGuardrail(ctx context.Context, accountID string, store *GuardrailStore, 
 		return nil, err
 	}
 	if !found {
-		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		return nil, errGuardrailNotFound(id, "")
 	}
 
 	version := aws.StringValue(input.GuardrailVersion)
@@ -399,7 +409,7 @@ func GetGuardrail(ctx context.Context, accountID string, store *GuardrailStore, 
 
 	snap, ok := rec.Versions[version]
 	if !ok {
-		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		return nil, errGuardrailNotFound(id, version)
 	}
 	return guardrailViewToGetOutput(rec.ARN, id, bedrock.GuardrailStatusReady, snap.Version, snap.guardrailView), nil
 }
@@ -487,7 +497,7 @@ func UpdateGuardrail(ctx context.Context, accountID string, store *GuardrailStor
 		return nil, err
 	}
 	if !found {
-		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		return nil, errGuardrailNotFound(id, "")
 	}
 
 	rec.Name = aws.StringValue(input.Name)
@@ -582,7 +592,7 @@ func CreateGuardrailVersion(ctx context.Context, accountID string, store *Guardr
 		return nil, err
 	}
 	if !found {
-		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		return nil, errGuardrailNotFound(id, "")
 	}
 
 	rec.NextVersion++
@@ -623,7 +633,7 @@ func ApplyGuardrail(ctx context.Context, accountID string, store *GuardrailStore
 		return nil, err
 	}
 	if !found {
-		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		return nil, errGuardrailNotFound(id, "")
 	}
 
 	view := rec.guardrailView
@@ -631,7 +641,7 @@ func ApplyGuardrail(ctx context.Context, accountID string, store *GuardrailStore
 	if version != guardrailDraftVersion {
 		snap, ok := rec.Versions[version]
 		if !ok {
-			return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+			return nil, errGuardrailNotFound(id, version)
 		}
 		view = snap.guardrailView
 	}

--- a/spinifex/gateway/bedrock/guardrail.go
+++ b/spinifex/gateway/bedrock/guardrail.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
 	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	"github.com/mulgadc/spinifex/spinifex/kvutil"
@@ -596,4 +597,72 @@ func CreateGuardrailVersion(ctx context.Context, accountID string, store *Guardr
 	}
 
 	return &bedrock.CreateGuardrailVersionOutput{GuardrailId: aws.String(id), Version: aws.String(version)}, nil
+}
+
+// ApplyGuardrail runs the guardrail engine over input.Content for
+// input.Source, honouring input.GuardrailVersion (DRAFT or a numbered
+// snapshot), and returns the aws-sdk-go bedrockruntime shape the runtime op
+// hands back to the caller. Unknown/foreign guardrail or version both report
+// ResourceNotFoundException, the same as the control-plane ops.
+func ApplyGuardrail(ctx context.Context, accountID string, store *GuardrailStore, input *bedrockruntime.ApplyGuardrailInput) (*bedrockruntime.ApplyGuardrailOutput, error) {
+	if input == nil || aws.StringValue(input.GuardrailIdentifier) == "" ||
+		aws.StringValue(input.GuardrailVersion) == "" || aws.StringValue(input.Source) == "" {
+		return nil, errors.New(awserrors.ErrorValidationException)
+	}
+	id, err := resolveGuardrailID(aws.StringValue(input.GuardrailIdentifier), store.region, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rec, found, err := getGuardrailRecord(ctx, kv, accountID, id)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	view := rec.guardrailView
+	version := aws.StringValue(input.GuardrailVersion)
+	if version != guardrailDraftVersion {
+		snap, ok := rec.Versions[version]
+		if !ok {
+			return nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		}
+		view = snap.guardrailView
+	}
+
+	texts := make([]string, 0, len(input.Content))
+	for _, c := range input.Content {
+		if c == nil || c.Text == nil {
+			continue
+		}
+		texts = append(texts, aws.StringValue(c.Text.Text))
+	}
+
+	action, assessments, outputTexts, usage := applyGuardrailPolicies(view, texts, aws.StringValue(input.Source))
+
+	outputs := make([]*bedrockruntime.GuardrailOutputContent, 0, len(outputTexts))
+	if action == bedrockruntime.GuardrailActionGuardrailIntervened {
+		message := view.BlockedInputMessaging
+		if aws.StringValue(input.Source) == bedrockruntime.GuardrailContentSourceOutput {
+			message = view.BlockedOutputsMessaging
+		}
+		outputs = append(outputs, &bedrockruntime.GuardrailOutputContent{Text: aws.String(message)})
+	} else {
+		for _, t := range outputTexts {
+			outputs = append(outputs, &bedrockruntime.GuardrailOutputContent{Text: aws.String(t)})
+		}
+	}
+
+	return &bedrockruntime.ApplyGuardrailOutput{
+		Action:      aws.String(action),
+		Assessments: assessments,
+		Outputs:     outputs,
+		Usage:       usage,
+	}, nil
 }

--- a/spinifex/gateway/bedrock/guardrail_filter.go
+++ b/spinifex/gateway/bedrock/guardrail_filter.go
@@ -1,0 +1,323 @@
+package gateway_bedrock
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
+)
+
+// piiPattern binds one AWS PII entity type to the regex that detects it.
+// Ordered (not a map) so assessment output is deterministic across runs.
+type piiPattern struct {
+	entityType string
+	pattern    *regexp.Regexp
+}
+
+// builtinPIIPatterns is the regex-detectable PII entity subset a guardrail
+// can enforce without a classifier. Entities like NAME or ADDRESS need a
+// model and are out of scope: a guardrail configuring one of those simply
+// never matches here, the same as any other unsupported entity type.
+var builtinPIIPatterns = []piiPattern{
+	{bedrock.GuardrailPiiEntityTypeEmail, regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)},
+	{bedrock.GuardrailPiiEntityTypePhone, regexp.MustCompile(`(?:\+?1[-.\s])?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b`)},
+	{bedrock.GuardrailPiiEntityTypeUsSocialSecurityNumber, regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`)},
+	{bedrock.GuardrailPiiEntityTypeCreditDebitCardNumber, regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{1,4}\b`)},
+	{bedrock.GuardrailPiiEntityTypeIpAddress, regexp.MustCompile(`\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b|\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b`)},
+	{bedrock.GuardrailPiiEntityTypeUrl, regexp.MustCompile(`\bhttps?://[^\s<>"]+`)},
+	{bedrock.GuardrailPiiEntityTypeAwsAccessKey, regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`)},
+	{bedrock.GuardrailPiiEntityTypeAwsSecretKey, regexp.MustCompile(`\b[A-Za-z0-9+/]{40}\b`)},
+}
+
+// builtinPIIPattern looks up the detector regex for an AWS PII entity type,
+// or nil when the type has no deterministic (regex-only) detector.
+func builtinPIIPattern(entityType string) *regexp.Regexp {
+	for _, p := range builtinPIIPatterns {
+		if p.entityType == entityType {
+			return p.pattern
+		}
+	}
+	return nil
+}
+
+// managedProfanityWords is a small starter seed for the guardrail's
+// PROFANITY managed word list. A real deployment would back this with a
+// maintained wordlist; this is deliberately minimal.
+var managedProfanityWords = []string{
+	"damn", "hell", "crap", "bastard", "bitch", "asshole", "bullshit", "shit", "fuck",
+}
+
+// wordBoundaryPattern compiles a case-insensitive, whole-word regex for word,
+// so a blocklist entry like "hell" never matches inside "hello".
+func wordBoundaryPattern(word string) (*regexp.Regexp, error) {
+	return regexp.Compile(`(?i)\b` + regexp.QuoteMeta(word) + `\b`)
+}
+
+// matchesWord reports whether word appears, whole-word and case-insensitive,
+// in any of texts.
+func matchesWord(texts []string, word string) bool {
+	re, err := wordBoundaryPattern(word)
+	if err != nil {
+		return false
+	}
+	return slices.ContainsFunc(texts, re.MatchString)
+}
+
+// assessWordPolicy checks texts against cfg's custom blocklist and managed
+// profanity list. Every match is a block: wordPolicy has no ANONYMIZE action
+// in AWS's own shape, only BLOCKED.
+func assessWordPolicy(cfg *bedrock.GuardrailWordPolicyConfig, texts []string) (*bedrockruntime.GuardrailWordPolicyAssessment, bool) {
+	if cfg == nil {
+		return nil, false
+	}
+
+	blocked := false
+	customWords := []*bedrockruntime.GuardrailCustomWord{}
+	for _, w := range cfg.WordsConfig {
+		if w == nil {
+			continue
+		}
+		word := aws.StringValue(w.Text)
+		if word == "" || !matchesWord(texts, word) {
+			continue
+		}
+		customWords = append(customWords, &bedrockruntime.GuardrailCustomWord{
+			Action: aws.String(bedrockruntime.GuardrailWordPolicyActionBlocked),
+			Match:  aws.String(word),
+		})
+		blocked = true
+	}
+
+	managedWords := []*bedrockruntime.GuardrailManagedWord{}
+	for _, m := range cfg.ManagedWordListsConfig {
+		if m == nil || aws.StringValue(m.Type) != bedrock.GuardrailManagedWordsTypeProfanity {
+			continue
+		}
+		for _, word := range managedProfanityWords {
+			if !matchesWord(texts, word) {
+				continue
+			}
+			managedWords = append(managedWords, &bedrockruntime.GuardrailManagedWord{
+				Action: aws.String(bedrockruntime.GuardrailWordPolicyActionBlocked),
+				Match:  aws.String(word),
+				Type:   aws.String(bedrockruntime.GuardrailManagedWordTypeProfanity),
+			})
+			blocked = true
+		}
+	}
+
+	return &bedrockruntime.GuardrailWordPolicyAssessment{CustomWords: customWords, ManagedWordLists: managedWords}, blocked
+}
+
+// assessSensitiveInformationPolicy scans texts for every PII entity type and
+// custom regex cfg configures, recording one filter entry per match. A BLOCK
+// action match sets blocked; an ANONYMIZE match is recorded but left for
+// redactSensitiveInformation to apply once the caller knows nothing blocked.
+func assessSensitiveInformationPolicy(cfg *bedrock.GuardrailSensitiveInformationPolicyConfig, texts []string) (*bedrockruntime.GuardrailSensitiveInformationPolicyAssessment, bool) {
+	if cfg == nil {
+		return nil, false
+	}
+
+	blocked := false
+	piiEntities := []*bedrockruntime.GuardrailPiiEntityFilter{}
+	for _, e := range cfg.PiiEntitiesConfig {
+		if e == nil {
+			continue
+		}
+		entityType := aws.StringValue(e.Type)
+		pattern := builtinPIIPattern(entityType)
+		if pattern == nil {
+			continue
+		}
+		respAction := bedrockruntime.GuardrailSensitiveInformationPolicyActionAnonymized
+		if aws.StringValue(e.Action) == bedrock.GuardrailSensitiveInformationActionBlock {
+			respAction = bedrockruntime.GuardrailSensitiveInformationPolicyActionBlocked
+		}
+		for _, t := range texts {
+			for _, match := range pattern.FindAllString(t, -1) {
+				if respAction == bedrockruntime.GuardrailSensitiveInformationPolicyActionBlocked {
+					blocked = true
+				}
+				piiEntities = append(piiEntities, &bedrockruntime.GuardrailPiiEntityFilter{
+					Action: aws.String(respAction),
+					Match:  aws.String(match),
+					Type:   aws.String(entityType),
+				})
+			}
+		}
+	}
+
+	regexes := []*bedrockruntime.GuardrailRegexFilter{}
+	for _, r := range cfg.RegexesConfig {
+		if r == nil {
+			continue
+		}
+		re, err := regexp.Compile(aws.StringValue(r.Pattern))
+		if err != nil {
+			continue
+		}
+		respAction := bedrockruntime.GuardrailSensitiveInformationPolicyActionAnonymized
+		if aws.StringValue(r.Action) == bedrock.GuardrailSensitiveInformationActionBlock {
+			respAction = bedrockruntime.GuardrailSensitiveInformationPolicyActionBlocked
+		}
+		for _, t := range texts {
+			for _, match := range re.FindAllString(t, -1) {
+				if respAction == bedrockruntime.GuardrailSensitiveInformationPolicyActionBlocked {
+					blocked = true
+				}
+				regexes = append(regexes, &bedrockruntime.GuardrailRegexFilter{
+					Action: aws.String(respAction),
+					Match:  aws.String(match),
+					Name:   r.Name,
+					Regex:  r.Pattern,
+				})
+			}
+		}
+	}
+
+	return &bedrockruntime.GuardrailSensitiveInformationPolicyAssessment{PiiEntities: piiEntities, Regexes: regexes}, blocked
+}
+
+// redactSensitiveInformation replaces every ANONYMIZE-configured entity or
+// custom-regex match with a sentinel ({ENTITY_TYPE} for a PII entity, or
+// {NAME} for a custom regex). Only called once nothing in the guardrail's
+// policies blocked the request outright.
+func redactSensitiveInformation(cfg *bedrock.GuardrailSensitiveInformationPolicyConfig, texts []string) []string {
+	out := make([]string, len(texts))
+	copy(out, texts)
+
+	for _, e := range cfg.PiiEntitiesConfig {
+		if e == nil || aws.StringValue(e.Action) != bedrock.GuardrailSensitiveInformationActionAnonymize {
+			continue
+		}
+		pattern := builtinPIIPattern(aws.StringValue(e.Type))
+		if pattern == nil {
+			continue
+		}
+		sentinel := fmt.Sprintf("{%s}", aws.StringValue(e.Type))
+		for i, t := range out {
+			out[i] = pattern.ReplaceAllString(t, sentinel)
+		}
+	}
+
+	for _, r := range cfg.RegexesConfig {
+		if r == nil || aws.StringValue(r.Action) != bedrock.GuardrailSensitiveInformationActionAnonymize {
+			continue
+		}
+		re, err := regexp.Compile(aws.StringValue(r.Pattern))
+		if err != nil {
+			continue
+		}
+		sentinel := fmt.Sprintf("{%s}", aws.StringValue(r.Name))
+		for i, t := range out {
+			out[i] = re.ReplaceAllString(t, sentinel)
+		}
+	}
+
+	return out
+}
+
+// scaffoldContentPolicyAssessment records that a configured content policy
+// was evaluated with no filters triggered: v1 has no classifier to score
+// hate/insults/sexual/violence/misconduct/prompt-attack, so it always
+// evaluates to NONE. A later classifier-backed policy fills this branch in
+// rather than replacing it.
+func scaffoldContentPolicyAssessment(cfg *bedrock.GuardrailContentPolicyConfig) *bedrockruntime.GuardrailContentPolicyAssessment {
+	if cfg == nil {
+		return nil
+	}
+	return &bedrockruntime.GuardrailContentPolicyAssessment{Filters: []*bedrockruntime.GuardrailContentFilter{}}
+}
+
+// scaffoldTopicPolicyAssessment is scaffoldContentPolicyAssessment's sibling
+// for denied topics: no classifier means every configured topic evaluates to
+// NONE rather than being matched against the text.
+func scaffoldTopicPolicyAssessment(cfg *bedrock.GuardrailTopicPolicyConfig) *bedrockruntime.GuardrailTopicPolicyAssessment {
+	if cfg == nil {
+		return nil
+	}
+	return &bedrockruntime.GuardrailTopicPolicyAssessment{Topics: []*bedrockruntime.GuardrailTopic{}}
+}
+
+// scaffoldContextualGroundingPolicyAssessment is
+// scaffoldContentPolicyAssessment's sibling for grounding/relevance: without
+// a source to ground against and a classifier to score it, it evaluates to
+// NONE.
+func scaffoldContextualGroundingPolicyAssessment(cfg *bedrock.GuardrailContextualGroundingPolicyConfig) *bedrockruntime.GuardrailContextualGroundingPolicyAssessment {
+	if cfg == nil {
+		return nil
+	}
+	return &bedrockruntime.GuardrailContextualGroundingPolicyAssessment{Filters: []*bedrockruntime.GuardrailContextualGroundingFilter{}}
+}
+
+// guardrailUsage reports policy units processed as len(texts) for every
+// policy view actually configures, and zero for one it doesn't: a cheap,
+// deterministic stand-in for AWS's real usage metering.
+func guardrailUsage(view guardrailView, texts []string) *bedrockruntime.GuardrailUsage {
+	n := aws.Int64(int64(len(texts)))
+	zero := aws.Int64(0)
+	usage := &bedrockruntime.GuardrailUsage{
+		WordPolicyUnits:                     zero,
+		SensitiveInformationPolicyUnits:     zero,
+		SensitiveInformationPolicyFreeUnits: aws.Int64(0),
+		ContentPolicyUnits:                  zero,
+		TopicPolicyUnits:                    zero,
+		ContextualGroundingPolicyUnits:      zero,
+	}
+	if view.WordPolicy != nil {
+		usage.WordPolicyUnits = n
+	}
+	if view.SensitiveInformationPolicy != nil {
+		usage.SensitiveInformationPolicyUnits = n
+	}
+	if view.ContentPolicy != nil {
+		usage.ContentPolicyUnits = n
+	}
+	if view.TopicPolicy != nil {
+		usage.TopicPolicyUnits = n
+	}
+	if view.ContextualGroundingPolicy != nil {
+		usage.ContextualGroundingPolicyUnits = n
+	}
+	return usage
+}
+
+// applyGuardrailPolicies is the pure filter engine: it evaluates view's
+// policies over texts for source (INPUT or OUTPUT) and returns the
+// aws-sdk-go bedrockruntime shape's pieces. wordPolicy and
+// sensitiveInformationPolicy are enforced; content/topic/contextualGrounding
+// evaluate to NONE (see the scaffold* helpers). A BLOCK anywhere makes the
+// overall action GUARDRAIL_INTERVENED and short-circuits redaction, since the
+// caller substitutes the guardrail's blocked messaging instead of the text.
+// source is accepted (not yet branched on) for parity with AWS's
+// per-source assessment shape; the deterministic policies apply identically
+// to INPUT and OUTPUT text until a content-policy classifier needs to tell
+// them apart via InputStrength/OutputStrength.
+func applyGuardrailPolicies(view guardrailView, texts []string, source string) (string, []*bedrockruntime.GuardrailAssessment, []string, *bedrockruntime.GuardrailUsage) {
+	_ = source
+
+	wordAssessment, wordBlocked := assessWordPolicy(view.WordPolicy, texts)
+	piiAssessment, piiBlocked := assessSensitiveInformationPolicy(view.SensitiveInformationPolicy, texts)
+
+	action := bedrockruntime.GuardrailActionNone
+	outputs := texts
+	switch {
+	case wordBlocked || piiBlocked:
+		action = bedrockruntime.GuardrailActionGuardrailIntervened
+	case view.SensitiveInformationPolicy != nil:
+		outputs = redactSensitiveInformation(view.SensitiveInformationPolicy, texts)
+	}
+
+	assessment := &bedrockruntime.GuardrailAssessment{
+		WordPolicy:                 wordAssessment,
+		SensitiveInformationPolicy: piiAssessment,
+		ContentPolicy:              scaffoldContentPolicyAssessment(view.ContentPolicy),
+		TopicPolicy:                scaffoldTopicPolicyAssessment(view.TopicPolicy),
+		ContextualGroundingPolicy:  scaffoldContextualGroundingPolicyAssessment(view.ContextualGroundingPolicy),
+	}
+
+	return action, []*bedrockruntime.GuardrailAssessment{assessment}, outputs, guardrailUsage(view, texts)
+}

--- a/spinifex/gateway/bedrock/guardrail_filter_test.go
+++ b/spinifex/gateway/bedrock/guardrail_filter_test.go
@@ -316,14 +316,14 @@ func TestApplyGuardrail_UnknownOrForeignGuardrail(t *testing.T) {
 
 	_, err := ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(aws.String("does-not-exist"), guardrailDraftVersion, bedrockruntime.GuardrailContentSourceInput, "hello"))
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("apply-guardrail-foreign"))
 	require.NoError(t, err)
 
 	_, err = ApplyGuardrail(ctx, grOtherCaller, store, applyGuardrailInput(createOut.GuardrailId, guardrailDraftVersion, bedrockruntime.GuardrailContentSourceInput, "hello"))
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 }
 
 // TestApplyGuardrail_VersionResolution covers version handling: DRAFT
@@ -368,5 +368,5 @@ func TestApplyGuardrail_VersionResolution(t *testing.T) {
 	// An unknown numbered version is not-found.
 	_, err = ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(createOut.GuardrailId, "99", bedrockruntime.GuardrailContentSourceInput, "hello"))
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 }

--- a/spinifex/gateway/bedrock/guardrail_filter_test.go
+++ b/spinifex/gateway/bedrock/guardrail_filter_test.go
@@ -1,0 +1,372 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyGuardrailPolicies_WordAndPII is the filter-engine table test: pure
+// guardrailView + texts in, (action, assessments, outputs) out, no I/O.
+func TestApplyGuardrailPolicies_WordAndPII(t *testing.T) {
+	blockWord := guardrailView{
+		WordPolicy: &bedrock.GuardrailWordPolicyConfig{
+			WordsConfig: []*bedrock.GuardrailWordConfig{{Text: aws.String("badword")}},
+		},
+	}
+	managedProfanity := guardrailView{
+		WordPolicy: &bedrock.GuardrailWordPolicyConfig{
+			ManagedWordListsConfig: []*bedrock.GuardrailManagedWordsConfig{
+				{Type: aws.String(bedrock.GuardrailManagedWordsTypeProfanity)},
+			},
+		},
+	}
+	blockPII := func(entityType string) guardrailView {
+		return guardrailView{
+			SensitiveInformationPolicy: &bedrock.GuardrailSensitiveInformationPolicyConfig{
+				PiiEntitiesConfig: []*bedrock.GuardrailPiiEntityConfig{
+					{Type: aws.String(entityType), Action: aws.String(bedrock.GuardrailSensitiveInformationActionBlock)},
+				},
+			},
+		}
+	}
+	anonymizePII := func(entityType string) guardrailView {
+		return guardrailView{
+			SensitiveInformationPolicy: &bedrock.GuardrailSensitiveInformationPolicyConfig{
+				PiiEntitiesConfig: []*bedrock.GuardrailPiiEntityConfig{
+					{Type: aws.String(entityType), Action: aws.String(bedrock.GuardrailSensitiveInformationActionAnonymize)},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name         string
+		view         guardrailView
+		texts        []string
+		source       string
+		wantAction   string
+		wantOutput   string
+		wantBlocked  bool
+		wantAnonym   bool
+		wantEntities []string
+	}{
+		{
+			name:       "clean text is NONE",
+			view:       blockWord,
+			texts:      []string{"nothing to see here"},
+			source:     bedrockruntime.GuardrailContentSourceInput,
+			wantAction: bedrockruntime.GuardrailActionNone,
+			wantOutput: "nothing to see here",
+		},
+		{
+			name:        "custom blocklist word intervenes",
+			view:        blockWord,
+			texts:       []string{"this contains a badword right here"},
+			source:      bedrockruntime.GuardrailContentSourceInput,
+			wantAction:  bedrockruntime.GuardrailActionGuardrailIntervened,
+			wantBlocked: true,
+		},
+		{
+			name:        "managed profanity list intervenes",
+			view:        managedProfanity,
+			texts:       []string{"that is such bullshit honestly"},
+			source:      bedrockruntime.GuardrailContentSourceOutput,
+			wantAction:  bedrockruntime.GuardrailActionGuardrailIntervened,
+			wantBlocked: true,
+		},
+		{
+			name:         "email detected and anonymized",
+			view:         anonymizePII(bedrock.GuardrailPiiEntityTypeEmail),
+			texts:        []string{"reach me at jane@example.com please"},
+			source:       bedrockruntime.GuardrailContentSourceInput,
+			wantAction:   bedrockruntime.GuardrailActionNone,
+			wantOutput:   "reach me at {EMAIL} please",
+			wantAnonym:   true,
+			wantEntities: []string{bedrock.GuardrailPiiEntityTypeEmail},
+		},
+		{
+			name:         "phone number detected and anonymized",
+			view:         anonymizePII(bedrock.GuardrailPiiEntityTypePhone),
+			texts:        []string{"call me at 415-555-0100 tomorrow"},
+			source:       bedrockruntime.GuardrailContentSourceInput,
+			wantAction:   bedrockruntime.GuardrailActionNone,
+			wantOutput:   "call me at {PHONE} tomorrow",
+			wantAnonym:   true,
+			wantEntities: []string{bedrock.GuardrailPiiEntityTypePhone},
+		},
+		{
+			name:         "SSN detected and blocked",
+			view:         blockPII(bedrock.GuardrailPiiEntityTypeUsSocialSecurityNumber),
+			texts:        []string{"my ssn is 123-45-6789 ok"},
+			source:       bedrockruntime.GuardrailContentSourceInput,
+			wantAction:   bedrockruntime.GuardrailActionGuardrailIntervened,
+			wantBlocked:  true,
+			wantEntities: []string{bedrock.GuardrailPiiEntityTypeUsSocialSecurityNumber},
+		},
+		{
+			name:         "credit card number detected and anonymized",
+			view:         anonymizePII(bedrock.GuardrailPiiEntityTypeCreditDebitCardNumber),
+			texts:        []string{"card 4111 1111 1111 1111 on file"},
+			source:       bedrockruntime.GuardrailContentSourceInput,
+			wantAction:   bedrockruntime.GuardrailActionNone,
+			wantOutput:   "card {CREDIT_DEBIT_CARD_NUMBER} on file",
+			wantAnonym:   true,
+			wantEntities: []string{bedrock.GuardrailPiiEntityTypeCreditDebitCardNumber},
+		},
+		{
+			name:         "IPv4 address detected and anonymized",
+			view:         anonymizePII(bedrock.GuardrailPiiEntityTypeIpAddress),
+			texts:        []string{"connect to 192.168.1.10 now"},
+			source:       bedrockruntime.GuardrailContentSourceOutput,
+			wantAction:   bedrockruntime.GuardrailActionNone,
+			wantOutput:   "connect to {IP_ADDRESS} now",
+			wantAnonym:   true,
+			wantEntities: []string{bedrock.GuardrailPiiEntityTypeIpAddress},
+		},
+		{
+			name:         "URL detected and anonymized",
+			view:         anonymizePII(bedrock.GuardrailPiiEntityTypeUrl),
+			texts:        []string{"see https://example.com/path for details"},
+			source:       bedrockruntime.GuardrailContentSourceOutput,
+			wantAction:   bedrockruntime.GuardrailActionNone,
+			wantOutput:   "see {URL} for details",
+			wantAnonym:   true,
+			wantEntities: []string{bedrock.GuardrailPiiEntityTypeUrl},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			action, assessments, outputs, usage := applyGuardrailPolicies(tc.view, tc.texts, tc.source)
+			assert.Equal(t, tc.wantAction, action)
+			require.Len(t, assessments, 1)
+			require.NotNil(t, usage)
+
+			if tc.wantOutput != "" {
+				require.Len(t, outputs, 1)
+				assert.Equal(t, tc.wantOutput, outputs[0])
+			}
+
+			if tc.wantBlocked {
+				blockedSomewhere := false
+				if wp := assessments[0].WordPolicy; wp != nil {
+					blockedSomewhere = blockedSomewhere || len(wp.CustomWords) > 0 || len(wp.ManagedWordLists) > 0
+				}
+				if sip := assessments[0].SensitiveInformationPolicy; sip != nil {
+					for _, e := range sip.PiiEntities {
+						if aws.StringValue(e.Action) == bedrockruntime.GuardrailSensitiveInformationPolicyActionBlocked {
+							blockedSomewhere = true
+						}
+					}
+				}
+				assert.True(t, blockedSomewhere, "expected a blocked entry in the assessment")
+			}
+
+			if tc.wantAnonym {
+				require.NotNil(t, assessments[0].SensitiveInformationPolicy)
+				var gotEntities []string
+				for _, e := range assessments[0].SensitiveInformationPolicy.PiiEntities {
+					assert.Equal(t, bedrockruntime.GuardrailSensitiveInformationPolicyActionAnonymized, aws.StringValue(e.Action))
+					gotEntities = append(gotEntities, aws.StringValue(e.Type))
+				}
+				assert.Equal(t, tc.wantEntities, gotEntities)
+			}
+		})
+	}
+}
+
+// TestApplyGuardrailPolicies_CustomRegex covers a guardrail-defined regex
+// pattern, independent of the built-in PII entity table.
+func TestApplyGuardrailPolicies_CustomRegex(t *testing.T) {
+	view := guardrailView{
+		SensitiveInformationPolicy: &bedrock.GuardrailSensitiveInformationPolicyConfig{
+			RegexesConfig: []*bedrock.GuardrailRegexConfig{
+				{Name: aws.String("account-id"), Pattern: aws.String(`\d{12}`), Action: aws.String(bedrock.GuardrailSensitiveInformationActionAnonymize)},
+			},
+		},
+	}
+
+	action, assessments, outputs, _ := applyGuardrailPolicies(view, []string{"account 123456789012 is active"}, bedrockruntime.GuardrailContentSourceInput)
+	assert.Equal(t, bedrockruntime.GuardrailActionNone, action)
+	require.Len(t, outputs, 1)
+	assert.Equal(t, "account {account-id} is active", outputs[0])
+	require.NotNil(t, assessments[0].SensitiveInformationPolicy)
+	require.Len(t, assessments[0].SensitiveInformationPolicy.Regexes, 1)
+	assert.Equal(t, "123456789012", aws.StringValue(assessments[0].SensitiveInformationPolicy.Regexes[0].Match))
+
+	viewBlock := guardrailView{
+		SensitiveInformationPolicy: &bedrock.GuardrailSensitiveInformationPolicyConfig{
+			RegexesConfig: []*bedrock.GuardrailRegexConfig{
+				{Name: aws.String("account-id"), Pattern: aws.String(`\d{12}`), Action: aws.String(bedrock.GuardrailSensitiveInformationActionBlock)},
+			},
+		},
+	}
+	action, _, _, _ = applyGuardrailPolicies(viewBlock, []string{"account 123456789012 is active"}, bedrockruntime.GuardrailContentSourceInput)
+	assert.Equal(t, bedrockruntime.GuardrailActionGuardrailIntervened, action)
+}
+
+// TestApplyGuardrailPolicies_ScaffoldPolicies covers the classifier-backed
+// policies: configuring content/topic/contextualGrounding records an
+// assessment (so the caller can see the policy was evaluated) but never
+// intervenes, since v1 has no classifier to score them.
+func TestApplyGuardrailPolicies_ScaffoldPolicies(t *testing.T) {
+	view := guardrailView{
+		ContentPolicy: &bedrock.GuardrailContentPolicyConfig{
+			FiltersConfig: []*bedrock.GuardrailContentFilterConfig{
+				{Type: aws.String(bedrock.GuardrailContentFilterTypeHate), InputStrength: aws.String(bedrock.GuardrailFilterStrengthHigh), OutputStrength: aws.String(bedrock.GuardrailFilterStrengthHigh)},
+			},
+		},
+		TopicPolicy: &bedrock.GuardrailTopicPolicyConfig{
+			TopicsConfig: []*bedrock.GuardrailTopicConfig{
+				{Name: aws.String("competitors"), Definition: aws.String("mentions of competitors"), Type: aws.String(bedrock.GuardrailTopicTypeDeny)},
+			},
+		},
+		ContextualGroundingPolicy: &bedrock.GuardrailContextualGroundingPolicyConfig{
+			FiltersConfig: []*bedrock.GuardrailContextualGroundingFilterConfig{
+				{Type: aws.String(bedrock.GuardrailContextualGroundingFilterTypeGrounding), Threshold: aws.Float64(0.5)},
+			},
+		},
+	}
+
+	action, assessments, outputs, _ := applyGuardrailPolicies(view, []string{"our competitor's product is inferior"}, bedrockruntime.GuardrailContentSourceInput)
+	assert.Equal(t, bedrockruntime.GuardrailActionNone, action)
+	assert.Equal(t, []string{"our competitor's product is inferior"}, outputs)
+
+	require.NotNil(t, assessments[0].ContentPolicy)
+	assert.Empty(t, assessments[0].ContentPolicy.Filters)
+	require.NotNil(t, assessments[0].TopicPolicy)
+	assert.Empty(t, assessments[0].TopicPolicy.Topics)
+	require.NotNil(t, assessments[0].ContextualGroundingPolicy)
+	assert.Empty(t, assessments[0].ContextualGroundingPolicy.Filters)
+}
+
+// TestApplyGuardrailPolicies_UnconfiguredPoliciesAreOmitted covers that a
+// policy the guardrail never configured has no assessment entry at all,
+// rather than an empty scaffold one.
+func TestApplyGuardrailPolicies_UnconfiguredPoliciesAreOmitted(t *testing.T) {
+	_, assessments, _, _ := applyGuardrailPolicies(guardrailView{}, []string{"hello"}, bedrockruntime.GuardrailContentSourceInput)
+	require.Len(t, assessments, 1)
+	assert.Nil(t, assessments[0].WordPolicy)
+	assert.Nil(t, assessments[0].SensitiveInformationPolicy)
+	assert.Nil(t, assessments[0].ContentPolicy)
+	assert.Nil(t, assessments[0].TopicPolicy)
+	assert.Nil(t, assessments[0].ContextualGroundingPolicy)
+}
+
+// applyGuardrailInput is a small ApplyGuardrail request builder for the
+// contract tests below, mirroring createGuardrailInput's role for CRUD.
+func applyGuardrailInput(guardrailID *string, version, source, text string) *bedrockruntime.ApplyGuardrailInput {
+	return &bedrockruntime.ApplyGuardrailInput{
+		GuardrailIdentifier: guardrailID,
+		GuardrailVersion:    aws.String(version),
+		Source:              aws.String(source),
+		Content: []*bedrockruntime.GuardrailContentBlock{
+			{Text: &bedrockruntime.GuardrailTextBlock{Text: aws.String(text)}},
+		},
+	}
+}
+
+// TestApplyGuardrail_InputBlock covers the runtime op end to end: a
+// word-policy hit on INPUT content intervenes.
+func TestApplyGuardrail_InputBlock(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("apply-guardrail-block"))
+	require.NoError(t, err)
+
+	out, err := ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(createOut.GuardrailId, guardrailDraftVersion, bedrockruntime.GuardrailContentSourceInput, "this has a badword in it"))
+	require.NoError(t, err)
+	assert.Equal(t, bedrockruntime.GuardrailActionGuardrailIntervened, aws.StringValue(out.Action))
+	require.Len(t, out.Outputs, 1)
+	assert.Equal(t, "Your input violates our policy.", aws.StringValue(out.Outputs[0].Text))
+	require.Len(t, out.Assessments, 1)
+	require.NotNil(t, out.Usage)
+}
+
+// TestApplyGuardrail_OutputAnonymize covers OUTPUT content redaction: the PII
+// entity configured ANONYMIZE, so the text comes back transformed rather than
+// replaced by the blocked-outputs message.
+func TestApplyGuardrail_OutputAnonymize(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("apply-guardrail-anonymize"))
+	require.NoError(t, err)
+
+	out, err := ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(createOut.GuardrailId, guardrailDraftVersion, bedrockruntime.GuardrailContentSourceOutput, "contact jane@example.com for support"))
+	require.NoError(t, err)
+	assert.Equal(t, bedrockruntime.GuardrailActionNone, aws.StringValue(out.Action))
+	require.Len(t, out.Outputs, 1)
+	assert.Equal(t, "contact {EMAIL} for support", aws.StringValue(out.Outputs[0].Text))
+}
+
+// TestApplyGuardrail_UnknownOrForeignGuardrail covers both a guardrail id
+// that was never created and one that belongs to another account.
+func TestApplyGuardrail_UnknownOrForeignGuardrail(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	_, err := ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(aws.String("does-not-exist"), guardrailDraftVersion, bedrockruntime.GuardrailContentSourceInput, "hello"))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("apply-guardrail-foreign"))
+	require.NoError(t, err)
+
+	_, err = ApplyGuardrail(ctx, grOtherCaller, store, applyGuardrailInput(createOut.GuardrailId, guardrailDraftVersion, bedrockruntime.GuardrailContentSourceInput, "hello"))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestApplyGuardrail_VersionResolution covers version handling: DRAFT
+// defaults available on the mutable copy, and a numbered version created via
+// CreateGuardrailVersion resolves to its own frozen policy config.
+func TestApplyGuardrail_VersionResolution(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("apply-guardrail-version"))
+	require.NoError(t, err)
+
+	verOut, err := CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+
+	// Mutate the DRAFT's word policy after the snapshot was taken.
+	_, err = UpdateGuardrail(ctx, grCallerAccount, store, &bedrock.UpdateGuardrailInput{
+		GuardrailIdentifier:     createOut.GuardrailId,
+		Name:                    aws.String("apply-guardrail-version"),
+		BlockedInputMessaging:   aws.String("Your input violates our policy."),
+		BlockedOutputsMessaging: aws.String("The model response violates our policy."),
+		WordPolicyConfig: &bedrock.GuardrailWordPolicyConfig{
+			WordsConfig: []*bedrock.GuardrailWordConfig{{Text: aws.String("newword")}},
+		},
+	})
+	require.NoError(t, err)
+
+	// The numbered version still enforces the original "badword" blocklist.
+	outSnap, err := ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(createOut.GuardrailId, aws.StringValue(verOut.Version), bedrockruntime.GuardrailContentSourceInput, "this has a badword in it"))
+	require.NoError(t, err)
+	assert.Equal(t, bedrockruntime.GuardrailActionGuardrailIntervened, aws.StringValue(outSnap.Action))
+
+	// The DRAFT no longer blocks "badword" but does block "newword".
+	outDraftOld, err := ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(createOut.GuardrailId, guardrailDraftVersion, bedrockruntime.GuardrailContentSourceInput, "this has a badword in it"))
+	require.NoError(t, err)
+	assert.Equal(t, bedrockruntime.GuardrailActionNone, aws.StringValue(outDraftOld.Action))
+
+	outDraftNew, err := ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(createOut.GuardrailId, guardrailDraftVersion, bedrockruntime.GuardrailContentSourceInput, "this has a newword in it"))
+	require.NoError(t, err)
+	assert.Equal(t, bedrockruntime.GuardrailActionGuardrailIntervened, aws.StringValue(outDraftNew.Action))
+
+	// An unknown numbered version is not-found.
+	_, err = ApplyGuardrail(ctx, grCallerAccount, store, applyGuardrailInput(createOut.GuardrailId, "99", bedrockruntime.GuardrailContentSourceInput, "hello"))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}

--- a/spinifex/gateway/bedrock/guardrail_inference.go
+++ b/spinifex/gateway/bedrock/guardrail_inference.go
@@ -1,0 +1,411 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// enforceGuardrail is the single resolve->load->filter path Converse and
+// ConverseStream both call, mirroring ApplyGuardrail's own sequence. An
+// unresolvable or foreign guardrail fails closed: ResourceNotFoundException.
+func enforceGuardrail(ctx context.Context, store *GuardrailStore, accountID, ident, version, source string, texts []string) (blocked bool, blockedMessage string, redactedTexts []string, assessments []*bedrockruntime.GuardrailAssessment, err error) {
+	if store == nil || ident == "" {
+		return false, "", texts, nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+	id, err := resolveGuardrailID(ident, store.region, accountID)
+	if err != nil {
+		return false, "", texts, nil, err
+	}
+
+	kv, err := store.bucket(ctx)
+	if err != nil {
+		return false, "", texts, nil, err
+	}
+	rec, found, err := getGuardrailRecord(ctx, kv, accountID, id)
+	if err != nil {
+		return false, "", texts, nil, err
+	}
+	if !found {
+		return false, "", texts, nil, errors.New(awserrors.ErrorResourceNotFoundException)
+	}
+
+	view := rec.guardrailView
+	if version != "" && version != guardrailDraftVersion {
+		snap, ok := rec.Versions[version]
+		if !ok {
+			return false, "", texts, nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		}
+		view = snap.guardrailView
+	}
+
+	action, gassessments, outputs, _ := applyGuardrailPolicies(view, texts, source)
+	if action == bedrockruntime.GuardrailActionGuardrailIntervened {
+		message := view.BlockedInputMessaging
+		if source == bedrockruntime.GuardrailContentSourceOutput {
+			message = view.BlockedOutputsMessaging
+		}
+		return true, message, texts, gassessments, nil
+	}
+	return false, "", outputs, gassessments, nil
+}
+
+// converseGuardrailTexts collects the INPUT-checkable text from a Converse
+// request: every system prompt block plus every user-role message's text,
+// matching AWS's default of assessing the whole message.
+func converseGuardrailTexts(input *bedrockruntime.ConverseInput) []string {
+	var texts []string
+	for _, s := range input.System {
+		if s != nil && s.Text != nil {
+			texts = append(texts, aws.StringValue(s.Text))
+		}
+	}
+	for _, m := range input.Messages {
+		if m == nil || aws.StringValue(m.Role) != bedrockruntime.ConversationRoleUser {
+			continue
+		}
+		for _, c := range m.Content {
+			if c != nil && c.Text != nil {
+				texts = append(texts, aws.StringValue(c.Text))
+			}
+		}
+	}
+	return texts
+}
+
+// streamGuardrailTexts is converseGuardrailTexts' sibling for
+// ConverseStreamInput: the two request shapes are field-identical for
+// Messages/System, only the generated Go type name differs.
+func streamGuardrailTexts(input *bedrockruntime.ConverseStreamInput) []string {
+	var texts []string
+	for _, s := range input.System {
+		if s != nil && s.Text != nil {
+			texts = append(texts, aws.StringValue(s.Text))
+		}
+	}
+	for _, m := range input.Messages {
+		if m == nil || aws.StringValue(m.Role) != bedrockruntime.ConversationRoleUser {
+			continue
+		}
+		for _, c := range m.Content {
+			if c != nil && c.Text != nil {
+				texts = append(texts, aws.StringValue(c.Text))
+			}
+		}
+	}
+	return texts
+}
+
+// converseOutputTexts collects the OUTPUT-checkable text from a completed
+// ConverseOutput's assistant message.
+func converseOutputTexts(out *bedrockruntime.ConverseOutput) []string {
+	if out == nil || out.Output == nil || out.Output.Message == nil {
+		return nil
+	}
+	var texts []string
+	for _, c := range out.Output.Message.Content {
+		if c != nil && c.Text != nil {
+			texts = append(texts, aws.StringValue(c.Text))
+		}
+	}
+	return texts
+}
+
+// setConverseOutputTexts writes texts back into out's assistant message text
+// blocks, in order, substituting the (possibly ANONYMIZE-redacted) text
+// applyGuardrailPolicies returned for each original text block.
+func setConverseOutputTexts(out *bedrockruntime.ConverseOutput, texts []string) {
+	if out == nil || out.Output == nil || out.Output.Message == nil {
+		return
+	}
+	i := 0
+	for _, c := range out.Output.Message.Content {
+		if c == nil || c.Text == nil {
+			continue
+		}
+		if i < len(texts) {
+			c.Text = aws.String(texts[i])
+		}
+		i++
+	}
+}
+
+// blockedConverseOutput builds a complete, valid ConverseOutput for an INPUT
+// guardrail block: the backend is never called, so usage is zero and latency
+// reflects only the time spent resolving and evaluating the guardrail.
+func blockedConverseOutput(message string, latency time.Duration) *bedrockruntime.ConverseOutput {
+	return &bedrockruntime.ConverseOutput{
+		Output: &bedrockruntime.ConverseOutput_{
+			Message: &bedrockruntime.Message{
+				Role:    aws.String(bedrockruntime.ConversationRoleAssistant),
+				Content: []*bedrockruntime.ContentBlock{{Text: aws.String(message)}},
+			},
+		},
+		StopReason: aws.String(bedrockruntime.StopReasonGuardrailIntervened),
+		Usage: &bedrockruntime.TokenUsage{
+			InputTokens:  aws.Int64(0),
+			OutputTokens: aws.Int64(0),
+			TotalTokens:  aws.Int64(0),
+		},
+		Metrics: &bedrockruntime.ConverseMetrics{LatencyMs: aws.Int64(latency.Milliseconds())},
+	}
+}
+
+// converseGuardrailTrace builds the ConverseTrace AWS returns when
+// GuardrailConfig.Trace is "enabled", keyed by the resolved guardrail id, or
+// nil when neither check produced an assessment to report.
+func converseGuardrailTrace(guardrailID string, inputAssessments, outputAssessments []*bedrockruntime.GuardrailAssessment) *bedrockruntime.ConverseTrace {
+	if len(inputAssessments) == 0 && len(outputAssessments) == 0 {
+		return nil
+	}
+	assessment := &bedrockruntime.GuardrailTraceAssessment{}
+	if len(inputAssessments) > 0 {
+		assessment.InputAssessment = map[string]*bedrockruntime.GuardrailAssessment{guardrailID: inputAssessments[0]}
+	}
+	if len(outputAssessments) > 0 {
+		assessment.OutputAssessments = map[string][]*bedrockruntime.GuardrailAssessment{guardrailID: outputAssessments}
+	}
+	return &bedrockruntime.ConverseTrace{Guardrail: assessment}
+}
+
+// writeBlockedConverseStream emits the minimal guarded event sequence for a
+// pre-stream INPUT block (messageStart..messageStop plus metadata); the
+// backend is never opened. Records one InvocationRecord, own exit path.
+func writeBlockedConverseStream(ctx context.Context, w http.ResponseWriter, modelID string, rc streamRecordCtx, message string, traceEnabled bool, guardrailID string, assessments []*bedrockruntime.GuardrailAssessment) error {
+	fw, err := newFrameWriter(w)
+	if err != nil {
+		return err
+	}
+
+	metadata := &bedrockruntime.ConverseStreamMetadataEvent{
+		Usage:   &bedrockruntime.TokenUsage{InputTokens: aws.Int64(0), OutputTokens: aws.Int64(0), TotalTokens: aws.Int64(0)},
+		Metrics: &bedrockruntime.ConverseStreamMetrics{LatencyMs: aws.Int64(time.Since(rc.start).Milliseconds())},
+	}
+	if traceEnabled && len(assessments) > 0 {
+		metadata.Trace = &bedrockruntime.ConverseStreamTrace{
+			Guardrail: &bedrockruntime.GuardrailTraceAssessment{
+				InputAssessment: map[string]*bedrockruntime.GuardrailAssessment{guardrailID: assessments[0]},
+			},
+		}
+	}
+
+	events := []ConverseStreamEvent{
+		{Kind: converseStreamEventMessageStart, MessageStart: &bedrockruntime.MessageStartEvent{Role: aws.String(bedrockruntime.ConversationRoleAssistant)}},
+		{Kind: converseStreamEventContentBlockStart, ContentBlockStart: &bedrockruntime.ContentBlockStartEvent{ContentBlockIndex: aws.Int64(0), Start: &bedrockruntime.ContentBlockStart{}}},
+		{Kind: converseStreamEventContentBlockDelta, ContentBlockDelta: &bedrockruntime.ContentBlockDeltaEvent{ContentBlockIndex: aws.Int64(0), Delta: &bedrockruntime.ContentBlockDelta{Text: aws.String(message)}}},
+		{Kind: converseStreamEventContentBlockStop, ContentBlockStop: &bedrockruntime.ContentBlockStopEvent{ContentBlockIndex: aws.Int64(0)}},
+		{Kind: converseStreamEventMessageStop, MessageStop: &bedrockruntime.MessageStopEvent{StopReason: aws.String(bedrockruntime.StopReasonGuardrailIntervened)}},
+		{Kind: converseStreamEventMetadata, Metadata: metadata},
+	}
+
+	for _, event := range events {
+		payload, perr := event.payload()
+		if perr != nil {
+			slog.Error("converse-stream: failed to marshal guarded event", "model", modelID, "kind", event.Kind, "err", perr)
+			break
+		}
+		if werr := fw.writeEvent(event.Kind.eventType(), payload); werr != nil {
+			slog.Error("converse-stream: failed to write guarded frame, aborting", "model", modelID, "err", werr)
+			break
+		}
+	}
+
+	rc.recorder.Record(ctx, InvocationRecord{
+		RequestID:  rc.requestID,
+		AccountID:  rc.accountID,
+		ModelID:    modelID,
+		Operation:  rc.operation,
+		Backend:    rc.backend,
+		LatencyMs:  time.Since(rc.start).Milliseconds(),
+		HTTPStatus: http.StatusOK,
+		InputText:  rc.inputText,
+		OutputText: message,
+	})
+	return nil
+}
+
+// guardrailStreamSource wraps a converseStreamSource for buffered/SYNC OUTPUT
+// enforcement: every contentBlockDelta is held until its block closes, then
+// assessed once and replaced by a single guarded delta before forwarding.
+type guardrailStreamSource struct {
+	inner converseStreamSource
+
+	store     *GuardrailStore
+	accountID string
+	ident     string
+	version   string
+	trace     bool
+
+	inputAssessments []*bedrockruntime.GuardrailAssessment
+
+	text        strings.Builder
+	blockIndex  *int64
+	queue       []ConverseStreamEvent
+	assessed    bool
+	blocked     bool
+	assessErr   error
+	assessments []*bedrockruntime.GuardrailAssessment
+}
+
+// newGuardrailStreamSource constructs a guardrailStreamSource. inputAssessments
+// is the already-computed result of the pre-stream INPUT check, carried
+// through so the trailing metadata event's trace can report both halves.
+func newGuardrailStreamSource(inner converseStreamSource, store *GuardrailStore, accountID, ident, version string, trace bool, inputAssessments []*bedrockruntime.GuardrailAssessment) *guardrailStreamSource {
+	return &guardrailStreamSource{inner: inner, store: store, accountID: accountID, ident: ident, version: version, trace: trace, inputAssessments: inputAssessments}
+}
+
+var _ converseStreamSource = (*guardrailStreamSource)(nil)
+var _ usageReporter = (*guardrailStreamSource)(nil)
+
+func (g *guardrailStreamSource) Close() error {
+	return g.inner.Close()
+}
+
+// usage delegates to the wrapped source when it reports real usage,
+// otherwise falls back to the same zero/estimated contract pumpConverseStream
+// already applies to every non-usageReporter source.
+func (g *guardrailStreamSource) usage() (inputTokens, outputTokens int64, estimated bool) {
+	if ur, ok := g.inner.(usageReporter); ok {
+		return ur.usage()
+	}
+	return 0, 0, true
+}
+
+// assess runs the OUTPUT guardrail check exactly once, over the full
+// accumulated delta text, and rewrites g.text in place to the guarded
+// (blocked-message or possibly ANONYMIZE-redacted) replacement.
+func (g *guardrailStreamSource) assess(ctx context.Context) {
+	if g.assessed {
+		return
+	}
+	g.assessed = true
+	blocked, message, redacted, assessments, err := enforceGuardrail(ctx, g.store, g.accountID, g.ident, g.version,
+		bedrockruntime.GuardrailContentSourceOutput, []string{g.text.String()})
+	if err != nil {
+		g.assessErr = err
+		return
+	}
+	g.blocked = blocked
+	g.assessments = assessments
+	g.text.Reset()
+	switch {
+	case blocked:
+		g.text.WriteString(message)
+	case len(redacted) > 0:
+		g.text.WriteString(redacted[0])
+	}
+}
+
+// guardedDeltaEvent is the single synthetic contentBlockDelta emitted in
+// place of every raw delta a block suppressed, carrying the post-assessment
+// text.
+func (g *guardrailStreamSource) guardedDeltaEvent() ConverseStreamEvent {
+	return ConverseStreamEvent{
+		Kind: converseStreamEventContentBlockDelta,
+		ContentBlockDelta: &bedrockruntime.ContentBlockDeltaEvent{
+			ContentBlockIndex: g.blockIndexOrZero(),
+			Delta:             &bedrockruntime.ContentBlockDelta{Text: aws.String(g.text.String())},
+		},
+	}
+}
+
+func (g *guardrailStreamSource) blockIndexOrZero() *int64 {
+	if g.blockIndex != nil {
+		return g.blockIndex
+	}
+	return aws.Int64(0)
+}
+
+// Next drains inner, buffering contentBlockDelta text until the block closes
+// (or, defensively, messageStop), assesses it once, queues the guarded delta
+// ahead of the stop event, and overrides StopReason when it blocked.
+func (g *guardrailStreamSource) Next(ctx context.Context) (ConverseStreamEvent, bool, error) {
+	if len(g.queue) > 0 {
+		event := g.queue[0]
+		g.queue = g.queue[1:]
+		return event, true, nil
+	}
+
+	for {
+		event, ok, err := g.inner.Next(ctx)
+		if err != nil || !ok {
+			return event, ok, err
+		}
+
+		switch event.Kind {
+		case converseStreamEventContentBlockDelta:
+			if event.ContentBlockDelta != nil {
+				if g.blockIndex == nil {
+					g.blockIndex = event.ContentBlockDelta.ContentBlockIndex
+				}
+				if event.ContentBlockDelta.Delta != nil {
+					g.text.WriteString(aws.StringValue(event.ContentBlockDelta.Delta.Text))
+				}
+			}
+			continue
+
+		case converseStreamEventContentBlockStop:
+			g.assess(ctx)
+			if g.assessErr != nil {
+				return ConverseStreamEvent{}, false, g.assessErr
+			}
+			return g.dequeue(g.guardedDeltaEvent(), event), true, nil
+
+		case converseStreamEventMessageStop:
+			if !g.assessed {
+				g.assess(ctx)
+				if g.assessErr != nil {
+					return ConverseStreamEvent{}, false, g.assessErr
+				}
+				g.queue = append(g.queue, g.guardedDeltaEvent(),
+					ConverseStreamEvent{Kind: converseStreamEventContentBlockStop, ContentBlockStop: &bedrockruntime.ContentBlockStopEvent{ContentBlockIndex: g.blockIndexOrZero()}})
+			}
+			if g.blocked {
+				event.MessageStop = &bedrockruntime.MessageStopEvent{StopReason: aws.String(bedrockruntime.StopReasonGuardrailIntervened)}
+			}
+			return g.dequeue(event), true, nil
+
+		case converseStreamEventMetadata:
+			if g.trace && event.Metadata != nil {
+				event.Metadata.Trace = g.buildTrace()
+			}
+			return event, true, nil
+
+		default:
+			return event, true, nil
+		}
+	}
+}
+
+// dequeue appends events to g.queue and pops+returns the first one, the
+// shared tail of Next's contentBlockStop and messageStop branches.
+func (g *guardrailStreamSource) dequeue(events ...ConverseStreamEvent) ConverseStreamEvent {
+	g.queue = append(g.queue, events...)
+	next := g.queue[0]
+	g.queue = g.queue[1:]
+	return next
+}
+
+// buildTrace merges the pre-stream INPUT assessment with the OUTPUT
+// assessment computed at block-close, mirroring Converse's own
+// converseGuardrailTrace. Returns nil when neither ran.
+func (g *guardrailStreamSource) buildTrace() *bedrockruntime.ConverseStreamTrace {
+	if len(g.inputAssessments) == 0 && len(g.assessments) == 0 {
+		return nil
+	}
+	assessment := &bedrockruntime.GuardrailTraceAssessment{}
+	if len(g.inputAssessments) > 0 {
+		assessment.InputAssessment = map[string]*bedrockruntime.GuardrailAssessment{g.ident: g.inputAssessments[0]}
+	}
+	if len(g.assessments) > 0 {
+		assessment.OutputAssessments = map[string][]*bedrockruntime.GuardrailAssessment{g.ident: g.assessments}
+	}
+	return &bedrockruntime.ConverseStreamTrace{Guardrail: assessment}
+}

--- a/spinifex/gateway/bedrock/guardrail_inference.go
+++ b/spinifex/gateway/bedrock/guardrail_inference.go
@@ -2,7 +2,6 @@ package gateway_bedrock
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
-	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
 
 // enforceGuardrail is the single resolve->load->filter path Converse and
@@ -18,7 +16,7 @@ import (
 // unresolvable or foreign guardrail fails closed: ResourceNotFoundException.
 func enforceGuardrail(ctx context.Context, store *GuardrailStore, accountID, ident, version, source string, texts []string) (blocked bool, blockedMessage string, redactedTexts []string, assessments []*bedrockruntime.GuardrailAssessment, err error) {
 	if store == nil || ident == "" {
-		return false, "", texts, nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		return false, "", texts, nil, errGuardrailNotFound(ident, "")
 	}
 	id, err := resolveGuardrailID(ident, store.region, accountID)
 	if err != nil {
@@ -34,14 +32,14 @@ func enforceGuardrail(ctx context.Context, store *GuardrailStore, accountID, ide
 		return false, "", texts, nil, err
 	}
 	if !found {
-		return false, "", texts, nil, errors.New(awserrors.ErrorResourceNotFoundException)
+		return false, "", texts, nil, errGuardrailNotFound(id, "")
 	}
 
 	view := rec.guardrailView
 	if version != "" && version != guardrailDraftVersion {
 		snap, ok := rec.Versions[version]
 		if !ok {
-			return false, "", texts, nil, errors.New(awserrors.ErrorResourceNotFoundException)
+			return false, "", texts, nil, errGuardrailNotFound(id, version)
 		}
 		view = snap.guardrailView
 	}

--- a/spinifex/gateway/bedrock/guardrail_inference_test.go
+++ b/spinifex/gateway/bedrock/guardrail_inference_test.go
@@ -382,6 +382,331 @@ func TestGuardrailStreamSource_TraceEnabledSurfacesAssessment(t *testing.T) {
 	assert.NotEmpty(t, metadata.Metadata.Trace.Guardrail.OutputAssessments)
 }
 
+// countingLlamaCompletionsServer answers every request with a fixed
+// non-streaming Llama /v1/completions response carrying text, and a counter
+// of how many requests it actually received.
+func countingLlamaCompletionsServer(t *testing.T, text string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"choices": [{"text": "` + text + `", "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1}
+		}`))
+	}))
+	t.Cleanup(ts.Close)
+	return ts, &hits
+}
+
+func TestInvokeRouter_GuardrailInputBlock_Llama_SkipsBackend(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-input-block-llama"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, hits := countingLlamaCompletionsServer(t, "hi")
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	respBody, contentType, err := rt.InvokeModel(ctx, grCallerAccount, modelID, []byte(`{"prompt":"this has a badword in it"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), hits.Load(), "the backend must never be called on an INPUT block")
+	assert.Equal(t, "application/json", contentType)
+
+	var out llamaInvokeResponse
+	require.NoError(t, json.Unmarshal(respBody, &out))
+	assert.Equal(t, "Your input violates our policy.", out.Generation)
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, out.StopReason)
+}
+
+// TestInvokeRouter_GuardrailInputBlock_Anthropic_SkipsBackend proves the
+// INPUT check runs -- and short-circuits -- before the Anthropic adapter's
+// InvokeModel ever opens a connection: no local server is needed at all,
+// since a blocked request must never reach the network.
+func TestInvokeRouter_GuardrailInputBlock_Anthropic_SkipsBackend(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-input-block-anthropic"))
+	require.NoError(t, err)
+
+	modelID := "anthropic.claude-3-5-sonnet-20240620-v1:0"
+	rt := NewInvokeRouter(stubCredentialResolver{key: "sk-test", ok: true}, nil, nil, grantAll{}, nil, store)
+
+	body := []byte(`{"anthropic_version":"bedrock-2023-05-31","max_tokens":100,"messages":[{"role":"user","content":[{"type":"text","text":"this has a badword in it"}]}]}`)
+	respBody, contentType, err := rt.InvokeModel(ctx, grCallerAccount, modelID, body, aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", contentType)
+
+	texts, ok := extractAnthropicCompletionTexts(respBody)
+	require.True(t, ok)
+	assert.Equal(t, []string{"Your input violates our policy."}, texts)
+}
+
+func TestInvokeRouter_GuardrailOutputBlock_Llama(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-output-block-llama"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, _ := countingLlamaCompletionsServer(t, "this has a badword in it")
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	respBody, _, err := rt.InvokeModel(ctx, grCallerAccount, modelID, []byte(`{"prompt":"hello"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.NoError(t, err)
+
+	var out llamaInvokeResponse
+	require.NoError(t, json.Unmarshal(respBody, &out))
+	assert.Equal(t, "The model response violates our policy.", out.Generation)
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, out.StopReason)
+}
+
+func TestInvokeRouter_GuardrailOutputAnonymize_Llama(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-output-anonymize-llama"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, _ := countingLlamaCompletionsServer(t, "contact jane@example.com for support")
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	respBody, _, err := rt.InvokeModel(ctx, grCallerAccount, modelID, []byte(`{"prompt":"hello"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.NoError(t, err)
+
+	var out llamaInvokeResponse
+	require.NoError(t, json.Unmarshal(respBody, &out))
+	assert.Equal(t, "contact {EMAIL} for support", out.Generation)
+	// Redaction alone (no block) leaves the backend's own stop reason intact.
+	assert.Equal(t, "stop", out.StopReason)
+}
+
+func TestInvokeRouter_NoGuardrailHeader_Regression(t *testing.T) {
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, hits := countingLlamaCompletionsServer(t, "hi there")
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
+
+	respBody, _, err := rt.InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), "", "")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), hits.Load())
+
+	var out llamaInvokeResponse
+	require.NoError(t, json.Unmarshal(respBody, &out))
+	assert.Equal(t, "hi there", out.Generation)
+}
+
+func TestInvokeRouter_UnknownOrForeignGuardrailReturnsResourceNotFound(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, hits := countingLlamaCompletionsServer(t, "hi")
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	_, _, err := rt.InvokeModel(ctx, grCallerAccount, modelID, []byte(`{"prompt":"hello"}`), "does-not-exist", guardrailDraftVersion)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-foreign"))
+	require.NoError(t, err)
+
+	_, _, err = rt.InvokeModel(ctx, grOtherCaller, modelID, []byte(`{"prompt":"hello"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	assert.Equal(t, int32(0), hits.Load(), "an unresolvable guardrail must fail closed before the backend is ever reached")
+}
+
+// llamaBadwordStreamFixture is a canned OpenAI /v1/completions streaming SSE
+// body whose accumulated text trips the "badword" blocklist entry.
+const llamaBadwordStreamFixture = `data: {"choices":[{"text":"this has a ","finish_reason":null}]}
+
+data: {"choices":[{"text":"badword in it","finish_reason":null}]}
+
+data: {"choices":[{"text":"","finish_reason":"stop"}]}
+
+data: {"choices":[],"usage":{"prompt_tokens":6,"completion_tokens":2}}
+
+data: [DONE]
+
+`
+
+// llamaAnonymizeStreamFixture is llamaBadwordStreamFixture's sibling whose
+// accumulated text trips the email PII ANONYMIZE entry instead.
+const llamaAnonymizeStreamFixture = `data: {"choices":[{"text":"contact jane@","finish_reason":null}]}
+
+data: {"choices":[{"text":"example.com for support","finish_reason":null}]}
+
+data: {"choices":[{"text":"","finish_reason":"stop"}]}
+
+data: {"choices":[],"usage":{"prompt_tokens":6,"completion_tokens":2}}
+
+data: [DONE]
+
+`
+
+func TestInvokeStreamRouter_GuardrailInputBlock_SkipsBackend(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-stream-input-block"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(llamaCompletionsStreamFixture))
+	}))
+	defer ts.Close()
+
+	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil, store)
+
+	src, err := rt.InvokeModelWithResponseStream(ctx, grCallerAccount, modelID, []byte(`{"prompt":"this has a badword in it"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.NoError(t, err)
+	chunks := drainInvokeStream(t, src)
+	assert.Equal(t, int32(0), hits.Load(), "the backend stream must never be started on an INPUT block")
+	require.Len(t, chunks, 2)
+
+	var delta llamaInvokeStreamChunk
+	require.NoError(t, json.Unmarshal(chunks[0], &delta))
+	assert.Equal(t, "Your input violates our policy.", delta.Generation)
+
+	var final llamaInvokeStreamFinalChunk
+	require.NoError(t, json.Unmarshal(chunks[1], &final))
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, final.StopReason)
+}
+
+func TestInvokeStreamRouter_GuardrailOutputBlock_Buffered(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-stream-output-block"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(llamaBadwordStreamFixture))
+	}))
+	defer ts.Close()
+
+	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil, store)
+
+	src, err := rt.InvokeModelWithResponseStream(ctx, grCallerAccount, modelID, []byte(`{"prompt":"hello"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.NoError(t, err)
+	chunks := drainInvokeStream(t, src)
+	require.Len(t, chunks, 2, "the raw deltas must collapse into exactly one guarded delta + final chunk")
+
+	var delta llamaInvokeStreamChunk
+	require.NoError(t, json.Unmarshal(chunks[0], &delta))
+	assert.Equal(t, "The model response violates our policy.", delta.Generation)
+
+	var final llamaInvokeStreamFinalChunk
+	require.NoError(t, json.Unmarshal(chunks[1], &final))
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, final.StopReason)
+}
+
+func TestInvokeStreamRouter_GuardrailOutputAnonymize_Buffered(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-stream-output-anonymize"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(llamaAnonymizeStreamFixture))
+	}))
+	defer ts.Close()
+
+	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil, store)
+
+	src, err := rt.InvokeModelWithResponseStream(ctx, grCallerAccount, modelID, []byte(`{"prompt":"hello"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
+	require.NoError(t, err)
+	chunks := drainInvokeStream(t, src)
+	require.Len(t, chunks, 2)
+
+	var delta llamaInvokeStreamChunk
+	require.NoError(t, json.Unmarshal(chunks[0], &delta))
+	assert.Equal(t, "contact {EMAIL} for support", delta.Generation)
+
+	var final llamaInvokeStreamFinalChunk
+	require.NoError(t, json.Unmarshal(chunks[1], &final))
+	// Redaction alone leaves the model's own stop reason intact.
+	assert.Equal(t, "stop", final.StopReason)
+}
+
+func TestInvokeStreamRouter_NoGuardrailHeader_Regression(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(llamaCompletionsStreamFixture))
+	}))
+	defer ts.Close()
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil, nil)
+
+	src, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), "", "")
+	require.NoError(t, err)
+	chunks := drainInvokeStream(t, src)
+	require.Len(t, chunks, 3)
+
+	var delta llamaInvokeStreamChunk
+	require.NoError(t, json.Unmarshal(chunks[0], &delta))
+	assert.Equal(t, "Hello", delta.Generation)
+}
+
+// TestExtractAnthropicPromptTexts_SystemAndUserOnly covers the pieces
+// extractInvokePromptTexts reads for the Anthropic family: the system prompt
+// plus every user message's text blocks, skipping assistant turns.
+func TestExtractAnthropicPromptTexts_SystemAndUserOnly(t *testing.T) {
+	body := []byte(`{"anthropic_version":"bedrock-2023-05-31","max_tokens":100,"system":"be nice","messages":[{"role":"user","content":[{"type":"text","text":"hello there"}]},{"role":"assistant","content":[{"type":"text","text":"ignored"}]}]}`)
+	texts, ok := extractAnthropicPromptTexts(body)
+	require.True(t, ok)
+	assert.Equal(t, []string{"be nice", "hello there"}, texts)
+}
+
+// TestAnthropicCompletionGuardrailHelpers_PreserveUnrelatedFields drives the
+// OUTPUT-side Anthropic helpers directly (no live network double exists for
+// the Anthropic family at Router level, mirroring the rest of this package's
+// InvokeAdapter-level Anthropic coverage): redaction and a wholesale block
+// must both leave id/model/usage untouched.
+func TestAnthropicCompletionGuardrailHelpers_PreserveUnrelatedFields(t *testing.T) {
+	respBody := []byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20240620","content":[{"type":"text","text":"contact jane@example.com for support"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":2}}`)
+
+	texts, ok := extractAnthropicCompletionTexts(respBody)
+	require.True(t, ok)
+	assert.Equal(t, []string{"contact jane@example.com for support"}, texts)
+
+	redacted, err := setAnthropicCompletionTexts(respBody, []string{"contact {EMAIL} for support"})
+	require.NoError(t, err)
+	texts, ok = extractAnthropicCompletionTexts(redacted)
+	require.True(t, ok)
+	assert.Equal(t, []string{"contact {EMAIL} for support"}, texts)
+	assert.Contains(t, string(redacted), `"msg_1"`)
+	assert.Contains(t, string(redacted), `"input_tokens":1`)
+
+	blocked, err := replaceAnthropicCompletion(respBody, "The model response violates our policy.")
+	require.NoError(t, err)
+	texts, ok = extractAnthropicCompletionTexts(blocked)
+	require.True(t, ok)
+	assert.Equal(t, []string{"The model response violates our policy."}, texts)
+	assert.Contains(t, string(blocked), bedrockruntime.StopReasonGuardrailIntervened)
+	assert.Contains(t, string(blocked), `"msg_1"`)
+
+	inputBlocked, err := buildAnthropicBlockedResponse("anthropic.claude-3-5-sonnet-20240620-v1:0", "Your input violates our policy.")
+	require.NoError(t, err)
+	texts, ok = extractAnthropicCompletionTexts(inputBlocked)
+	require.True(t, ok)
+	assert.Equal(t, []string{"Your input violates our policy."}, texts)
+}
+
 func TestGuardrailStreamSource_TraceDisabledOmitsAssessment(t *testing.T) {
 	store := newGuardrailTestStore(t)
 	ctx := context.Background()

--- a/spinifex/gateway/bedrock/guardrail_inference_test.go
+++ b/spinifex/gateway/bedrock/guardrail_inference_test.go
@@ -1,0 +1,398 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingVLLMServer returns an httptest.Server that answers every request
+// with a fixed non-streaming vLLM chat-completions response carrying content,
+// and a counter of how many requests it actually received — the "backend NOT
+// called" assertion for an INPUT-blocked guardrail.
+func countingVLLMServer(t *testing.T, content string) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"choices": [{"message": {"role": "assistant", "content": "` + content + `"}, "finish_reason": "stop"}],
+			"usage": {"prompt_tokens": 1, "completion_tokens": 1}
+		}`))
+	}))
+	t.Cleanup(ts.Close)
+	return ts, &hits
+}
+
+// guardedConverseInput builds a ConverseInput carrying one user message and a
+// GuardrailConfig addressing guardrailID's DRAFT.
+func guardedConverseInput(text string, guardrailID *string, trace bool) *bedrockruntime.ConverseInput {
+	cfg := &bedrockruntime.GuardrailConfiguration{
+		GuardrailIdentifier: guardrailID,
+		GuardrailVersion:    aws.String(guardrailDraftVersion),
+	}
+	if trace {
+		cfg.Trace = aws.String(bedrockruntime.GuardrailTraceEnabled)
+	}
+	return &bedrockruntime.ConverseInput{
+		Messages: []*bedrockruntime.Message{
+			{Role: aws.String(bedrockruntime.ConversationRoleUser), Content: []*bedrockruntime.ContentBlock{{Text: aws.String(text)}}},
+		},
+		GuardrailConfig: cfg,
+	}
+}
+
+func TestRouter_Converse_GuardrailInputBlock_SkipsBackend(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("converse-input-block"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, hits := countingVLLMServer(t, "hi")
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	out, err := rt.Converse(ctx, grCallerAccount, modelID, guardedConverseInput("this has a badword in it", createOut.GuardrailId, false))
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(0), hits.Load(), "the backend must never be called on an INPUT block")
+	require.NotNil(t, out.Output.Message)
+	require.Len(t, out.Output.Message.Content, 1)
+	assert.Equal(t, "Your input violates our policy.", aws.StringValue(out.Output.Message.Content[0].Text))
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, aws.StringValue(out.StopReason))
+	assert.Equal(t, int64(0), aws.Int64Value(out.Usage.InputTokens))
+	assert.Nil(t, out.Trace)
+}
+
+func TestRouter_Converse_GuardrailOutputBlock(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("converse-output-block"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, _ := countingVLLMServer(t, "this has a badword in it")
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	out, err := rt.Converse(ctx, grCallerAccount, modelID, guardedConverseInput("hello", createOut.GuardrailId, false))
+	require.NoError(t, err)
+
+	require.NotNil(t, out.Output.Message)
+	require.Len(t, out.Output.Message.Content, 1)
+	assert.Equal(t, "The model response violates our policy.", aws.StringValue(out.Output.Message.Content[0].Text))
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, aws.StringValue(out.StopReason))
+}
+
+func TestRouter_Converse_GuardrailOutputAnonymize(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("converse-output-anonymize"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, _ := countingVLLMServer(t, "contact jane@example.com for support")
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	out, err := rt.Converse(ctx, grCallerAccount, modelID, guardedConverseInput("hello", createOut.GuardrailId, false))
+	require.NoError(t, err)
+
+	require.NotNil(t, out.Output.Message)
+	require.Len(t, out.Output.Message.Content, 1)
+	assert.Equal(t, "contact {EMAIL} for support", aws.StringValue(out.Output.Message.Content[0].Text))
+	// Redaction alone (no block) leaves the backend's own stop reason intact.
+	assert.Equal(t, bedrockruntime.StopReasonEndTurn, aws.StringValue(out.StopReason))
+}
+
+func TestRouter_Converse_NoGuardrailConfig_Regression(t *testing.T) {
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, hits := countingVLLMServer(t, "hi there")
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
+
+	out, err := rt.Converse(context.Background(), "000000000001", modelID, converseInput())
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), hits.Load())
+	require.NotNil(t, out.Output.Message)
+	assert.Equal(t, "hi there", aws.StringValue(out.Output.Message.Content[0].Text))
+	assert.Nil(t, out.Trace)
+}
+
+func TestRouter_Converse_UnknownOrForeignGuardrailReturnsResourceNotFound(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, hits := countingVLLMServer(t, "hi")
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	_, err := rt.Converse(ctx, grCallerAccount, modelID, guardedConverseInput("hello", aws.String("does-not-exist"), false))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("converse-foreign"))
+	require.NoError(t, err)
+
+	_, err = rt.Converse(ctx, grOtherCaller, modelID, guardedConverseInput("hello", createOut.GuardrailId, false))
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	assert.Equal(t, int32(0), hits.Load(), "an unresolvable guardrail must fail closed before the backend is ever reached")
+}
+
+func TestRouter_Converse_TraceEnabledSurfacesAssessment(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("converse-trace-on"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, _ := countingVLLMServer(t, "contact jane@example.com for support")
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	out, err := rt.Converse(ctx, grCallerAccount, modelID, guardedConverseInput("hello", createOut.GuardrailId, true))
+	require.NoError(t, err)
+
+	require.NotNil(t, out.Trace)
+	require.NotNil(t, out.Trace.Guardrail)
+	assert.NotEmpty(t, out.Trace.Guardrail.InputAssessment)
+	assert.NotEmpty(t, out.Trace.Guardrail.OutputAssessments)
+}
+
+func TestRouter_Converse_TraceDisabledOmitsAssessment(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("converse-trace-off"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	ts, _ := countingVLLMServer(t, "contact jane@example.com for support")
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+
+	out, err := rt.Converse(ctx, grCallerAccount, modelID, guardedConverseInput("hello", createOut.GuardrailId, false))
+	require.NoError(t, err)
+
+	assert.Nil(t, out.Trace)
+}
+
+// guardrailStreamConverseInput builds a ConverseStreamInput carrying one user
+// message and a GuardrailStreamConfiguration addressing guardrailID's DRAFT.
+func guardrailStreamConverseInput(text string, guardrailID *string, trace bool) *bedrockruntime.ConverseStreamInput {
+	cfg := &bedrockruntime.GuardrailStreamConfiguration{
+		GuardrailIdentifier: guardrailID,
+		GuardrailVersion:    aws.String(guardrailDraftVersion),
+	}
+	if trace {
+		cfg.Trace = aws.String(bedrockruntime.GuardrailTraceEnabled)
+	}
+	return &bedrockruntime.ConverseStreamInput{
+		Messages: []*bedrockruntime.Message{
+			{Role: aws.String(bedrockruntime.ConversationRoleUser), Content: []*bedrockruntime.ContentBlock{{Text: aws.String(text)}}},
+		},
+		GuardrailConfig: cfg,
+	}
+}
+
+type decodedDelta struct {
+	Delta struct {
+		Text string `json:"text"`
+	} `json:"delta"`
+}
+
+type decodedMessageStop struct {
+	StopReason string `json:"stopReason"`
+}
+
+func TestConverseStream_GuardrailInputBlock_SkipsBackend(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("stream-input-block"))
+	require.NoError(t, err)
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	var hits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vllmStreamFixture))
+	}))
+	defer ts.Close()
+
+	rec := httptest.NewRecorder()
+	body, err := json.Marshal(guardrailStreamConverseInput("this has a badword in it", createOut.GuardrailId, false))
+	require.NoError(t, err)
+
+	err = ConverseStream(ctx, rec, grCallerAccount, modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, store)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), hits.Load(), "the backend stream must never be started on an INPUT block")
+
+	frames := decodeAllFrames(t, rec.Body.Bytes())
+	require.Len(t, frames, 6)
+	assert.Equal(t, []string{"messageStart", "contentBlockStart", "contentBlockDelta", "contentBlockStop", "messageStop", "metadata"},
+		[]string{frames[0].Type, frames[1].Type, frames[2].Type, frames[3].Type, frames[4].Type, frames[5].Type})
+
+	var delta decodedDelta
+	require.NoError(t, json.Unmarshal(frames[2].Payload, &delta))
+	assert.Equal(t, "Your input violates our policy.", delta.Delta.Text)
+
+	var stop decodedMessageStop
+	require.NoError(t, json.Unmarshal(frames[4].Payload, &stop))
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, stop.StopReason)
+}
+
+func TestConverseStream_UnknownOrForeignGuardrailReturnsResourceNotFoundPreHeader(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+
+	rec := httptest.NewRecorder()
+	body, err := json.Marshal(guardrailStreamConverseInput("hello", aws.String("does-not-exist"), false))
+	require.NoError(t, err)
+
+	err = ConverseStream(ctx, rec, grCallerAccount, modelID, body, nil, nil, nil, grantAll{}, nil, store)
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	// A pre-stream failure must not have written anything.
+	assert.Equal(t, 0, rec.Body.Len())
+}
+
+func TestConverseStream_NoGuardrailConfig_Regression(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(vllmStreamFixture))
+	}))
+	defer ts.Close()
+
+	modelID := "meta.llama3-2-1b-instruct-v1:0"
+	rec := httptest.NewRecorder()
+	body, err := json.Marshal(converseStreamInput())
+	require.NoError(t, err)
+
+	err = ConverseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
+	require.NoError(t, err)
+
+	frames := decodeAllFrames(t, rec.Body.Bytes())
+	require.Len(t, frames, 7)
+	assert.Equal(t, "contentBlockDelta", frames[2].Type)
+	var delta decodedDelta
+	require.NoError(t, json.Unmarshal(frames[2].Payload, &delta))
+	assert.Equal(t, "Hello", delta.Delta.Text)
+}
+
+// guardrailStreamFixtureEvents builds the taxonomy a backend reframer emits
+// for a single-block text completion, for driving guardrailStreamSource
+// directly without a real HTTP SSE fixture.
+func guardrailStreamFixtureEvents(chunks ...string) []ConverseStreamEvent {
+	events := []ConverseStreamEvent{
+		{Kind: converseStreamEventMessageStart, MessageStart: &bedrockruntime.MessageStartEvent{Role: aws.String(bedrockruntime.ConversationRoleAssistant)}},
+		{Kind: converseStreamEventContentBlockStart, ContentBlockStart: &bedrockruntime.ContentBlockStartEvent{ContentBlockIndex: aws.Int64(0), Start: &bedrockruntime.ContentBlockStart{}}},
+	}
+	for _, c := range chunks {
+		events = append(events, ConverseStreamEvent{
+			Kind: converseStreamEventContentBlockDelta,
+			ContentBlockDelta: &bedrockruntime.ContentBlockDeltaEvent{
+				ContentBlockIndex: aws.Int64(0),
+				Delta:             &bedrockruntime.ContentBlockDelta{Text: aws.String(c)},
+			},
+		})
+	}
+	events = append(events,
+		ConverseStreamEvent{Kind: converseStreamEventContentBlockStop, ContentBlockStop: &bedrockruntime.ContentBlockStopEvent{ContentBlockIndex: aws.Int64(0)}},
+		ConverseStreamEvent{Kind: converseStreamEventMessageStop, MessageStop: &bedrockruntime.MessageStopEvent{StopReason: aws.String(bedrockruntime.StopReasonEndTurn)}},
+		ConverseStreamEvent{Kind: converseStreamEventMetadata, Metadata: &bedrockruntime.ConverseStreamMetadataEvent{
+			Usage:   &bedrockruntime.TokenUsage{InputTokens: aws.Int64(1), OutputTokens: aws.Int64(2), TotalTokens: aws.Int64(3)},
+			Metrics: &bedrockruntime.ConverseStreamMetrics{LatencyMs: aws.Int64(1)},
+		}},
+	)
+	return events
+}
+
+func TestGuardrailStreamSource_OutputBlock_BuffersAndReplacesText(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("stream-output-block"))
+	require.NoError(t, err)
+
+	inner := &fakeConverseStreamSource{events: guardrailStreamFixtureEvents("this has a ", "badword in it")}
+	src := newGuardrailStreamSource(inner, store, grCallerAccount, aws.StringValue(createOut.GuardrailId), guardrailDraftVersion, false, nil)
+
+	events := drainConverseStream(t, src)
+	// The two raw deltas collapse into exactly one guarded delta.
+	kinds := make([]converseStreamEventKind, len(events))
+	for i, ev := range events {
+		kinds[i] = ev.Kind
+	}
+	assert.Equal(t, []converseStreamEventKind{
+		converseStreamEventMessageStart,
+		converseStreamEventContentBlockStart,
+		converseStreamEventContentBlockDelta,
+		converseStreamEventContentBlockStop,
+		converseStreamEventMessageStop,
+		converseStreamEventMetadata,
+	}, kinds)
+
+	deltaEvent := events[2]
+	assert.Equal(t, "The model response violates our policy.", aws.StringValue(deltaEvent.ContentBlockDelta.Delta.Text))
+	assert.Equal(t, bedrockruntime.StopReasonGuardrailIntervened, aws.StringValue(events[4].MessageStop.StopReason))
+}
+
+func TestGuardrailStreamSource_OutputAnonymize_RedactsAccumulatedText(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("stream-output-anonymize"))
+	require.NoError(t, err)
+
+	inner := &fakeConverseStreamSource{events: guardrailStreamFixtureEvents("contact jane@", "example.com for support")}
+	src := newGuardrailStreamSource(inner, store, grCallerAccount, aws.StringValue(createOut.GuardrailId), guardrailDraftVersion, false, nil)
+
+	events := drainConverseStream(t, src)
+	require.Len(t, events, 6)
+	assert.Equal(t, "contact {EMAIL} for support", aws.StringValue(events[2].ContentBlockDelta.Delta.Text))
+	// Redaction alone leaves the model's own stop reason intact.
+	assert.Equal(t, bedrockruntime.StopReasonEndTurn, aws.StringValue(events[4].MessageStop.StopReason))
+}
+
+func TestGuardrailStreamSource_TraceEnabledSurfacesAssessment(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("stream-trace-on"))
+	require.NoError(t, err)
+
+	inputAssessments := []*bedrockruntime.GuardrailAssessment{{}}
+	inner := &fakeConverseStreamSource{events: guardrailStreamFixtureEvents("contact jane@example.com for support")}
+	src := newGuardrailStreamSource(inner, store, grCallerAccount, aws.StringValue(createOut.GuardrailId), guardrailDraftVersion, true, inputAssessments)
+
+	events := drainConverseStream(t, src)
+	metadata := events[len(events)-1]
+	require.Equal(t, converseStreamEventMetadata, metadata.Kind)
+	require.NotNil(t, metadata.Metadata.Trace)
+	require.NotNil(t, metadata.Metadata.Trace.Guardrail)
+	assert.NotEmpty(t, metadata.Metadata.Trace.Guardrail.InputAssessment)
+	assert.NotEmpty(t, metadata.Metadata.Trace.Guardrail.OutputAssessments)
+}
+
+func TestGuardrailStreamSource_TraceDisabledOmitsAssessment(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("stream-trace-off"))
+	require.NoError(t, err)
+
+	inner := &fakeConverseStreamSource{events: guardrailStreamFixtureEvents("contact jane@example.com for support")}
+	src := newGuardrailStreamSource(inner, store, grCallerAccount, aws.StringValue(createOut.GuardrailId), guardrailDraftVersion, false, nil)
+
+	events := drainConverseStream(t, src)
+	metadata := events[len(events)-1]
+	require.Equal(t, converseStreamEventMetadata, metadata.Kind)
+	assert.Nil(t, metadata.Metadata.Trace)
+}

--- a/spinifex/gateway/bedrock/guardrail_inference_test.go
+++ b/spinifex/gateway/bedrock/guardrail_inference_test.go
@@ -137,14 +137,14 @@ func TestRouter_Converse_UnknownOrForeignGuardrailReturnsResourceNotFound(t *tes
 
 	_, err := rt.Converse(ctx, grCallerAccount, modelID, guardedConverseInput("hello", aws.String("does-not-exist"), false))
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("converse-foreign"))
 	require.NoError(t, err)
 
 	_, err = rt.Converse(ctx, grOtherCaller, modelID, guardedConverseInput("hello", createOut.GuardrailId, false))
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	assert.Equal(t, int32(0), hits.Load(), "an unresolvable guardrail must fail closed before the backend is ever reached")
 }
@@ -261,7 +261,7 @@ func TestConverseStream_UnknownOrForeignGuardrailReturnsResourceNotFoundPreHeade
 
 	err = ConverseStream(ctx, rec, grCallerAccount, modelID, body, nil, nil, nil, grantAll{}, nil, store)
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 	// A pre-stream failure must not have written anything.
 	assert.Equal(t, 0, rec.Body.Len())
 }
@@ -507,14 +507,14 @@ func TestInvokeRouter_UnknownOrForeignGuardrailReturnsResourceNotFound(t *testin
 
 	_, _, err := rt.InvokeModel(ctx, grCallerAccount, modelID, []byte(`{"prompt":"hello"}`), "does-not-exist", guardrailDraftVersion)
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("invoke-foreign"))
 	require.NoError(t, err)
 
 	_, _, err = rt.InvokeModel(ctx, grOtherCaller, modelID, []byte(`{"prompt":"hello"}`), aws.StringValue(createOut.GuardrailId), guardrailDraftVersion)
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	assert.Equal(t, int32(0), hits.Load(), "an unresolvable guardrail must fail closed before the backend is ever reached")
 }

--- a/spinifex/gateway/bedrock/guardrail_invoke.go
+++ b/spinifex/gateway/bedrock/guardrail_invoke.go
@@ -1,0 +1,480 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+)
+
+// extractLlamaPromptTexts parses a Bedrock-native Llama InvokeModel request
+// body into its single INPUT-checkable text, mirroring extractTokenUsage's
+// reuse of the family's own wire struct.
+func extractLlamaPromptTexts(body []byte) ([]string, bool) {
+	var lr llamaInvokeRequest
+	if json.Unmarshal(body, &lr) != nil {
+		return nil, false
+	}
+	if lr.Prompt == "" {
+		return nil, true
+	}
+	return []string{lr.Prompt}, true
+}
+
+// extractLlamaCompletionTexts parses a Bedrock-native Llama InvokeModel
+// response body into its single OUTPUT-checkable text.
+func extractLlamaCompletionTexts(body []byte) ([]string, bool) {
+	var lr llamaInvokeResponse
+	if json.Unmarshal(body, &lr) != nil {
+		return nil, false
+	}
+	return []string{lr.Generation}, true
+}
+
+// buildLlamaBlockedResponse builds a complete, valid Llama-shaped InvokeModel
+// response body for an INPUT guardrail block: the backend is never called, so
+// token counts are zero and stop_reason reports the intervention.
+func buildLlamaBlockedResponse(message string) ([]byte, error) {
+	return json.Marshal(llamaInvokeResponse{
+		Generation: message,
+		StopReason: bedrockruntime.StopReasonGuardrailIntervened,
+	})
+}
+
+// replaceLlamaCompletion rewrites body's generation wholesale with message
+// and marks stop_reason as guardrail-intervened, for an OUTPUT block.
+func replaceLlamaCompletion(body []byte, message string) ([]byte, error) {
+	var lr llamaInvokeResponse
+	if err := json.Unmarshal(body, &lr); err != nil {
+		return nil, err
+	}
+	lr.Generation = message
+	lr.StopReason = bedrockruntime.StopReasonGuardrailIntervened
+	return json.Marshal(lr)
+}
+
+// setLlamaCompletionText rewrites body's generation with text, preserving
+// every other field (token counts, the backend's own stop_reason) verbatim,
+// for an OUTPUT ANONYMIZE redaction.
+func setLlamaCompletionText(body []byte, text string) ([]byte, error) {
+	var lr llamaInvokeResponse
+	if err := json.Unmarshal(body, &lr); err != nil {
+		return nil, err
+	}
+	lr.Generation = text
+	return json.Marshal(lr)
+}
+
+// extractAnthropicPromptTexts parses a Bedrock-native Anthropic InvokeModel
+// request body -- the wire shape anthropicRequest already models -- into its
+// INPUT-checkable text: the system prompt plus every user message's text
+// blocks, mirroring converseGuardrailTexts.
+func extractAnthropicPromptTexts(body []byte) ([]string, bool) {
+	var req anthropicRequest
+	if json.Unmarshal(body, &req) != nil {
+		return nil, false
+	}
+	var texts []string
+	if req.System != "" {
+		texts = append(texts, req.System)
+	}
+	for _, m := range req.Messages {
+		if m.Role != "user" {
+			continue
+		}
+		for _, c := range m.Content {
+			if c.Type == "text" && c.Text != "" {
+				texts = append(texts, c.Text)
+			}
+		}
+	}
+	return texts, true
+}
+
+// extractAnthropicCompletionTexts parses a Bedrock-native Anthropic
+// InvokeModel response body into its OUTPUT-checkable text: every text
+// content block, in order.
+func extractAnthropicCompletionTexts(body []byte) ([]string, bool) {
+	var resp anthropicResponse
+	if json.Unmarshal(body, &resp) != nil {
+		return nil, false
+	}
+	var texts []string
+	for _, c := range resp.Content {
+		if c.Type == "text" {
+			texts = append(texts, c.Text)
+		}
+	}
+	return texts, true
+}
+
+// buildAnthropicBlockedResponse builds a complete, valid Anthropic-shaped
+// InvokeModel response body for an INPUT guardrail block: the backend is
+// never called, so usage is zero and stop_reason reports the intervention.
+func buildAnthropicBlockedResponse(modelID, message string) ([]byte, error) {
+	return json.Marshal(struct {
+		Type       string                  `json:"type"`
+		Role       string                  `json:"role"`
+		Model      string                  `json:"model"`
+		Content    []anthropicContentBlock `json:"content"`
+		StopReason string                  `json:"stop_reason"`
+		Usage      anthropicUsage          `json:"usage"`
+	}{
+		Type:       "message",
+		Role:       "assistant",
+		Model:      anthropicModelID(modelID),
+		Content:    []anthropicContentBlock{{Type: "text", Text: message}},
+		StopReason: bedrockruntime.StopReasonGuardrailIntervened,
+	})
+}
+
+// replaceAnthropicCompletion rewrites body's content wholesale with a single
+// text block carrying message, and marks stop_reason as guardrail-intervened,
+// preserving every other field (id, model, usage) verbatim -- InvokeModel
+// forwards Anthropic's response bytes as-is, so a guardrail block must not
+// lose fields it doesn't understand.
+func replaceAnthropicCompletion(body []byte, message string) ([]byte, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, err
+	}
+	contentJSON, err := json.Marshal([]anthropicContentBlock{{Type: "text", Text: message}})
+	if err != nil {
+		return nil, err
+	}
+	fields["content"] = contentJSON
+	stopReasonJSON, err := json.Marshal(bedrockruntime.StopReasonGuardrailIntervened)
+	if err != nil {
+		return nil, err
+	}
+	fields["stop_reason"] = stopReasonJSON
+	return json.Marshal(fields)
+}
+
+// setAnthropicCompletionTexts rewrites body's text content blocks in place
+// with texts, in order, preserving every other field (id, model, stop_reason,
+// usage) verbatim, for an OUTPUT ANONYMIZE redaction.
+func setAnthropicCompletionTexts(body []byte, texts []string) ([]byte, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, err
+	}
+	var blocks []anthropicContentBlock
+	if raw, ok := fields["content"]; ok {
+		if err := json.Unmarshal(raw, &blocks); err != nil {
+			return nil, err
+		}
+	}
+	i := 0
+	for bi := range blocks {
+		if blocks[bi].Type != "text" {
+			continue
+		}
+		if i < len(texts) {
+			blocks[bi].Text = texts[i]
+		}
+		i++
+	}
+	contentJSON, err := json.Marshal(blocks)
+	if err != nil {
+		return nil, err
+	}
+	fields["content"] = contentJSON
+	return json.Marshal(fields)
+}
+
+// extractInvokePromptTexts dispatches to the family-specific INPUT-text
+// extractor for backend (an InvocationRecord/catalog Provider tag), mirroring
+// extractTokenUsage's own backend switch. ok is false when body doesn't
+// decode as backend's shape or backend has no guardrail support.
+func extractInvokePromptTexts(backend string, body []byte) (texts []string, ok bool) {
+	switch {
+	case backend == tierSelfHost:
+		return extractLlamaPromptTexts(body)
+	case strings.HasPrefix(backend, providerPrefix):
+		switch strings.TrimPrefix(backend, providerPrefix) {
+		case vendorAnthropic:
+			return extractAnthropicPromptTexts(body)
+		}
+	}
+	return nil, false
+}
+
+// extractInvokeCompletionTexts is extractInvokePromptTexts' OUTPUT sibling.
+func extractInvokeCompletionTexts(backend string, body []byte) (texts []string, ok bool) {
+	switch {
+	case backend == tierSelfHost:
+		return extractLlamaCompletionTexts(body)
+	case strings.HasPrefix(backend, providerPrefix):
+		switch strings.TrimPrefix(backend, providerPrefix) {
+		case vendorAnthropic:
+			return extractAnthropicCompletionTexts(body)
+		}
+	}
+	return nil, false
+}
+
+// invokeGuardrailBlockedResponse builds a complete, valid family-native
+// InvokeModel response body carrying message as the assistant text, for an
+// INPUT guardrail block -- the backend is never called.
+func invokeGuardrailBlockedResponse(backend, modelID, message string) ([]byte, error) {
+	switch {
+	case backend == tierSelfHost:
+		return buildLlamaBlockedResponse(message)
+	case strings.HasPrefix(backend, providerPrefix):
+		switch strings.TrimPrefix(backend, providerPrefix) {
+		case vendorAnthropic:
+			return buildAnthropicBlockedResponse(modelID, message)
+		}
+	}
+	return nil, errors.New(awserrors.ErrorInternalError)
+}
+
+// invokeGuardrailBlockedCompletion rewrites respBody's assistant text
+// wholesale with message, for an OUTPUT guardrail block.
+func invokeGuardrailBlockedCompletion(backend string, respBody []byte, message string) ([]byte, error) {
+	switch {
+	case backend == tierSelfHost:
+		return replaceLlamaCompletion(respBody, message)
+	case strings.HasPrefix(backend, providerPrefix):
+		switch strings.TrimPrefix(backend, providerPrefix) {
+		case vendorAnthropic:
+			return replaceAnthropicCompletion(respBody, message)
+		}
+	}
+	return respBody, nil
+}
+
+// invokeGuardrailRedactedCompletion rewrites respBody's assistant text
+// positionally with texts, for an OUTPUT ANONYMIZE redaction.
+func invokeGuardrailRedactedCompletion(backend string, respBody []byte, texts []string) ([]byte, error) {
+	switch {
+	case backend == tierSelfHost:
+		if len(texts) == 0 {
+			return respBody, nil
+		}
+		return setLlamaCompletionText(respBody, texts[0])
+	case strings.HasPrefix(backend, providerPrefix):
+		switch strings.TrimPrefix(backend, providerPrefix) {
+		case vendorAnthropic:
+			return setAnthropicCompletionTexts(respBody, texts)
+		}
+	}
+	return respBody, nil
+}
+
+// extractInvokeStreamChunkText extracts the assistant-text delta (if any)
+// carried in one raw provider-native invoke-stream chunk, for buffered
+// OUTPUT guardrail accumulation. ok is false when the chunk carries no
+// assistant text (e.g. a control/metadata event), not a decode error.
+func extractInvokeStreamChunkText(backend string, chunk []byte) (text string, ok bool) {
+	switch {
+	case backend == tierSelfHost:
+		var c struct {
+			Generation string `json:"generation"`
+		}
+		if json.Unmarshal(chunk, &c) != nil {
+			return "", false
+		}
+		return c.Generation, c.Generation != ""
+	case strings.HasPrefix(backend, providerPrefix):
+		switch strings.TrimPrefix(backend, providerPrefix) {
+		case vendorAnthropic:
+			var c struct {
+				Type  string `json:"type"`
+				Delta struct {
+					Text string `json:"text"`
+				} `json:"delta"`
+			}
+			if json.Unmarshal(chunk, &c) != nil || c.Type != "content_block_delta" {
+				return "", false
+			}
+			return c.Delta.Text, c.Delta.Text != ""
+		}
+	}
+	return "", false
+}
+
+// llamaGuardedStreamChunks builds the two-chunk (delta + final) Llama
+// invoke-stream sequence carrying message as the whole guarded generation.
+func llamaGuardedStreamChunks(message string, blocked bool) ([][]byte, error) {
+	delta, err := json.Marshal(llamaInvokeStreamChunk{Generation: message})
+	if err != nil {
+		return nil, err
+	}
+	stopReason := "stop"
+	if blocked {
+		stopReason = bedrockruntime.StopReasonGuardrailIntervened
+	}
+	final, err := json.Marshal(llamaInvokeStreamFinalChunk{StopReason: stopReason})
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{delta, final}, nil
+}
+
+// anthropicGuardedStreamChunks builds a minimal valid Anthropic invoke-stream
+// event sequence (content_block_start/delta/stop, message_delta,
+// message_stop) carrying message as the whole guarded assistant text.
+func anthropicGuardedStreamChunks(message string, blocked bool) ([][]byte, error) {
+	contentStart, err := json.Marshal(map[string]any{
+		"type": "content_block_start", "index": 0,
+		"content_block": map[string]string{"type": "text", "text": ""},
+	})
+	if err != nil {
+		return nil, err
+	}
+	delta, err := json.Marshal(map[string]any{
+		"type": "content_block_delta", "index": 0,
+		"delta": map[string]string{"type": "text_delta", "text": message},
+	})
+	if err != nil {
+		return nil, err
+	}
+	contentStop, err := json.Marshal(map[string]any{"type": "content_block_stop", "index": 0})
+	if err != nil {
+		return nil, err
+	}
+	stopReason := bedrockruntime.StopReasonEndTurn
+	if blocked {
+		stopReason = bedrockruntime.StopReasonGuardrailIntervened
+	}
+	msgDelta, err := json.Marshal(map[string]any{
+		"type": "message_delta", "delta": map[string]string{"stop_reason": stopReason},
+	})
+	if err != nil {
+		return nil, err
+	}
+	msgStop, err := json.Marshal(map[string]string{"type": "message_stop"})
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{contentStart, delta, contentStop, msgDelta, msgStop}, nil
+}
+
+// buildGuardedInvokeStreamChunks dispatches to the family-specific guarded
+// invoke-stream chunk builder for backend.
+func buildGuardedInvokeStreamChunks(backend, message string, blocked bool) ([][]byte, error) {
+	switch {
+	case backend == tierSelfHost:
+		return llamaGuardedStreamChunks(message, blocked)
+	case strings.HasPrefix(backend, providerPrefix):
+		switch strings.TrimPrefix(backend, providerPrefix) {
+		case vendorAnthropic:
+			return anthropicGuardedStreamChunks(message, blocked)
+		}
+	}
+	return nil, errors.New(awserrors.ErrorInternalError)
+}
+
+// blockedInvokeStreamSource yields exactly the guarded chunks built for an
+// INPUT guardrail block, then EOF; the backend stream is never opened.
+type blockedInvokeStreamSource struct {
+	chunks [][]byte
+}
+
+var _ invokeStreamSource = (*blockedInvokeStreamSource)(nil)
+
+func (b *blockedInvokeStreamSource) Next(_ context.Context) ([]byte, bool, error) {
+	if len(b.chunks) == 0 {
+		return nil, false, nil
+	}
+	c := b.chunks[0]
+	b.chunks = b.chunks[1:]
+	return c, true, nil
+}
+
+func (b *blockedInvokeStreamSource) Close() error { return nil }
+
+// guardrailInvokeStreamSource wraps an invokeStreamSource for buffered/SYNC
+// OUTPUT enforcement: every raw chunk is withheld and its assistant-text
+// accumulated until the inner stream ends, then assessed once and replaced
+// by a guarded chunk sequence before forwarding -- the invoke-stream
+// counterpart of guardrailStreamSource.
+type guardrailInvokeStreamSource struct {
+	inner   invokeStreamSource
+	backend string
+
+	store     *GuardrailStore
+	accountID string
+	ident     string
+	version   string
+
+	text     strings.Builder
+	buffered [][]byte
+	queue    [][]byte
+	assessed bool
+}
+
+// newGuardrailInvokeStreamSource constructs a guardrailInvokeStreamSource.
+func newGuardrailInvokeStreamSource(inner invokeStreamSource, store *GuardrailStore, accountID, ident, version, backend string) *guardrailInvokeStreamSource {
+	return &guardrailInvokeStreamSource{inner: inner, store: store, accountID: accountID, ident: ident, version: version, backend: backend}
+}
+
+var _ invokeStreamSource = (*guardrailInvokeStreamSource)(nil)
+var _ usageReporter = (*guardrailInvokeStreamSource)(nil)
+
+func (g *guardrailInvokeStreamSource) Close() error {
+	return g.inner.Close()
+}
+
+// usage delegates to the wrapped source when it reports real usage,
+// mirroring guardrailStreamSource.usage.
+func (g *guardrailInvokeStreamSource) usage() (inputTokens, outputTokens int64, estimated bool) {
+	if ur, ok := g.inner.(usageReporter); ok {
+		return ur.usage()
+	}
+	return 0, 0, true
+}
+
+// Next drains and buffers the entire inner stream on first call, assesses
+// the accumulated text once the inner stream ends, then serves the guarded
+// (or, when nothing triggered, the original unmodified) chunk sequence.
+func (g *guardrailInvokeStreamSource) Next(ctx context.Context) ([]byte, bool, error) {
+	if len(g.queue) > 0 {
+		c := g.queue[0]
+		g.queue = g.queue[1:]
+		return c, true, nil
+	}
+	if g.assessed {
+		return nil, false, nil
+	}
+
+	for {
+		chunk, ok, err := g.inner.Next(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		if !ok {
+			break
+		}
+		g.buffered = append(g.buffered, chunk)
+		if text, hasText := extractInvokeStreamChunkText(g.backend, chunk); hasText {
+			g.text.WriteString(text)
+		}
+	}
+	g.assessed = true
+
+	original := g.text.String()
+	blocked, message, redacted, _, err := enforceGuardrail(ctx, g.store, g.accountID, g.ident, g.version,
+		bedrockruntime.GuardrailContentSourceOutput, []string{original})
+	if err != nil {
+		return nil, false, err
+	}
+
+	switch {
+	case blocked:
+		g.queue, err = buildGuardedInvokeStreamChunks(g.backend, message, true)
+	case len(redacted) > 0 && redacted[0] != original:
+		g.queue, err = buildGuardedInvokeStreamChunks(g.backend, redacted[0], false)
+	default:
+		g.queue = g.buffered
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return g.Next(ctx)
+}

--- a/spinifex/gateway/bedrock/guardrail_test.go
+++ b/spinifex/gateway/bedrock/guardrail_test.go
@@ -144,11 +144,11 @@ func TestGetGuardrail_NotFound(t *testing.T) {
 
 	_, err = GetGuardrail(ctx, grOtherCaller, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: out.GuardrailId})
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: aws.String("does-not-exist")})
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 }
 
 // TestCreateGuardrailVersion_SnapshotsImmutably is the plan's core version
@@ -222,7 +222,7 @@ func TestGetGuardrail_VersionField(t *testing.T) {
 		GuardrailVersion:    aws.String("1"),
 	})
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 }
 
 // TestListGuardrails_AccountScoped is the plan's explicit isolation
@@ -318,7 +318,7 @@ func TestUpdateGuardrail_NotFound(t *testing.T) {
 		BlockedOutputsMessaging: aws.String("z"),
 	})
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 }
 
 // TestDeleteGuardrail_VersionDeletesOnlyThatSnapshot covers Delete's
@@ -346,7 +346,7 @@ func TestDeleteGuardrail_VersionDeletesOnlyThatSnapshot(t *testing.T) {
 		GuardrailVersion:    aws.String("1"),
 	})
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	// Version "2" and the DRAFT both survive.
 	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{
@@ -412,7 +412,7 @@ func TestDeleteGuardrail_WholeGuardrailAndAbsentIsNoop(t *testing.T) {
 
 	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 
 	// Deleting the already-absent guardrail again is a no-op success.
 	_, err = DeleteGuardrail(ctx, grCallerAccount, store, &bedrock.DeleteGuardrailInput{GuardrailIdentifier: aws.String("never-created")})
@@ -427,7 +427,7 @@ func TestCreateGuardrailVersion_NotFound(t *testing.T) {
 
 	_, err := CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: aws.String("does-not-exist")})
 	require.Error(t, err)
-	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+	assert.True(t, awserrors.IsErrorCode(err, awserrors.ErrorResourceNotFoundException))
 }
 
 // TestGuardrailID_ResolvesBareOrARN covers the shape every guardrail op's

--- a/spinifex/gateway/bedrock/guardrail_test.go
+++ b/spinifex/gateway/bedrock/guardrail_test.go
@@ -1,0 +1,453 @@
+package gateway_bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/bedrock"
+	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	grCallerAccount = "000000000001"
+	grOtherCaller   = "000000000002"
+)
+
+func newGuardrailTestStore(t *testing.T) *GuardrailStore {
+	t.Helper()
+	_, _, js := testutil.StartTestJetStream(t)
+	return NewGuardrailStore(js, 1, ptTestRegion)
+}
+
+// createGuardrailInput builds a minimal valid CreateGuardrailInput carrying
+// one policy of each of the five kinds, so tests can prove the full config
+// round-trips through Create/Get untouched.
+func createGuardrailInput(name string) *bedrock.CreateGuardrailInput {
+	return &bedrock.CreateGuardrailInput{
+		Name:                    aws.String(name),
+		Description:             aws.String("blocks bad words and redacts email"),
+		BlockedInputMessaging:   aws.String("Your input violates our policy."),
+		BlockedOutputsMessaging: aws.String("The model response violates our policy."),
+		WordPolicyConfig: &bedrock.GuardrailWordPolicyConfig{
+			WordsConfig: []*bedrock.GuardrailWordConfig{
+				{Text: aws.String("badword")},
+			},
+			ManagedWordListsConfig: []*bedrock.GuardrailManagedWordsConfig{
+				{Type: aws.String(bedrock.GuardrailManagedWordsTypeProfanity)},
+			},
+		},
+		SensitiveInformationPolicyConfig: &bedrock.GuardrailSensitiveInformationPolicyConfig{
+			PiiEntitiesConfig: []*bedrock.GuardrailPiiEntityConfig{
+				{Type: aws.String(bedrock.GuardrailPiiEntityTypeEmail), Action: aws.String(bedrock.GuardrailSensitiveInformationActionAnonymize)},
+			},
+			RegexesConfig: []*bedrock.GuardrailRegexConfig{
+				{Name: aws.String("account-id"), Pattern: aws.String(`\d{12}`), Action: aws.String(bedrock.GuardrailSensitiveInformationActionBlock)},
+			},
+		},
+		ContentPolicyConfig: &bedrock.GuardrailContentPolicyConfig{
+			FiltersConfig: []*bedrock.GuardrailContentFilterConfig{
+				{Type: aws.String(bedrock.GuardrailContentFilterTypeHate), InputStrength: aws.String(bedrock.GuardrailFilterStrengthHigh), OutputStrength: aws.String(bedrock.GuardrailFilterStrengthHigh)},
+			},
+		},
+		TopicPolicyConfig: &bedrock.GuardrailTopicPolicyConfig{
+			TopicsConfig: []*bedrock.GuardrailTopicConfig{
+				{Name: aws.String("competitors"), Definition: aws.String("mentions of competitor products"), Type: aws.String(bedrock.GuardrailTopicTypeDeny)},
+			},
+		},
+		ContextualGroundingPolicyConfig: &bedrock.GuardrailContextualGroundingPolicyConfig{
+			FiltersConfig: []*bedrock.GuardrailContextualGroundingFilterConfig{
+				{Type: aws.String(bedrock.GuardrailContextualGroundingFilterTypeGrounding), Threshold: aws.Float64(0.5)},
+			},
+		},
+	}
+}
+
+// TestCreateGuardrail_MintsARNAndDraft covers Create's happy path: a
+// well-formed, self-parseable ARN, Status READY, and every policy config
+// persisted verbatim (round-tripped back through Get).
+func TestCreateGuardrail_MintsARNAndDraft(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	out, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+	require.NotNil(t, out.GuardrailArn)
+	require.NotNil(t, out.GuardrailId)
+	assert.Equal(t, guardrailDraftVersion, aws.StringValue(out.Version))
+
+	parsed, err := ParseGuardrailARN(aws.StringValue(out.GuardrailArn), ptTestRegion, grCallerAccount)
+	require.NoError(t, err, "Create must return a well-formed, self-parseable ARN")
+	assert.Equal(t, aws.StringValue(out.GuardrailId), parsed.ID)
+
+	getOut, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: out.GuardrailId})
+	require.NoError(t, err)
+	assert.Equal(t, bedrock.GuardrailStatusReady, aws.StringValue(getOut.Status))
+	assert.Equal(t, "my-guardrail", aws.StringValue(getOut.Name))
+	assert.Equal(t, guardrailDraftVersion, aws.StringValue(getOut.Version))
+
+	require.NotNil(t, getOut.WordPolicy)
+	require.Len(t, getOut.WordPolicy.Words, 1)
+	assert.Equal(t, "badword", aws.StringValue(getOut.WordPolicy.Words[0].Text))
+	require.Len(t, getOut.WordPolicy.ManagedWordLists, 1)
+
+	require.NotNil(t, getOut.SensitiveInformationPolicy)
+	require.Len(t, getOut.SensitiveInformationPolicy.PiiEntities, 1)
+	assert.Equal(t, bedrock.GuardrailPiiEntityTypeEmail, aws.StringValue(getOut.SensitiveInformationPolicy.PiiEntities[0].Type))
+	require.Len(t, getOut.SensitiveInformationPolicy.Regexes, 1)
+	assert.Equal(t, `\d{12}`, aws.StringValue(getOut.SensitiveInformationPolicy.Regexes[0].Pattern))
+
+	require.NotNil(t, getOut.ContentPolicy)
+	require.Len(t, getOut.ContentPolicy.Filters, 1)
+	assert.Equal(t, bedrock.GuardrailContentFilterTypeHate, aws.StringValue(getOut.ContentPolicy.Filters[0].Type))
+
+	require.NotNil(t, getOut.TopicPolicy)
+	require.Len(t, getOut.TopicPolicy.Topics, 1)
+	assert.Equal(t, "competitors", aws.StringValue(getOut.TopicPolicy.Topics[0].Name))
+
+	require.NotNil(t, getOut.ContextualGroundingPolicy)
+	require.Len(t, getOut.ContextualGroundingPolicy.Filters, 1)
+	assert.InDelta(t, 0.5, aws.Float64Value(getOut.ContextualGroundingPolicy.Filters[0].Threshold), 0.0001)
+}
+
+// TestCreateGuardrail_RejectsMissingRequiredFields covers the required-field
+// validation AWS's own CreateGuardrailInput.Validate() enforces.
+func TestCreateGuardrail_RejectsMissingRequiredFields(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	cases := []*bedrock.CreateGuardrailInput{
+		nil,
+		{BlockedInputMessaging: aws.String("x"), BlockedOutputsMessaging: aws.String("y")},
+		{Name: aws.String("x"), BlockedOutputsMessaging: aws.String("y")},
+		{Name: aws.String("x"), BlockedInputMessaging: aws.String("y")},
+	}
+	for _, input := range cases {
+		_, err := CreateGuardrail(ctx, grCallerAccount, store, input)
+		require.Error(t, err)
+		assert.Equal(t, awserrors.ErrorValidationException, awserrors.ValidErrorCodeFromError(err))
+	}
+}
+
+// TestGetGuardrail_NotFound covers both a bare id that was never created and
+// a foreign account presenting its own accountID: both must read as
+// not-found, never leaking whether the id exists elsewhere.
+func TestGetGuardrail_NotFound(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	out, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+
+	_, err = GetGuardrail(ctx, grOtherCaller, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: out.GuardrailId})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: aws.String("does-not-exist")})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestCreateGuardrailVersion_SnapshotsImmutably is the plan's core version
+// invariant: a numbered version freezes the DRAFT at creation time, and a
+// later DRAFT mutation never reaches an already-created snapshot.
+func TestCreateGuardrailVersion_SnapshotsImmutably(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("v1-name"))
+	require.NoError(t, err)
+
+	verOut, err := CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+	assert.Equal(t, "1", aws.StringValue(verOut.Version))
+
+	// Mutate the DRAFT after the snapshot was taken.
+	_, err = UpdateGuardrail(ctx, grCallerAccount, store, &bedrock.UpdateGuardrailInput{
+		GuardrailIdentifier:     createOut.GuardrailId,
+		Name:                    aws.String("v2-name"),
+		BlockedInputMessaging:   aws.String("updated input message"),
+		BlockedOutputsMessaging: aws.String("updated output message"),
+	})
+	require.NoError(t, err)
+
+	// DRAFT reflects the mutation.
+	draftOut, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+	assert.Equal(t, "v2-name", aws.StringValue(draftOut.Name))
+
+	// The numbered snapshot still reads the original name, untouched by the
+	// later DRAFT mutation.
+	snapOut, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String("1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "v1-name", aws.StringValue(snapOut.Name))
+	assert.Equal(t, "1", aws.StringValue(snapOut.Version))
+	assert.Equal(t, bedrock.GuardrailStatusReady, aws.StringValue(snapOut.Status))
+
+	// A second version bumps the counter monotonically.
+	verOut2, err := CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+	assert.Equal(t, "2", aws.StringValue(verOut2.Version))
+}
+
+// TestGetGuardrail_VersionField covers Get's version handling: empty and
+// "DRAFT" both mean the mutable working copy; a numbered version that was
+// never created is not-found.
+func TestGetGuardrail_VersionField(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+
+	outEmpty, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+	assert.Equal(t, guardrailDraftVersion, aws.StringValue(outEmpty.Version))
+
+	outDraft, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String(guardrailDraftVersion),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, guardrailDraftVersion, aws.StringValue(outDraft.Version))
+
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String("1"),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestListGuardrails_AccountScoped is the plan's explicit isolation
+// requirement: account B never sees account A's guardrail.
+func TestListGuardrails_AccountScoped(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	_, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("acct-a-guardrail"))
+	require.NoError(t, err)
+
+	listA, err := ListGuardrails(ctx, grCallerAccount, store, nil)
+	require.NoError(t, err)
+	require.Len(t, listA.Guardrails, 1)
+	assert.Equal(t, "acct-a-guardrail", aws.StringValue(listA.Guardrails[0].Name))
+
+	listB, err := ListGuardrails(ctx, grOtherCaller, store, nil)
+	require.NoError(t, err)
+	assert.Empty(t, listB.Guardrails, "account B must not see account A's guardrail")
+}
+
+// TestListGuardrails_SortedDeterministically covers List's ordering
+// guarantee: repeated calls return guardrails in the same (creation-time,
+// then id) order.
+func TestListGuardrails_SortedDeterministically(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	_, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("first"))
+	require.NoError(t, err)
+	_, err = CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("second"))
+	require.NoError(t, err)
+
+	list1, err := ListGuardrails(ctx, grCallerAccount, store, nil)
+	require.NoError(t, err)
+	list2, err := ListGuardrails(ctx, grCallerAccount, store, nil)
+	require.NoError(t, err)
+	require.Len(t, list1.Guardrails, 2)
+	require.Len(t, list2.Guardrails, 2)
+	assert.Equal(t, aws.StringValue(list1.Guardrails[0].Id), aws.StringValue(list2.Guardrails[0].Id))
+	assert.Equal(t, aws.StringValue(list1.Guardrails[1].Id), aws.StringValue(list2.Guardrails[1].Id))
+}
+
+// TestUpdateGuardrail_MutatesDraftOnly covers Update's scope: it changes the
+// DRAFT's fields (including swapping a policy config wholesale) and never
+// touches the Versions map.
+func TestUpdateGuardrail_MutatesDraftOnly(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("original"))
+	require.NoError(t, err)
+	_, err = CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+
+	updateInput := createGuardrailInput("updated")
+	_, err = UpdateGuardrail(ctx, grCallerAccount, store, &bedrock.UpdateGuardrailInput{
+		GuardrailIdentifier:              createOut.GuardrailId,
+		Name:                             updateInput.Name,
+		BlockedInputMessaging:            updateInput.BlockedInputMessaging,
+		BlockedOutputsMessaging:          updateInput.BlockedOutputsMessaging,
+		WordPolicyConfig:                 &bedrock.GuardrailWordPolicyConfig{WordsConfig: []*bedrock.GuardrailWordConfig{{Text: aws.String("newword")}}},
+		SensitiveInformationPolicyConfig: updateInput.SensitiveInformationPolicyConfig,
+	})
+	require.NoError(t, err)
+
+	getOut, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", aws.StringValue(getOut.Name))
+	require.Len(t, getOut.WordPolicy.Words, 1)
+	assert.Equal(t, "newword", aws.StringValue(getOut.WordPolicy.Words[0].Text))
+
+	// The already-created version "1" still reads the pre-update DRAFT.
+	snapOut, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String("1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "original", aws.StringValue(snapOut.Name))
+}
+
+// TestUpdateGuardrail_NotFound guards that Update on a never-created (or
+// foreign-account) guardrail reports not-found rather than silently creating
+// one.
+func TestUpdateGuardrail_NotFound(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	_, err := UpdateGuardrail(ctx, grCallerAccount, store, &bedrock.UpdateGuardrailInput{
+		GuardrailIdentifier:     aws.String("does-not-exist"),
+		Name:                    aws.String("x"),
+		BlockedInputMessaging:   aws.String("y"),
+		BlockedOutputsMessaging: aws.String("z"),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestDeleteGuardrail_VersionDeletesOnlyThatSnapshot covers Delete's
+// version-aware half: deleting version "1" removes only that snapshot, and
+// the DRAFT plus any other version survive.
+func TestDeleteGuardrail_VersionDeletesOnlyThatSnapshot(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+	_, err = CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+	_, err = CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+
+	_, err = DeleteGuardrail(ctx, grCallerAccount, store, &bedrock.DeleteGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String("1"),
+	})
+	require.NoError(t, err)
+
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String("1"),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	// Version "2" and the DRAFT both survive.
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String("2"),
+	})
+	require.NoError(t, err)
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+}
+
+// TestDeleteGuardrail_AbsentVersionIsNoop covers deleting a numbered version
+// that was never created: idempotent-friendly, not an error.
+func TestDeleteGuardrail_AbsentVersionIsNoop(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+
+	_, err = DeleteGuardrail(ctx, grCallerAccount, store, &bedrock.DeleteGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String("99"),
+	})
+	require.NoError(t, err)
+
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err, "the DRAFT must survive deleting a version that never existed")
+}
+
+// TestDeleteGuardrail_RejectsDeletingDraftByVersion pins the invariant that
+// "DRAFT" is not a deletable snapshot: it must be deleted by omitting
+// GuardrailVersion entirely (which deletes the whole guardrail).
+func TestDeleteGuardrail_RejectsDeletingDraftByVersion(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+
+	_, err = DeleteGuardrail(ctx, grCallerAccount, store, &bedrock.DeleteGuardrailInput{
+		GuardrailIdentifier: createOut.GuardrailId,
+		GuardrailVersion:    aws.String(guardrailDraftVersion),
+	})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorValidationException, awserrors.ValidErrorCodeFromError(err))
+}
+
+// TestDeleteGuardrail_WholeGuardrailAndAbsentIsNoop covers Delete's
+// whole-guardrail half (no GuardrailVersion) and its idempotence on an
+// already-absent guardrail.
+func TestDeleteGuardrail_WholeGuardrailAndAbsentIsNoop(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+	_, err = CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+
+	_, err = DeleteGuardrail(ctx, grCallerAccount, store, &bedrock.DeleteGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+
+	// Deleting the already-absent guardrail again is a no-op success.
+	_, err = DeleteGuardrail(ctx, grCallerAccount, store, &bedrock.DeleteGuardrailInput{GuardrailIdentifier: aws.String("never-created")})
+	require.NoError(t, err)
+}
+
+// TestCreateGuardrailVersion_NotFound guards that versioning a never-created
+// (or foreign-account) guardrail reports not-found.
+func TestCreateGuardrailVersion_NotFound(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	_, err := CreateGuardrailVersion(ctx, grCallerAccount, store, &bedrock.CreateGuardrailVersionInput{GuardrailIdentifier: aws.String("does-not-exist")})
+	require.Error(t, err)
+	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
+}
+
+// TestGuardrailID_ResolvesBareOrARN covers the shape every guardrail op's
+// GuardrailIdentifier field allows: a bare id or a full ARN, resolved through
+// Get to prove both reach the same record.
+func TestGuardrailID_ResolvesBareOrARN(t *testing.T) {
+	store := newGuardrailTestStore(t)
+	ctx := context.Background()
+
+	createOut, err := CreateGuardrail(ctx, grCallerAccount, store, createGuardrailInput("my-guardrail"))
+	require.NoError(t, err)
+
+	byID, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailId})
+	require.NoError(t, err)
+	byARN, err := GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: createOut.GuardrailArn})
+	require.NoError(t, err)
+	assert.Equal(t, aws.StringValue(byID.GuardrailId), aws.StringValue(byARN.GuardrailId))
+
+	// A foreign-account ARN never resolves under the caller's own account.
+	foreignARN := FormatGuardrailARN(ptTestRegion, grOtherCaller, aws.StringValue(createOut.GuardrailId))
+	_, err = GetGuardrail(ctx, grCallerAccount, store, &bedrock.GetGuardrailInput{GuardrailIdentifier: aws.String(foreignARN)})
+	require.Error(t, err)
+}

--- a/spinifex/gateway/bedrock/invoke.go
+++ b/spinifex/gateway/bedrock/invoke.go
@@ -3,9 +3,11 @@ package gateway_bedrock
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/bedrockruntime"
 	"github.com/google/uuid"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 )
@@ -30,13 +32,17 @@ type InvokeRouter struct {
 	// means InvokeModel rejects any PT ARN as ResourceNotFoundException
 	// rather than a bare modelId's usual denial.
 	provisioned *ProvisionedStore
+	// guardrails resolves an InvokeModel request's guardrail header. Nil
+	// fails closed on any guardrail identifier (ResourceNotFoundException)
+	// rather than proceeding unguarded; a request with none is unaffected.
+	guardrails *GuardrailStore
 }
 
 // NewInvokeRouter constructs an InvokeRouter. A nil resolver, endpointResolver,
 // or recorder falls back to a no-op implementation, and a nil access falls back
 // to denying every model, so an InvokeRouter is always safe to use even before
 // the real stores are wired in. A nil provisioned disables PT ARN acceptance.
-func NewInvokeRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) *InvokeRouter {
+func NewInvokeRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore, guardrails *GuardrailStore) *InvokeRouter {
 	if resolver == nil {
 		resolver = NoopCredentialResolver
 	}
@@ -49,15 +55,17 @@ func NewInvokeRouter(resolver CredentialResolver, endpointResolver EndpointResol
 	if access == nil {
 		access = DenyAllAccessResolver
 	}
-	return &InvokeRouter{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access, provisioned: provisioned}
+	return &InvokeRouter{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access, provisioned: provisioned, guardrails: guardrails}
 }
 
 // InvokeModel routes modelID to its family adapter via the catalog. Unknown
 // modelIds and unresolvable vendors return ResourceNotFoundException; an
 // ungranted model, or a vendor with no resolvable credential, returns
 // AccessDeniedException. Every exit records an InvocationRecord via the
-// deferred closure.
-func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID string, body []byte) (respBody []byte, contentType string, err error) {
+// deferred closure. guardrailIdent/guardrailVersion come from the request's
+// X-Amzn-Bedrock-Guardrail* headers; an empty guardrailIdent leaves behaviour
+// byte-identical to a request with no guardrail at all.
+func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID string, body []byte, guardrailIdent, guardrailVersion string) (respBody []byte, contentType string, err error) {
 	requestID := uuid.NewString()
 	start := time.Now()
 	var backend string
@@ -130,16 +138,71 @@ func (rt *InvokeRouter) InvokeModel(ctx context.Context, accountID, modelID stri
 		return nil, "", err
 	}
 
+	// INPUT guardrail check happens after the adapter is resolved (matching
+	// Router.Converse), before the backend is ever called. Text extraction is
+	// per-family, since the body is opaque/family-native at this layer.
+	if guardrailIdent != "" {
+		var texts []string
+		var extractOK bool
+		texts, extractOK = extractInvokePromptTexts(backend, body)
+		if !extractOK {
+			err = errors.New(awserrors.ErrorValidationException)
+			return nil, "", err
+		}
+		var blocked bool
+		var message string
+		blocked, message, _, _, err = enforceGuardrail(ctx, rt.guardrails, accountID, guardrailIdent, guardrailVersion,
+			bedrockruntime.GuardrailContentSourceInput, texts)
+		if err != nil {
+			return nil, "", err
+		}
+		if blocked {
+			respBody, err = invokeGuardrailBlockedResponse(backend, modelID, message)
+			if err != nil {
+				return nil, "", err
+			}
+			return respBody, "application/json", nil
+		}
+	}
+
 	respBody, contentType, err = a.InvokeModel(ctx, modelID, body)
-	return respBody, contentType, err
+	if err != nil || guardrailIdent == "" {
+		return respBody, contentType, err
+	}
+
+	texts, extractOK := extractInvokeCompletionTexts(backend, respBody)
+	if !extractOK {
+		slog.Error("invoke: failed to extract completion text for guardrail OUTPUT check, forwarding unguarded", "model", modelID, "backend", backend)
+		return respBody, contentType, err
+	}
+	var blockedOut bool
+	var messageOut string
+	var redacted []string
+	var gerr error
+	blockedOut, messageOut, redacted, _, gerr = enforceGuardrail(ctx, rt.guardrails, accountID, guardrailIdent, guardrailVersion,
+		bedrockruntime.GuardrailContentSourceOutput, texts)
+	if gerr != nil {
+		err = gerr
+		return nil, "", err
+	}
+	if blockedOut {
+		respBody, err = invokeGuardrailBlockedCompletion(backend, respBody, messageOut)
+	} else {
+		respBody, err = invokeGuardrailRedactedCompletion(backend, respBody, redacted)
+	}
+	if err != nil {
+		return nil, "", err
+	}
+	return respBody, contentType, nil
 }
 
 // InvokeModel is the bedrock-runtime InvokeModel entry point used by the
 // gateway route table. resolver, endpointResolver, recorder, access and
 // provisioned may be nil; NewInvokeRouter supplies no-op (and, for access,
-// deny-all; for provisioned, PT-ARN-rejecting) fallbacks.
-func InvokeModel(ctx context.Context, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) ([]byte, string, error) {
-	return NewInvokeRouter(resolver, endpointResolver, recorder, access, provisioned).InvokeModel(ctx, accountID, modelID, body)
+// deny-all; for provisioned, PT-ARN-rejecting) fallbacks. guardrailIdent/
+// guardrailVersion come from the request's X-Amzn-Bedrock-Guardrail* headers.
+func InvokeModel(ctx context.Context, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore, guardrailIdent, guardrailVersion string, guardrails *GuardrailStore) ([]byte, string, error) {
+	return NewInvokeRouter(resolver, endpointResolver, recorder, access, provisioned, guardrails).InvokeModel(ctx, accountID, modelID, body, guardrailIdent, guardrailVersion)
 }
 
 // InvokeStreamAdapter is the optional streaming capability an InvokeAdapter
@@ -161,6 +224,9 @@ type InvokeStreamRouter struct {
 	// means InvokeModelWithResponseStream rejects any PT ARN as
 	// ResourceNotFoundException, mirroring InvokeRouter.
 	provisioned *ProvisionedStore
+	// guardrails resolves an InvokeModelWithResponseStream request's
+	// guardrail header, mirroring InvokeRouter.guardrails.
+	guardrails *GuardrailStore
 }
 
 // NewInvokeStreamRouter constructs an InvokeStreamRouter. A nil resolver or
@@ -168,7 +234,7 @@ type InvokeStreamRouter struct {
 // nil access falls back to denying every model, so an InvokeStreamRouter is
 // always safe to use even before the real stores are wired in. A nil
 // provisioned disables PT ARN acceptance.
-func NewInvokeStreamRouter(resolver CredentialResolver, endpointResolver EndpointResolver, access AccessResolver, provisioned *ProvisionedStore) *InvokeStreamRouter {
+func NewInvokeStreamRouter(resolver CredentialResolver, endpointResolver EndpointResolver, access AccessResolver, provisioned *ProvisionedStore, guardrails *GuardrailStore) *InvokeStreamRouter {
 	if resolver == nil {
 		resolver = NoopCredentialResolver
 	}
@@ -178,14 +244,19 @@ func NewInvokeStreamRouter(resolver CredentialResolver, endpointResolver Endpoin
 	if access == nil {
 		access = DenyAllAccessResolver
 	}
-	return &InvokeStreamRouter{resolver: resolver, endpointResolver: endpointResolver, access: access, provisioned: provisioned}
+	return &InvokeStreamRouter{resolver: resolver, endpointResolver: endpointResolver, access: access, provisioned: provisioned, guardrails: guardrails}
 }
 
 // InvokeModelWithResponseStream routes modelID to its family adapter via the
 // catalog, exactly like InvokeRouter.InvokeModel — including the same
 // translate-before-resolve treatment of a PT ARN via rt.provisioned — then
 // requires the resolved adapter to also implement InvokeStreamAdapter.
-func (rt *InvokeStreamRouter) InvokeModelWithResponseStream(ctx context.Context, accountID, modelID string, body []byte) (invokeStreamSource, error) {
+// guardrailIdent/guardrailVersion come from the request's
+// X-Amzn-Bedrock-Guardrail* headers; an empty guardrailIdent leaves behaviour
+// byte-identical to a request with no guardrail at all. An INPUT block never
+// opens the backend stream; OUTPUT enforcement wraps the resolved source for
+// buffered/SYNC assessment at end-of-stream.
+func (rt *InvokeStreamRouter) InvokeModelWithResponseStream(ctx context.Context, accountID, modelID string, body []byte, guardrailIdent, guardrailVersion string) (invokeStreamSource, error) {
 	// Translate before resolve, exactly like InvokeRouter.InvokeModel.
 	ptAccountID, modelID, err := resolveInferenceTarget(ctx, accountID, modelID, rt.provisioned)
 	if err != nil {
@@ -227,5 +298,32 @@ func (rt *InvokeStreamRouter) InvokeModelWithResponseStream(ctx context.Context,
 	if !ok {
 		return nil, errors.New(awserrors.ErrorValidationException)
 	}
-	return sa.InvokeModelWithResponseStream(ctx, modelID, body)
+
+	if guardrailIdent != "" {
+		texts, extractOK := extractInvokePromptTexts(entry.Provider, body)
+		if !extractOK {
+			return nil, errors.New(awserrors.ErrorValidationException)
+		}
+		blocked, message, _, _, gerr := enforceGuardrail(ctx, rt.guardrails, accountID, guardrailIdent, guardrailVersion,
+			bedrockruntime.GuardrailContentSourceInput, texts)
+		if gerr != nil {
+			return nil, gerr
+		}
+		if blocked {
+			chunks, berr := buildGuardedInvokeStreamChunks(entry.Provider, message, true)
+			if berr != nil {
+				return nil, berr
+			}
+			return &blockedInvokeStreamSource{chunks: chunks}, nil
+		}
+	}
+
+	src, err := sa.InvokeModelWithResponseStream(ctx, modelID, body)
+	if err != nil {
+		return nil, err
+	}
+	if guardrailIdent != "" {
+		src = newGuardrailInvokeStreamSource(src, rt.guardrails, accountID, guardrailIdent, guardrailVersion, entry.Provider)
+	}
+	return src, nil
 }

--- a/spinifex/gateway/bedrock/invoke_stream.go
+++ b/spinifex/gateway/bedrock/invoke_stream.go
@@ -31,8 +31,9 @@ type invokeStreamSource interface {
 // resolver, endpointResolver, recorder and access may be nil;
 // NewInvokeStreamRouter and the internal NoopRecorder fallback keep this call
 // safe either way. provisioned may be nil, disabling PT ARN acceptance (any
-// PT ARN then reads as an unknown modelId).
-func InvokeModelWithResponseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, requestContentType string, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) error {
+// PT ARN then reads as an unknown modelId). guardrailIdent/guardrailVersion
+// come from the request's X-Amzn-Bedrock-Guardrail* headers.
+func InvokeModelWithResponseStream(ctx context.Context, w http.ResponseWriter, accountID, modelID string, body []byte, resolver CredentialResolver, endpointResolver EndpointResolver, requestContentType string, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore, guardrailIdent, guardrailVersion string, guardrails *GuardrailStore) error {
 	if recorder == nil {
 		recorder = NoopRecorder
 	}
@@ -45,7 +46,7 @@ func InvokeModelWithResponseStream(ctx context.Context, w http.ResponseWriter, a
 	_, recordModelID, _ := resolveInferenceTarget(ctx, accountID, modelID, provisioned)
 	entry, _ := lookupCatalogEntry(recordModelID) // InvokeStreamRouter below re-validates; only its Provider tag is needed here.
 
-	src, err := NewInvokeStreamRouter(resolver, endpointResolver, access, provisioned).InvokeModelWithResponseStream(ctx, accountID, modelID, body)
+	src, err := NewInvokeStreamRouter(resolver, endpointResolver, access, provisioned, guardrails).InvokeModelWithResponseStream(ctx, accountID, modelID, body, guardrailIdent, guardrailVersion)
 	if err != nil {
 		return err
 	}

--- a/spinifex/gateway/bedrock/invoke_stream_test.go
+++ b/spinifex/gateway/bedrock/invoke_stream_test.go
@@ -119,7 +119,7 @@ func TestPumpInvokeStream_RecordsInvocationOnUpstreamFault(t *testing.T) {
 
 func TestInvokeModelWithResponseStream_UnknownModelReturnsResourceNotFoundPreHeader(t *testing.T) {
 	rec := httptest.NewRecorder()
-	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, "application/json", nil, grantAll{}, nil)
+	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, "application/json", nil, grantAll{}, nil, "", "", nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 	assert.Equal(t, 0, rec.Body.Len())
@@ -137,7 +137,7 @@ func TestInvokeModelWithResponseStream_SelfHostHappyPath_WritesChunkFrames(t *te
 	rec := httptest.NewRecorder()
 	body := []byte(`{"prompt":"hello","max_gen_len":128}`)
 
-	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{}, nil)
+	err := InvokeModelWithResponseStream(context.Background(), rec, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{}, nil, "", "", nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -162,7 +162,7 @@ func TestInvokeModelWithResponseStream_NonFlusherWriter_ReturnsPreHeaderError(t 
 	w := &nonFlusherWriter{}
 	body := []byte(`{"prompt":"hello"}`)
 
-	err := InvokeModelWithResponseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{}, nil)
+	err := InvokeModelWithResponseStream(context.Background(), w, "000000000001", modelID, body, nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), "application/json", nil, grantAll{}, nil, "", "", nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorInternalError, err.Error())
 	assert.False(t, w.wroteHeader)

--- a/spinifex/gateway/bedrock/invoke_test.go
+++ b/spinifex/gateway/bedrock/invoke_test.go
@@ -24,9 +24,9 @@ func TestInvokeRouter_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+	rt := NewInvokeRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
 
-	respBody, contentType, err := rt.InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`))
+	respBody, contentType, err := rt.InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "application/json", contentType)
 
@@ -36,22 +36,22 @@ func TestInvokeRouter_SelfHostSuccess(t *testing.T) {
 }
 
 func TestInvokeRouter_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewInvokeRouter(nil, nil, nil, grantAll{}, nil)
-	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`))
+	rt := NewInvokeRouter(nil, nil, nil, grantAll{}, nil, nil)
+	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestInvokeRouter_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewInvokeRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil)
-	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", []byte(`{}`))
+	rt := NewInvokeRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil, nil)
+	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", []byte(`{}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
 }
 
 func TestInvokeRouter_SelfHostNoEndpointReturnsModelNotReady(t *testing.T) {
-	rt := NewInvokeRouter(nil, nil, nil, grantAll{}, nil)
-	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
+	rt := NewInvokeRouter(nil, nil, nil, grantAll{}, nil, nil)
+	_, _, err := rt.InvokeModel(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
 }
@@ -68,7 +68,7 @@ func TestInvokeModel_PackageEntryPoint_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	respBody, contentType, err := InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+	respBody, contentType, err := InvokeModel(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, "", "", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "application/json", contentType)
 
@@ -78,7 +78,7 @@ func TestInvokeModel_PackageEntryPoint_SelfHostSuccess(t *testing.T) {
 }
 
 func TestInvokeModel_PackageEntryPoint_UnknownModel(t *testing.T) {
-	_, _, err := InvokeModel(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, nil, grantAll{}, nil)
+	_, _, err := InvokeModel(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`), nil, nil, nil, grantAll{}, nil, "", "", nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
@@ -92,9 +92,9 @@ func TestInvokeStreamRouter_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil)
+	rt := NewInvokeStreamRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), grantAll{}, nil, nil)
 
-	src, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`))
+	src, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", modelID, []byte(`{"prompt":"hello"}`), "", "")
 	require.NoError(t, err)
 	defer func() { _ = src.Close() }()
 
@@ -103,22 +103,22 @@ func TestInvokeStreamRouter_SelfHostSuccess(t *testing.T) {
 }
 
 func TestInvokeStreamRouter_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewInvokeStreamRouter(nil, nil, grantAll{}, nil)
-	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`))
+	rt := NewInvokeStreamRouter(nil, nil, grantAll{}, nil, nil)
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "does.not-exist-v1:0", []byte(`{}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestInvokeStreamRouter_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewInvokeStreamRouter(stubCredentialResolver{ok: false}, nil, grantAll{}, nil)
-	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", []byte(`{}`))
+	rt := NewInvokeStreamRouter(stubCredentialResolver{ok: false}, nil, grantAll{}, nil, nil)
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", []byte(`{}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
 }
 
 func TestInvokeStreamRouter_SelfHostNoEndpointReturnsModelNotReady(t *testing.T) {
-	rt := NewInvokeStreamRouter(nil, nil, grantAll{}, nil)
-	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`))
+	rt := NewInvokeStreamRouter(nil, nil, grantAll{}, nil, nil)
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", []byte(`{"prompt":"hello"}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
 }

--- a/spinifex/gateway/bedrock/provider.go
+++ b/spinifex/gateway/bedrock/provider.go
@@ -39,13 +39,16 @@ type Router struct {
 	// Nil (a Router built without one) means Converse rejects any PT ARN as
 	// ResourceNotFoundException rather than a bare modelId's usual denial.
 	provisioned *ProvisionedStore
+	// guardrails resolves a Converse request's GuardrailConfig. Nil fails
+	// closed on any GuardrailConfig (ResourceNotFoundException) rather than
+	// proceeding unguarded; a request with none is unaffected either way.
+	guardrails *GuardrailStore
 }
 
-// NewRouter constructs a Router. A nil resolver, endpointResolver, or recorder
-// falls back to a no-op implementation, and a nil access falls back to denying
-// every model, so a Router is always safe to use even before the real stores
-// are wired in. A nil provisioned disables PT ARN acceptance.
-func NewRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) *Router {
+// NewRouter constructs a Router. A nil resolver, endpointResolver, or
+// recorder falls back to a no-op, and a nil access denies every model, so a
+// Router is always safe to use even before the real stores are wired in.
+func NewRouter(resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore, guardrails *GuardrailStore) *Router {
 	if resolver == nil {
 		resolver = NoopCredentialResolver
 	}
@@ -58,7 +61,7 @@ func NewRouter(resolver CredentialResolver, endpointResolver EndpointResolver, r
 	if access == nil {
 		access = DenyAllAccessResolver
 	}
-	return &Router{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access, provisioned: provisioned}
+	return &Router{resolver: resolver, endpointResolver: endpointResolver, recorder: recorder, access: access, provisioned: provisioned, guardrails: guardrails}
 }
 
 // Converse routes modelID to its provider via the catalog. Unknown modelIds
@@ -156,16 +159,58 @@ func (rt *Router) Converse(ctx context.Context, accountID, modelID string, input
 		return nil, err
 	}
 
+	// An INPUT block returns early with a guarded ConverseOutput, never
+	// reaching p.Converse; inputAssessments survives past the INPUT branch
+	// so a Trace at the end can report both INPUT and OUTPUT halves.
+	var inputAssessments []*bedrockruntime.GuardrailAssessment
+	gc := input.GuardrailConfig
+	if gc != nil {
+		ident, version := aws.StringValue(gc.GuardrailIdentifier), aws.StringValue(gc.GuardrailVersion)
+		var blockedIn bool
+		var messageIn string
+		blockedIn, messageIn, _, inputAssessments, err = enforceGuardrail(ctx, rt.guardrails, accountID, ident, version,
+			bedrockruntime.GuardrailContentSourceInput, converseGuardrailTexts(input))
+		if err != nil {
+			return nil, err
+		}
+		if blockedIn {
+			out = blockedConverseOutput(messageIn, time.Since(start))
+			if aws.StringValue(gc.Trace) == bedrockruntime.GuardrailTraceEnabled {
+				out.Trace = converseGuardrailTrace(ident, inputAssessments, nil)
+			}
+			return out, nil
+		}
+	}
+
 	out, err = p.Converse(ctx, modelID, input)
-	return out, err
+	if err != nil || gc == nil {
+		return out, err
+	}
+
+	ident, version := aws.StringValue(gc.GuardrailIdentifier), aws.StringValue(gc.GuardrailVersion)
+	blockedOut, messageOut, redacted, outputAssessments, gerr := enforceGuardrail(ctx, rt.guardrails, accountID, ident, version,
+		bedrockruntime.GuardrailContentSourceOutput, converseOutputTexts(out))
+	if gerr != nil {
+		err = gerr
+		return nil, err
+	}
+	if blockedOut {
+		out.Output.Message.Content = []*bedrockruntime.ContentBlock{{Text: aws.String(messageOut)}}
+		out.StopReason = aws.String(bedrockruntime.StopReasonGuardrailIntervened)
+	} else {
+		setConverseOutputTexts(out, redacted)
+	}
+	if aws.StringValue(gc.Trace) == bedrockruntime.GuardrailTraceEnabled {
+		out.Trace = converseGuardrailTrace(ident, inputAssessments, outputAssessments)
+	}
+	return out, nil
 }
 
 // Converse is the bedrock-runtime Converse entry point used by the gateway
-// route table. resolver, endpointResolver, recorder, access and provisioned
-// may be nil; NewRouter supplies no-op (and, for access, deny-all; for
-// provisioned, PT-ARN-rejecting) fallbacks.
-func Converse(ctx context.Context, accountID, modelID string, input *bedrockruntime.ConverseInput, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore) (*bedrockruntime.ConverseOutput, error) {
-	return NewRouter(resolver, endpointResolver, recorder, access, provisioned).Converse(ctx, accountID, modelID, input)
+// route table. All dependency params may be nil; NewRouter supplies safe
+// fallbacks (deny-all access, PT-ARN- and GuardrailConfig-rejecting).
+func Converse(ctx context.Context, accountID, modelID string, input *bedrockruntime.ConverseInput, resolver CredentialResolver, endpointResolver EndpointResolver, recorder Recorder, access AccessResolver, provisioned *ProvisionedStore, guardrails *GuardrailStore) (*bedrockruntime.ConverseOutput, error) {
+	return NewRouter(resolver, endpointResolver, recorder, access, provisioned, guardrails).Converse(ctx, accountID, modelID, input)
 }
 
 // ConverseStreamProvider is the optional streaming capability a Provider may

--- a/spinifex/gateway/bedrock/provisioned_inference_test.go
+++ b/spinifex/gateway/bedrock/provisioned_inference_test.go
@@ -169,9 +169,9 @@ func TestInvokeRouter_InvokeModel_ProvisionedThroughputARN_ResolvesPinnedEndpoin
 	arn := createPTCommitment(t, store, ptCallerAccount)
 
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewInvokeRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewInvokeRouter(nil, spy, nil, grantAll{}, store, nil)
 
-	respBody, contentType, err := rt.InvokeModel(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`))
+	respBody, contentType, err := rt.InvokeModel(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`), "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "application/json", contentType)
 
@@ -197,9 +197,9 @@ func TestInvokeRouter_InvokeModel_BareModelID_StillUsesGlobalShorthand(t *testin
 
 	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewInvokeRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewInvokeRouter(nil, spy, nil, grantAll{}, store, nil)
 
-	_, _, err := rt.InvokeModel(context.Background(), ptCallerAccount, selfHostTestModel, []byte(`{"prompt":"hello"}`))
+	_, _, err := rt.InvokeModel(context.Background(), ptCallerAccount, selfHostTestModel, []byte(`{"prompt":"hello"}`), "", "")
 	require.NoError(t, err)
 
 	require.Len(t, spy.endpointCalls, 1)

--- a/spinifex/gateway/bedrock/provisioned_inference_test.go
+++ b/spinifex/gateway/bedrock/provisioned_inference_test.go
@@ -88,7 +88,7 @@ func TestRouter_Converse_ProvisionedThroughputARN_ResolvesPinnedEndpointForRecor
 	arn := createPTCommitment(t, store, ptCallerAccount)
 
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewRouter(nil, spy, nil, grantAll{}, store, nil)
 
 	out, err := rt.Converse(context.Background(), ptCallerAccount, arn, converseInput())
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestRouter_Converse_BareModelID_StillUsesGlobalShorthand(t *testing.T) {
 	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
 
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewRouter(nil, spy, nil, grantAll{}, store, nil)
 
 	_, err := rt.Converse(context.Background(), ptCallerAccount, selfHostTestModel, converseInput())
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestRouter_Converse_ProvisionedThroughputARN_UnknownCommitment(t *testing.T
 	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
 	arn := FormatProvisionedModelARN(ptTestRegion, ptCallerAccount, "does-not-exist")
 
-	rt := NewRouter(nil, &spyEndpointResolver{}, nil, grantAll{}, store)
+	rt := NewRouter(nil, &spyEndpointResolver{}, nil, grantAll{}, store, nil)
 	_, err := rt.Converse(context.Background(), ptCallerAccount, arn, converseInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
@@ -142,7 +142,7 @@ func TestRouter_Converse_ProvisionedThroughputARN_ForeignAccount(t *testing.T) {
 	arn := createPTCommitment(t, store, ptCallerAccount)
 
 	spy := &spyEndpointResolver{baseURL: "http://unused:8000"}
-	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewRouter(nil, spy, nil, grantAll{}, store, nil)
 
 	_, err := rt.Converse(context.Background(), ptOtherCaller, arn, converseInput())
 	require.Error(t, err)

--- a/spinifex/gateway/bedrock/provisioned_stream_inference_test.go
+++ b/spinifex/gateway/bedrock/provisioned_stream_inference_test.go
@@ -48,7 +48,7 @@ func TestRouter_ConverseStream_ProvisionedThroughputARN_ResolvesPinnedEndpointFo
 	arn := createPTCommitment(t, store, ptCallerAccount)
 
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewRouter(nil, spy, nil, grantAll{}, store, nil)
 
 	src, err := rt.ConverseStream(context.Background(), ptCallerAccount, arn, converseStreamInput())
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestRouter_ConverseStream_BareModelID_StillUsesGlobalShorthand(t *testing.T
 	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
 
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewRouter(nil, spy, nil, grantAll{}, store, nil)
 
 	src, err := rt.ConverseStream(context.Background(), ptCallerAccount, selfHostTestModel, converseStreamInput())
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestRouter_ConverseStream_ProvisionedThroughputARN_UnknownCommitment(t *tes
 	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
 	arn := FormatProvisionedModelARN(ptTestRegion, ptCallerAccount, "does-not-exist")
 
-	rt := NewRouter(nil, &spyEndpointResolver{}, nil, grantAll{}, store)
+	rt := NewRouter(nil, &spyEndpointResolver{}, nil, grantAll{}, store, nil)
 	_, err := rt.ConverseStream(context.Background(), ptCallerAccount, arn, converseStreamInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
@@ -104,7 +104,7 @@ func TestRouter_ConverseStream_ProvisionedThroughputARN_ForeignAccount(t *testin
 	arn := createPTCommitment(t, store, ptCallerAccount)
 
 	spy := &spyEndpointResolver{baseURL: "http://unused:8000"}
-	rt := NewRouter(nil, spy, nil, grantAll{}, store)
+	rt := NewRouter(nil, spy, nil, grantAll{}, store, nil)
 
 	_, err := rt.ConverseStream(context.Background(), ptOtherCaller, arn, converseStreamInput())
 	require.Error(t, err)

--- a/spinifex/gateway/bedrock/provisioned_stream_inference_test.go
+++ b/spinifex/gateway/bedrock/provisioned_stream_inference_test.go
@@ -121,9 +121,9 @@ func TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputA
 	arn := createPTCommitment(t, store, ptCallerAccount)
 
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store)
+	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store, nil)
 
-	src, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`))
+	src, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`), "", "")
 	require.NoError(t, err)
 	chunks := drainInvokeStream(t, src)
 	assert.NotEmpty(t, chunks)
@@ -142,9 +142,9 @@ func TestInvokeStreamRouter_InvokeModelWithResponseStream_BareModelID_StillUsesG
 	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
 
 	spy := &spyEndpointResolver{baseURL: ts.URL}
-	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store)
+	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store, nil)
 
-	src, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, selfHostTestModel, []byte(`{"prompt":"hello"}`))
+	src, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, selfHostTestModel, []byte(`{"prompt":"hello"}`), "", "")
 	require.NoError(t, err)
 	drainInvokeStream(t, src)
 
@@ -160,8 +160,8 @@ func TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputA
 	store := newProvisionedTestStore(t, newStubEndpointProvisioner())
 	arn := FormatProvisionedModelARN(ptTestRegion, ptCallerAccount, "does-not-exist")
 
-	rt := NewInvokeStreamRouter(nil, &spyEndpointResolver{}, grantAll{}, store)
-	_, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`))
+	rt := NewInvokeStreamRouter(nil, &spyEndpointResolver{}, grantAll{}, store, nil)
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), ptCallerAccount, arn, []byte(`{"prompt":"hello"}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
@@ -174,9 +174,9 @@ func TestInvokeStreamRouter_InvokeModelWithResponseStream_ProvisionedThroughputA
 	arn := createPTCommitment(t, store, ptCallerAccount)
 
 	spy := &spyEndpointResolver{baseURL: "http://unused:8000"}
-	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store)
+	rt := NewInvokeStreamRouter(nil, spy, grantAll{}, store, nil)
 
-	_, err := rt.InvokeModelWithResponseStream(context.Background(), ptOtherCaller, arn, []byte(`{"prompt":"hello"}`))
+	_, err := rt.InvokeModelWithResponseStream(context.Background(), ptOtherCaller, arn, []byte(`{"prompt":"hello"}`), "", "")
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 	assert.Empty(t, spy.endpointForAccountCalls, "a foreign-account ARN must never reach endpoint resolution")

--- a/spinifex/gateway/bedrock/router_test.go
+++ b/spinifex/gateway/bedrock/router_test.go
@@ -46,7 +46,7 @@ func TestRouter_Converse_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
 
 	out, err := rt.Converse(context.Background(), "000000000001", modelID, converseInput())
 	require.NoError(t, err)
@@ -55,14 +55,14 @@ func TestRouter_Converse_SelfHostSuccess(t *testing.T) {
 }
 
 func TestRouter_Converse_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil, nil)
 	_, err := rt.Converse(context.Background(), "000000000001", "does.not-exist-v1:0", converseInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestRouter_Converse_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil)
+	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil, nil)
 	_, err := rt.Converse(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", converseInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
@@ -80,14 +80,14 @@ func TestConverse_PackageEntryPoint_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	out, err := Converse(context.Background(), "000000000001", modelID, converseInput(), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+	out, err := Converse(context.Background(), "000000000001", modelID, converseInput(), nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, out.Output.Message)
 	assert.Equal(t, "via package Converse", *out.Output.Message.Content[0].Text)
 }
 
 func TestConverse_PackageEntryPoint_UnknownModel(t *testing.T) {
-	_, err := Converse(context.Background(), "000000000001", "does.not-exist-v1:0", converseInput(), nil, nil, nil, grantAll{}, nil)
+	_, err := Converse(context.Background(), "000000000001", "does.not-exist-v1:0", converseInput(), nil, nil, nil, grantAll{}, nil, nil)
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
@@ -109,7 +109,7 @@ func TestRouter_ConverseStream_SelfHostSuccess(t *testing.T) {
 	defer ts.Close()
 
 	modelID := "meta.llama3-2-1b-instruct-v1:0"
-	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil)
+	rt := NewRouter(nil, NewStaticEndpointResolver(map[string]string{modelID: ts.URL}), nil, grantAll{}, nil, nil)
 
 	src, err := rt.ConverseStream(context.Background(), "000000000001", modelID, converseStreamInput())
 	require.NoError(t, err)
@@ -120,28 +120,28 @@ func TestRouter_ConverseStream_SelfHostSuccess(t *testing.T) {
 }
 
 func TestRouter_ConverseStream_UnknownModelReturnsResourceNotFound(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil, nil)
 	_, err := rt.ConverseStream(context.Background(), "000000000001", "does.not-exist-v1:0", converseStreamInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorResourceNotFoundException, err.Error())
 }
 
 func TestRouter_ConverseStream_AnthropicNoCredentialReturnsAccessDenied(t *testing.T) {
-	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil)
+	rt := NewRouter(stubCredentialResolver{ok: false}, nil, nil, grantAll{}, nil, nil)
 	_, err := rt.ConverseStream(context.Background(), "000000000001", "anthropic.claude-3-5-sonnet-20240620-v1:0", converseStreamInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorAccessDeniedException, err.Error())
 }
 
 func TestRouter_ConverseStream_SelfHostNoEndpointReturnsModelNotReady(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil, nil)
 	_, err := rt.ConverseStream(context.Background(), "000000000001", "meta.llama3-2-1b-instruct-v1:0", converseStreamInput())
 	require.Error(t, err)
 	assert.Equal(t, awserrors.ErrorModelNotReadyException, err.Error())
 }
 
 func TestNewRouter_NilArgumentsFallBackToNoops(t *testing.T) {
-	rt := NewRouter(nil, nil, nil, grantAll{}, nil)
+	rt := NewRouter(nil, nil, nil, grantAll{}, nil, nil)
 	require.NotNil(t, rt)
 
 	// Self-host model with no endpoint resolver configured resolves nothing,

--- a/spinifex/gateway/bedrockruntime.go
+++ b/spinifex/gateway/bedrockruntime.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
@@ -29,15 +30,16 @@ type bedrockRuntimeRoute struct {
 // gw.bedrockEndpointResolver() over the configured pinned self-host
 // endpoints; recorder is gw.bedrockRecorder() (invocation recorder or no-op);
 // access is gw.bedrockAccessResolver() (grant store or deny-all); provisioned
-// is gw.bedrockProvisionedStore(), consulted when modelId is a PT ARN.
-type bedrockRuntimeRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error)
+// is gw.bedrockProvisionedStore(), consulted when modelId is a PT ARN;
+// guardrails is gw.bedrockGuardrailStore().
+type bedrockRuntimeRouteHandler func(ctx context.Context, accountID string, params []string, body []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error)
 
 // bedrockRuntimeRoutes is the dispatch table. InvokeModel has no handler
 // function here: BedrockRuntime_Request special-cases its action to bypass
 // the JSON-marshaling dispatch below, since its response is raw bytes.
 var bedrockRuntimeRoutes = []bedrockRuntimeRoute{
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/converse$`), "Converse",
-		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
 			input := new(bedrockruntime.ConverseInput)
 			if len(b) > 0 {
 				if err := json.Unmarshal(b, input); err != nil {
@@ -49,6 +51,18 @@ var bedrockRuntimeRoutes = []bedrockRuntimeRoute{
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/invoke$`), "InvokeModel", nil},
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/converse-stream$`), "ConverseStream", nil},
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/invoke-with-response-stream$`), "InvokeModelWithResponseStream", nil},
+	{"POST", regexp.MustCompile(`^/guardrail/([^/]+)/version/([^/]+)/apply$`), "ApplyGuardrail",
+		func(ctx context.Context, acct string, p []string, b []byte, _ gateway_bedrock.CredentialResolver, _ gateway_bedrock.EndpointResolver, _ gateway_bedrock.Recorder, _ gateway_bedrock.AccessResolver, _ *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
+			input := new(bedrockruntime.ApplyGuardrailInput)
+			if len(b) > 0 {
+				if err := json.Unmarshal(b, input); err != nil {
+					return nil, errors.New(awserrors.ErrorValidationException)
+				}
+			}
+			input.GuardrailIdentifier = aws.String(p[0])
+			input.GuardrailVersion = aws.String(p[1])
+			return gateway_bedrock.ApplyGuardrail(ctx, acct, guardrails, input)
+		}},
 }
 
 // lookupBedrockRuntimeAction matches method+path against bedrockRuntimeRoutes,
@@ -146,7 +160,7 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 		return gateway_bedrock.InvokeModelWithResponseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), r.Header.Get("Content-Type"), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
 	}
 
-	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
+	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), gw.bedrockGuardrailStore())
 	if err != nil {
 		return err
 	}

--- a/spinifex/gateway/bedrockruntime.go
+++ b/spinifex/gateway/bedrockruntime.go
@@ -39,14 +39,14 @@ type bedrockRuntimeRouteHandler func(ctx context.Context, accountID string, para
 // the JSON-marshaling dispatch below, since its response is raw bytes.
 var bedrockRuntimeRoutes = []bedrockRuntimeRoute{
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/converse$`), "Converse",
-		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, _ *gateway_bedrock.GuardrailStore) (any, error) {
+		func(ctx context.Context, acct string, p []string, b []byte, resolver gateway_bedrock.CredentialResolver, endpoints gateway_bedrock.EndpointResolver, recorder gateway_bedrock.Recorder, access gateway_bedrock.AccessResolver, provisioned *gateway_bedrock.ProvisionedStore, guardrails *gateway_bedrock.GuardrailStore) (any, error) {
 			input := new(bedrockruntime.ConverseInput)
 			if len(b) > 0 {
 				if err := json.Unmarshal(b, input); err != nil {
 					return nil, errors.New(awserrors.ErrorValidationException)
 				}
 			}
-			return gateway_bedrock.Converse(ctx, acct, p[0], input, resolver, endpoints, recorder, access, provisioned)
+			return gateway_bedrock.Converse(ctx, acct, p[0], input, resolver, endpoints, recorder, access, provisioned, guardrails)
 		}},
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/invoke$`), "InvokeModel", nil},
 	{"POST", regexp.MustCompile(`^/model/([^/]+)/converse-stream$`), "ConverseStream", nil},
@@ -154,7 +154,7 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 	// (-> ErrorHandler); once streaming starts they always return nil,
 	// surfacing any further failure as an in-band exception event.
 	if action == "ConverseStream" {
-		return gateway_bedrock.ConverseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
+		return gateway_bedrock.ConverseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), gw.bedrockGuardrailStore())
 	}
 	if action == "InvokeModelWithResponseStream" {
 		return gateway_bedrock.InvokeModelWithResponseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), r.Header.Get("Content-Type"), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())

--- a/spinifex/gateway/bedrockruntime.go
+++ b/spinifex/gateway/bedrockruntime.go
@@ -16,6 +16,13 @@ import (
 	gateway_bedrock "github.com/mulgadc/spinifex/spinifex/gateway/bedrock"
 )
 
+// InvokeModel/InvokeModelWithResponseStream carry their guardrail selection
+// as headers rather than body fields (unlike Converse's GuardrailConfig).
+const (
+	bedrockGuardrailIdentifierHeader = "X-Amzn-Bedrock-Guardrailidentifier"
+	bedrockGuardrailVersionHeader    = "X-Amzn-Bedrock-Guardrailversion"
+)
+
 // bedrockRuntimeRoute maps one HTTP method + path regex to an AWS action and handler.
 type bedrockRuntimeRoute struct {
 	method  string
@@ -139,7 +146,9 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 	// InvokeModel returns provider-native bytes, not a struct WriteJSONResponse
 	// could marshal, so it writes its own response body directly.
 	if action == "InvokeModel" {
-		respBody, contentType, err := gateway_bedrock.InvokeModel(r.Context(), accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
+		guardrailIdent := r.Header.Get(bedrockGuardrailIdentifierHeader)
+		guardrailVersion := r.Header.Get(bedrockGuardrailVersionHeader)
+		respBody, contentType, err := gateway_bedrock.InvokeModel(r.Context(), accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), guardrailIdent, guardrailVersion, gw.bedrockGuardrailStore())
 		if err != nil {
 			return err
 		}
@@ -157,7 +166,9 @@ func (gw *GatewayConfig) BedrockRuntime_Request(w http.ResponseWriter, r *http.R
 		return gateway_bedrock.ConverseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), gw.bedrockGuardrailStore())
 	}
 	if action == "InvokeModelWithResponseStream" {
-		return gateway_bedrock.InvokeModelWithResponseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), r.Header.Get("Content-Type"), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore())
+		guardrailIdent := r.Header.Get(bedrockGuardrailIdentifierHeader)
+		guardrailVersion := r.Header.Get(bedrockGuardrailVersionHeader)
+		return gateway_bedrock.InvokeModelWithResponseStream(r.Context(), w, accountID, params[0], body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), r.Header.Get("Content-Type"), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), guardrailIdent, guardrailVersion, gw.bedrockGuardrailStore())
 	}
 
 	output, err := handler(r.Context(), accountID, params, body, gw.bedrockResolver(), gw.bedrockEndpointResolver(), gw.bedrockRecorder(), gw.bedrockAccessResolver(), gw.bedrockProvisionedStore(), gw.bedrockGuardrailStore())

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -151,6 +151,10 @@ type GatewayConfig struct {
 	// drives the pinned endpoint underneath each one. Nil falls back to an
 	// unconfigured store, under which reads/writes error rather than panic.
 	BedrockProvisioned *gateway_bedrock.ProvisionedStore
+	// BedrockGuardrails persists guardrail control-plane records (CreateGuardrail
+	// and friends). Nil falls back to an unconfigured store, under which
+	// reads/writes error rather than panic.
+	BedrockGuardrails *gateway_bedrock.GuardrailStore
 }
 
 var supportedServices = map[string]bool{

--- a/spinifex/gateway/gateway.go
+++ b/spinifex/gateway/gateway.go
@@ -427,10 +427,10 @@ func (gw *GatewayConfig) GetService(r *http.Request) (string, error) {
 	// bedrock and bedrock-runtime share the SigV4 signing name "bedrock", so the
 	// credential scope alone cannot tell the control plane from the data plane —
 	// AWS separates them by endpoint hostname, but the gateway serves one
-	// endpoint. The request path is the discriminator: /model/... is exclusive to
-	// the data plane (Converse/InvokeModel and their streaming variants), so a
-	// "bedrock"-scoped call to it is really bedrock-runtime.
-	if svc == "bedrock" && strings.HasPrefix(r.URL.Path, "/model/") {
+	// endpoint. The request path is the discriminator: /model/... and singular
+	// /guardrail/... are exclusive to the data plane; control-plane guardrail
+	// CRUD uses the plural /guardrails, so the prefixes never collide.
+	if svc == "bedrock" && (strings.HasPrefix(r.URL.Path, "/model/") || strings.HasPrefix(r.URL.Path, "/guardrail/")) {
 		svc = "bedrock-runtime"
 	}
 	if !supportedServices[svc] {

--- a/spinifex/gateway/gateway_test.go
+++ b/spinifex/gateway/gateway_test.go
@@ -761,6 +761,28 @@ func TestGetService(t *testing.T) {
 			path:    "/model/meta.llama3-70b-instruct-v1:0/invoke",
 			wantSvc: "bedrock-runtime",
 		},
+		{
+			// ApplyGuardrail is a data-plane op registered under the singular
+			// /guardrail/ path, distinct from the plural control-plane CRUD.
+			name:    "bedrock scope on ApplyGuardrail path resolves to bedrock-runtime",
+			ctxVal:  "bedrock",
+			path:    "/guardrail/gr-abc123/version/1/apply",
+			wantSvc: "bedrock-runtime",
+		},
+		{
+			// CreateGuardrail is control-plane CRUD under the plural /guardrails
+			// path, which must not be captured by the singular /guardrail/ check.
+			name:    "bedrock scope on CreateGuardrail path stays bedrock",
+			ctxVal:  "bedrock",
+			path:    "/guardrails",
+			wantSvc: "bedrock",
+		},
+		{
+			name:    "bedrock scope on GetGuardrail path stays bedrock",
+			ctxVal:  "bedrock",
+			path:    "/guardrails/gr-abc123",
+			wantSvc: "bedrock",
+		},
 	}
 
 	for _, tc := range tests {

--- a/spinifex/services/awsgw/awsgw.go
+++ b/spinifex/services/awsgw/awsgw.go
@@ -350,6 +350,11 @@ func launchService(config *config.ClusterConfig) error {
 	bedrockProvisioned := gateway_bedrock.NewProvisionedStore(js, len(config.Nodes), nodeConfig.Region,
 		handlers_bedrock.NewProvisionedEndpointAdapter(bedrockEndpointSvc))
 
+	// Bedrock guardrails: control-plane CRUD only at this stage — the record
+	// stores the full policy config so a later stage's filter engine and
+	// inference enforcement can read it back, but nothing enforces it yet.
+	bedrockGuardrails := gateway_bedrock.NewGuardrailStore(js, len(config.Nodes), nodeConfig.Region)
+
 	// Bedrock invocation records: every Converse/InvokeModel call (streaming
 	// or not) is published to the invocation stream, then fanned out by
 	// deliveryConsumer to any account with a configured destination bucket
@@ -405,6 +410,7 @@ func launchService(config *config.ClusterConfig) error {
 		BedrockAccess:           bedrockAccess,
 		BedrockAccessAdmin:      bedrockAccess,
 		BedrockProvisioned:      bedrockProvisioned,
+		BedrockGuardrails:       bedrockGuardrails,
 	}
 
 	// Rotate the ECR signing key on a 30-day cadence, retaining the previous keys


### PR DESCRIPTION
## Summary

Stage 1 of Ochre Guardrails (bead mulga-vmfng.8), first of 4 stages. Adds the guardrail control-plane CRUD store and ARN handling. No filter engine, no ApplyGuardrail, no inference enforcement — those are stages 2-4.

- `gateway/bedrock/guardrail.go`: `GuardrailStore` (JetStream KV, account-scoped keys) backing `CreateGuardrail`, `CreateGuardrailVersion`, `GetGuardrail`, `ListGuardrails`, `UpdateGuardrail`, `DeleteGuardrail`. Records persist the full policy config (word / sensitive-information / content / topic / contextual-grounding) verbatim so later stages can read it back without re-deriving it. DRAFT is mutable; numbered versions are immutable snapshots minted by `CreateGuardrailVersion`.
- `gateway/bedrock/arn.go`: `FormatGuardrailARN` / `ParseGuardrailARN` / `resolveGuardrailID`, mirroring the existing provisioned-throughput ARN trio.
- `gateway/bedrock.go`, `gateway/gateway.go`, `services/awsgw/awsgw.go`: route registration (6 new routes) and store construction/wiring.

## Test plan

- [x] `go test ./gateway/bedrock/...` passes (21 new guardrail tests + 6 new ARN tests)
- [x] `golangci-lint run ./gateway/bedrock/...` clean
- [ ] `make preflight` — blocked in this worktree by a pre-existing, unrelated `go.work` -> northstar/predastore `otel/log` API mismatch (verified via git-stash that it predates this change and reproduces identically with these commits removed)