### PR TITLE
chore: bump Go toolchain to 1.26.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
 
       - name: Build microVM artifacts (lb-agent + kernel + initramfs)
         run: cd spinifex && make build-microvm-image

--- a/Makefile
+++ b/Makefile
@@ -317,9 +317,9 @@ install-system:
 		ovn-central ovn-host openvswitch-switch dhcpcd-base
 
 install-go:
-	@echo -e "\n....Installing Go 1.26.5 for $(ARCH) ($(GO_ARCH))...."
+	@echo -e "\n....Installing Go 1.26.6 for $(ARCH) ($(GO_ARCH))...."
 	@if [ ! -d "/usr/local/go" ]; then \
-		curl -L https://go.dev/dl/go1.26.5.linux-$(GO_ARCH).tar.gz | tar -C /usr/local -xz; \
+		curl -L https://go.dev/dl/go1.26.6.linux-$(GO_ARCH).tar.gz | tar -C /usr/local -xz; \
 	else \
 		echo "Go already installed in /usr/local/go"; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mulgadc/spinifex
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8

--- a/scripts/workload-performance.sh
+++ b/scripts/workload-performance.sh
@@ -5,8 +5,8 @@
 sudo apt update
 sudo apt install -y make gcc git
 
-wget https://go.dev/dl/go1.26.5.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.26.5.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.26.6.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.6.linux-amd64.tar.gz
 
 echo "export PATH=$PATH:/usr/local/go/bin" >> $HOME/.bashrc
 source $HOME/.bashrc


### PR DESCRIPTION
## Summary

Bumps the Go toolchain pin from 1.26.5 to 1.26.6 across spinifex. Four Go
stdlib advisories (GO-2026-6088, GO-2026-6089, GO-2026-6090, GO-2026-6091)
were published on 2026-08-13 and are fixed in go1.26.6. predastore CI is
already failing govulncheck because of them, so the team decided to move the
whole monorepo to 1.26.6 in one pass. Bead: mulga-0q99f.

This is more than a consistency pass for spinifex specifically. A
before/after `govulncheck` run shows spinifex's own reachable code calls into
all four of the named advisories, plus three more already-fixed stdlib CVEs
that also land in go1.26.6:

- GO-2026-6088 (encoding/xml recursion depth) — reached via objectstore,
  rdsgw, dns zone lookup
- GO-2026-6089 (net/http ReadHeaderTimeout on unencrypted HTTP/2) — reached
  via awsgw and the daemon HTTP server
- GO-2026-6090 (crypto/tls post-handshake message limit) — reached via NATS,
  the daemon HTTP server, OVN, and predastore
- GO-2026-6091 (html/template JS regexp context tracking) — reached via the
  daemon HTTP server
- GO-2026-6218 (net/url resolvePath quadratic complexity) — reached via the
  Bedrock vLLM provider
- GO-2026-5972 (encoding/asn1 recursion depth) — reached via admin cert
  generation
- GO-2026-5026 (golang.org/x/net/idna Punycode validation) — reached via
  several HTTP client call sites

`govulncheck` on 1.26.5 reports 7 called standard library vulnerabilities;
on 1.26.6 it reports 0.

## Files changed

- `go.mod` — `go 1.26.5` to `go 1.26.6`
- `Makefile` — `install-go` target's echo string and curl download URL
- `.github/workflows/release.yml` — `setup-go` `go-version` input
- `scripts/workload-performance.sh` — wget/tar download of the Go tarball

No logic changes. Every other workflow uses `go-version-file`, which follows
the go.mod bump automatically, so nothing else needed touching.

One comment in `spinifex/handlers/acm/privateca.go` references "go1.26.5"
describing a one-time historical verification of stdlib constraint-matching
behavior; it is prose, not a toolchain pin, and was left as-is. A comment in
`scripts/mkosi-build.sh` discusses avoiding "a second pin" but does not
contain an actual version pin — it documents why the Dockerfile has none, so
nothing there needed changing either.

## Test plan

- [x] `GOWORK=off go build ./...` succeeds
- [x] `GOWORK=off make preflight` passes (manifest-lint, golangci-lint,
      govulncheck, unit tests)
- [x] `GOWORK=off go tool govulncheck ./...` reports 0 called vulnerabilities
      after the bump (down from 7 before)