### PR TITLE
fix: synchronise the bedrock system-VPC test fake

### DIFF
--- a/spinifex/handlers/bedrock/fakes_test.go
+++ b/spinifex/handlers/bedrock/fakes_test.go
@@ -20,6 +20,9 @@ import (
 // launch_test.go fixture of the same name (the systemvpc package's own rules
 // are covered in its package tests, not re-verified here).
 type fakeSystemVPC struct {
+	// The service under test launches concurrently, so the methods below
+	// run on more than one goroutine and share this state.
+	mu         sync.Mutex
 	seq        int
 	igwCreated bool
 }
@@ -33,6 +36,8 @@ var (
 )
 
 func (f *fakeSystemVPC) id(prefix string) *string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.seq++
 	return aws.String(fmt.Sprintf("%s-%04d", prefix, f.seq))
 }
@@ -110,7 +115,9 @@ func (f *fakeSystemVPC) ReleaseAddress(context.Context, *ec2.ReleaseAddressInput
 }
 
 func (f *fakeSystemVPC) CreateInternetGateway(context.Context, *ec2.CreateInternetGatewayInput, string) (*ec2.CreateInternetGatewayOutput, error) {
+	f.mu.Lock()
 	f.igwCreated = true
+	f.mu.Unlock()
 	return &ec2.CreateInternetGatewayOutput{InternetGateway: &ec2.InternetGateway{InternetGatewayId: aws.String("igw-bedrocksys")}}, nil
 }
 
@@ -130,7 +137,10 @@ func (f *fakeSystemVPC) DeleteInternetGateway(context.Context, *ec2.DeleteIntern
 // attaches an IGW and then re-reads it, so the pre-create lookup must find
 // nothing (or no IGW is ever created) and only the post-attach one answered.
 func (f *fakeSystemVPC) DescribeInternetGateways(_ context.Context, in *ec2.DescribeInternetGatewaysInput, _ string) (*ec2.DescribeInternetGatewaysOutput, error) {
-	if !f.igwCreated {
+	f.mu.Lock()
+	created := f.igwCreated
+	f.mu.Unlock()
+	if !created {
 		return &ec2.DescribeInternetGatewaysOutput{}, nil
 	}
 	return &ec2.DescribeInternetGatewaysOutput{InternetGateways: []*ec2.InternetGateway{{


### PR DESCRIPTION
## Summary

`make -C spinifex test-race` fails intermittently in CI:

```
WARNING: DATA RACE
Read at 0x00c00074b010 by goroutine 3612:
  ...bedrock.(*fakeSystemVPC).id()  fakes_test.go:36
  ...bedrock.(*fakeSystemVPC).CreateSubnet()  fakes_test.go:57
Previous write at 0x00c00074b010 by goroutine 3613:
  ...bedrock.(*fakeSystemVPC).id()  fakes_test.go:36
  ...bedrock.(*fakeSystemVPC).AssociateRouteTable()  fakes_test.go:85
--- FAIL: TestList_ReturnsEndpointsAcrossAllAccountsIncludingPinned
    testing.go:1712: race detected during execution of test
```

`Service.Ensure` starts concurrent launches, so both goroutines reach `systemvpc.Ensure` and share the fake. `seq` and `igwCreated` were unsynchronised.

This is a test-double defect only — no production code is involved, and driving `systemvpc.Ensure` concurrently is legitimate behaviour of the service under test.

## Fix

Guard the fake's mutable state with a mutex.

## Verification

`go test -race -count=8 ./spinifex/handlers/bedrock/` — clean (51s). Previously reproduced in CI run 31590801051.

Bead: `mulga-02epm`
