### PR TITLE
docs: reconcile the listener inventory with the listeners that exist

### DIFF
--- a/docs/security/network-connections/README.md
+++ b/docs/security/network-connections/README.md
@@ -71,10 +71,13 @@ The inventory in [§1](#1-inbound-listeners)–[§2](#2-outbound-connections) sa
 
 ## 1. Inbound Listeners
 
-"Scope" classifies intended reach:
+"Scope" classifies intended reach. It maps onto the node's network planes — see
+*Planes and scope* below, because a node with fewer NICs collapses them:
 
-- **External** — reachable by tenant/operator networks. Authenticated and TLS-protected.
-- **Cluster** — reachable only from peer Spinifex nodes. Operator must restrict via host or network firewall.
+- **External** — reachable by tenant/operator networks, on the `wan` plane. Authenticated and TLS-protected.
+- **Cluster** — reachable only from peer Spinifex nodes, on the `lan` plane. Operator must restrict via host or network firewall.
+- **Encap** — reachable only from peer chassis, on the `vpc` plane. Carries the tenant overlay and the IPsec that protects it.
+- **Guest** — bound to a per-instance interface and reachable only by that instance's VM.
 - **Localhost** — bound to `127.0.0.1`; not reachable off-node.
 
 | Port | Service | Protocol | Scope | Purpose | Auth / Verification |
@@ -82,18 +85,32 @@ The inventory in [§1](#1-inbound-listeners)–[§2](#2-outbound-connections) sa
 | 9999 | spinifex-awsgw | HTTPS | External | AWS-compatible API (EC2, S3, ELBv2, IAM) — customer endpoint | AWS SigV4 + TLS (cluster CA) |
 | 3000 | spinifex-ui | HTTPS | External | Operator web dashboard | Session cookie + TLS |
 | 22 | OpenSSH | SSH | External | Operator administration | Key-based auth (operator-managed) |
-| 4432 | Formation server | HTTPS | External (bootstrap only) | Cluster join coordination; active only while a join token is valid. See *Formation port lifecycle* below. | Short-lived bearer token + TLS¹ |
+| 53 | northstar | DNS (UDP + TCP) | External | Authoritative DNS for the cluster's zones, resolved directly by instances and by operator networks. Binds the node's advertise (wan) address specifically, not the wildcard, so it does not collide with the `systemd-resolved` stub. | None — public authoritative DNS |
+| 8443 | spinifex-predastore (gate) | HTTPS | External | S3-compatible object storage (AMIs, snapshots, user objects). S3 is a public plane: the gate binds `0.0.0.0` by design. | AWS SigV4 + TLS |
+| 4432 | Formation server | HTTPS | Cluster (bootstrap only) | Cluster join coordination; active only while a join token is valid. Binds the node's `--bind` (lan) address. See *Formation port lifecycle* below. | Short-lived bearer token + TLS¹ |
 | 4222 | spinifex-nats (client) | NATS + TLS | Cluster | Internal service bus for EC2/EBS/VPC/S3 handlers | Token + mutual TLS (cluster CA) |
 | 4248 | spinifex-nats (cluster) | NATS + TLS | Cluster | Inter-node NATS federation | Token + mutual TLS (cluster CA) |
-| 8443 | spinifex-predastore (gate) | HTTPS | Cluster | S3-compatible object storage (AMIs, snapshots, user objects) | AWS SigV4 + TLS |
+| 5300 | northstar | DNS (UDP + TCP) | Cluster | Forward target for every node's per-instance DNS shim, dialled cross-node. Binds the wildcard address. | None — restrict by firewall |
 | 6660 | predastore (blob node) | QUIC / UDP | Cluster | Erasure-coded object shard transport between hosts. Multi-node clusters only — see *Predastore ports* below. | TLS 1.3, server certificate verified against the cluster CA |
 | 7660 | predastore (meta node) | QUIC / UDP | Cluster | Raft consensus over global state — buckets and the object index — between hosts. Multi-node clusters only. | TLS 1.3, server certificate verified against the cluster CA |
 | 6641 | OVN Northbound DB (client) | OVSDB/TCP | Cluster | Logical network topology consumed by vpcd. Binds `127.0.0.1` plus the node's lan-plane address (`--lan-addr`), never the wildcard address. On a node with no separate lan plane that address is the public one, and a host firewall is the only remaining control. | Cluster network only; TLS planned |
 | 6642 | OVN Southbound DB (client) | OVSDB/TCP | Cluster | Chassis / port / MAC binding state. Binds `127.0.0.1` plus the node's lan-plane address (`--lan-addr`), never the wildcard address. On a node with no separate lan plane that address is the public one, and a host firewall is the only remaining control. | Cluster network only; TLS planned |
 | 6643 | OVN Northbound DB (RAFT) | OVSDB/TCP | Cluster | NB database RAFT replication between the 3 quorum nodes | Cluster network only; TLS planned |
 | 6644 | OVN Southbound DB (RAFT) | OVSDB/TCP | Cluster | SB database RAFT replication between the 3 quorum nodes | Cluster network only; TLS planned |
+| 6081 | OVN (Geneve) | UDP | Encap | Tenant traffic overlay between chassis. A kernel UDP-tunnel socket, so packets are delivered locally and traverse the host's netfilter input hook before OVS sees them — a host firewall must accept them explicitly. | None — see 500/4500 |
+| 500, 4500 | strongSwan `charon` | IKEv2 / UDP | Encap | IKE and NAT-T for the IPsec protecting Geneve, managed entirely by `ovs-monitor-ipsec`. Binds the wildcard address (upstream strongSwan default), so reach must be restricted by firewall. | Certificate-based, against the cluster CA |
+| — | ESP | IP proto 50 | Encap | The IPsec payload itself, once IKE has negotiated an SA | Cluster CA |
 | 8222 | spinifex-nats (monitoring) | HTTP | Localhost | `varz`/`subsz` metrics consumed by the daemon | Loopback only |
+| 323 | chronyd | NTP | Localhost | Time sync client control socket | Loopback only |
+| 169.254.169.254:80 | spinifex-vpcd (IMDS) | HTTP | Guest | Instance metadata service. One socket per instance, bound to that instance's `ime-*` interface. Terminates on the host, so it traverses the netfilter input hook. | Instance identity by interface; IMDSv2 tokens |
+| 169.254.169.253:53 | spinifex-vpcd (VPC DNS) | DNS (UDP + TCP) | Guest | Per-VPC DNS resolver, forwarding to northstar `:5300` on peer nodes. Same per-instance binding as above. | Instance identity by interface |
 | socket / dynamic TCP | nbdkit (Viperblock) | NBD | Host-local / cluster | Block device transport for guest EBS volumes | Unix socket by default; TCP only in remote/DPU mode |
+
+**Planes and scope.** A node resolves three planes — `wan`, `lan` and `vpc` — from its
+interfaces, and collapses `vpc` ← `lan` ← `wan` when a plane has no interface of its own. On
+a single-NIC node every scope in this table lands on the public address, so **Cluster** and
+**Encap** describe intent, not a guarantee. Verify with `ss -tulnp` against the node's actual
+addresses rather than assuming the classification holds.
 
 ¹ **Formation port lifecycle.** 4432 opens during `spx admin init` / `spx admin join` while a bootstrap token is outstanding and closes once the cluster is formed (token TTL default 30 min, `--token-ttl`). The server presents an ephemeral self-signed cert that pre-dates trust bootstrap, so the joining node does not verify the certificate chain for this single dial. Authenticity rests on the operator supplying the leader address out-of-band plus possession of the bearer token. Document in the security plan so reviewers do not flag 4432 as a persistent open port.
 
@@ -118,7 +135,7 @@ Spinifex nodes initiate a small, fixed set of outbound connections.
 | `https://d2yp8ipz5jfqcw.cloudfront.net` | Alpine image for managed HAProxy load-balancer | HTTPS | TLS + checksum verification |
 | `https://install.mulgadc.com/install` | One-shot install telemetry POST on `spx admin init` / `join`. | HTTPS | TLS |
 
-**To peer nodes (cluster-internal):** NATS federation (4248), Predastore S3 (8443), OVN NB/SB (6641/6642) — see [§3](#3-cross-node-internal-connections) for encryption and verification of each. The daemon also polls local NATS monitoring at `127.0.0.1:8222/varz` (loopback HTTP). It opens no connection to Predastore for status: the storage topology it reports comes from reading `predastore.toml`, and no Predastore node serves a status endpoint.
+**To peer nodes (cluster-internal):** NATS federation (4248), Predastore S3 (8443), OVN NB/SB (6641/6642), northstar DNS forwarding (5300), and the Geneve/IPsec overlay (6081, 500, 4500, ESP) — see [§3](#3-cross-node-internal-connections) for encryption and verification of each. The daemon also polls local NATS monitoring at `127.0.0.1:8222/varz` (loopback HTTP). It opens no connection to Predastore for status: the storage topology it reports comes from reading `predastore.toml`, and no Predastore node serves a status endpoint.
 
 **Update checks and metadata.** Spinifex does not check for updates and does not consume a cloud metadata service (`169.254.169.254` is served *by* the cluster to guest VMs). Node software updates come from the operator's OS package channel. The install-telemetry endpoint above is the only vendor-operated destination contacted by a node; closed-egress deployments should disable it and record the opt-out in the security plan.
 
@@ -136,26 +153,68 @@ Control-plane and data-plane traffic between Spinifex nodes, for completeness an
 | Predastore meta | UDP 7660 | QUIC with TLS 1.3; server certificate verified against the cluster CA | Raft consensus over buckets and the object index. Same port on every machine. |
 | OVN NB/SB (client) | 6641 / 6642 | Cluster network only (TLS planned) | Network control plane; vpcd and ovn-controller dial the quorum |
 | OVN NB/SB (RAFT) | 6643 / 6644 | Cluster network only (TLS planned) | NB/SB database replication across the 3 quorum nodes |
-| OVN tunnels (Geneve) | UDP 6081 | None | Tenant traffic overlay between chassis, inside the cluster subnet |
+| OVN tunnels (Geneve) | UDP 6081 | Encapsulated by IPsec when `network.ipsec_enabled` is true, which is the default on multi-node clusters | Tenant traffic overlay between chassis, on the `vpc` plane |
+| OVN IPsec (IKE / NAT-T / ESP) | UDP 500, UDP 4500, IP proto 50 | Certificate-based against the cluster CA, negotiated by `ovs-monitor-ipsec` | Protects the Geneve tunnels above. OVN-native only — no layer manages strongSwan directly. |
+| Instance DNS forwarding | UDP/TCP 5300 | None | Each node's per-instance DNS shim forwards guest queries to peer nodes' northstar `:5300` |
 
 Nodes **must** sit on a network segment that is not routed to tenant/guest VMs or to the internet. The Predastore blob and meta transports and the OVN DBs are cluster-internal and must not be reachable from anywhere else.
 
 ## 4. Limiting Controls
 
-Default external surface is three listeners — **9999** (AWS API), **3000** (UI), **22** (SSH) — plus **4432** transiently during bootstrap. Every other listener is cluster-only and the operator must enforce this with a host firewall (`nftables`/`iptables`/`firewalld`) or an upstream network ACL. Minimal `nftables` reference:
+Default external surface is five listeners — **9999** (AWS API), **3000** (UI), **22** (SSH), **8443** (S3) and **53** (DNS) — plus **4432** transiently during bootstrap. Every other listener is cluster- or encap-scoped and the operator must enforce this with a host firewall or an upstream network ACL.
+
+The nodes ship no firewall policy today. Until one is installed, this is the operator's responsibility and the reference below is the starting point.
+
+> **Read the notes under the ruleset before applying it.** A default-deny input policy that
+> omits any of the loopback, conntrack, `ime-*` or Geneve rules will break instance
+> networking, guest metadata or your own SSH session. Apply it to one node and verify before
+> applying it cluster-wide.
 
 ```
-# External: from anywhere
-tcp dport { 22, 9999, 3000 } accept
+table inet spinifex_filter {
+  chain input {
+    type filter hook input priority filter; policy drop;
 
-# Cluster-only: replace 10.0.1.0/24 with your cluster CIDR
-ip saddr 10.0.1.0/24 tcp dport { 4222, 4248, 8443, 6641-6644 } accept
-ip saddr 10.0.1.0/24 udp dport { 6081, 6660, 7660 } accept
+    ct state established,related accept
+    ct state invalid drop
+    iif lo accept
 
-# Default deny
-tcp dport 0-65535 drop
-udp dport 0-65535 drop
+    # Guest metadata and per-VPC DNS terminate on the host, on per-instance
+    # interfaces. Omitting this breaks cloud-init, instance role credentials
+    # and all guest DNS.
+    iifname "ime-*" accept
+
+    # Path MTU discovery is not optional under a Geneve overlay: dropping
+    # destination-unreachable produces silent blackholes on large flows.
+    icmp type { echo-request, destination-unreachable, time-exceeded, parameter-problem } accept
+    icmpv6 type { echo-request, destination-unreachable, packet-too-big, time-exceeded,
+                  parameter-problem, nd-neighbor-solicit, nd-neighbor-advert,
+                  nd-router-advert } accept
+
+    # External, from anywhere
+    tcp dport { 22, 3000, 8443, 9999 } accept
+    tcp dport 53 accept
+    udp dport 53 accept
+
+    # Cluster, from peer nodes only. Replace with your nodes' lan-plane
+    # addresses — a CIDR does not generalise to nodes on different subnets.
+    ip saddr { 10.0.1.1, 10.0.1.2, 10.0.1.3 } tcp dport { 4222, 4248, 4432, 5300, 6641, 6642, 6643, 6644 } accept
+    ip saddr { 10.0.1.1, 10.0.1.2, 10.0.1.3 } udp dport { 5300, 6660, 7660 } accept
+
+    # Encap, from peer chassis only. Replace with your nodes' vpc-plane
+    # addresses. Geneve arrives as host-local UDP and must be accepted here.
+    ip saddr { 10.0.2.1, 10.0.2.2, 10.0.2.3 } udp dport { 6081, 500, 4500 } accept
+    ip saddr { 10.0.2.1, 10.0.2.2, 10.0.2.3 } meta l4proto esp accept
+  }
+}
 ```
+
+Notes that make the difference between this working and locking you out:
+
+- **Use a dedicated table and never flush the others.** `vpcd` writes MASQUERADE and per-EIP FORWARD rules into the `ip filter` and `ip nat` tables, and only reinstalls them when the service starts. `iptables -F`, `nft flush ruleset`, `ufw enable` and `firewalld` all destroy them silently, and instance networking stays broken until the next restart.
+- **Do not add a `forward` hook.** nftables evaluates every table registered on a hook and any `drop` is final, so a default-deny forward chain here would override `vpcd`'s accepts in the other table and break every routed-NAT instance and every EIP. Filtering forwarded guest traffic is the security group's job, not the host firewall's.
+- **`output` is deliberately untouched.** The metadata service's reply path egresses through per-instance policy routing; filtering `output` breaks it in ways that are hard to attribute.
+- **On a single-NIC node the cluster and encap sets are the node's public addresses**, because the planes collapse. The rules are still correct, but they are no longer a boundary — an upstream ACL is the only real control there.
 
 Port 4432 must be closed outside the bootstrap window; `spx admin join` opens it transiently. Outbound egress can be limited to the image-catalogue hostnames in [§2](#2-outbound-connections) plus the operator's OS package repositories; on air-gapped nodes, block all outbound HTTPS and use `spx admin images import --file`.
 
@@ -165,10 +224,11 @@ Every listener and outbound destination is controlled by one of these files. Cha
 
 | File | Keys | Controls |
 |------|------|----------|
-| `/etc/spinifex/spinifex.toml` | `nodes.<node>.{awsgw,nats,predastore,daemon}.host`, `nodes.<node>.vpcd.ovn_{nb,sb}_addr`, `nodes.<node>.daemon.dev_networking` | Per-service bind addresses/ports; dev-mode QEMU port forwarding. |
+| `/etc/spinifex/spinifex.toml` | `nodes.<node>.{awsgw,nats,predastore,daemon}.host`, `nodes.<node>.vpcd.ovn_{nb,sb}_addr`, `nodes.<node>.daemon.dev_networking`, `network.ipsec_enabled` | Per-service bind addresses/ports; dev-mode QEMU port forwarding. `network.ipsec_enabled` (default `true`) decides whether OVN-native IPsec protects the Geneve tunnels, and therefore whether `charon` listens on 500/4500 — single-node clusters never enable it. |
 | `/etc/spinifex/nats.conf` | `listen`, `cluster.listen`, `cluster.routes`, `http`, `tls`, `cluster.authorization` | NATS client/cluster/monitoring listeners, peer routes, TLS, cluster token. |
 | `/etc/spinifex/predastore/predastore.toml` | `[[host]].bind_addr`, `[[host]].addr`, `[[host]].tls_cert`, `[[host]].tls_key`, `[[host.node]].role`, `[[host.node]].port` | Predastore host and node layout: `bind_addr` is the address the host's sockets bind, `addr` is the address peer hosts dial it on, and both carry no port — the nodes pinned to the host supply their own. The service's `--host`/`--port` override the bind address and the gate's S3 port. |
-| OVN packages (`ovn-central`, `ovn-host`) | `ovn-nb-db`, `ovn-sb-db` (via `ovs-vsctl set open_vswitch …`) | OVN DB bind addresses. |
+| `/etc/spinifex/northstar/northstar.toml` | `listen`, `forwarders` | DNS listen addresses (`:53` on the advertise address, `:5300` wildcard) and upstream resolvers. |
+| OVN packages (`ovn-central`, `ovn-host`) | `ovn-nb-db`, `ovn-sb-db` (via `ovs-vsctl set open_vswitch …`); `setup-ovn.sh --lan-addr` for the NB/SB client bind; `--encap-ip` for the Geneve endpoint | OVN DB bind addresses and the encap plane. |
 | Spinifex UI service | Built-in defaults: `host = "0.0.0.0"`, `port = 3000`. No `spinifex.toml` block today. | UI listener. |
 | `spx admin init` / `spx admin join` | `--port`, `--token-ttl`, `--no-telemetry` (or `SPX_NO_TELEMETRY=1`) | Formation port, token TTL, telemetry opt-out. |
 | Image catalogue (built-in) | Fixed URLs listed in [§2](#2-outbound-connections); not operator-configurable | Outbound HTTPS destinations for image downloads. |
@@ -176,7 +236,8 @@ Every listener and outbound destination is controlled by one of these files. Cha
 ## 6. Operator Checklist
 
 - Inventory recorded in the system security plan — inbound ([§1](#1-inbound-listeners)), outbound ([§2](#2-outbound-connections)), cross-node ([§3](#3-cross-node-internal-connections)) — matches what is observed on the node (`ss -tlnp`, `ss -unlp`).
-- Host firewall enforces the external/cluster/localhost split in [§4](#4-limiting-controls): external surface limited to 9999, 3000, 22 (and 4432 only during bootstrap).
+- Host firewall enforces the scope split in [§4](#4-limiting-controls): external surface limited to 9999, 3000, 22, 8443 and 53 (and 4432 only during bootstrap).
+- Node planes verified: `ss -tulnp` shows cluster-scope listeners on the `lan` address and encap-scope listeners reachable only from peer chassis. On a single-NIC node, record that the planes are collapsed and that an upstream ACL is the only boundary.
 - Cluster subnet is isolated from tenant guest VM networks and from the public internet.
 - Formation port 4432 is closed on nodes not actively running a bootstrap token.
 - Outbound HTTPS restricted to the [§2](#2-outbound-connections) image-catalogue hosts, or replaced with air-gapped import.


### PR DESCRIPTION
Docs only. Covers F3, F4 and proposal 5 of `mulga-adgld`; plan is
`docs/development/bugs/port-security-charon-and-firewall.md` in mulga.

## Missing listeners

§1 asks the operator to compare the table against `ss -tulnp`, which was not
possible while six listeners were absent from it:

- **northstar** — `53` udp+tcp on the advertise (wan) address, and `5300` udp+tcp on
  the wildcard. 5300 is dialled cross-node: every node's per-instance DNS shim forwards
  guest queries to peer nodes on it, so it is a cluster-scope listener that no firewall
  guidance mentioned.
- **charon** — `500`, `4500` and ESP, on the encap plane.
- **Geneve** — `6081`, previously only in §3.
- **IMDS `169.254.169.254:80` and VPC DNS `169.254.169.253:53`** — per-instance sockets
  that terminate on the host.
- **chronyd `323`**.

## Wrong classifications

- **8443 was Cluster.** predastore binds the S3 gate to `0.0.0.0` deliberately, because S3
  is a public plane. Now External.
- **4432 was External.** It binds the node's `--bind` (lan) address and is transient. Now
  Cluster, bootstrap only.

## Scope vocabulary

The External / Cluster / Localhost split predates the three-plane model, so it had no way
to express the encap plane and no way to record that a node with fewer NICs collapses
`vpc` ← `lan` ← `wan`. Added Encap and Guest, and a note that on a single-NIC node every
scope lands on the public address — so Cluster and Encap state intent, not a guarantee.

## The reference ruleset

The §4 nftables snippet is replaced rather than patched. As written it had no
`ct state established,related accept`, no `iif lo accept`, no ICMP and no `ime-*` rule,
and ended in a blanket `tcp dport 0-65535 drop`. An operator who applied it would lose
guest metadata, guest DNS, all egress return traffic and their own SSH session.

The replacement is input-only in a dedicated `table inet spinifex_filter`, with the
reasoning recorded inline:

- nftables evaluates every table on a hook and any `drop` is final, so a default-deny
  `forward` chain in a new table would override the ACCEPTs `vpcd` writes to `ip filter`
  and break every routed-NAT instance and every EIP.
- `iptables -F`, `nft flush ruleset`, `ufw enable` and `firewalld` destroy `vpcd`'s
  MASQUERADE and per-EIP rules, which are only reinstalled when the service restarts.
- Geneve arrives as host-local UDP and traverses the input hook, so it needs an explicit
  accept. Verified on a live node: `0.0.0.0:6081` has no owning process and appears in
  `/proc/net/udp` as a uid-0 kernel UDP-tunnel socket.
- PMTUD matters under an overlay, so ICMP `destination-unreachable` cannot be dropped.

## Verification

Listener facts checked against a live 5-node cluster, not just against source.

`make preflight` passes on the rebased branch.
