### PR TITLE
docs: record the AMI-metadata upgrade cliff and binary-swap skew

### DIFF
--- a/docs/admin/update/README.md
+++ b/docs/admin/update/README.md
@@ -35,6 +35,17 @@ For operators who want to review migrations before they are applied, a manual up
 > [!WARNING]
 > **Object storage is exempt when upgrading from v1.15.0 or earlier to v1.16.0.** Predastore's configuration schema and on-disk layout changed with the object storage cutover in v1.16.0, and no migration converts an installation from before it. `spx admin upgrade` will not report anything pending for `predastore.toml`, and updating the binary over such an installation leaves Predastore unable to start. Those clusters have to be re-initialised from scratch, which discards their stored objects — export anything you need first. Upgrades between v1.16.0 and later releases are unaffected.
 
+> [!WARNING]
+> **AMI metadata is exempt when upgrading from v1.16.0 or earlier to the release carrying the EBS-provider decoupling.** AMI metadata moved to `ebsmetadata` documents, and the legacy path that read it from `ami-<id>/config.json` was removed rather than migrated. There is no prefix scan, no fallback and no backfill at daemon start, so an AMI imported before the change becomes invisible to the control plane afterwards: `describe-images --image-ids` answers `InvalidAMIID.NotFound` and launches fail with `AMI has no snapshot ID, cannot perform zero-copy clone`. As with object storage above, `spx admin upgrade` reports nothing pending, because the gap is in stored data rather than in a config file.
+>
+> **Re-import affected AMIs after upgrading**, using [`spx admin images import`](/docs/admin/spinifex-admin-cli), which writes metadata in the new location. If the source images are no longer available, the installation has to be re-initialised. Verify before you rely on it — an AMI is only healthy if it resolves by ID, not merely if it appears in the list:
+>
+> ```bash
+> aws ec2 describe-images --image-ids <ami-id>
+> ```
+>
+> This warning covers AMI metadata specifically, which is what has been observed. Check any other imported state you depend on before upgrading a cluster you cannot rebuild.
+
 ## Instructions
 
 ## Step 1. Re-run the Installer
@@ -129,3 +140,37 @@ sudo systemctl restart spinifex.target
 ```
 
 A restart preserves any running guests — they are not rebooted, and storage returns within seconds. See [Host and Guest Lifecycle](/docs/admin/host-lifecycle) for the full contract.
+
+### A Node Answers Some Requests as if It Were Still on the Old Build
+
+Replacing `/usr/local/bin/spx` while `spinifex.target` is running does **not** move the running services onto the new binary. They keep executing the replaced file's now-unlinked inode until each unit restarts, so a node can serve the old build indefinitely. Only a service that happens to restart for its own reasons picks the new one up, which leaves a node running a mixture.
+
+This is easy to miss, because the request handlers are NATS queue-group workers spread across nodes: one skewed node in three answers roughly one request in three with the old behaviour, which reads as an intermittent fault rather than a broken node.
+
+Check for it with:
+
+```bash
+for u in spinifex-daemon spinifex-awsgw spinifex-viperblock spinifex-vpcd spinifex-ui spinifex-predastore; do
+  pid=$(systemctl show -p MainPID --value "$u")
+  [ "$pid" != "0" ] && printf '%-22s %s\n' "$u" "$(sudo readlink /proc/$pid/exe)"
+done
+```
+
+Any line ending `(deleted)` is running a replaced binary. Restart the target to clear it:
+
+```bash
+sudo systemctl restart spinifex.target
+```
+
+Re-running the installer avoids this entirely — it restarts services after installing. Prefer it over copying a binary onto a live node.
+
+### Instances Fail to Launch After an Upgrade
+
+```
+AMI has no snapshot ID, cannot perform zero-copy clone
+```
+
+Or `describe-images --image-ids` reports `InvalidAMIID.NotFound` for an AMI that still appears in the unfiltered `describe-images` list. Two different causes produce this, so check them in order:
+
+1. **A node running a replaced binary**, per the previous entry. Suspect this first if the failure is intermittent — the same command succeeding on some attempts and failing on others is characteristic.
+2. **AMI metadata predating the EBS-provider decoupling**, per the warning at the top of this page. This is consistent rather than intermittent, and is resolved by re-importing the AMI.


### PR DESCRIPTION
## Summary

Two operator-facing gaps found while root-causing a phantom `InvalidAMIID.NotFound` on a lab cluster.

### 1. AMI metadata has no upgrade path

AMI metadata moved to `ebsmetadata` documents and the legacy `ami-<id>/config.json` read path was removed rather than migrated — no prefix scan, no fallback, no backfill at daemon start. An AMI imported before the change becomes invisible to the control plane after upgrading: `describe-images --image-ids` answers `InvalidAMIID.NotFound` and launches fail with `AMI has no snapshot ID, cannot perform zero-copy clone`.

`spx admin upgrade` reports nothing pending, because the gap is in stored data rather than in a config file — the same shape as the existing object-storage exemption for v1.16.0, so it is documented alongside it.

Recovery is to re-import affected AMIs; failing that, re-initialise. The warning is deliberately scoped to AMI metadata, which is what was actually observed, with a note to check other imported state rather than implying it has been verified.

### 2. Replacing the binary under a running target

Replacing `/usr/local/bin/spx` while `spinifex.target` runs leaves services executing the replaced file's unlinked inode. Observed on a lab node where five units ran a build 40 commits behind the on-disk binary for most of a day; only `spinifex-predastore` had picked the new one up, because it happened to be crash-looping at the time.

Because handlers are NATS queue-group workers, one skewed node in three answered roughly one request in three with the old behaviour — which reads as an intermittent fault, not a broken node. Measured 6 failures in 20 identical `describe-images` calls; 20/20 after a target restart.

Adds a check (`readlink /proc/<MainPID>/exe`, look for `(deleted)`), the fix, and a pointer to prefer re-running the installer.

Also adds a troubleshooting entry for the launch failure itself, listing both causes in the order worth checking — intermittent points at binary skew, consistent points at the metadata cliff.

Docs only.

Related: `mulga-leg2v` (closed), `mulga-38bca` (guard for the skew), `mulga-wcwq5`
