### PR TITLE
feat: render predastore templates with the cluster and S3 planes split

### DIFF
--- a/cmd/spinifex/cmd/predastore_planes_test.go
+++ b/cmd/spinifex/cmd/predastore_planes_test.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	pds "github.com/mulgadc/predastore"
+	"github.com/mulgadc/spinifex/spinifex/admin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadRenderedPredastore parses a rendered template with predastore's own
+// loader. Asserting on the TOML text would only prove the template renders;
+// this proves the cluster it describes is one predastore will start.
+func loadRenderedPredastore(t *testing.T, content string) *pds.Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "predastore.toml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	cfg, err := pds.LoadConfig(path)
+	require.NoError(t, err, "the installer must not write a config predastore rejects")
+	return cfg
+}
+
+// singleNodeSettings is what a real install renders with: the paths predastore
+// validates are absolute, which the shared fixture leaves empty because the
+// tests around it only read the rendered text.
+func singleNodeSettings() admin.ConfigSettings {
+	settings := northstarSettings()
+	settings.ConfigDir = "/etc/spinifex"
+	settings.PredastoreDataDir = admin.PredastoreDataDir("/var/lib/spinifex")
+	return settings
+}
+
+func gateNode(t *testing.T, host pds.HostConfig) pds.NodeConfig {
+	t.Helper()
+	for _, n := range host.Nodes {
+		if n.Role == pds.RoleGate {
+			return n
+		}
+	}
+	t.Fatalf("host %d runs no gate", host.ID)
+	return pds.NodeConfig{}
+}
+
+// A single machine holds every shard of an object whatever the erasure code
+// is, so parity there costs a split, an encode and a second write for a copy
+// the same disk failure takes with it. Redundancy belongs to the pool under
+// the data directory.
+func TestPredastoreSingleNodeTemplateUsesNoParity(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadRenderedPredastore(t, renderTemplate(t, predastoreTomlTemplate, singleNodeSettings()))
+
+	assert.Equal(t, 1, cfg.RS.Data, "a single node splits nothing")
+	assert.Equal(t, 0, cfg.RS.Parity, "a single node has nowhere to put parity")
+}
+
+// A single node is one server: one of each role. A second blob node would only
+// hash-partition the keys across another index on the same drive, and a second
+// meta node would add an fsync to every commit for a quorum sharing the disk it
+// exists to survive.
+func TestPredastoreSingleNodeTemplateRunsOneOfEachRole(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadRenderedPredastore(t, renderTemplate(t, predastoreTomlTemplate, singleNodeSettings()))
+
+	require.Len(t, cfg.Hosts, 1, "a single node is one host")
+
+	byRole := make(map[pds.Role]int)
+	for _, n := range cfg.Hosts[0].Nodes {
+		byRole[n.Role]++
+	}
+	assert.Equal(t, map[pds.Role]int{pds.RoleGate: 1, pds.RoleBlob: 1, pds.RoleMeta: 1}, byRole)
+}
+
+// S3 is a public service and replication is not. The gate binds every
+// interface; raft and blob traffic bind the host's own address and stay there.
+func TestPredastoreSingleNodeTemplateSplitsThePlanes(t *testing.T) {
+	t.Parallel()
+
+	cfg := loadRenderedPredastore(t, renderTemplate(t, predastoreTomlTemplate, singleNodeSettings()))
+
+	require.Len(t, cfg.Hosts, 1)
+	assert.Equal(t, "0.0.0.0", gateNode(t, cfg.Hosts[0]).BindAddr, "S3 must answer on every interface")
+	assert.NotEqual(t, "0.0.0.0", cfg.Hosts[0].BindAddr, "the cluster plane must not be a wildcard")
+}
+
+func TestPredastoreMultiNodeTemplateSplitsThePlanes(t *testing.T) {
+	t.Parallel()
+
+	content, err := admin.GenerateMultiNodePredastoreConfig(
+		predastoreMultiNodeTemplate, predastoreMultinodeNodes(), "AK", "SK", "ap-southeast-2", "tok",
+		"/cfg", "/var/lib/spinifex", "10.0.0.1", 0, admin.NorthstarCredentials{},
+	)
+	require.NoError(t, err)
+
+	cfg := loadRenderedPredastore(t, content)
+
+	require.Len(t, cfg.Hosts, 3)
+	for _, host := range cfg.Hosts {
+		// Every machine's replication plane is the address its peers dial, so
+		// a second interface on any of them carries no cluster traffic.
+		assert.Equal(t, host.Addr, host.BindAddr, "host %d binds the cluster plane off its dial address", host.ID)
+		assert.Equal(t, "0.0.0.0", gateNode(t, host).BindAddr, "host %d must serve public S3", host.ID)
+	}
+}
+
+// The bind_addr under [[host.node]] is the gate's alone: no other role has a
+// listener to point anywhere, and predastore rejects one that tries.
+func TestPredastoreTemplatesBindOnlyTheGate(t *testing.T) {
+	t.Parallel()
+
+	multinode, err := admin.GenerateMultiNodePredastoreConfig(
+		predastoreMultiNodeTemplate, predastoreMultinodeNodes(), "AK", "SK", "ap-southeast-2", "tok",
+		"/cfg", "/var/lib/spinifex", "10.0.0.1", 0, admin.NorthstarCredentials{},
+	)
+	require.NoError(t, err)
+
+	for name, content := range map[string]string{
+		"single-node": renderTemplate(t, predastoreTomlTemplate, singleNodeSettings()),
+		"multi-node":  multinode,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, host := range loadRenderedPredastore(t, content).Hosts {
+				for _, n := range host.Nodes {
+					if n.Role != pds.RoleGate {
+						assert.Empty(t, n.BindAddr, "node %d has role %q and must bind nothing of its own", n.ID, n.Role)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/spinifex/cmd/templates/predastore-multinode.toml
+++ b/cmd/spinifex/cmd/templates/predastore-multinode.toml
@@ -15,8 +15,13 @@ parity = 1
 {{- end}}
 
 # One host per machine: a predastore process owning a data directory, a TLS
-# identity and the nodes pinned to it. bind_addr binds every interface; addr is
-# what the other hosts dial, so it carries no port and names one machine.
+# identity and the nodes pinned to it. addr is what the other hosts dial, so it
+# carries no port and names one machine.
+#
+# bind_addr is the cluster plane: raft consensus and blob shard traffic listen
+# there and nowhere else. It is the address peers dial rather than a wildcard,
+# so on a multi-homed machine replication never reaches the public interface.
+# The gate below binds the public plane separately.
 #
 # Each machine runs a gate for the S3 API, a blob node for erasure-coded object
 # shards and a meta node for the Raft quorum over global state. Ports are
@@ -25,7 +30,7 @@ parity = 1
 
 [[host]]
 id = {{$host.ID}}
-bind_addr = "0.0.0.0"
+bind_addr = "{{$host.Host}}"
 addr = "{{$host.Host}}"
 data_dir = "{{$.PredastoreDataDir}}"
 tls_cert = "{{$.ConfigDir}}/server.pem"
@@ -38,6 +43,11 @@ encryption_key = "{{$.ConfigDir}}/predastore/encryption.key"
 id = {{.ID}}
 role = "{{.Role}}"
 port = {{.Port}}
+{{- if eq .Role "gate"}}
+# S3 is the public plane and answers on every interface; the host's bind_addr
+# above keeps raft and blob traffic off them. Only a gate may set this.
+bind_addr = "0.0.0.0"
+{{- end}}
 {{- end}}
 {{- end}}
 {{- end}}

--- a/cmd/spinifex/cmd/templates/predastore.toml
+++ b/cmd/spinifex/cmd/templates/predastore.toml
@@ -5,18 +5,28 @@ region = "{{.Region}}"
 
 # Reed-Solomon erasure code. data + parity must not exceed the number of blob
 # nodes in the cluster.
-# RS(2,1), 2 data, 1 parity. Minimum
-# RS(3,2), 3 data, 2 parity. Recommended for production
+#
+# RS(1,0) is one shard on one node: no split, no parity encode and no fan-out.
+# Every shard of a wider code would land on this one machine anyway, so parity
+# buys nothing a second copy of the same disk failure would not take with it.
+# Redundancy here is the pool's job — ZFS raidz or a mirror under the data
+# directory. Multi-node installs get a real erasure code from the multi-node
+# template: RS(2,1) minimum, RS(3,2) recommended.
 [rs]
-data = 2
-parity = 1
+data = 1
+parity = 0
 
 # A host is one predastore process: it owns a data directory, a TLS identity
 # and the nodes pinned to it. Everything is colocated here, so the nodes talk
 # over the in-process pipe and only the gate binds a socket.
+#
+# bind_addr is the cluster plane — raft and blob traffic. A single-host install
+# opens no socket for it at all, but it is set to the loopback address rather
+# than left wide, so adding a second host later cannot quietly publish
+# replication to every interface.
 [[host]]
 id = 1
-bind_addr = "0.0.0.0"
+bind_addr = "127.0.0.1"
 addr = "127.0.0.1"
 data_dir = "{{.PredastoreDataDir}}"
 tls_cert = "{{.ConfigDir}}/server.pem"
@@ -24,44 +34,30 @@ tls_key = "{{.ConfigDir}}/server.key"
 encryption_key = "{{.ConfigDir}}/predastore/encryption.key"
 
 # The gate serves the S3 API. Without one the host answers no S3 request.
+# S3 is the public plane, so it binds every interface while the host's
+# bind_addr above keeps everything else private. Only a gate may set this.
 [[host.node]]
 id = 1
 role = "gate"
 port = 8443
+bind_addr = "0.0.0.0"
 
-# Blob nodes hold erasure-coded object shards; a stripe spreads over distinct
-# ones, so RS(2,1) needs 3. Colocated nodes bind no socket, but each still
-# needs a port unique within its host.
+# One blob node holds every object. Extra blob nodes would only hash-partition
+# the keys across more segment files and more badger indexes on the same drive,
+# which costs memory and compaction work and buys no redundancy. Colocated
+# nodes bind no socket, but each still needs a port unique within its host.
 [[host.node]]
 id = 2
 role = "blob"
 port = 6660
 
+# One meta node is the whole Raft quorum. Replicas here would share the disk
+# they are meant to survive, so each commit would pay their fsyncs for a quorum
+# that fails together.
 [[host.node]]
 id = 3
-role = "blob"
-port = 6661
-
-[[host.node]]
-id = 4
-role = "blob"
-port = 6662
-
-# Meta nodes form the Raft quorum over global state (buckets, object index).
-[[host.node]]
-id = 5
 role = "meta"
 port = 7660
-
-[[host.node]]
-id = 6
-role = "meta"
-port = 7661
-
-[[host.node]]
-id = 7
-role = "meta"
-port = 7662
 
 [[bucket]]
 name = "predastore"

--- a/cmd/spinifex/cmd/templates/spinifex.toml
+++ b/cmd/spinifex/cmd/templates/spinifex.toml
@@ -127,8 +127,9 @@ bridge_mode = "{{.BridgeMode}}"
 
 [nodes.{{.Node}}.predastore]
 # Wildcard rather than the bind IP: S3 is a public service and has to answer on
-# the wan plane. The service binds this address and serves S3 on this port,
-# leaving [[host]].addr — the address peer hosts dial — as predastore.toml has it.
+# the wan plane. This settles the gate node's own bind address and port, and
+# nothing else: raft and blob traffic bind [[host]].bind_addr from
+# predastore.toml, which is the private plane and stays there.
 #
 # This doubles as the local dial target, and 0.0.0.0 is not one: config loading
 # rewrites it to 127.0.0.1 for this node, and admin.DialTarget does the same for

--- a/docs/aws-model-operation-coverage.md
+++ b/docs/aws-model-operation-coverage.md
@@ -12,7 +12,7 @@ Implemented means a modelled operation is registered to a real handler. Stub and
 | ecs | 2014-11-13 | 56 | 39 | 31 | 5 | 0 | 20 | 3 |
 | elasticloadbalancingv2 | 2015-12-01 | 46 | 37 | 33 | 0 | 0 | 13 | 4 |
 | iam | 2010-05-08 | 159 | 75 | 75 | 0 | 0 | 84 | 0 |
-| rds | 2014-10-31 | 162 | 40 | 24 | 0 | 12 | 126 | 4 |
+| rds | 2014-10-31 | 162 | 41 | 24 | 0 | 12 | 126 | 5 |
 | s3 | 2006-03-01 | 99 | — | — | — | — | — | — |
 | sts | 2011-06-15 | 8 | 4 | 4 | 0 | 0 | 4 | 0 |
 
@@ -527,9 +527,9 @@ None.
 
 </details>
 
-<details><summary>Registered outside the pinned model (4)</summary>
+<details><summary>Registered outside the pinned model (5)</summary>
 
-`GetDBBootstrapConfig`, `PollDBCommands`, `RegisterDBInstance`, `SubmitDBStateChange`
+`AcknowledgeDBBootstrap`, `GetDBBootstrapConfig`, `PollDBCommands`, `RegisterDBInstance`, `SubmitDBStateChange`
 
 
 </details>

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.4.0
 	github.com/miekg/dns v1.1.72
 	github.com/mulgadc/northstar v1.15.1-0.20260810233215-04fade67fb2c
-	github.com/mulgadc/predastore v1.15.1-0.20260811065833-4de8654e083d
+	github.com/mulgadc/predastore v1.15.1-0.20260811210342-f8e0ba321f1f
 	github.com/mulgadc/viperblock v1.15.0
 	github.com/nats-io/nats-server/v2 v2.14.4
 	github.com/nats-io/nats.go v1.52.0

--- a/go.sum
+++ b/go.sum
@@ -1331,6 +1331,8 @@ github.com/mulgadc/predastore v1.15.1-0.20260811050847-9195a584281f h1:MuT8mWIXG
 github.com/mulgadc/predastore v1.15.1-0.20260811050847-9195a584281f/go.mod h1:ph+eASnkMogVZ0cMiO/6aUw1S1+Gl3+NnVtlqCNdBo8=
 github.com/mulgadc/predastore v1.15.1-0.20260811065833-4de8654e083d h1:FqQUtsf1poXTzGSvzmZ1fkzLpZxg1p+ssPvwnBKSIOI=
 github.com/mulgadc/predastore v1.15.1-0.20260811065833-4de8654e083d/go.mod h1:ph+eASnkMogVZ0cMiO/6aUw1S1+Gl3+NnVtlqCNdBo8=
+github.com/mulgadc/predastore v1.15.1-0.20260811210342-f8e0ba321f1f h1:S1PQPHazI9Y+uIGRT8Nz2HIS+uDGgOVEJz3X16HxHIU=
+github.com/mulgadc/predastore v1.15.1-0.20260811210342-f8e0ba321f1f/go.mod h1:ph+eASnkMogVZ0cMiO/6aUw1S1+Gl3+NnVtlqCNdBo8=
 github.com/mulgadc/viperblock v1.15.0 h1:nZ8d8q8lSgMucd43GYgvwpmnCWXN379z6H2MxUHGo9g=
 github.com/mulgadc/viperblock v1.15.0/go.mod h1:/pkP/liHmG+yzojZ3+xSvAcqMHb/zfiEQVsHeK9EPYM=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/spinifex/services/predastore/predastore.go
+++ b/spinifex/services/predastore/predastore.go
@@ -23,9 +23,11 @@ var serviceName = "predastore"
 type Config struct {
 	ConfigPath string
 	Port       int
-	Host       string
-	TlsCert    string
-	TlsKey     string
+	// Host is where the S3 API listens, and only that: the cluster plane binds
+	// the host's own address from the predastore configuration file.
+	Host    string
+	TlsCert string
+	TlsKey  string
 
 	// BasePath is where this service keeps its pid file. Predastore itself has
 	// no base path — its directories come from the configuration file — but
@@ -132,7 +134,9 @@ func (svc *Service) mergeHost(cfg *pds.Config) (pds.HostID, error) {
 		return 0, fmt.Errorf("predastore host %d is not in %s", svc.Config.HostID, svc.Config.ConfigPath)
 	}
 
-	host.BindAddr = cmp.Or(svc.Config.Host, host.BindAddr, host.Addr)
+	// host.BindAddr is left as the file has it: it is the cluster plane, there
+	// is no flag for it, and predastore falls back to the host's dial address
+	// when it is empty.
 	host.TLSCert = cmp.Or(svc.Config.TlsCert, host.TLSCert)
 	host.TLSKey = cmp.Or(svc.Config.TlsKey, host.TLSKey)
 
@@ -148,6 +152,10 @@ func (svc *Service) mergeHost(cfg *pds.Config) (pds.HostID, error) {
 	if gate < 0 {
 		return 0, fmt.Errorf("predastore host %d runs no gate node in %s", svc.Config.HostID, svc.Config.ConfigPath)
 	}
+	// The address spinifex.toml carries is the S3 endpoint, which is the gate's
+	// alone. Settling it on the host would put raft and blob traffic on the
+	// public interface with it, which is the one place they must never be.
+	host.Nodes[gate].BindAddr = cmp.Or(svc.Config.Host, host.Nodes[gate].BindAddr)
 	host.Nodes[gate].Port = cmp.Or(svc.Config.Port, host.Nodes[gate].Port)
 
 	return hostID, cfg.Validate()

--- a/spinifex/services/predastore/predastore_test.go
+++ b/spinifex/services/predastore/predastore_test.go
@@ -174,12 +174,41 @@ func TestMergeHostFlagsBeatFile(t *testing.T) {
 	merged, err := mergeHost(t, cfg)
 
 	require.NoError(t, err)
-	assert.Equal(t, "0.0.0.0", merged.Hosts[0].BindAddr)
 	assert.Equal(t, cfg.TlsCert, merged.Hosts[0].TLSCert)
 	assert.Equal(t, cfg.TlsKey, merged.Hosts[0].TLSKey)
 	assert.Equal(t, 19443, gateOf(t, merged).Port)
 	// The dial address is the cluster's business, not this host's flags.
 	assert.Equal(t, "10.0.0.1", merged.Hosts[0].Addr)
+}
+
+// TestMergeHostBindsTheGateNotTheCluster is the plane split: the address
+// spinifex.toml carries is the public S3 endpoint, so settling it on the host
+// would put raft and blob traffic on the public interface along with it.
+func TestMergeHostBindsTheGateNotTheCluster(t *testing.T) {
+	dir := t.TempDir()
+
+	merged, err := mergeHost(t, &Config{
+		ConfigPath: singleHost(t, dir),
+		Host:       "0.0.0.0",
+		HostID:     1,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0", gateOf(t, merged).BindAddr, "S3 answers on every interface")
+	assert.Equal(t, "10.0.0.1", merged.Hosts[0].BindAddr, "raft and blob stay on the host address")
+}
+
+// TestMergeHostWithoutAnS3AddressLeavesBothPlanesOnTheHost covers the
+// single-homed case: nothing to split, so the gate follows the host and the
+// file alone decides.
+func TestMergeHostWithoutAnS3AddressLeavesBothPlanesOnTheHost(t *testing.T) {
+	dir := t.TempDir()
+
+	merged, err := mergeHost(t, &Config{ConfigPath: singleHost(t, dir), HostID: 1})
+
+	require.NoError(t, err)
+	assert.Empty(t, gateOf(t, merged).BindAddr, "the gate names no address of its own")
+	assert.Equal(t, "10.0.0.1", merged.Hosts[0].BindAddr)
 }
 
 // TestMergeHostReturnsTheResolvedHostID pins what Start hands predastore.Run:
@@ -213,19 +242,21 @@ func TestMergeHostKeepsFileValues(t *testing.T) {
 	assert.Equal(t, 8443, gateOf(t, merged).Port)
 }
 
-// TestMergeHostBindAddrFallsBackToAddr covers the last resort: a file that
-// names only the dial address leaves this host listening on it, rather than on
-// nothing.
-func TestMergeHostBindAddrFallsBackToAddr(t *testing.T) {
+// TestMergeHostLeavesTheClusterPlaneToTheFile covers the one host-local field
+// no service flag owns. There is no flag for the cluster plane, so a file that
+// names only the dial address is left alone here and resolved by predastore,
+// which is the single place that decides what an empty bind address means.
+func TestMergeHostLeavesTheClusterPlaneToTheFile(t *testing.T) {
 	dir := t.TempDir()
 	path := writeTopology(t, dir,
 		hostSpec{id: 1, addr: "10.0.0.1", dataDir: filepath.Join(dir, "data")},
 		[]nodeSpec{{id: 1, role: "gate", port: 8443}, {id: 2, role: "blob", port: 6660}})
 
-	merged, err := mergeHost(t, &Config{ConfigPath: path, HostID: 1})
+	merged, err := mergeHost(t, &Config{ConfigPath: path, Host: "0.0.0.0", HostID: 1})
 
 	require.NoError(t, err)
-	assert.Equal(t, "10.0.0.1", merged.Hosts[0].BindAddr)
+	assert.Empty(t, merged.Hosts[0].BindAddr, "the S3 address must not settle on the host")
+	assert.Equal(t, "10.0.0.1", pds.HostBindAddr(merged.Hosts[0]), "predastore resolves it to the dial address")
 }
 
 // TestMergeHostRejectsMissingHostID covers the one field with no default: the


### PR DESCRIPTION
## Summary

Renders the predastore configuration with the cluster plane and the S3 plane separated, so the installer can hand S3 the WAN without exposing raft and blob replication with it.

- A host binds the cluster plane on the address peers dial; the gate node carries its own `bind_addr` for the S3 API.
- `mergeHost` no longer settles the S3 address onto the host. The address `spinifex.toml` carries is the gate's alone — settling it on the host is what put raft and blob on the public interface.
- The single-node template drops to one node of each role. Extra blob nodes only hash-partition keys across more badger indexes on the same drive, and extra meta replicas add fsyncs for a quorum that dies with the machine.

## Depends on mulgadc/predastore#79

**This will not build until that merges.** `predastore.go:158` sets `host.Nodes[gate].BindAddr`, and dev's `config.Node` has no such field:

```
GOWORK=off go build ./spinifex/services/predastore/
predastore.go:158:71: host.Nodes[gate].BindAddr undefined (type config.Node has no field or method BindAddr)
```

CI resolves siblings by matching branch name and otherwise falls back to `dev`, and the predastore branch is named `feat/split-bind-planes`, so this PR's first run will resolve predastore to `dev` and fail to compile. Expected. Once predastore#79 is on dev, the go.mod pin needs moving to the merged dev commit — the `d40747ac` pattern — and the re-push will re-trigger CI against a dev that has the field.

## Verification

- `make preflight` passes.
- New `predastore_planes_test.go` asserts the rendered single-node template runs one gate, one blob and one meta, and that the planes land on the right addresses.
- Confirmed at runtime through the ISO path: `firstboot.go:265` passes `--bind <LANIP> --cluster-bind <LANIP>` with `--advertise <WANIP>`, and a single-node host ends up with one socket for S3 and no QUIC socket at all.