### PR TITLE
fix(e2e): resolve the listener inventory without a Go toolchain on the target node

### DIFF
--- a/docs/security/network-connections/inventory.go
+++ b/docs/security/network-connections/inventory.go
@@ -1,9 +1,6 @@
 // Package networkconnections embeds the inbound-listener inventory doc that
-// lives alongside it. //go:embed cannot reach outside its own directory, so
-// this package exists to give that traversal a compile-time home: callers
-// get the doc's bytes without shelling out to a Go toolchain at runtime,
-// which matters for test binaries that run on nodes with no toolchain
-// installed.
+// lives alongside it, so test binaries can read it on nodes with no Go
+// toolchain. //go:embed cannot reach outside its own directory.
 package networkconnections
 
 import _ "embed"

--- a/docs/security/network-connections/inventory.go
+++ b/docs/security/network-connections/inventory.go
@@ -1,0 +1,18 @@
+// Package networkconnections embeds the inbound-listener inventory doc that
+// lives alongside it. //go:embed cannot reach outside its own directory, so
+// this package exists to give that traversal a compile-time home: callers
+// get the doc's bytes without shelling out to a Go toolchain at runtime,
+// which matters for test binaries that run on nodes with no toolchain
+// installed.
+package networkconnections
+
+import _ "embed"
+
+//go:embed README.md
+var readme []byte
+
+// README returns the raw bytes of the inbound-listener inventory doc
+// (docs/security/network-connections/README.md), embedded at compile time.
+func README() []byte {
+	return readme
+}

--- a/spinifex/network/invariants/listener_bind_test.go
+++ b/spinifex/network/invariants/listener_bind_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	networkconnections "github.com/mulgadc/spinifex/docs/security/network-connections"
 	"github.com/mulgadc/spinifex/spinifex/network/listenerinventory"
 )
 
@@ -37,10 +38,9 @@ import (
 // it at review time.
 func TestListenerBindSitesMatchInventory(t *testing.T) {
 	root := repoRoot(t)
-	docPath := listenerinventory.DocPath(root)
-	table, err := listenerinventory.ParseFile(docPath)
+	table, err := listenerinventory.Parse(string(networkconnections.README()))
 	if err != nil {
-		t.Fatalf("parse %s: %v", relTo(docPath, root), err)
+		t.Fatalf("parse docs/security/network-connections/README.md: %v", err)
 	}
 
 	var bad []string
@@ -231,4 +231,32 @@ func checkBindSite(table *listenerinventory.Table, s bindSite, root string) stri
 			rel, s.line, s.port, s.raw, r.Scope)
 	}
 	return ""
+}
+
+// TestCheckBindSite_RejectsUndocumentedPort proves the invariant still has
+// teeth after switching its doc source to an embedded copy: a bind site on a
+// port absent from the inventory must still be rejected, not silently
+// waved through.
+func TestCheckBindSite_RejectsUndocumentedPort(t *testing.T) {
+	const doc = `# doc
+
+## 1. Inbound Listeners
+
+| Port | Service | Protocol | Scope | Purpose | Auth / Verification |
+|------|---------|----------|-------|---------|--------------------|
+| 9999 | gw | HTTPS | External | public API | TLS |
+`
+	table, err := listenerinventory.Parse(doc)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	site := bindSite{file: "fixture.sh", line: 7, port: 31337, wildcard: true, raw: "0.0.0.0:31337"}
+	msg := checkBindSite(table, site, "/repo")
+	if msg == "" {
+		t.Fatalf("checkBindSite let an undocumented port (31337) through with no violation")
+	}
+	if !strings.Contains(msg, "no row in") {
+		t.Fatalf("checkBindSite message for an undocumented port = %q, want it to say there is no inventory row", msg)
+	}
 }

--- a/spinifex/network/listenerinventory/table.go
+++ b/spinifex/network/listenerinventory/table.go
@@ -3,7 +3,6 @@ package listenerinventory
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"slices"
 	"strconv"
@@ -232,23 +231,4 @@ func IsWildcardAddr(addr string) bool {
 	default:
 		return false
 	}
-}
-
-// RepoRoot returns the spinifex module root via `go env GOMOD`.
-func RepoRoot() (string, error) {
-	out, err := exec.Command("go", "env", "GOMOD").Output()
-	if err != nil {
-		return "", fmt.Errorf("listenerinventory: go env GOMOD: %w", err)
-	}
-	gomod := strings.TrimSpace(string(out))
-	if gomod == "" || gomod == "/dev/null" {
-		return "", fmt.Errorf("listenerinventory: not in a go module (GOMOD=%q)", gomod)
-	}
-	return strings.TrimSuffix(gomod, "/go.mod"), nil
-}
-
-// DocPath returns the standard location of the inbound-listener inventory
-// relative to root.
-func DocPath(root string) string {
-	return root + "/docs/security/network-connections/README.md"
 }

--- a/spinifex/network/listenerinventory/table_test.go
+++ b/spinifex/network/listenerinventory/table_test.go
@@ -3,6 +3,7 @@ package listenerinventory_test
 import (
 	"testing"
 
+	networkconnections "github.com/mulgadc/spinifex/docs/security/network-connections"
 	"github.com/mulgadc/spinifex/spinifex/network/listenerinventory"
 )
 
@@ -128,13 +129,9 @@ func TestIsWildcardAddr(t *testing.T) {
 }
 
 func TestParse_RealDoc(t *testing.T) {
-	root, err := listenerinventory.RepoRoot()
+	table, err := listenerinventory.Parse(string(networkconnections.README()))
 	if err != nil {
-		t.Fatalf("RepoRoot: %v", err)
-	}
-	table, err := listenerinventory.ParseFile(listenerinventory.DocPath(root))
-	if err != nil {
-		t.Fatalf("ParseFile: %v", err)
+		t.Fatalf("Parse: %v", err)
 	}
 	if len(table.Rows) < 15 {
 		t.Fatalf("got %d rows from the real inventory, expected considerably more", len(table.Rows))

--- a/tests/e2e/multinode/listener_invariant_test.go
+++ b/tests/e2e/multinode/listener_invariant_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	networkconnections "github.com/mulgadc/spinifex/docs/security/network-connections"
 	"github.com/mulgadc/spinifex/spinifex/network/listenerinventory"
 	"github.com/mulgadc/spinifex/tests/e2e/harness"
 )
@@ -28,11 +29,7 @@ import (
 func runListenerInvariant(t *testing.T, fix *Fixture) {
 	harness.Phase(t, "Multinode — Listener Invariant")
 
-	root, err := listenerinventory.RepoRoot()
-	if err != nil {
-		t.Fatalf("resolve module root: %v", err)
-	}
-	table, err := listenerinventory.ParseFile(listenerinventory.DocPath(root))
+	table, err := listenerinventory.Parse(string(networkconnections.README()))
 	if err != nil {
 		t.Fatalf("parse inbound listener inventory: %v", err)
 	}


### PR DESCRIPTION
## Summary

The `multinode` E2E suite has been red on `dev` since 57bfbc20d. The runtime half of the listener invariant (`tests/e2e/multinode/listener_invariant_test.go`) resolved `docs/security/network-connections/README.md` by shelling out to `go env GOMOD` and joining a relative path. That works fine under `go test`, which is how the static guard in `spinifex/network/invariants/` runs on the CI runner. But the multinode suite is compiled with `go test -c` and `scp`'d to a tofu-provisioned node that has no Go toolchain, so the exec fails before a single listener is inspected:

```
resolve module root: listenerinventory: go env GOMOD: exec: "go": executable file not found in $PATH
```

That is a build-time vs. run-time distinction: a `.test` binary is a static Go binary, but nothing in it can call back out to the toolchain that built it unless the toolchain also happens to be on the machine that runs it.

## Fix

`//go:embed` cannot traverse `..`, so the embed directive needs to live in a package whose own directory contains the doc. This adds `docs/security/network-connections/inventory.go`, a small package that embeds `README.md` and exposes its bytes. Every caller now does:

```go
table, err := listenerinventory.Parse(string(networkconnections.README()))
```

instead of resolving a path at runtime. The doc is embedded at compile time from the real file, so there is exactly one source of truth — no copy, no drift risk. `listenerinventory.RepoRoot()` and `DocPath()` are now unused (confirmed via `find_refs`-equivalent grep) and are removed. `spinifex/network/invariants/layers_test.go`'s own separate, unexported `repoRoot(t)` helper is untouched — it's a different, purely static helper unrelated to this doc.

Updated call sites:
- `tests/e2e/multinode/listener_invariant_test.go` — the runtime half that broke.
- `spinifex/network/invariants/listener_bind_test.go` — the static guard; kept working, now reads the same embedded bytes.
- `spinifex/network/listenerinventory/table_test.go` (`TestParse_RealDoc`) — no longer needs a live toolchain shell-out either.

`listenerinventory.Parse([]byte-backed string)` already existed, so no new parsing logic was added — just a new byte source.

## Proof the check still has teeth

Added `TestCheckBindSite_RejectsUndocumentedPort` in `spinifex/network/invariants/listener_bind_test.go`: it builds a synthetic one-row inventory table, feeds `checkBindSite` a bind site on a port absent from that table, and asserts a non-empty violation message containing "no row in" is returned. This exercises the exact code path (`table.KnownPort`) that a real undocumented listener would trip.

## Test plan

- [x] `go build ./...`
- [x] `go test ./spinifex/network/...` — all packages pass, including the new test
- [x] Built the multinode e2e binary the same way CI does (`go test -c -tags=e2e -o _bin/multinode.test ./multinode/` from `tests/e2e`), then ran it with `PATH` scrubbed to `/usr/bin:/bin` (no `go` binary reachable). It got past doc resolution and failed only at the SSH-to-live-cluster step (`ssh tf-user@127.0.0.1: ... Permission denied (publickey)`), with no `go env GOMOD` or `executable file not found` anywhere in the output — exactly the "fails for lack of a live cluster, not for lack of a toolchain" outcome expected off-cluster.
- [x] `make preflight` passes.