### PR TITLE
refactor(test): route duplicated NATS bootstraps through testutil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ install-microvm: $(MICROVM_ARTIFACTS) ## Install microVM artifacts to /usr/share
 # the pre-commit gate: manifest checks, lint, vuln, and the unit and e2e-harness tiers.
 # integration and race tests skipped to keep quick, they run in CI.
 preflight:
-	@$(MAKE) --no-print-directory QUIET=1 manifest-check manifest-lint lint govulncheck test-cover diff-coverage test-harness
+	@$(MAKE) --no-print-directory QUIET=1 manifest-check manifest-lint lint govulncheck test-cover diff-coverage test-package-check test-harness
 	@echo -e "\n ✅ Preflight passed — safe to commit."
 
 # E2E harness unit tests. Build-tagged `e2e` so they're skipped by the
@@ -252,6 +252,10 @@ test-images:
 # Check that new/changed code meets coverage threshold (runs tests first)
 diff-coverage: test-cover
 	@QUIET=$(QUIET) scripts/diff-coverage.sh $(COVERPROFILE)
+
+# Check that newly added test files use an external test package
+test-package-check:
+	@QUIET=$(QUIET) scripts/check-test-package.sh
 
 bench:
 	@echo -e "\n....Running benchmarks for $(GO_PROJECT_NAME)...."
@@ -392,7 +396,7 @@ distro-arm64:
 distro-clean:
 	rm -rf dist/
 
-.PHONY: build build-ui build-installer build-lb-agent build-ecs-agent build-system-image build-eks-node-image import-eks-node-image publish-eks-node-image build-ecs-node-image import-ecs-node-image build-rds-postgres-image import-rds-postgres-image build-microvm-image install-microvm go_build preflight test test-cover test-race diff-coverage bench test-actions test-images test-harness test-integration generate-aws-model-coverage aws-model-coverage test-segscan-oracle manifest-check manifest-lint manifest-lint-update \
+.PHONY: test-package-check build build-ui build-installer build-lb-agent build-ecs-agent build-system-image build-eks-node-image import-eks-node-image publish-eks-node-image build-ecs-node-image import-ecs-node-image build-rds-postgres-image import-rds-postgres-image build-microvm-image install-microvm go_build preflight test test-cover test-race diff-coverage bench test-actions test-images test-harness test-integration generate-aws-model-coverage aws-model-coverage test-segscan-oracle manifest-check manifest-lint manifest-lint-update \
 	deploy reinstall clean \
 	install-system install-go install-aws quickinstall \
 	lint fix govulncheck nilaway \

--- a/cmd/spinifex/cmd/admin_upgrade_test.go
+++ b/cmd/spinifex/cmd/admin_upgrade_test.go
@@ -1,4 +1,4 @@
-package cmd
+package cmd_test
 
 import (
 	"os"

--- a/internal/preflightgate/rungate_test.go
+++ b/internal/preflightgate/rungate_test.go
@@ -1,7 +1,7 @@
 // Package preflightgate tests the preflight gate wrapper. It exists as a Go
 // test so `go test ./...` exercises it; the repo's shell suites are not yet
 // wired into CI.
-package preflightgate
+package preflightgate_test
 
 import (
 	"errors"

--- a/scripts/check-test-package.sh
+++ b/scripts/check-test-package.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires newly added test files to use an external test package.
+#
+# `package foo_test` binds tests to the exported API, so internals can be
+# refactored without rewriting tests, and it lets packages share test doubles
+# (an in-package double is invisible to every other package). Coverage is
+# unaffected — Go compiles internal and external test packages into a single
+# binary per package, so attribution is identical either way.
+#
+# Only ADDED files are checked; existing in-package tests are left alone.
+# A file that genuinely needs unexported access can either opt out with a
+# `//go:build` free marker comment (see ALLOW_MARKER) or move the unexported
+# hook into an export_test.go.
+#
+# Usage: scripts/check-test-package.sh [--base <ref>]
+#
+# Base ref auto-detection matches diff-coverage.sh:
+#   main branch   → HEAD~1
+#   dev branch    → origin/main
+#   other branch  → origin/dev
+
+BASE_REF=""
+QUIET="${QUIET:-}"
+ALLOW_MARKER="//test:in-package"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base) BASE_REF="$2"; shift 2 ;;
+        -*)     echo "Unknown option: $1" >&2; exit 1 ;;
+        *)      echo "Unexpected argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$BASE_REF" ]]; then
+    BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+    case "$BRANCH" in
+        main) BASE_REF="HEAD~1" ;;
+        dev)  BASE_REF="origin/main" ;;
+        *)    BASE_REF="origin/dev" ;;
+    esac
+    [[ -z "$QUIET" ]] && echo "Base ref: $BASE_REF (branch: $BRANCH)"
+fi
+
+if ! git rev-parse --verify "$BASE_REF" &>/dev/null; then
+    echo "Error: base ref '$BASE_REF' not reachable." >&2
+    echo "Fetch it first: git fetch origin <branch>" >&2
+    exit 1
+fi
+
+# e2e and integration suites share a package-level fixture built in
+# main_test.go, so their files cannot move individually.
+ADDED=$(git diff "$BASE_REF" HEAD --name-only --diff-filter=A -- '*_test.go' \
+    ':!tests/e2e/*' ':!tests/integration/*' || true)
+
+if [[ -z "$ADDED" ]]; then
+    [[ -z "$QUIET" ]] && echo "No new test files — skipping test package check."
+    exit 0
+fi
+
+VIOLATIONS=()
+for f in $ADDED; do
+    [[ -f "$f" ]] || continue
+    if grep -qF "$ALLOW_MARKER" "$f"; then
+        continue
+    fi
+    pkg=$(awk '/^package /{print $2; exit}' "$f")
+    if [[ -n "$pkg" && "$pkg" != *_test ]]; then
+        VIOLATIONS+=("$f (package $pkg)")
+    fi
+done
+
+if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+    echo "ERROR: new test files must use an external test package (package <pkg>_test):" >&2
+    for v in "${VIOLATIONS[@]}"; do
+        echo "  $v" >&2
+    done
+    echo "" >&2
+    echo "Move unexported hooks into export_test.go, or add the comment" >&2
+    echo "'$ALLOW_MARKER' to the file with a reason if in-package access is required." >&2
+    exit 1
+fi
+
+[[ -z "$QUIET" ]] && echo "Test package check OK ($(echo "$ADDED" | wc -w) new file(s))"
+exit 0

--- a/spinifex/daemon/daemon_handlers_test.go
+++ b/spinifex/daemon/daemon_handlers_test.go
@@ -39,9 +39,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/testutil/ebsfake"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/vm"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -137,22 +135,7 @@ func createFullTestDaemonWithJetStream(t *testing.T, natsURL string) *Daemon {
 // using an isolated embedded NATS JetStream server per test to avoid shared KV state.
 func initAccountServiceForTest(t *testing.T, daemon *Daemon) {
 	t.Helper()
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc, _ := testutil.StartTestJetStream(t)
 
 	svc, err := handlers_ec2_account.NewAccountSettingsServiceImplWithNATS(t.Context(), nil, nc)
 	require.NoError(t, err)
@@ -2286,22 +2269,7 @@ func createVPCTestDaemon(t *testing.T) *Daemon {
 
 	daemon := createTestDaemon(t, sharedNATSURL)
 
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc, _ := testutil.StartTestJetStream(t)
 
 	testutil.StubVpcdSGResponder(t, nc)
 
@@ -2604,22 +2572,7 @@ func TestDelegateHandlers_EIGW(t *testing.T) {
 	daemon := createTestDaemon(t, sharedNATSURL)
 
 	// Create an isolated JetStream NATS server for the EIGW service
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc, _ := testutil.StartTestJetStream(t)
 
 	eigwSvc, err := handlers_ec2_eigw.NewEgressOnlyIGWServiceImplWithNATS(t.Context(), daemon.config, nc)
 	require.NoError(t, err)
@@ -3520,25 +3473,8 @@ func TestHandleEC2TerminateStoppedInstance_WritesToTerminatedKV(t *testing.T) {
 func TestDelegateHandlers_EIP(t *testing.T) {
 	daemon := createVPCTestDaemon(t)
 
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
+	_, nc, js := testutil.StartTestJetStream(t)
 
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
-
-	js, err := jetstream.New(nc)
-	require.NoError(t, err)
 	ipam, err := handlers_ec2_vpc.NewExternalIPAM(t.Context(), js, []external.ExternalPoolConfig{
 		{Name: "test-pool", RangeStart: "192.168.100.2", RangeEnd: "192.168.100.254", Gateway: "192.168.100.1", PrefixLen: 24},
 	})
@@ -3713,22 +3649,7 @@ func TestDelegateHandlers_RouteTable(t *testing.T) {
 	daemon := createVPCTestDaemon(t)
 
 	// Route table service needs its own JetStream for KV buckets
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc, _ := testutil.StartTestJetStream(t)
 
 	rtbSvc, err := handlers_ec2_routetable.NewRouteTableServiceImplWithNATS(t.Context(), daemon.config, nc)
 	require.NoError(t, err)
@@ -3846,22 +3767,7 @@ func TestDelegateHandlers_RouteTable(t *testing.T) {
 func TestDelegateHandlers_PlacementGroup(t *testing.T) {
 	daemon := createTestDaemon(t, sharedNATSURL)
 
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc, _ := testutil.StartTestJetStream(t)
 
 	pgSvc, err := handlers_ec2_placementgroup.NewPlacementGroupServiceImplWithNATS(t.Context(), daemon.config, nc)
 	require.NoError(t, err)

--- a/spinifex/daemon/daemon_system_instance_test.go
+++ b/spinifex/daemon/daemon_system_instance_test.go
@@ -20,9 +20,7 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/tags"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/vm"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -734,25 +732,8 @@ func TestLaunchSystemInstance_NATFailureRollsBackPublicIP(t *testing.T) {
 
 	// Wire an ExternalIPAM against a fresh JS server. The pool gives us a
 	// known IP that the rollback must release back.
-	jsNS, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go jsNS.Start()
-	require.True(t, jsNS.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { jsNS.Shutdown() })
+	_, _, js := testutil.StartTestJetStream(t)
 
-	jsNC, err := nats.Connect(jsNS.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { jsNC.Close() })
-
-	js, err := jetstream.New(jsNC)
-	require.NoError(t, err)
 	ipam, err := handlers_ec2_vpc.NewExternalIPAM(t.Context(), js, []external.ExternalPoolConfig{
 		{Name: "wan-test", RangeStart: "203.0.113.10", RangeEnd: "203.0.113.20", Gateway: "203.0.113.1", PrefixLen: 24},
 	})
@@ -856,25 +837,8 @@ func TestLaunchSystemInstance_NATFailureRollsBackPublicIP(t *testing.T) {
 func TestReleaseSystemInstanceEIP_ReleasesEipServiceAllocation(t *testing.T) {
 	d := createVPCTestDaemon(t)
 
-	jsNS, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go jsNS.Start()
-	require.True(t, jsNS.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { jsNS.Shutdown() })
+	_, jsNC, js := testutil.StartTestJetStream(t)
 
-	jsNC, err := nats.Connect(jsNS.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { jsNC.Close() })
-
-	js, err := jetstream.New(jsNC)
-	require.NoError(t, err)
 	ipam, err := handlers_ec2_vpc.NewExternalIPAM(t.Context(), js, []external.ExternalPoolConfig{
 		{Name: "wan-test", RangeStart: "203.0.113.10", RangeEnd: "203.0.113.20", Gateway: "203.0.113.1", PrefixLen: 24},
 	})

--- a/spinifex/daemon/shutdown_invariant_test.go
+++ b/spinifex/daemon/shutdown_invariant_test.go
@@ -1,4 +1,4 @@
-package daemon
+package daemon_test
 
 import (
 	"fmt"

--- a/spinifex/daemon/vm_adapters_test.go
+++ b/spinifex/daemon/vm_adapters_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -17,7 +16,6 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/vm"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -560,21 +558,7 @@ func TestInstanceCleanerAdapter_DetachAndDeleteENI_AbsentPrimaryDoesNotLogFalseS
 func TestInstanceCleanerAdapter_ReleaseAttachedENIs_ListInstanceENIsErrorTolerated(t *testing.T) {
 	daemon := createTestDaemon(t, sharedNATSURL)
 
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
+	_, nc, _ := testutil.StartTestJetStream(t)
 	testutil.StubVpcdSGResponder(t, nc)
 
 	vpcSvc, err := handlers_ec2_vpc.NewVPCServiceImplWithNATS(t.Context(), daemon.config, nc)

--- a/spinifex/daemon/vpc_adapter_test.go
+++ b/spinifex/daemon/vpc_adapter_test.go
@@ -3,14 +3,11 @@ package daemon
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	handlers_ec2_vpc "github.com/mulgadc/spinifex/spinifex/handlers/ec2/vpc"
 	"github.com/mulgadc/spinifex/spinifex/testutil"
-	"github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,21 +100,7 @@ func TestDaemonENICreator_ListInstanceENIs_NoAttachments(t *testing.T) {
 func TestDaemonENICreator_ListInstanceENIs_KVError(t *testing.T) {
 	daemon := createTestDaemon(t, sharedNATSURL)
 
-	ns, err := server.NewServer(&server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	})
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
+	_, nc, _ := testutil.StartTestJetStream(t)
 	testutil.StubVpcdSGResponder(t, nc)
 
 	vpcSvc, err := handlers_ec2_vpc.NewVPCServiceImplWithNATS(t.Context(), daemon.config, nc)

--- a/spinifex/gateway/ec2/vpc/network_interface_hotplug_test.go
+++ b/spinifex/gateway/ec2/vpc/network_interface_hotplug_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/mulgadc/spinifex/spinifex/awserrors"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,21 +18,7 @@ import (
 
 func newTestNATS(t *testing.T) *nats.Conn {
 	t.Helper()
-	opts := &server.Options{
-		Host:   "127.0.0.1",
-		Port:   -1,
-		NoLog:  true,
-		NoSigs: true,
-	}
-	ns, err := server.NewServer(opts)
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartTestNATS(t)
 	return nc
 }
 

--- a/spinifex/handlers/ec2/instance/service_impl_test.go
+++ b/spinifex/handlers/ec2/instance/service_impl_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/mulgadc/spinifex/spinifex/ebsmetadata"
 	"github.com/mulgadc/spinifex/spinifex/gpu"
 	"github.com/mulgadc/spinifex/spinifex/tags"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	spxtypes "github.com/mulgadc/spinifex/spinifex/types"
 	"github.com/mulgadc/spinifex/spinifex/utils"
 	"github.com/mulgadc/spinifex/spinifex/vm"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
@@ -1733,21 +1733,7 @@ func (f *fakePublicIPReleaser) ReleaseIP(_ context.Context, pool, ip, ownerENIID
 // ebs.delete path inside TerminateStoppedInstance.
 func embeddedNATS(t *testing.T) *nats.Conn {
 	t.Helper()
-	opts := &server.Options{
-		Host:   "127.0.0.1",
-		Port:   -1,
-		NoLog:  true,
-		NoSigs: true,
-	}
-	ns, err := server.NewServer(opts)
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc := testutil.StartTestNATS(t)
 	return nc
 }
 

--- a/spinifex/handlers/ec2/volume/testhelpers_test.go
+++ b/spinifex/handlers/ec2/volume/testhelpers_test.go
@@ -5,13 +5,12 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mulgadc/spinifex/spinifex/ebsmetadata"
 	"github.com/mulgadc/spinifex/spinifex/objectstore"
-	"github.com/nats-io/nats-server/v2/server"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/require"
 )
@@ -19,23 +18,7 @@ import (
 // startTestNATS spins up an in-process NATS server and returns a connected client.
 func startTestNATS(t *testing.T) *nats.Conn {
 	t.Helper()
-	opts := &server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	}
-	ns, err := server.NewServer(opts)
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc, _ := testutil.StartTestJetStream(t)
 	return nc
 }
 

--- a/spinifex/handlers/iam/account_test.go
+++ b/spinifex/handlers/iam/account_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/mulgadc/spinifex/spinifex/testutil"
 	"github.com/mulgadc/spinifex/spinifex/utils"
-	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -387,23 +387,7 @@ func TestSeedBootstrap_AccountScoped(t *testing.T) {
 // ============================================================================
 
 func TestCreateAccount_PublishesEvent(t *testing.T) {
-	opts := &server.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-		NoLog:     true,
-		NoSigs:    true,
-	}
-	ns, err := server.NewServer(opts)
-	require.NoError(t, err)
-	go ns.Start()
-	require.True(t, ns.ReadyForConnections(5*time.Second))
-	t.Cleanup(func() { ns.Shutdown() })
-
-	nc, err := nats.Connect(ns.ClientURL())
-	require.NoError(t, err)
-	t.Cleanup(func() { nc.Close() })
+	_, nc, _ := testutil.StartTestJetStream(t)
 
 	masterKey, err := GenerateMasterKey()
 	require.NoError(t, err)

--- a/spinifex/network/host/imds_netns_unit_test.go
+++ b/spinifex/network/host/imds_netns_unit_test.go
@@ -1,4 +1,4 @@
-package host
+package host_test
 
 import (
 	"os"

--- a/spinifex/services/awsgw/imds_absent_test.go
+++ b/spinifex/services/awsgw/imds_absent_test.go
@@ -1,4 +1,4 @@
-package awsgw
+package awsgw_test
 
 import (
 	"os"

--- a/spinifex/systemd/units_invariants_test.go
+++ b/spinifex/systemd/units_invariants_test.go
@@ -1,4 +1,4 @@
-package systemd
+package systemd_test
 
 import (
 	"os"

--- a/spinifex/utils/sudo_invariants_test.go
+++ b/spinifex/utils/sudo_invariants_test.go
@@ -1,4 +1,4 @@
-package utils
+package utils_test
 
 import (
 	"os"

--- a/spinifex/utils/tagmirror_test.go
+++ b/spinifex/utils/tagmirror_test.go
@@ -19,19 +19,13 @@ type tagMirrorRecord struct {
 }
 
 // seedKV creates a bucket on the jetstream API and populates it. Package utils
-// cannot use kvutil's helpers — kvutil imports utils — so the bucket is created
-// here directly.
+// cannot use kvutil's helpers — kvutil imports utils — so a fresh JetStream
+// server is bootstrapped here directly.
 func seedKV(t *testing.T, bucket string, entries map[string][]byte) jetstream.KeyValue {
 	t.Helper()
 	_, nc, _ := testutil.StartTestJetStream(t)
 	js := testutil.NewJetStream(t, nc)
-	kv, err := js.CreateKeyValue(t.Context(), jetstream.KeyValueConfig{Bucket: bucket, History: 1})
-	require.NoError(t, err)
-	for k, v := range entries {
-		_, err := kv.Put(t.Context(), k, v)
-		require.NoError(t, err)
-	}
-	return kv
+	return testutil.SeedKV(t, js, bucket, entries)
 }
 
 func TestMergeTagsMut(t *testing.T) {

--- a/tests/integration/predastore_test.go
+++ b/tests/integration/predastore_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package integration
+package integration_test
 
 import (
 	"bytes"


### PR DESCRIPTION
## Problem

`spinifex/testutil` already exports `StartTestNATS`, `StartTestJetStream` and `SeedKV`, and 51 packages import it, but 29 test sites still hand-rolled a raw NATS or JetStream bootstrap and 4 cloned `SeedKV`.

## Changes

- 13 bootstrap sites and 1 `seedKV` clone routed through the shared helpers. Net 231 LoC removed, no production files touched.
- 8 test files moved to external test packages where they declare no helper used by a sibling.
- New preflight check `scripts/check-test-package.sh` requiring newly added test files to use an external test package.

## Deliberately not converted

Sites whose options genuinely diverge: fixed ports needed for reconnect and restart scenarios, custom TLS, token auth, custom `MaxPayload`, and `TestMain` entry points with no `testing.TB` for `t.Cleanup`.

The natgw and routetable `seedKV` clones use `CreateOrUpdateKeyValue` where `testutil.SeedKV` uses `CreateKeyValue`, so their failure behaviour differs and they stay as they are.

## Notes on the lint rule

Checks added files only, so the existing in-package tests are untouched. e2e and integration are exempt because both share a package-level fixture built in `main_test.go` and cannot move file by file. A file needing unexported access can opt out with `//test:in-package`.

Coverage is unaffected by the placement change: Go compiles internal and external test packages into one binary per package, so attribution is identical. Verified by measurement, not assumption.

## Testing

`make preflight` passes, including `go vet` under the default, `e2e` and `integration` tag sets.

Closes mulga-fh0mq.