### PR TITLE
fix(e2e): stop flagging a Cluster bind to a single-homed node's own address

### DIFF
--- a/tests/e2e/multinode/listener_invariant_test.go
+++ b/tests/e2e/multinode/listener_invariant_test.go
@@ -5,6 +5,7 @@ package multinode
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -34,6 +35,19 @@ func runListenerInvariant(t *testing.T, fix *Fixture) {
 		t.Fatalf("parse inbound listener inventory: %v", err)
 	}
 
+	// SPINIFEX_WAN_IP is read directly (not via harness.Env.WANHost, which
+	// falls back to the first NodeIPs entry — i.e. some node's own peer
+	// address — when unset) so a WAN address is only ever trusted here when
+	// it was positively supplied, never inferred.
+	wanAddr := strings.TrimSpace(os.Getenv("SPINIFEX_WAN_IP"))
+	if wanAddr == "" {
+		harness.Detail(t, "wan_bind_check",
+			"skipped for every node: SPINIFEX_WAN_IP is unset, so no address can be "+
+				"distinguished from each node's cluster peer address")
+	} else {
+		harness.Detail(t, "wan_addr", wanAddr)
+	}
+
 	ssh := harness.NewPeerSSH()
 	var violations []string
 	for _, node := range fix.Cluster.Nodes {
@@ -45,12 +59,18 @@ func runListenerInvariant(t *testing.T, fix *Fixture) {
 			t.Fatalf("ss -tulnp on %s: %v", node.Name, runErr)
 		}
 
+		if wanAddr != "" && wanAddr == node.Addr {
+			harness.Detail(t, "wan_bind_check", fmt.Sprintf(
+				"skipped on %s: SPINIFEX_WAN_IP equals this node's peer address, so it is "+
+					"single-homed for the purpose of this check", node.Name))
+		}
+
 		for _, sock := range parseSSOutput(string(out)) {
 			for _, r := range table.RowsForPort(sock.port) {
 				if r.Scope != listenerinventory.ScopeCluster && r.Scope != listenerinventory.ScopeEncap {
 					continue
 				}
-				if v := checkSocketScope(node, sock, r); v != "" {
+				if v := checkSocketScope(node, sock, r, wanAddr); v != "" {
 					violations = append(violations, v)
 				}
 			}
@@ -67,8 +87,13 @@ func runListenerInvariant(t *testing.T, fix *Fixture) {
 
 // checkSocketScope reports a violation message if sock is bound somewhere
 // row's Scope does not permit, honoring row's own doc-declared wildcard
-// exception. Returns "" if the socket is clean for this row.
-func checkSocketScope(node harness.Node, sock ssSocket, row listenerinventory.Row) string {
+// exception. node.Addr is the cluster peer address (SSH target, not
+// necessarily WAN-facing — a single-homed node has no other address).
+// wanAddr is a positively-known WAN address, or "" when none is available;
+// it is only meaningful when distinct from node.Addr, since on a
+// single-homed node they are the same address by definition. Returns "" if
+// the socket is clean for this row.
+func checkSocketScope(node harness.Node, sock ssSocket, row listenerinventory.Row, wanAddr string) string {
 	wildcard := listenerinventory.IsWildcardAddr(sock.addr)
 	switch {
 	case wildcard && row.WildcardOK():
@@ -77,10 +102,10 @@ func checkSocketScope(node harness.Node, sock ssSocket, row listenerinventory.Ro
 		return fmt.Sprintf(
 			"%s: port %d (%s, %s scope) bound to the wildcard address %s; its inventory row does not declare a wildcard exception",
 			node.Name, sock.port, sock.proto, row.Scope, sock.addr)
-	case sock.addr == node.Addr:
+	case wanAddr != "" && wanAddr != node.Addr && sock.addr == wanAddr:
 		return fmt.Sprintf(
-			"%s: port %d (%s, %s scope) bound to %s, the node's WAN address",
-			node.Name, sock.port, sock.proto, row.Scope, sock.addr)
+			"%s: port %d (%s, %s scope) bound to %s, a WAN address distinct from the node's peer address %s",
+			node.Name, sock.port, sock.proto, row.Scope, sock.addr, node.Addr)
 	}
 	return ""
 }

--- a/tests/e2e/multinode/listener_invariant_unit_test.go
+++ b/tests/e2e/multinode/listener_invariant_unit_test.go
@@ -1,0 +1,77 @@
+//go:build e2e
+
+package multinode
+
+import (
+	"testing"
+
+	"github.com/mulgadc/spinifex/spinifex/network/listenerinventory"
+	"github.com/mulgadc/spinifex/tests/e2e/harness"
+)
+
+// TestCheckSocketScope covers the four outcomes checkSocketScope must
+// produce: the wildcard rule (with and without a row-declared exception)
+// and the WAN-vs-peer-address rule (single-homed passes, a genuinely
+// distinct WAN bind fails).
+func TestCheckSocketScope(t *testing.T) {
+	clusterRow := listenerinventory.Row{Scope: listenerinventory.ScopeCluster}
+	wildcardOKRow := listenerinventory.Row{
+		Scope:   listenerinventory.ScopeCluster,
+		Purpose: "Binds the wildcard by design.",
+	}
+
+	tests := []struct {
+		name        string
+		node        harness.Node
+		sock        ssSocket
+		row         listenerinventory.Row
+		wanAddr     string
+		wantMessage bool
+	}{
+		{
+			name:        "wildcard bind with declared exception passes",
+			node:        harness.Node{Name: "node1", Addr: "10.2.0.5"},
+			sock:        ssSocket{proto: "tcp", addr: "0.0.0.0", port: 5300},
+			row:         wildcardOKRow,
+			wanAddr:     "",
+			wantMessage: false,
+		},
+		{
+			name:        "wildcard bind without a declared exception fails",
+			node:        harness.Node{Name: "node1", Addr: "10.2.0.5"},
+			sock:        ssSocket{proto: "tcp", addr: "0.0.0.0", port: 6641},
+			row:         clusterRow,
+			wanAddr:     "",
+			wantMessage: true,
+		},
+		{
+			name:        "single-homed node bound to its only address passes",
+			node:        harness.Node{Name: "node1", Addr: "192.168.0.22"},
+			sock:        ssSocket{proto: "tcp", addr: "192.168.0.22", port: 4432},
+			row:         clusterRow,
+			wanAddr:     "",
+			wantMessage: false,
+		},
+		{
+			name:        "multi-homed node bound to a distinct WAN address fails",
+			node:        harness.Node{Name: "node4", Addr: "10.2.0.5"},
+			sock:        ssSocket{proto: "tcp", addr: "72.52.77.231", port: 6641},
+			row:         clusterRow,
+			wanAddr:     "72.52.77.231",
+			wantMessage: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkSocketScope(tc.node, tc.sock, tc.row, tc.wanAddr)
+			if tc.wantMessage && got == "" {
+				t.Fatalf("checkSocketScope() = %q, want a violation message", got)
+			}
+			if !tc.wantMessage && got != "" {
+				t.Fatalf("checkSocketScope() = %q, want no violation", got)
+			}
+			t.Logf("checkSocketScope() = %q", got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`checkSocketScope` in `tests/e2e/multinode/listener_invariant_test.go` flagged a Cluster-scope
socket bound to `node.Addr` as a "WAN address" violation. `harness.Node.Addr` is documented as
"IP or hostname; used for SSH and as peer address for partition rules" — it is the cluster peer
address, not a WAN address. CI's tofu nodes are single-homed (`SPINIFEX_NODES` and
`SPINIFEX_NODE_IPS` are set to the same CSV, `SPINIFEX_WAN_IP` is never set), so the peer
address is each node's only address. The check therefore rejected every Cluster-scope bind no
matter what it bound to, alongside the wildcard case, leaving no way for a legitimate
Cluster-scope service to pass. This produced 12 false-positive violations on `dev` run
31666585693 across ports 4222, 4248, 4432, 6641-6644, 6660, 7660.

`docs/development/bugs/port-security.md` in the mulga repo verified these exact binds as
correct: `10.2.0.5:4432` (formation on the LAN address of a three-plane node) is graded
"Correct bind", and 6643/6644 "bind the LAN correctly" via `--db-cluster-local-addr`. The
genuine defect that doc records (F1, OVN NB/SB on `0.0.0.0`) is the wildcard case, which this
PR does not touch.

## Changes

- `checkSocketScope` now takes a `wanAddr` parameter and only flags a bind when it equals a
  positively-known WAN address that is distinct from the node's peer address. The peer address
  itself is never treated as a WAN address, so a single-homed node's own bind always passes.
- `wanAddr` is read directly from `SPINIFEX_WAN_IP` in the test, not via `harness.Env.WANHost`
  — that field falls back to the first `NodeIPs` entry when the env var is unset, which is not
  reliably distinct from any given node's peer address, so it can't be trusted as a WAN signal
  here.
- When `SPINIFEX_WAN_IP` is unset (the CI case today), or equals a given node's peer address,
  the WAN-vs-peer check is skipped and that is recorded via `harness.Detail` so it is visible in
  the log rather than silently passing.
- The wildcard rule (bound to `0.0.0.0`/`[::]`, honoring a row's doc-declared exception) is
  unchanged. That half is what would catch a regression of the OVN NB/SB wildcard defect the
  invariant was built to catch, and it still fires exactly as before.

## Test plan

- [x] New table-driven `TestCheckSocketScope` in `listener_invariant_unit_test.go` covers all
      four outcomes directly: wildcard-with-exception passes, wildcard-without-exception fails,
      single-homed peer-address bind passes, multi-homed distinct-WAN-address bind fails. All
      pass (`go test -tags=e2e -run TestCheckSocketScope -v ./multinode/`).
- [x] `go test -c -tags=e2e -o _bin/multinode.test ./multinode/` builds cleanly, matching the CI
      build step.
- [x] `make preflight` passes.